### PR TITLE
Normalized onedocker name

### DIFF
--- a/fbpcs/entity/mpc_game_config.py
+++ b/fbpcs/entity/mpc_game_config.py
@@ -19,5 +19,5 @@ class MPCGameArgument:
 @dataclass
 class MPCGameConfig:
     game_name: str
-    one_docker_package_name: str
+    onedocker_package_name: str
     arguments: List[MPCGameArgument]

--- a/fbpcs/service/mpc.py
+++ b/fbpcs/service/mpc.py
@@ -70,7 +70,7 @@ class MPCService:
 
     game_config = {
     "game": {
-        "one_docker_package_name": "package_name",
+        "onedocker_package_name": "package_name",
         "arguments": [
             {"name": "input_filenames", "required": True},
             {"name": "input_directory", "required": True},
@@ -252,7 +252,7 @@ class MPCService:
             game_arg = game_args[i] if game_args is not None else {}
             server_ip = ip_addresses[i] if ip_addresses is not None else None
             cmd_tuple_list.append(
-                self.mpc_game_svc.build_one_docker_args(
+                self.mpc_game_svc.build_onedocker_args(
                     game_name=game_name,
                     mpc_role=mpc_role,
                     server_ip=server_ip,

--- a/fbpcs/service/mpc_game.py
+++ b/fbpcs/service/mpc_game.py
@@ -23,7 +23,7 @@ class MPCGameService:
         self.mpc_game_repository: MPCGameRepository = mpc_game_repository
 
     # returns package_name and cmd which includes only arguments (no executable)
-    def build_one_docker_args(
+    def build_onedocker_args(
         self,
         game_name: str,
         mpc_role: MPCRole,
@@ -33,7 +33,7 @@ class MPCGameService:
     ) -> Tuple[str, str]:
         mpc_game_config = self.mpc_game_repository.get_game(game_name)
         return (
-            mpc_game_config.one_docker_package_name,
+            mpc_game_config.onedocker_package_name,
             self._build_cmd(
                 mpc_game_config=mpc_game_config,
                 mpc_role=mpc_role,

--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -15,9 +15,9 @@ from fbpcs.error.pcs import PcsError
 from fbpcs.service.container import ContainerService
 
 
-ONE_DOCKER_CMD_PREFIX = (
+ONEDOCKER_CMD_PREFIX = (
     # patternlint-disable-next-line f-string-may-be-missing-leading-f
-    "python3.8 -m one_docker_runner --package_name={0} --cmd='/root/one_docker/package/"
+    "python3.8 -m onedocker.script.runner {package_name} --cmd='/root/onedocker/package/"
 )
 
 
@@ -96,4 +96,4 @@ class OneDockerService:
         """
         if timeout is not None:
             cmd_timeout = f" --timeout={timeout}"
-        return f"{ONE_DOCKER_CMD_PREFIX.format(package_name, timeout)}{self._get_exe_name(package_name)} {cmd_args}'{cmd_timeout}"
+        return f"{ONEDOCKER_CMD_PREFIX.format(package_name=package_name)}{self._get_exe_name(package_name)} {cmd_args}'{cmd_timeout}"

--- a/onedocker/dockerfile
+++ b/onedocker/dockerfile
@@ -35,9 +35,7 @@ RUN mkdir -p /root/src/
 ADD pip_requirements.txt /root/src
 RUN python3.8 -m pip install --user -r /root/src/pip_requirements.txt
 
-# add one_docker_runner and make the folder that's going to host the executables in runtime
-ADD env.py one_docker_runner.py /root
-RUN mkdir -p /root/one_docker/package
+RUN mkdir -p /root/onedocker/package
 
 CMD ["/bin/bash"]
 WORKDIR /root

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -94,7 +94,7 @@ class TestMPCService(unittest.TestCase):
             game_args=GAME_ARGS,
         )
 
-    async def test_spin_up_containers_one_docker_inconsistent_arguments(self):
+    async def test_spin_up_containers_onedocker_inconsistent_arguments(self):
         with self.assertRaisesRegex(
             ValueError,
             "The number of containers is not consistent with the number of game argument dictionary.",
@@ -169,9 +169,9 @@ class TestMPCService(unittest.TestCase):
         self.mpc_service.container_svc.create_instances_async = AsyncMock(
             return_value=created_instances
         )
-        built_one_docker_args = ("private_lift/lift", "test one docker arguments")
-        self.mpc_service.mpc_game_svc.build_one_docker_args = MagicMock(
-            return_value=built_one_docker_args
+        built_onedocker_args = ("private_lift/lift", "test one docker arguments")
+        self.mpc_service.mpc_game_svc.build_onedocker_args = MagicMock(
+            return_value=built_onedocker_args
         )
         # check that update is called with correct status
         self.mpc_service.start_instance(TEST_INSTANCE_ID)

--- a/tests/service/test_mpc_game.py
+++ b/tests/service/test_mpc_game.py
@@ -21,11 +21,11 @@ OUTPUT_PATH_1 = "out_path_1"
 OUTPUT_PATH_2 = "out_path_2"
 CONCURRENCY = 2
 GAME_NAME = "test_game"
-ONE_DOCKER_PACKAGE_NAME = "one_docker_package/package_name"
+ONEDOCKER_PACKAGE_NAME = "onedocker_package/package_name"
 
 GAME_CONFIG = {
     GAME_NAME: {
-        "one_docker_package_name": ONE_DOCKER_PACKAGE_NAME,
+        "onedocker_package_name": ONEDOCKER_PACKAGE_NAME,
         "arguments": [
             {"name": "input_filenames", "required": True},
             {"name": "input_directory", "required": True},
@@ -47,7 +47,7 @@ class TestMPCGameService(unittest.TestCase):
         ]
         self.mpc_game_config = MPCGameConfig(
             game_name=GAME_NAME,
-            one_docker_package_name=GAME_CONFIG[GAME_NAME]["one_docker_package_name"],
+            onedocker_package_name=GAME_CONFIG[GAME_NAME]["onedocker_package_name"],
             arguments=arguments,
         )
         self.mpc_game_svc.mpc_game_repository.get_game = MagicMock(
@@ -128,7 +128,7 @@ class TestMPCGameService(unittest.TestCase):
             f"--output_directory={OUTPUT_DIRECTORY} --concurrency={CONCURRENCY}",
         )
 
-    def test_build_one_docker_args(self):
+    def test_build_onedocker_args(self):
         game_args = [
             {
                 "input_filenames": INPUT_PATH_1,
@@ -148,13 +148,13 @@ class TestMPCGameService(unittest.TestCase):
 
         expected_arguments = [
             (
-                ONE_DOCKER_PACKAGE_NAME,
+                ONEDOCKER_PACKAGE_NAME,
                 f"--party=1 --input_filenames={INPUT_PATH_1} --input_directory={INPUT_DIRECTORY} "
                 f"--output_filenames={OUTPUT_PATH_1} --output_directory={OUTPUT_DIRECTORY} "
                 f"--concurrency={CONCURRENCY}",
             ),
             (
-                ONE_DOCKER_PACKAGE_NAME,
+                ONEDOCKER_PACKAGE_NAME,
                 f"--party=1 --input_filenames={INPUT_PATH_2} --input_directory={INPUT_DIRECTORY} "
                 f"--output_filenames={OUTPUT_PATH_2} --output_directory={OUTPUT_DIRECTORY} "
                 f"--concurrency={CONCURRENCY}",
@@ -165,7 +165,7 @@ class TestMPCGameService(unittest.TestCase):
             expected_argument = expected_arguments[i]
             game_arg = game_args[i]
             self.assertEqual(
-                self.mpc_game_svc.build_one_docker_args(
+                self.mpc_game_svc.build_onedocker_args(
                     game_name="game",
                     mpc_role=MPCRole.SERVER,
                     **game_arg,

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -57,7 +57,7 @@ class TestOneDockerService(unittest.TestCase):
         package_name = "project/exe_name"
         cmd_args = "--k1=v1 --k2=v2"
         timeout = 3600
-        expected_cmd_without_timeout = "python3.8 -m one_docker_runner --package_name=project/exe_name --cmd='/root/one_docker/package/exe_name --k1=v1 --k2=v2'"
+        expected_cmd_without_timeout = "python3.8 -m onedocker.script.runner project/exe_name --cmd='/root/onedocker/package/exe_name --k1=v1 --k2=v2'"
         expected_cmd_with_timeout = expected_cmd_without_timeout + " --timeout=3600"
         cmd_without_timeout = self.onedocker_svc._get_cmd(package_name, cmd_args)
         cmd_with_timeout = self.onedocker_svc._get_cmd(package_name, cmd_args, timeout)


### PR DESCRIPTION
Summary:
## Why
1. We have onedocker and one_docker in our codebase and we want to normalize it to onedocker
2. We updated the way of running onedocker_runner in D29046360 (https://github.com/facebookresearch/fbpcs/commit/e6ee9f13b3d53499a1f1d0faa7c9663b1dc90b4f) so we want to update onedocker service to run onedocker_runner in the new way.

## What
1. Normalized ondocker name
2. Updated onedocker service generated cmds.

## Next
After this gets approved, I will update onedocker prod/test image.

Differential Revision: D29012938

