### PR TITLE
add cancel_instances in ContainerService

### DIFF
--- a/fbpcs/error/invalid_parameter.py
+++ b/fbpcs/error/invalid_parameter.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcs.error.pcs import PcsError
+
+
+class InvalidParameterError(PcsError):
+    pass

--- a/fbpcs/error/mapper/aws.py
+++ b/fbpcs/error/mapper/aws.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from botocore.exceptions import ClientError
+from fbpcs.error.invalid_parameter import InvalidParameterError
 from fbpcs.error.pcs import PcsError
 from fbpcs.error.throttling import ThrottlingError
 
@@ -16,7 +17,10 @@ def map_aws_error(error: ClientError) -> PcsError:
     code = error.response["Error"]["Code"]
     message = error.response["Error"]["Message"]
 
+    if code == "InvalidParameterException":
+        return InvalidParameterError(message)
+
     if code == "ThrottlingException":
         return ThrottlingError(message)
-    else:
-        return PcsError(message)
+
+    return PcsError(message)

--- a/fbpcs/gateway/ecs.py
+++ b/fbpcs/gateway/ecs.py
@@ -75,8 +75,8 @@ class ECSGateway:
         return self.client.list_tasks(cluster=cluster)["taskArns"]
 
     @error_handler
-    def stop_task(self, cluster: str, task_id: str) -> Dict[str, Any]:
-        return self.client.stop_task(
+    def stop_task(self, cluster: str, task_id: str) -> None:
+        self.client.stop_task(
             cluster=cluster,
             task=task_id,
         )

--- a/fbpcs/service/container.py
+++ b/fbpcs/service/container.py
@@ -7,9 +7,10 @@
 # pyre-strict
 
 import abc
-from typing import List
+from typing import List, Optional
 
 from fbpcs.entity.container_instance import ContainerInstance
+from fbpcs.error.pcs import PcsError
 
 
 class ContainerService(abc.ABC):
@@ -35,4 +36,8 @@ class ContainerService(abc.ABC):
 
     @abc.abstractmethod
     def get_instances(self, instance_ids: List[str]) -> List[ContainerInstance]:
+        pass
+
+    @abc.abstractmethod
+    def cancel_instances(self, instance_ids: List[str]) -> List[Optional[PcsError]]:
         pass

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -10,6 +10,7 @@ import asyncio
 from typing import Any, Dict, List, Optional, Tuple
 
 from fbpcs.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcs.error.pcs import PcsError
 from fbpcs.gateway.ecs import ECSGateway
 from fbpcs.service.container import ContainerService
 from fbpcs.util.typing import checked_cast
@@ -54,6 +55,9 @@ class AWSContainerService(ContainerService):
 
     def stop_task(self, task_id: str) -> None:
         self.ecs_gateway.stop_task(cluster=self.cluster, task_id=task_id)
+
+    def cancel_instances(self, instance_ids: List[str]) -> List[Optional[PcsError]]:
+        return []
 
     def _split_container_definition(self, container_definition: str) -> Tuple[str, str]:
         """

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -52,8 +52,8 @@ class AWSContainerService(ContainerService):
     def list_tasks(self) -> List[str]:
         return self.ecs_gateway.list_tasks(cluster=self.cluster)
 
-    def stop_task(self, task_id: str) -> Dict[str, Any]:
-        return self.ecs_gateway.stop_task(cluster=self.cluster, task_id=task_id)
+    def stop_task(self, task_id: str) -> None:
+        self.ecs_gateway.stop_task(cluster=self.cluster, task_id=task_id)
 
     def _split_container_definition(self, container_definition: str) -> Tuple[str, str]:
         """


### PR DESCRIPTION
Summary:
We should define and implement cancel_instances as we have create_instances in container service. So it's the responsibility of containerservice to cancel a list of containers.

Next: once Ziyan land his diff, I will implement it.

Differential Revision: D28921998

