### PR TITLE
No ExitCode Bug Fix

### DIFF
--- a/fbpcs/mapper/aws.py
+++ b/fbpcs/mapper/aws.py
@@ -26,7 +26,7 @@ def map_ecstask_to_containerinstance(task: Dict[str, Any]) -> ContainerInstance:
     if status == "RUNNING":
         status = ContainerInstanceStatus.STARTED
     elif status == "STOPPED":
-        if container["exitCode"] == 0:
+        if container.get("exitCode") == 0:
             status = ContainerInstanceStatus.COMPLETED
         else:
             status = ContainerInstanceStatus.FAILED


### PR DESCRIPTION
Summary: Calling describe_tasks after a container is manually shut down in AWS gives an output with no exitCode, leading to a PcsError

Reviewed By: corbantek, peking2, zhuang-93

Differential Revision: D29273587

