### PR TITLE
Use a list of subnets instead of one subnet when run tasks

### DIFF
--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -22,7 +22,7 @@ class AWSContainerService(ContainerService):
         self,
         region: str,
         cluster: str,
-        subnet: str,
+        subnets: List[str],
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
@@ -30,7 +30,7 @@ class AWSContainerService(ContainerService):
         self.logger: logging.Logger = logging.getLogger(__name__)
         self.region = region
         self.cluster = cluster
-        self.subnet = subnet
+        self.subnets = subnets
         self.ecs_gateway = ECSGateway(region, access_key_id, access_key_data, config)
 
     def create_instance(self, container_definition: str, cmd: str) -> ContainerInstance:
@@ -75,18 +75,14 @@ class AWSContainerService(ContainerService):
         s = container_definition.split("#")
         return (s[0], s[1])
 
-    def _process_subnets(self, subnet: str) -> List[str]:
-        return subnet.split(",")
-
     async def _create_instance_async(
         self, container_definition: str, cmd: str
     ) -> ContainerInstance:
         task_definition, container = self._split_container_definition(
             container_definition
         )
-        subnets = self._process_subnets(self.subnet)
         instance = self.ecs_gateway.run_task(
-            task_definition, container, cmd, self.cluster, subnets
+            task_definition, container, cmd, self.cluster, self.subnets
         )
 
         # wait until the container is in running state

--- a/tests/service/test_container_aws.py
+++ b/tests/service/test_container_aws.py
@@ -20,7 +20,7 @@ TEST_REGION = "us-west-2"
 TEST_KEY_ID = "test-key-id"
 TEST_KEY_DATA = "test-key-data"
 TEST_CLUSTER = "test-cluster"
-TEST_SUBNET = "test-subnet0, test-subnet1"
+TEST_SUBNETS = ["test-subnet0", "test-subnet1"]
 TEST_IP_ADDRESS = "127.0.0.1"
 TEST_CONTAINER_DEFNITION = "test-task-definition#test-container-definition"
 
@@ -29,7 +29,7 @@ class TestAWSContainerService(unittest.TestCase):
     @patch("fbpcs.gateway.ecs.ECSGateway")
     def setUp(self, MockECSGateway):
         self.container_svc = AWSContainerService(
-            TEST_REGION, TEST_CLUSTER, TEST_SUBNET, TEST_KEY_ID, TEST_KEY_DATA
+            TEST_REGION, TEST_CLUSTER, TEST_SUBNETS, TEST_KEY_ID, TEST_KEY_DATA
         )
         self.container_svc.ecs_gateway = MockECSGateway()
 


### PR DESCRIPTION
Summary:
Uses "List[str]" instead of "str" for the subnets. Anywhere that is using the `AWSContainerService` or `FBAWSContainerService` needs to be changed, including:
* all config files
* onedocker_cli.py
* platform_cli.py
* fb_aws_cli.py
* handler.py (publisher config)
* container_aws_fb.py and its test
* container_aws.py and its test
* pce_config related
* deploy.sh (Cloudbridge)
* gen_config.py

Please let me know if I missed anywhere else.

Reviewed By: ajaybhargavb

Differential Revision: D29370548

