### PR TITLE
Make build_cmd_args an utility function

### DIFF
--- a/fbpcs/service/mpc_game.py
+++ b/fbpcs/service/mpc_game.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional, Tuple
 from fbpcs.entity.mpc_game_config import MPCGameConfig
 from fbpcs.entity.mpc_instance import MPCRole
 from fbpcs.repository.mpc_game_repository import MPCGameRepository
+from fbpcs.util.arg_builder import build_cmd_args
 
 LIFT_GAME_NAME = "lift"
 LIFT_AGGREGATOR_GAME_NAME = "aggregator"
@@ -59,8 +60,7 @@ class MPCGameService:
             port=port,
             **kwargs,
         )
-        # patternlint-disable-next-line f-string-may-be-missing-leading-f
-        return " ".join([f"--{key}={value}" for (key, value) in args.items()])
+        return build_cmd_args(**args)
 
     def _prepare_args(
         self,

--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -8,12 +8,12 @@
 
 import asyncio
 import logging
-from shlex import quote
 from typing import List, Optional
 
 from fbpcs.entity.container_instance import ContainerInstance
 from fbpcs.error.pcs import PcsError
 from fbpcs.service.container import ContainerService
+from fbpcs.util.arg_builder import build_cmd_args
 
 
 ONEDOCKER_CMD_PREFIX = (
@@ -108,7 +108,7 @@ class OneDockerService:
         cmd_args: Optional[str] = None,
         timeout: Optional[int] = None,
     ) -> str:
-        runner_args = self._build_cmd_args(
+        runner_args = build_cmd_args(
             exe_args=cmd_args,
             version=version,
             timeout=timeout,
@@ -117,12 +117,3 @@ class OneDockerService:
             package_name=package_name,
             runner_args=runner_args,
         ).strip()
-
-    # TODO make this a utility for both mpc_game service and onedocker service
-    def _build_cmd_args(
-        self,
-        **kwargs: object,
-    ) -> str:
-        return " ".join(
-            [f"--{key}={quote(str(value))}" for key, value in kwargs.items() if value]
-        )

--- a/fbpcs/util/arg_builder.py
+++ b/fbpcs/util/arg_builder.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from shlex import quote
+
+
+def build_cmd_args(
+    **kwargs: object,
+) -> str:
+    return " ".join(
+        [
+            f"--{key}={quote(str(value))}"
+            for key, value in kwargs.items()
+            if value is not None
+        ]
+    )

--- a/tests/util/test_arg_builder.py
+++ b/tests/util/test_arg_builder.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from fbpcs.util.arg_builder import build_cmd_args
+
+
+class TestArgBuilder(unittest.TestCase):
+    def test_build_cmd_args(self):
+        expected_cmd_args = (
+            "--arg1=value1 --arg2=value2 --arg3='--k1=v1 --k2=v2' --arg4=0"
+        )
+        self.assertEqual(
+            expected_cmd_args,
+            build_cmd_args(
+                arg1="value1", arg2="value2", arg3="--k1=v1 --k2=v2", arg4=0, arg5=None
+            ),
+        )


### PR DESCRIPTION
Summary: We have a function that builds key-value arguments to "--k1=v1 --k2=v2". We need to extract the logic into an util function so that onedocker service and mpc game service can use it.

Differential Revision: D29593642

