### PR TITLE
Use a list of subnets instead of one subnet when run tasks

### DIFF
--- a/fbpcs/gateway/ecs.py
+++ b/fbpcs/gateway/ecs.py
@@ -43,14 +43,19 @@ class ECSGateway:
 
     @error_handler
     def run_task(
-        self, task_definition: str, container: str, cmd: str, cluster: str, subnet: str
+        self,
+        task_definition: str,
+        container: str,
+        cmd: str,
+        cluster: str,
+        subnets: List[str],
     ) -> ContainerInstance:
         response = self.client.run_task(
             taskDefinition=task_definition,
             cluster=cluster,
             networkConfiguration={
                 "awsvpcConfiguration": {
-                    "subnets": [subnet],
+                    "subnets": subnets,
                     "assignPublicIp": "ENABLED",
                 }
             },

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -75,14 +75,18 @@ class AWSContainerService(ContainerService):
         s = container_definition.split("#")
         return (s[0], s[1])
 
+    def _process_subnets(self, subnet: str) -> List[str]:
+        return subnet.split(",")
+
     async def _create_instance_async(
         self, container_definition: str, cmd: str
     ) -> ContainerInstance:
         task_definition, container = self._split_container_definition(
             container_definition
         )
+        subnets = self._process_subnets(self.subnet)
         instance = self.ecs_gateway.run_task(
-            task_definition, container, cmd, self.cluster, [self.subnet]
+            task_definition, container, cmd, self.cluster, subnets
         )
 
         # wait until the container is in running state

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -82,7 +82,7 @@ class AWSContainerService(ContainerService):
             container_definition
         )
         instance = self.ecs_gateway.run_task(
-            task_definition, container, cmd, self.cluster, self.subnet
+            task_definition, container, cmd, self.cluster, [self.subnet]
         )
 
         # wait until the container is in running state

--- a/tests/gateway/test_ecs.py
+++ b/tests/gateway/test_ecs.py
@@ -18,7 +18,7 @@ class TestECSGateway(unittest.TestCase):
     TEST_CONTAINER = "test-container"
     TEST_CLUSTER = "test-cluster"
     TEST_CMD = "test-cmd"
-    TEST_SUBNET = "test-subnet"
+    TEST_SUBNETS = ["test-subnet"]
     TEST_ACCESS_KEY_ID = "test-access-key-id"
     TEST_ACCESS_KEY_DATA = "test-access-key-data"
     TEST_IP_ADDRESS = "127.0.0.1"
@@ -60,7 +60,7 @@ class TestECSGateway(unittest.TestCase):
             self.TEST_CONTAINER,
             self.TEST_CMD,
             self.TEST_CLUSTER,
-            self.TEST_SUBNET,
+            self.TEST_SUBNETS,
         )
         expected_task = ContainerInstance(
             self.TEST_TASK_ARN,

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -20,7 +20,7 @@ TEST_REGION = "us-west-2"
 TEST_KEY_ID = "test-key-id"
 TEST_KEY_DATA = "test-key-data"
 TEST_CLUSTER = "test-cluster"
-TEST_SUBNET = "test-subnet"
+TEST_SUBNET = "test-subnet0, test-subnet1"
 TEST_IP_ADDRESS = "127.0.0.1"
 TEST_CONTAINER_DEFNITION = "test-task-definition#test-container-definition"
 


### PR DESCRIPTION
Summary:
This diff changed the code on the ContainerService level. It will accept subnet ids as a string (e.g. "subnet_id0, subnetid1") and pass in a "List" of subnet ids into the ecs gateway.

With this change, we don't need to change any config.yml file, and if we want to use two subnets, just put the subnet ids into the "subnet" in config.yml.

Reviewed By: peking2

Differential Revision: D29105794

