### PR TITLE
Use a list of subnets instead of one subnet when run tasks

### DIFF
--- a/fbpcs/gateway/ecs.py
+++ b/fbpcs/gateway/ecs.py
@@ -43,14 +43,19 @@ class ECSGateway:
 
     @error_handler
     def run_task(
-        self, task_definition: str, container: str, cmd: str, cluster: str, subnet: str
+        self,
+        task_definition: str,
+        container: str,
+        cmd: str,
+        cluster: str,
+        subnets: List[str],
     ) -> ContainerInstance:
         response = self.client.run_task(
             taskDefinition=task_definition,
             cluster=cluster,
             networkConfiguration={
                 "awsvpcConfiguration": {
-                    "subnets": [subnet],
+                    "subnets": subnets,
                     "assignPublicIp": "ENABLED",
                 }
             },

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -82,7 +82,7 @@ class AWSContainerService(ContainerService):
             container_definition
         )
         instance = self.ecs_gateway.run_task(
-            task_definition, container, cmd, self.cluster, self.subnet
+            task_definition, container, cmd, self.cluster, [self.subnet]
         )
 
         # wait until the container is in running state

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -18,7 +18,7 @@ class TestECSGateway(unittest.TestCase):
     TEST_CONTAINER = "test-container"
     TEST_CLUSTER = "test-cluster"
     TEST_CMD = "test-cmd"
-    TEST_SUBNET = "test-subnet"
+    TEST_SUBNETS = ["test-subnet"]
     TEST_ACCESS_KEY_ID = "test-access-key-id"
     TEST_ACCESS_KEY_DATA = "test-access-key-data"
     TEST_IP_ADDRESS = "127.0.0.1"
@@ -60,7 +60,7 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_CONTAINER,
             self.TEST_CMD,
             self.TEST_CLUSTER,
-            self.TEST_SUBNET,
+            self.TEST_SUBNETS,
         )
         expected_task = ContainerInstance(
             self.TEST_TASK_ARN,


### PR DESCRIPTION
Summary:
For context, check task T92722503.

This diff is to change the ECSGateway to accept a list of subnets.

Reviewed By: peking2, ajaybhargavb

Differential Revision: D29081375

