### PR TITLE
Add ls_file interface to StorageService

### DIFF
--- a/fbpcs/service/storage.py
+++ b/fbpcs/service/storage.py
@@ -8,6 +8,7 @@
 
 import abc
 from enum import Enum
+from typing import Any, Dict
 
 
 class PathType(Enum):
@@ -41,4 +42,8 @@ class StorageService(abc.ABC):
 
     @abc.abstractmethod
     def get_file_size(self, filename: str) -> int:
+        pass
+
+    @abc.abstractmethod
+    def get_file_info(self, filename: str) -> Dict[str, Any]:
         pass

--- a/fbpcs/service/storage_s3.py
+++ b/fbpcs/service/storage_s3.py
@@ -189,7 +189,7 @@ class S3StorageService(StorageService):
         else:
             raise ValueError(f"File {filename} is not an S3 filepath")
 
-    def ls_file(self, filename: str) -> Dict[str, Any]:
+    def get_file_info(self, filename: str) -> Dict[str, Any]:
         """Show file information (last modified time, type and size)
         Keyword arguments:
         filename -- the s3 file to be shown


### PR DESCRIPTION
Summary: Add ls_file interface to StorageService so that we don't need to cast class type to S3StorageService when using this function

Differential Revision: D29757956

