### PR TITLE
Make subnets as an optional parameter for AWS container service

### DIFF
--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -22,7 +22,7 @@ class AWSContainerService(ContainerService):
         self,
         region: str,
         cluster: str,
-        subnets: List[str],
+        subnets: Optional[List[str]] = None,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
@@ -81,6 +81,12 @@ class AWSContainerService(ContainerService):
         task_definition, container = self._split_container_definition(
             container_definition
         )
+
+        if not self.subnets:
+            raise PcsError(
+                "No subnets specified. It's required to create container instances."
+            )
+
         instance = self.ecs_gateway.run_task(
             task_definition, container, cmd, self.cluster, self.subnets
         )


### PR DESCRIPTION
Summary: As we discussed in D29370548 (https://github.com/facebookresearch/fbpcs/commit/9d8542f8ee5fe200f9b66d9bcab1f59b949b71be), it doesn't sound it has to be a required parameter as we have clear use cases that it's optional, so just make the change.

Differential Revision: D29421575

