### PR TITLE
Serialize instances to JSON instead of pickling

### DIFF
--- a/fbpcs/entity/mpc_instance.py
+++ b/fbpcs/entity/mpc_instance.py
@@ -8,7 +8,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 
 from dataclasses_json import dataclass_json
 from fbpcs.entity.container_instance import ContainerInstance
@@ -36,14 +36,16 @@ class MPCInstance(InstanceBase):
     game_name: str
     mpc_role: MPCRole
     num_workers: int
+    ip_config_file: Optional[str]
     server_ips: Optional[List[str]]
     containers: List[ContainerInstance]
     status: MPCInstanceStatus
     game_args: Optional[List[Dict[str, Any]]]
-    arguments: Mapping[str, Any]
+    arguments: Dict[str, Any]
 
-    def __init__(
-        self,
+    @classmethod
+    def create_instance(
+        cls,
         instance_id: str,
         game_name: str,
         mpc_role: MPCRole,
@@ -54,17 +56,19 @@ class MPCInstance(InstanceBase):
         status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
         game_args: Optional[List[Dict[str, Any]]] = None,
         **arguments  # pyre-ignore
-    ) -> None:
-        self.instance_id = instance_id
-        self.game_name = game_name
-        self.mpc_role = mpc_role
-        self.num_workers = num_workers
-        self.ip_config_file = ip_config_file
-        self.server_ips = server_ips
-        self.containers = containers or []
-        self.status = status
-        self.game_args = game_args
-        self.arguments = arguments
+    ) -> "MPCInstance":
+        return cls(
+            instance_id,
+            game_name,
+            mpc_role,
+            num_workers,
+            ip_config_file,
+            server_ips,
+            containers or [],
+            status,
+            game_args,
+            arguments,
+        )
 
     def get_instance_id(self) -> str:
         return self.instance_id

--- a/fbpcs/service/mpc.py
+++ b/fbpcs/service/mpc.py
@@ -112,7 +112,7 @@ class MPCService:
     ) -> MPCInstance:
         self.logger.info(f"Creating MPC instance: {instance_id}")
 
-        instance = MPCInstance(
+        instance = MPCInstance.create_instance(
             instance_id=instance_id,
             game_name=game_name,
             mpc_role=mpc_role,

--- a/tests/repository/test_instance_local.py
+++ b/tests/repository/test_instance_local.py
@@ -30,7 +30,7 @@ ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
 class TestLocalInstanceRepository(unittest.TestCase):
     def setUp(self):
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,

--- a/tests/repository/test_instance_s3.py
+++ b/tests/repository/test_instance_s3.py
@@ -32,7 +32,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     def setUp(self):
         storage_svc = S3StorageService("us-west-1")
         self.s3_storage_repo = S3InstanceRepository(storage_svc, self.TEST_BASE_DIR)
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=self.TEST_INSTANCE_ID,
             game_name=self.TEST_GAME_NAME,
             mpc_role=self.TEST_MPC_ROLE,

--- a/tests/repository/test_mpc_instance_local.py
+++ b/tests/repository/test_mpc_instance_local.py
@@ -30,7 +30,7 @@ ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
 class TestLocalMPCInstanceRepository(unittest.TestCase):
     def setUp(self):
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,

--- a/tests/repository/test_mpc_instance_s3.py
+++ b/tests/repository/test_mpc_instance_s3.py
@@ -32,7 +32,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     def setUp(self):
         storage_svc = S3StorageService("us-west-1")
         self.s3_storage_repo = S3MPCInstanceRepository(storage_svc, TEST_BASE_DIR)
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -60,7 +60,7 @@ class TestMPCService(unittest.TestCase):
 
     @staticmethod
     def _get_sample_mpcinstance():
-        return MPCInstance(
+        return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,
@@ -72,7 +72,7 @@ class TestMPCService(unittest.TestCase):
 
     @staticmethod
     def _get_sample_mpcinstance_with_game_args():
-        return MPCInstance(
+        return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,
@@ -84,7 +84,7 @@ class TestMPCService(unittest.TestCase):
 
     @staticmethod
     def _get_sample_mpcinstance_client():
-        return MPCInstance(
+        return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=MPCRole.CLIENT,


### PR DESCRIPTION
Summary:
## What

* don't define custom constructors for MPCInstance and PostProcessingInstance dataclasses. Instead, define "create_instance" methods that take any custom arguments and call the constructor for you

## Why

* In the next diff, I add JSON serialization for the instance repository. As part of that serialization, it is necessary that the constructor takes only the arguments that are stored on the instance, else deserialization is impossible.

Reviewed By: peking2

Differential Revision: D29267882

