### PR TITLE
add get size support to s3 and local storage

### DIFF
--- a/fbpcs/gateway/s3.py
+++ b/fbpcs/gateway/s3.py
@@ -52,7 +52,7 @@ class S3Gateway:
         )
 
     def download_file(self, bucket: str, key: str, file_name: str) -> None:
-        file_size = self.client.head_object(Bucket=bucket, Key=key)["ContentLength"]
+        file_size = self.get_object_size(bucket, key)
         self.client.download_file(
             bucket,
             key,
@@ -66,6 +66,9 @@ class S3Gateway:
     def get_object(self, bucket: str, key: str) -> str:
         res = self.client.get_object(Bucket=bucket, Key=key)
         return res["Body"].read().decode()
+
+    def get_object_size(self, bucket: str, key: str) -> int:
+        return self.client.head_object(Bucket=bucket, Key=key)["ContentLength"]
 
     def get_object_info(self, bucket: str, key: str) -> Dict[str, Any]:
         return self.client.get_object(Bucket=bucket, Key=key)

--- a/fbpcs/service/storage.py
+++ b/fbpcs/service/storage.py
@@ -38,3 +38,7 @@ class StorageService(abc.ABC):
             return PathType.S3
 
         return PathType.Local
+
+    @abc.abstractmethod
+    def get_file_size(self, filename: str) -> int:
+        pass

--- a/fbpcs/service/storage_s3.py
+++ b/fbpcs/service/storage_s3.py
@@ -196,3 +196,7 @@ class S3StorageService(StorageService):
         """
         s3_path = S3Path(filename)
         return self.s3_gateway.get_object_info(s3_path.bucket, s3_path.key)
+
+    def get_file_size(self, filename: str) -> int:
+        s3_path = S3Path(filename)
+        return self.s3_gateway.get_object_size(s3_path.bucket, s3_path.key)


### PR DESCRIPTION
Summary: Based off discussion in D28492150, in order to automate shard size but while avoiding downloading a large file locally, I added support to read the file size from AWS. I plan to approximate the number of lines in the file based on the file size in: D28556212

Reviewed By: peking2

Differential Revision: D28556180

