### PR TITLE
Implement get_package_info function for OneDockerPackageRepository and replace the current onedocker_cli upload function logic

### DIFF
--- a/onedocker/onedocker_lib/repository/onedocker_package.py
+++ b/onedocker/onedocker_lib/repository/onedocker_package.py
@@ -8,12 +8,14 @@
 from typing import List
 
 from fbpcs.service.storage import StorageService
+from fbpcs.service.storage_s3 import S3StorageService
+from fbpcs.util.typing import checked_cast
 from onedocker.onedocker_lib.entity.package_info import PackageInfo
 
 
 class OneDockerPackageRepository:
     def __init__(self, storage_svc: StorageService, repository_path: str) -> None:
-        self.storage = storage_svc
+        self.storage_svc = storage_svc
         self.repository_path = repository_path
 
     def _build_package_path(self, package_name: str, version: str) -> str:
@@ -21,7 +23,7 @@ class OneDockerPackageRepository:
 
     def upload(self, package_name: str, version: str, source: str) -> None:
         package_path = self._build_package_path(package_name, version)
-        self.storage.copy(source, package_path)
+        self.storage_svc.copy(source, package_path)
 
     def download(self, package_name: str, version: str, destination: str) -> None:
         pass
@@ -33,4 +35,20 @@ class OneDockerPackageRepository:
         return []
 
     def get_package_info(self, package_name: str, version: str) -> PackageInfo:
-        raise NotImplementedError
+        # TODO: refactor storage service so we don't have to cast it
+        s3_storage_svc = checked_cast(S3StorageService, self.storage_svc)
+        package_path = self._build_package_path(package_name, version)
+
+        if not s3_storage_svc.file_exists(package_path):
+            raise ValueError(
+                f"Package {package_name}, version {version} not found in repository"
+            )
+
+        package_info_dict = s3_storage_svc.ls_file(package_path)
+        return PackageInfo(
+            package_name=package_name,
+            version=version,
+            last_modified=package_info_dict.get("LastModified").ctime(),
+            package_type=package_info_dict.get("ContentType"),
+            package_size=package_info_dict.get("ContentLength"),
+        )


### PR DESCRIPTION
Summary: Implement get_package_info function for OneDockerPackageRepository to encapsulate the get file information logic within the

Differential Revision: D29673410

