### PR TITLE
Add stop_containers in onedocker service

### DIFF
--- a/fbpcs/service/container.py
+++ b/fbpcs/service/container.py
@@ -41,3 +41,7 @@ class ContainerService(abc.ABC):
     @abc.abstractmethod
     def cancel_instances(self, instance_ids: List[str]) -> List[Optional[PcsError]]:
         pass
+
+    @abc.abstractmethod
+    def cancel_instance(self, instance_id: str) -> None:
+        pass

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -55,11 +55,18 @@ class AWSContainerService(ContainerService):
     def list_tasks(self) -> List[str]:
         return self.ecs_gateway.list_tasks(cluster=self.cluster)
 
-    def stop_task(self, task_id: str) -> None:
-        self.ecs_gateway.stop_task(cluster=self.cluster, task_id=task_id)
+    def cancel_instance(self, instance_id: str) -> None:
+        return self.ecs_gateway.stop_task(cluster=self.cluster, task_id=instance_id)
 
     def cancel_instances(self, instance_ids: List[str]) -> List[Optional[PcsError]]:
-        return []
+        errors = []
+        for instance_id in instance_ids:
+            try:
+                errors.append(self.cancel_instance(instance_id))
+            except PcsError as err:
+                errors.append(err)
+
+        return errors
 
     def _split_container_definition(self, container_definition: str) -> Tuple[str, str]:
         """

--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -11,6 +11,7 @@ import logging
 from typing import List, Optional
 
 from fbpcs.entity.container_instance import ContainerInstance
+from fbpcs.error.pcs import PcsError
 from fbpcs.service.container import ContainerService
 
 
@@ -77,6 +78,9 @@ class OneDockerService:
             container_definition, cmds
         )
         return container_ids
+
+    def stop_containers(self, containers: List[str]) -> List[Optional[PcsError]]:
+        return self.container_svc.cancel_instances(containers)
 
     def _get_exe_name(self, package_name: str) -> str:
         return package_name.split("/")[1]

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -7,6 +7,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from fbpcs.error.pcs import PcsError
 from fbpcs.service.container_aws import (
     ContainerInstance,
     ContainerInstanceStatus,
@@ -138,3 +139,9 @@ class TestAWSContainerService(unittest.TestCase):
         instance_ids = [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
         self.container_svc.ecs_gateway.list_tasks = MagicMock(return_value=instance_ids)
         self.assertEqual(instance_ids, self.container_svc.list_tasks())
+
+    def test_cancel_instances(self):
+        instance_ids = [TEST_INSTANCE_ID_1, TEST_INSTANCE_ID_2]
+        errors = [None, PcsError("instance id not found")]
+        self.container_svc.ecs_gateway.stop_task = MagicMock(side_effect=errors)
+        self.assertEqual(self.container_svc.cancel_instances(instance_ids), errors)

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -5,9 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcs.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcs.error.pcs import PcsError
 from fbpcs.service.onedocker import OneDockerService
 
 
@@ -62,3 +63,17 @@ class TestOneDockerService(unittest.TestCase):
         cmd_with_timeout = self.onedocker_svc._get_cmd(package_name, cmd_args, timeout)
         self.assertEqual(expected_cmd_without_timeout, cmd_without_timeout)
         self.assertEqual(expected_cmd_with_timeout, cmd_with_timeout)
+
+    def test_stop_containers(self):
+        containers = [
+            "0cc43cdb-3bee-4407-9c26-c0e6ea5bee84",
+            "6b809ef6-c67e-4467-921f-ee261c15a0a2",
+        ]
+        expected_results = [None, PcsError("instance id not found")]
+        self.onedocker_svc.container_svc.cancel_instances = MagicMock(
+            return_value=expected_results
+        )
+        self.assertEqual(
+            self.onedocker_svc.stop_containers(containers), expected_results
+        )
+        self.onedocker_svc.container_svc.cancel_instances.assert_called_with(containers)


### PR DESCRIPTION
Summary:
## Context
We want to add this api for upstream callers to manually kill containers on ECS

## Steps

1. Added stop_containers in onedocker service to kill all containers stored in a MPC instance
2. Added unit test for this api

## Next
1. Add new api at mpc service level to manually kill containers (call stop_containers I just added)

Reviewed By: peking2

Differential Revision: D28818989

