### PR TITLE
Refactor log service

### DIFF
--- a/fbpcs/gateway/cloudwatch.py
+++ b/fbpcs/gateway/cloudwatch.py
@@ -34,9 +34,16 @@ class CloudWatchGateway:
         self.client = boto3.client("logs", region_name=self.region, **config)
 
     @error_handler
-    def get_log_events(self, log_group: str, log_stream: str) -> List[LogEvent]:
+    def get_log_events(
+        self,
+        log_group: str,
+        log_stream: str,
+        start_time: int = 0,
+    ) -> List[LogEvent]:
         events = self.client.get_log_events(
-            logGroupName=log_group, logStreamName=log_stream
+            logGroupName=log_group,
+            logStreamName=log_stream,
+            startTime=start_time,
         )["events"]
 
         return [LogEvent(event["timestamp"], event["message"]) for event in events]

--- a/fbpcs/service/log.py
+++ b/fbpcs/service/log.py
@@ -14,5 +14,5 @@ from fbpcs.entity.log_event import LogEvent
 
 class LogService(abc.ABC):
     @abc.abstractmethod
-    def fetch(self, log_path: str) -> List[LogEvent]:
+    def fetch(self, log_path: str, start_time: int) -> List[LogEvent]:
         pass

--- a/fbpcs/service/log_cloudwatch.py
+++ b/fbpcs/service/log_cloudwatch.py
@@ -27,6 +27,8 @@ class CloudWatchLogService(LogService):
         )
         self.log_group = log_group
 
-    def fetch(self, log_path: str) -> List[LogEvent]:
+    def fetch(self, log_path: str, start_time: int = 0) -> List[LogEvent]:
         """Fetch logs"""
-        return self.cloudwatch_gateway.get_log_events(self.log_group, log_path)
+        return self.cloudwatch_gateway.get_log_events(
+            self.log_group, log_path, start_time
+        )


### PR DESCRIPTION
Summary:
1. remove log_event and log_event_message from config
2. add start_time to make the API more generic, so we don't have to hack. Also the existing hack may not work for a large amount of logs
3. remove SECRET_GROUP as we discussed in last diff

Differential Revision: D29412885

