### PR TITLE
Lift Migration script changes

### DIFF
--- a/fbpcs/service/mpc_game.py
+++ b/fbpcs/service/mpc_game.py
@@ -73,11 +73,8 @@ class MPCGameService:
         all_arguments: Dict[str, Any] = {}
 
         # push MPC required arguments to dict all_arguments
-        is_lift_game = (
-            mpc_game_config.game_name == LIFT_AGGREGATOR_GAME_NAME
-            or mpc_game_config.game_name == LIFT_GAME_NAME
-        )  # TODO: T88044929 remove "role" and only support "party" for lift games
-        role_or_party_key = "role" if is_lift_game else "party"
+        is_lift_compute_game = mpc_game_config.game_name == LIFT_GAME_NAME
+        role_or_party_key = "role" if is_lift_compute_game else "party"
         all_arguments[role_or_party_key] = 1 if mpc_role == MPCRole.SERVER else 2
 
         if mpc_role == MPCRole.CLIENT:


### PR DESCRIPTION
Summary:
**What:** Changes to the Lift codebase such that it uses the generic shard aggregator instead of the original lift binary.

**Why:** Now that we have a generic shard aggregator, we don't need a specific aggregator for Lift.  Having only one aggregator will improve maintainability of the codebase.

**Note:** There is a code freeze on the Python codebase, so this might need to wait to be landed.  I have included a detailed test plan below to demonstrate that existing functionality is preserved and, in the event that we are not able to land this in the near future, to show in detail how to re-test.

Differential Revision: D29640270

