### PR TITLE
Refactor onedocker-runner

### DIFF
--- a/onedocker/env.py
+++ b/onedocker/env.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This is the repository path that OneDocker downloads binaries from
+ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"
+
+# This is the local path that the binaries reside
+ONEDOCKER_EXE_PATH = "ONEDOCKER_EXE_PATH"


### PR DESCRIPTION
Summary:
1. define environment variables in a separate file
2. make a function to handle the logic to read a config, so it can be reused.

Differential Revision: D28562647

