### PR TITLE
Update default repository path to prod repository in runner

### DIFF
--- a/onedocker/script/runner/onedocker_runner.py
+++ b/onedocker/script/runner/onedocker_runner.py
@@ -38,10 +38,12 @@ from onedocker.common.util import run_cmd
 
 
 # the folder on s3 that the executables are to downloaded from
-DEFAULT_REPOSITORY_PATH = "https://one-docker-repository.s3.us-west-1.amazonaws.com/"
+DEFAULT_REPOSITORY_PATH = (
+    "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/"
+)
 
 # the folder in the docker image that is going to host the executables
-DEFAULT_EXE_FOLDER = "/root/one_docker/package/"
+DEFAULT_EXE_FOLDER = "/root/onedocker/package/"
 
 
 def run(


### PR DESCRIPTION
Summary:
## Why
Currently we install onedocker_runner by pip install and we can't easily update task definition for prod. So we have to commit this change before building a new onedocker image.

## What
1. Update default repository path to prod repository
2. Update working directory for onedocker package (This will be tested in next diff when I update onedocker service)

Differential Revision: D29072669

