### PR TITLE
Enforcing Typing

### DIFF
--- a/fbpcs/error/owdl.py
+++ b/fbpcs/error/owdl.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class OWDLError(Exception):
+    pass
+
+
+class OWDLParsingError(OWDLError):
+    pass

--- a/onedocker/onedocker_lib/entity/owdl_state.py
+++ b/onedocker/onedocker_lib/entity/owdl_state.py
@@ -10,8 +10,10 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 from dataclasses_json import config, DataClassJsonMixin
+from onedocker.onedocker_lib.util.enforce_types import enforce_types
 
 
+@enforce_types
 @dataclass
 class OWDLState(DataClassJsonMixin):
     type_: str = field(metadata=config(field_name="Type"))

--- a/onedocker/onedocker_lib/entity/owdl_workflow.py
+++ b/onedocker/onedocker_lib/entity/owdl_workflow.py
@@ -11,8 +11,10 @@ from typing import Dict, Optional
 
 from dataclasses_json import config, DataClassJsonMixin
 from onedocker.onedocker_lib.entity.owdl_state import OWDLState
+from onedocker.onedocker_lib.util.enforce_types import enforce_types
 
 
+@enforce_types
 @dataclass
 class OWDLWorkflow(DataClassJsonMixin):
     starts_at: str = field(metadata=config(field_name="StartAt"))

--- a/onedocker/onedocker_lib/util/enforce_types.py
+++ b/onedocker/onedocker_lib/util/enforce_types.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# File derived from https://github.com/matchawine/python-enforce-typing/
+# TODO: Import this Enforce Types library to fbcode
+
+import inspect
+import typing
+from contextlib import suppress
+from functools import wraps
+
+from fbpcs.error.owdl import OWDLParsingError
+
+
+def enforce_types(callable):
+    spec = inspect.getfullargspec(callable)
+
+    def check_types(*args, **kwargs):
+        parameters = dict(zip(spec.args, args))
+        parameters.update(kwargs)
+        for name, value in parameters.items():
+            with suppress(KeyError):  # Assume un-annotated parameters can be any type
+                type_hint = spec.annotations[name]
+                if isinstance(type_hint, typing._SpecialForm):
+                    # No check for typing.Any, typing.Union, typing.ClassVar (without parameters)
+                    continue
+                try:
+                    actual_type = type_hint.__origin__
+                except AttributeError:
+                    # In case of non-typing types (such as <class 'int'>, for instance)
+                    actual_type = type_hint
+                # In Python 3.8 one would replace the try/except with
+                # actual_type = typing.get_origin(type_hint) or type_hint
+                if isinstance(actual_type, typing._SpecialForm):
+                    # case of typing.Union[…] or typing.ClassVar[…]
+                    actual_type = type_hint.__args__
+
+                if not isinstance(value, actual_type):
+                    raise OWDLParsingError(
+                        f"Unexpected type for '{name}' (expected {type_hint} but found {type(value)})"
+                    )
+
+    def decorate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            check_types(*args, **kwargs)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if inspect.isclass(callable):
+        callable.__init__ = decorate(callable.__init__)
+        return callable
+
+    return decorate(callable)

--- a/onedocker/tests/service/test_owdl_parser.py
+++ b/onedocker/tests/service/test_owdl_parser.py
@@ -8,6 +8,7 @@ import json
 import unittest
 from typing import Any, Dict
 
+from fbpcs.error.owdl import OWDLParsingError
 from onedocker.onedocker_lib.service.owdl_parser import OWDLParserService
 
 
@@ -112,121 +113,121 @@ class ParserTestUtil(unittest.TestCase):
             json.dumps(input_str),
         )
 
-    # def test_parse_bad_value(self):
-    #     input_str = {
-    #         "StartAt": 12,
-    #         "States": {
-    #             "Calculate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": 100,
-    #                 "Next": "Aggregate",
-    #             },
-    #             "Aggregate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": 0,
-    #                 "End": True,
-    #             },
-    #         },
-    #     }
+    def test_parse_bad_value(self):
+        input_str = {
+            "StartAt": 12,
+            "States": {
+                "Calculate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": 100,
+                    "Next": "Aggregate",
+                },
+                "Aggregate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": 0,
+                    "End": True,
+                },
+            },
+        }
 
-    #     self.assertRaises(
-    #         ValueError,
-    #         self.parser.parse,
-    #         json.dumps(input_str),
-    #     )
+        self.assertRaises(
+            OWDLParsingError,
+            self.parser.parse,
+            json.dumps(input_str),
+        )
 
-    # def test_parse_bad_value_state(self):
-    #     input_str = {
-    #         "StartAt": "Calculate",
-    #         "States": {
-    #             "Calculate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": "1z00",
-    #                 "Next": "Aggregate",
-    #             },
-    #             "Aggregate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": 0,
-    #                 "End": True,
-    #             },
-    #         },
-    #     }
+    def test_parse_bad_value_state(self):
+        input_str = {
+            "StartAt": "Calculate",
+            "States": {
+                "Calculate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": "1z00",
+                    "Next": "Aggregate",
+                },
+                "Aggregate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": 0,
+                    "End": True,
+                },
+            },
+        }
 
-    #     self.assertRaises(
-    #         ValueError,
-    #         self.parser.parse,
-    #         json.dumps(input_str),
-    #     )
+        self.assertRaises(
+            OWDLParsingError,
+            self.parser.parse,
+            json.dumps(input_str),
+        )
 
-    # def test_parse_bad_value_state_2(self):
-    #     input_str = {
-    #         "StartAt": "Calculate",
-    #         "States": {
-    #             "Calculate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": "100",
-    #                 "Next": "Aggregate",
-    #             },
-    #             "Aggregate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": 0,
-    #                 "End": True,
-    #             },
-    #         },
-    #     }
+    def test_parse_bad_value_state_2(self):
+        input_str = {
+            "StartAt": "Calculate",
+            "States": {
+                "Calculate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": "100",
+                    "Next": "Aggregate",
+                },
+                "Aggregate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": 0,
+                    "End": True,
+                },
+            },
+        }
 
-    #     self.assertRaises(
-    #         ValueError,
-    #         self.parser.parse,
-    #         json.dumps(input_str),
-    #     )
+        self.assertRaises(
+            OWDLParsingError,
+            self.parser.parse,
+            json.dumps(input_str),
+        )
 
-    # def test_parse_bad_value_state_3(self):
-    #     input_str = {
-    #         "StartAt": "Calculate",
-    #         "States": {
-    #             "Calculate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": 100,
-    #                 "Next": "Aggregate",
-    #             },
-    #             "Aggregate": {
-    #                 "Type": "Task",
-    #                 "ContainerDefinition": "xx",
-    #                 "PackageName": "yy",
-    #                 "CmdArgsList": ["aa", "bb", "cc"],
-    #                 "Timeout": 0,
-    #                 "End": "true",
-    #             },
-    #         },
-    #     }
+    def test_parse_bad_value_state_3(self):
+        input_str = {
+            "StartAt": "Calculate",
+            "States": {
+                "Calculate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": 100,
+                    "Next": "Aggregate",
+                },
+                "Aggregate": {
+                    "Type": "Task",
+                    "ContainerDefinition": "xx",
+                    "PackageName": "yy",
+                    "CmdArgsList": ["aa", "bb", "cc"],
+                    "Timeout": 0,
+                    "End": "true",
+                },
+            },
+        }
 
-    #     self.assertRaises(
-    #         ValueError,
-    #         self.parser.parse,
-    #         json.dumps(input_str),
-    #     )
+        self.assertRaises(
+            OWDLParsingError,
+            self.parser.parse,
+            json.dumps(input_str),
+        )
 
     def test_parse_missing_key(self):
         input_str = {


### PR DESCRIPTION
Summary: Using local, slightly modified version of https://pypi.org/project/enforce-typing/ to enforce type checking on dataclasses (because the library is not supported internally). Throw OWDLParsingError when input types don't match expected ones.

Reviewed By: peking2

Differential Revision: D29047400

