### PR TITLE
Update the way of calling onedocker_runner (onedocker_runner release)

### DIFF
--- a/onedocker/script/__init__.py
+++ b/onedocker/script/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/onedocker/script/runner/__init__.py
+++ b/onedocker/script/runner/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/onedocker/script/runner/__main__.py
+++ b/onedocker/script/runner/__main__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from onedocker.script.runner.onedocker_runner import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
## Why
We don't want to manually add onedocker_runner into the onedocker image, so we can easily install and run onedocker_runner by adding __main__.py (onedocker was already installed through fbpcs installation since they are in the same repo now)

## What
1. Add __init__.py and __main__.py
2. Update onedocker_build.sh and dockerfile to get rid of onedocker_runner

## Next
1. My next diff will rename all one_docker to onedocker, so after that I will re-build the onedocker images for both prod and test.

Differential Revision: D29046360

