### PR TITLE
Remove deprecated fields from MPCInstance

### DIFF
--- a/fbpcs/entity/mpc_instance.py
+++ b/fbpcs/entity/mpc_instance.py
@@ -34,12 +34,10 @@ class MPCInstance(InstanceBase):
     game_name: str
     mpc_role: MPCRole
     num_workers: int
-    ip_config_file: Optional[str]
     server_ips: Optional[List[str]]
     containers: List[ContainerInstance]
     status: MPCInstanceStatus
     game_args: Optional[List[Dict[str, Any]]]
-    arguments: Dict[str, Any]
 
     @classmethod
     def create_instance(
@@ -48,24 +46,20 @@ class MPCInstance(InstanceBase):
         game_name: str,
         mpc_role: MPCRole,
         num_workers: int,
-        ip_config_file: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
         containers: Optional[List[ContainerInstance]] = None,
         status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
         game_args: Optional[List[Dict[str, Any]]] = None,
-        **arguments  # pyre-ignore
     ) -> "MPCInstance":
         return cls(
             instance_id,
             game_name,
             mpc_role,
             num_workers,
-            ip_config_file,
             server_ips,
             containers or [],
             status,
             game_args,
-            arguments,
         )
 
     def get_instance_id(self) -> str:

--- a/tests/repository/test_instance_local.py
+++ b/tests/repository/test_instance_local.py
@@ -18,11 +18,7 @@ TEST_GAME_NAME = "lift"
 TEST_MPC_ROLE = MPCRole.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0"]
-TEST_INPUT_ARGS = [{"input_filenames": "test_input_file"}]
-TEST_OUTPUT_ARGS = [{"output_filenames": "test_output_file"}]
-TEST_CONCURRENCY_ARGS = {"concurrency": 1}
-TEST_INPUT_DIRECTORY = "TEST_INPUT_DIRECTORY/"
-TEST_OUTPUT_DIRECTORY = "TEST_OUTPUT_DIRECTORY/"
+TEST_GAME_ARGS = [{}]
 ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
 ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
@@ -36,11 +32,7 @@ class TestLocalInstanceRepository(unittest.TestCase):
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,
-            input_args=TEST_INPUT_ARGS,
-            output_args=TEST_OUTPUT_ARGS,
-            concurrency_args=TEST_CONCURRENCY_ARGS,
-            input_directory=TEST_INPUT_DIRECTORY,
-            output_directory=TEST_OUTPUT_DIRECTORY,
+            game_args=TEST_GAME_ARGS,
         )
         self.local_instance_repo = LocalInstanceRepository(TEST_BASE_DIR)
 

--- a/tests/repository/test_instance_s3.py
+++ b/tests/repository/test_instance_s3.py
@@ -20,11 +20,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     TEST_MPC_ROLE = MPCRole.SERVER
     TEST_NUM_WORKERS = 1
     TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
-    TEST_INPUT_ARGS = [{"input_filenames": "test_input_file"}]
-    TEST_OUTPUT_ARGS = [{"output_filenames": "test_output_file"}]
-    TEST_CONCURRENCY_ARGS = {"concurrency": 2}
-    TEST_INPUT_DIRECTORY = "TEST_INPUT_DIRECTORY/"
-    TEST_OUTPUT_DIRECTROY = "TEST_OUTPUT_DIRECTORY/"
+    TEST_GAME_ARGS = [{}]
     ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
     ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
@@ -38,11 +34,7 @@ class TestS3InstanceRepository(unittest.TestCase):
             num_workers=self.TEST_NUM_WORKERS,
             server_ips=self.TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,
-            input_args=self.TEST_INPUT_ARGS,
-            output_args=self.TEST_OUTPUT_ARGS,
-            concurrency_args=self.TEST_CONCURRENCY_ARGS,
-            input_directory=self.TEST_INPUT_DIRECTORY,
-            output_directory=self.TEST_OUTPUT_DIRECTROY,
+            game_args=self.TEST_GAME_ARGS,
         )
 
     def test_create_non_existing_instance(self):

--- a/tests/repository/test_mpc_instance_local.py
+++ b/tests/repository/test_mpc_instance_local.py
@@ -18,11 +18,7 @@ TEST_GAME_NAME = "lift"
 TEST_MPC_ROLE = MPCRole.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0"]
-TEST_INPUT_ARGS = [{"input_filenames": "test_input_file"}]
-TEST_OUTPUT_ARGS = [{"output_filenames": "test_output_file"}]
-TEST_CONCURRENCY_ARGS = {"concurrency": 1}
-TEST_INPUT_DIRECTORY = "TEST_INPUT_DIRECTORY/"
-TEST_OUTPUT_DIRECTORY = "TEST_OUTPUT_DIRECTORY/"
+TEST_GAME_ARGS = [{}]
 ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
 ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
@@ -36,11 +32,7 @@ class TestLocalMPCInstanceRepository(unittest.TestCase):
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,
-            input_args=TEST_INPUT_ARGS,
-            output_args=TEST_OUTPUT_ARGS,
-            concurrency_args=TEST_CONCURRENCY_ARGS,
-            input_directory=TEST_INPUT_DIRECTORY,
-            output_directory=TEST_OUTPUT_DIRECTORY,
+            game_args=TEST_GAME_ARGS,
         )
         self.local_instance_repo = LocalMPCInstanceRepository(TEST_BASE_DIR)
 

--- a/tests/repository/test_mpc_instance_s3.py
+++ b/tests/repository/test_mpc_instance_s3.py
@@ -18,11 +18,7 @@ TEST_GAME_NAME = "lift"
 TEST_MPC_ROLE = MPCRole.SERVER
 TEST_NUM_WORKERS = 1
 TEST_SERVER_IPS = ["192.0.2.0"]
-TEST_INPUT_ARGS = [{"input_filenames": "test_input_file"}]
-TEST_OUTPUT_ARGS = [{"output_filenames": "test_output_file"}]
-TEST_CONCURRENCY_ARGS = {"concurrency": 1}
-TEST_INPUT_DIRECTORY = "TEST_INPUT_DIRECTORY/"
-TEST_OUTPUT_DIRECTORY = "TEST_OUTPUT_DIRECTORY/"
+TEST_GAME_ARGS = [{}]
 ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
 ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
@@ -38,11 +34,7 @@ class TestS3InstanceRepository(unittest.TestCase):
             num_workers=TEST_NUM_WORKERS,
             server_ips=TEST_SERVER_IPS,
             status=MPCInstanceStatus.CREATED,
-            input_args=TEST_INPUT_ARGS,
-            output_args=TEST_OUTPUT_ARGS,
-            concurrency_args=TEST_CONCURRENCY_ARGS,
-            input_directory=TEST_INPUT_DIRECTORY,
-            output_directory=TEST_OUTPUT_DIRECTORY,
+            game_args=TEST_GAME_ARGS,
         )
 
     def test_create_non_existing_instance(self):


### PR DESCRIPTION
Summary:
## What

* removed ip_config_file and arguments fields from MPCInstance
* Removed the corresponding arguments still in unit tests

## Why

* They're deprecated. Discussion here: D29267882 (https://github.com/facebookresearch/fbpcs/commit/df460b1e01619dc9fc42b32fa91b60ae853b89cc)

Reviewed By: peking2, zhuang-93

Differential Revision: D29317215

