### PR TITLE
Raise error when start_task fails

### DIFF
--- a/fbpcs/decorator/error_handler.py
+++ b/fbpcs/decorator/error_handler.py
@@ -15,6 +15,8 @@ def error_handler(f: Callable) -> Callable:
     def wrap(*args, **kwargs):
         try:
             return f(*args, **kwargs)
+        except PcsError as err:
+            raise err
         except ClientError as err:
             raise map_aws_error(err)
         except Exception as err:

--- a/fbpcs/gateway/ecs.py
+++ b/fbpcs/gateway/ecs.py
@@ -12,6 +12,7 @@ import boto3
 from fbpcs.decorator.error_handler import error_handler
 from fbpcs.entity.cluster_instance import Cluster
 from fbpcs.entity.container_instance import ContainerInstance
+from fbpcs.error.pcs import PcsError
 from fbpcs.mapper.aws import (
     map_ecstask_to_containerinstance,
     map_esccluster_to_clusterinstance,
@@ -53,6 +54,10 @@ class ECSGateway:
             },
             overrides={"containerOverrides": [{"name": container, "command": [cmd]}]},
         )
+
+        if not response["tasks"]:
+            failure = response["failures"][0]
+            raise PcsError(f"ECS failure: reason: {failure['reason']}")
 
         return map_ecstask_to_containerinstance(response["tasks"][0])
 


### PR DESCRIPTION
Summary:
Why?
Attribution encountered an error when starting 300 containers https://fburl.com/phabricator/5xvsgi4q. It seems ECS failed to create a container and it didn't throw an exception. Instead, it returns a failure object. So we need to catch the failure and throw an error.

Reviewed By: wenhaizhu

Differential Revision: D28893018

