### PR TITLE
Added Get Updated Container Instances to OneDocker Svc

### DIFF
--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -82,6 +82,9 @@ class OneDockerService:
     def stop_containers(self, containers: List[str]) -> List[Optional[PcsError]]:
         return self.container_svc.cancel_instances(containers)
 
+    def get_containers(self, instance_ids: List[str]) -> List[ContainerInstance]:
+        return self.container_svc.get_instances(instance_ids)
+
     def _get_exe_name(self, package_name: str) -> str:
         return package_name.split("/")[1]
 


### PR DESCRIPTION
Summary: Added method to get updated containers from the OneDocker Service (will be used for pulling updated containers in OWDLDriver Service)

Reviewed By: peking2

Differential Revision: D29306304

