### PR TITLE
Add binary version support in onedocker service

### DIFF
--- a/fbpcs/service/mpc.py
+++ b/fbpcs/service/mpc.py
@@ -262,7 +262,10 @@ class MPCService:
         cmd_args_list = [cmd_args for (package_name, cmd_args) in cmd_tuple_list]
 
         return await self.onedocker_svc.start_containers_async(
-            self.task_definition, cmd_tuple_list[0][0], cmd_args_list, timeout
+            container_definition=self.task_definition,
+            package_name=cmd_tuple_list[0][0],
+            cmd_args_list=cmd_args_list,
+            timeout=timeout,
         )
 
     def _update_container_instances(

--- a/onedocker/onedocker_lib/service/owdl_driver.py
+++ b/onedocker/onedocker_lib/service/owdl_driver.py
@@ -52,7 +52,10 @@ class OWDLDriver:
 
         # TODO Add versioning support to start_containers()
         container_list = self.onedocker.start_containers(
-            container_definition, package_name, cmd_args_list, timeout
+            container_definition=container_definition,
+            package_name=package_name,
+            cmd_args_list=cmd_args_list,
+            timeout=timeout,
         )
         curr_state_instance = OWDLStateInstance(
             curr_state, container_list, StateStatus.STARTED

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -28,7 +28,9 @@ class TestOneDockerService(unittest.TestCase):
             return_value=[mocked_container_info]
         )
         returned_container_info = self.onedocker_svc.start_container(
-            "task_def", "project/exe_name", "cmd_args"
+            container_definition="task_def",
+            package_name="project/exe_name",
+            cmd_args="cmd_args",
         )
         self.assertEqual(returned_container_info, mocked_container_info)
 
@@ -49,7 +51,9 @@ class TestOneDockerService(unittest.TestCase):
             return_value=mocked_container_info
         )
         returned_container_info = self.onedocker_svc.start_containers(
-            "task_def", "project/exe_name", ["--k1=v1", "--k2=v2"]
+            container_definition="task_def",
+            package_name="project/exe_name",
+            cmd_args_list=["--k1=v1", "--k2=v2"],
         )
         self.assertEqual(returned_container_info, mocked_container_info)
 
@@ -57,12 +61,17 @@ class TestOneDockerService(unittest.TestCase):
         package_name = "project/exe_name"
         cmd_args = "--k1=v1 --k2=v2"
         timeout = 3600
-        expected_cmd_without_timeout = "python3.8 -m onedocker.script.runner project/exe_name --cmd='/root/onedocker/package/exe_name --k1=v1 --k2=v2'"
-        expected_cmd_with_timeout = expected_cmd_without_timeout + " --timeout=3600"
-        cmd_without_timeout = self.onedocker_svc._get_cmd(package_name, cmd_args)
-        cmd_with_timeout = self.onedocker_svc._get_cmd(package_name, cmd_args, timeout)
-        self.assertEqual(expected_cmd_without_timeout, cmd_without_timeout)
-        self.assertEqual(expected_cmd_with_timeout, cmd_with_timeout)
+        version = "0.1.0"
+        expected_cmd_without_arguments = (
+            "python3.8 -m onedocker.script.runner project/exe_name --version=latest"
+        )
+        expected_cmd_with_arguments = f"python3.8 -m onedocker.script.runner project/exe_name --exe_args='{cmd_args}' --version={version} --timeout={timeout}"
+        cmd_without_arguments = self.onedocker_svc._get_cmd(package_name)
+        cmd_with_arguments = self.onedocker_svc._get_cmd(
+            package_name, version, cmd_args, timeout
+        )
+        self.assertEqual(expected_cmd_without_arguments, cmd_without_arguments)
+        self.assertEqual(expected_cmd_with_arguments, cmd_with_arguments)
 
     def test_stop_containers(self):
         containers = [


### PR DESCRIPTION
Summary: onedocker runner already had support for versioned binaries. We need to add version support in onedocker service.

Differential Revision: D29412407

