### PR TITLE
Serialize instances to JSON instead of pickling

### DIFF
--- a/fbpcs/entity/instance_base.py
+++ b/fbpcs/entity/instance_base.py
@@ -7,13 +7,24 @@
 # pyre-strict
 
 import abc
+from typing import Type, TypeVar
+
+from dataclasses_json import DataClassJsonMixin
+
+T = TypeVar("T", bound="InstanceBase")
 
 
-class InstanceBase(abc.ABC):
+class InstanceBase(DataClassJsonMixin):
     @abc.abstractmethod
     def get_instance_id(self) -> str:
         pass
 
-    @abc.abstractmethod
     def __str__(self) -> str:
-        pass
+        return self.to_json()
+
+    def dumps_schema(self) -> str:
+        return self.schema().dumps(self)
+
+    @classmethod
+    def loads_schema(cls: Type[T], json_schema_str: str) -> T:
+        return cls.schema().loads(json_schema_str, many=None)

--- a/fbpcs/entity/mpc_instance.py
+++ b/fbpcs/entity/mpc_instance.py
@@ -8,7 +8,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 
 from dataclasses_json import dataclass_json
 from fbpcs.entity.container_instance import ContainerInstance
@@ -36,14 +36,16 @@ class MPCInstance(InstanceBase):
     game_name: str
     mpc_role: MPCRole
     num_workers: int
+    ip_config_file: Optional[str]
     server_ips: Optional[List[str]]
     containers: List[ContainerInstance]
     status: MPCInstanceStatus
     game_args: Optional[List[Dict[str, Any]]]
-    arguments: Mapping[str, Any]
+    arguments: Dict[str, Any]
 
-    def __init__(
-        self,
+    @classmethod
+    def create_instance(
+        cls,
         instance_id: str,
         game_name: str,
         mpc_role: MPCRole,
@@ -54,17 +56,19 @@ class MPCInstance(InstanceBase):
         status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
         game_args: Optional[List[Dict[str, Any]]] = None,
         **arguments  # pyre-ignore
-    ) -> None:
-        self.instance_id = instance_id
-        self.game_name = game_name
-        self.mpc_role = mpc_role
-        self.num_workers = num_workers
-        self.ip_config_file = ip_config_file
-        self.server_ips = server_ips
-        self.containers = containers or []
-        self.status = status
-        self.game_args = game_args
-        self.arguments = arguments
+    ) -> "MPCInstance":
+        return cls(
+            instance_id,
+            game_name,
+            mpc_role,
+            num_workers,
+            ip_config_file,
+            server_ips,
+            containers or [],
+            status,
+            game_args,
+            arguments,
+        )
 
     def get_instance_id(self) -> str:
         return self.instance_id

--- a/fbpcs/entity/mpc_instance.py
+++ b/fbpcs/entity/mpc_instance.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from dataclasses_json import dataclass_json
 from fbpcs.entity.container_instance import ContainerInstance
 from fbpcs.entity.instance_base import InstanceBase
 
@@ -29,7 +28,6 @@ class MPCInstanceStatus(Enum):
     CANCELED = "CANCELED"
 
 
-@dataclass_json
 @dataclass
 class MPCInstance(InstanceBase):
     instance_id: str
@@ -72,7 +70,3 @@ class MPCInstance(InstanceBase):
 
     def get_instance_id(self) -> str:
         return self.instance_id
-
-    def __str__(self) -> str:
-        # pyre-ignore
-        return self.to_json()

--- a/fbpcs/repository/instance_local.py
+++ b/fbpcs/repository/instance_local.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import pickle
 from pathlib import Path
 
 from fbpcs.entity.instance_base import InstanceBase
@@ -21,25 +20,24 @@ class LocalInstanceRepository:
             raise RuntimeError(f"{instance.get_instance_id()} already exists")
 
         path = self.base_dir.joinpath(instance.get_instance_id())
-        with open(path, "wb") as f:
-            pickle.dump(instance, f)
+        with open(path, "w") as f:
+            f.write(instance.dumps_schema())
 
-    def read(self, instance_id: str) -> InstanceBase:
+    def read(self, instance_id: str) -> str:
         if not self._exist(instance_id):
             raise RuntimeError(f"{instance_id} does not exist")
 
         path = self.base_dir.joinpath(instance_id)
-        with open(path, "rb") as f:
-            instance = pickle.load(f)
-        return instance
+        with open(path, "r") as f:
+            return f.read().strip()
 
     def update(self, instance: InstanceBase) -> None:
         if not self._exist(instance.get_instance_id()):
             raise RuntimeError(f"{instance.get_instance_id()} does not exist")
 
         path = self.base_dir.joinpath(instance.get_instance_id())
-        with open(path, "wb") as f:
-            pickle.dump(instance, f)
+        with open(path, "w") as f:
+            f.write(instance.dumps_schema())
 
     def delete(self, instance_id: str) -> None:
         if not self._exist(instance_id):

--- a/fbpcs/repository/instance_s3.py
+++ b/fbpcs/repository/instance_s3.py
@@ -6,8 +6,6 @@
 
 # pyre-strict
 
-import pickle
-
 from fbpcs.entity.instance_base import InstanceBase
 from fbpcs.service.storage_s3 import S3StorageService
 
@@ -23,15 +21,14 @@ class S3InstanceRepository:
 
         filename = f"{self.base_dir}{instance.get_instance_id()}"
         # Use pickle protocol 0 to make ASCII only bytes that can be safely decoded into a string
-        self.s3_storage_svc.write(filename, pickle.dumps(instance, 0).decode())
+        self.s3_storage_svc.write(filename, instance.dumps_schema())
 
-    def read(self, instance_id: str) -> InstanceBase:
+    def read(self, instance_id: str) -> str:
         if not self._exist(instance_id):
             raise RuntimeError(f"{instance_id} does not exist")
 
         filename = f"{self.base_dir}{instance_id}"
-        instance = pickle.loads(self.s3_storage_svc.read(filename).encode())
-        return instance
+        return self.s3_storage_svc.read(filename)
 
     def update(self, instance: InstanceBase) -> None:
         if not self._exist(instance.get_instance_id()):
@@ -39,7 +36,7 @@ class S3InstanceRepository:
 
         filename = f"{self.base_dir}{instance.get_instance_id()}"
         # Use pickle protocol 0 to make ASCII only bytes that can be safely decoded into a string
-        self.s3_storage_svc.write(filename, pickle.dumps(instance, 0).decode())
+        self.s3_storage_svc.write(filename, instance.dumps_schema())
 
     def delete(self, instance_id: str) -> None:
         if not self._exist(instance_id):

--- a/fbpcs/repository/mpc_instance_local.py
+++ b/fbpcs/repository/mpc_instance_local.py
@@ -6,8 +6,6 @@
 
 # pyre-strict
 
-from typing import cast
-
 from fbpcs.entity.mpc_instance import MPCInstance
 from fbpcs.repository.instance_local import LocalInstanceRepository
 from fbpcs.repository.mpc_instance import MPCInstanceRepository
@@ -21,7 +19,7 @@ class LocalMPCInstanceRepository(MPCInstanceRepository):
         self.repo.create(instance)
 
     def read(self, instance_id: str) -> MPCInstance:
-        return cast(MPCInstance, self.repo.read(instance_id))
+        return MPCInstance.loads_schema(self.repo.read(instance_id))
 
     def update(self, instance: MPCInstance) -> None:
         self.repo.update(instance)

--- a/fbpcs/repository/mpc_instance_s3.py
+++ b/fbpcs/repository/mpc_instance_s3.py
@@ -6,8 +6,6 @@
 
 # pyre-strict
 
-from typing import cast
-
 from fbpcs.entity.mpc_instance import MPCInstance
 from fbpcs.repository.instance_s3 import S3InstanceRepository
 from fbpcs.repository.mpc_instance import MPCInstanceRepository
@@ -22,7 +20,7 @@ class S3MPCInstanceRepository(MPCInstanceRepository):
         self.repo.create(instance)
 
     def read(self, instance_id: str) -> MPCInstance:
-        return cast(MPCInstance, self.repo.read(instance_id))
+        return MPCInstance.loads_schema(self.repo.read(instance_id))
 
     def update(self, instance: MPCInstance) -> None:
         self.repo.update(instance)

--- a/fbpcs/service/mpc.py
+++ b/fbpcs/service/mpc.py
@@ -112,7 +112,7 @@ class MPCService:
     ) -> MPCInstance:
         self.logger.info(f"Creating MPC instance: {instance_id}")
 
-        instance = MPCInstance(
+        instance = MPCInstance.create_instance(
             instance_id=instance_id,
             game_name=game_name,
             mpc_role=mpc_role,

--- a/tests/repository/test_instance_local.py
+++ b/tests/repository/test_instance_local.py
@@ -30,7 +30,7 @@ ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
 class TestLocalInstanceRepository(unittest.TestCase):
     def setUp(self):
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,

--- a/tests/repository/test_instance_local.py
+++ b/tests/repository/test_instance_local.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-import pickle
 import unittest
 from pathlib import Path
 from unittest.mock import mock_open, MagicMock, patch
@@ -51,15 +50,11 @@ class TestLocalInstanceRepository(unittest.TestCase):
             self.local_instance_repo.create(self.mpc_instance)
 
     @patch("builtins.open")
-    @patch("pickle.dump")
-    def test_create_non_existing_instance(self, mock_dump, mock_open):
+    def test_create_non_existing_instance(self, mock_open):
         self.local_instance_repo._exist = MagicMock(return_value=False)
         path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
-        mock_dump.return_value = None
-        stream = mock_open().__enter__.return_value
         self.assertIsNone(self.local_instance_repo.create(self.mpc_instance))
-        mock_open.assert_called_with(path, "wb")
-        mock_dump.assert_called_with(self.mpc_instance, stream)
+        mock_open.assert_called_with(path, "w")
 
     def test_read_non_existing_instance(self):
         self.local_instance_repo._exist = MagicMock(return_value=False)
@@ -68,13 +63,15 @@ class TestLocalInstanceRepository(unittest.TestCase):
 
     def test_read_existing_instance(self):
         self.local_instance_repo._exist = MagicMock(return_value=True)
-        data = pickle.dumps(self.mpc_instance)
+        data = self.mpc_instance.dumps_schema()
         path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
         with patch("builtins.open", mock_open(read_data=data)) as mock_file:
-            self.assertEqual(open(path).read(), data)
-            mpc_instance = self.local_instance_repo.read(TEST_INSTANCE_ID)
+            self.assertEqual(open(path).read().strip(), data)
+            mpc_instance = MPCInstance.loads_schema(
+                self.local_instance_repo.read(TEST_INSTANCE_ID)
+            )
             self.assertEqual(self.mpc_instance, mpc_instance)
-            mock_file.assert_called_with(path, "rb")
+            mock_file.assert_called_with(path, "r")
 
     def test_update_non_existing_instance(self):
         self.local_instance_repo._exist = MagicMock(return_value=False)
@@ -82,17 +79,13 @@ class TestLocalInstanceRepository(unittest.TestCase):
             self.local_instance_repo.update(self.mpc_instance)
 
     @patch("builtins.open")
-    @patch("pickle.dump")
-    def test_update_existing_instance(self, mock_dump, mock_open):
+    def test_update_existing_instance(self, mock_open):
         self.local_instance_repo._exist = MagicMock(return_value=True)
         new_mpc_instance = copy.deepcopy(self.mpc_instance)
         new_mpc_instance.game_name = "aggregator"
         path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
-        mock_dump.return_value = None
-        stream = mock_open().__enter__.return_value
         self.assertIsNone(self.local_instance_repo.update(new_mpc_instance))
-        mock_open.assert_called_with(path, "wb")
-        mock_dump.assert_called_with(new_mpc_instance, stream)
+        mock_open.assert_called_with(path, "w")
 
     def test_exists(self):
         self.assertFalse(self.local_instance_repo._exist(TEST_INSTANCE_ID))

--- a/tests/repository/test_instance_s3.py
+++ b/tests/repository/test_instance_s3.py
@@ -32,7 +32,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     def setUp(self):
         storage_svc = S3StorageService("us-west-1")
         self.s3_storage_repo = S3InstanceRepository(storage_svc, self.TEST_BASE_DIR)
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=self.TEST_INSTANCE_ID,
             game_name=self.TEST_GAME_NAME,
             mpc_role=self.TEST_MPC_ROLE,

--- a/tests/repository/test_instance_s3.py
+++ b/tests/repository/test_instance_s3.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pickle
 import unittest
 import uuid
 from unittest.mock import MagicMock
@@ -69,9 +68,11 @@ class TestS3InstanceRepository(unittest.TestCase):
     def test_read_existing_instance(self):
         self.s3_storage_repo._exist = MagicMock(return_value=True)
         self.s3_storage_repo.s3_storage_svc.read = MagicMock(
-            return_value=pickle.dumps(self.mpc_instance, 0).decode()
+            return_value=self.mpc_instance.dumps_schema()
         )
-        instance = self.s3_storage_repo.read(self.mpc_instance)
+        instance = MPCInstance.loads_schema(
+            self.s3_storage_repo.read(self.mpc_instance)
+        )
         self.assertEqual(self.mpc_instance, instance)
 
     def test_update_non_existing_instance(self):

--- a/tests/repository/test_mpc_instance_local.py
+++ b/tests/repository/test_mpc_instance_local.py
@@ -30,7 +30,7 @@ ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
 class TestLocalMPCInstanceRepository(unittest.TestCase):
     def setUp(self):
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,

--- a/tests/repository/test_mpc_instance_s3.py
+++ b/tests/repository/test_mpc_instance_s3.py
@@ -32,7 +32,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     def setUp(self):
         storage_svc = S3StorageService("us-west-1")
         self.s3_storage_repo = S3MPCInstanceRepository(storage_svc, TEST_BASE_DIR)
-        self.mpc_instance = MPCInstance(
+        self.mpc_instance = MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,

--- a/tests/repository/test_mpc_instance_s3.py
+++ b/tests/repository/test_mpc_instance_s3.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pickle
 import unittest
 import uuid
 from unittest.mock import MagicMock
@@ -69,7 +68,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     def test_read_existing_instance(self):
         self.s3_storage_repo.repo._exist = MagicMock(return_value=True)
         self.s3_storage_repo.repo.s3_storage_svc.read = MagicMock(
-            return_value=pickle.dumps(self.mpc_instance, 0).decode()
+            return_value=self.mpc_instance.dumps_schema()
         )
         instance = self.s3_storage_repo.read(self.mpc_instance)
         self.assertEqual(self.mpc_instance, instance)

--- a/tests/service/test_mpc.py
+++ b/tests/service/test_mpc.py
@@ -60,7 +60,7 @@ class TestMPCService(unittest.TestCase):
 
     @staticmethod
     def _get_sample_mpcinstance():
-        return MPCInstance(
+        return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,
@@ -72,7 +72,7 @@ class TestMPCService(unittest.TestCase):
 
     @staticmethod
     def _get_sample_mpcinstance_with_game_args():
-        return MPCInstance(
+        return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=TEST_MPC_ROLE,
@@ -84,7 +84,7 @@ class TestMPCService(unittest.TestCase):
 
     @staticmethod
     def _get_sample_mpcinstance_client():
-        return MPCInstance(
+        return MPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_role=MPCRole.CLIENT,


### PR DESCRIPTION
Summary:
## What

* serialize instances using [marshmallow schema](https://marshmallow.readthedocs.io/en/stable/) and dump as json instead of using pickle
* `InstanceBase` now inherits from `DataClassJsonMixin` and provides default implementations for `dumps_schema`, `loads_schema`, and `__str__` methods
* Modify some test cases that were dependent on the usage of pickle

## Why

* Storing instances with pickle is bad...
    * allows for arbitrary code execution when deserializing
    * Can break when module layout changes

Reviewed By: corbantek, leegross

Differential Revision: D29246013

