### PR TITLE
Add env override in ecs gateway

### DIFF
--- a/fbpcs/gateway/ecs.py
+++ b/fbpcs/gateway/ecs.py
@@ -49,7 +49,14 @@ class ECSGateway:
         cmd: str,
         cluster: str,
         subnets: List[str],
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> ContainerInstance:
+        environment = []
+        if env_vars:
+            environment = [
+                {"name": env_name, "value": env_value}
+                for env_name, env_value in env_vars.items()
+            ]
         response = self.client.run_task(
             taskDefinition=task_definition,
             cluster=cluster,
@@ -59,7 +66,15 @@ class ECSGateway:
                     "assignPublicIp": "ENABLED",
                 }
             },
-            overrides={"containerOverrides": [{"name": container, "command": [cmd]}]},
+            overrides={
+                "containerOverrides": [
+                    {
+                        "name": container,
+                        "command": [cmd],
+                        "environment": environment,
+                    }
+                ]
+            },
         )
 
         if not response["tasks"]:


### PR DESCRIPTION
Summary:
## Context
Pid is migrating to OneDocker and it relies on dynamic env overrides. This diff will add env overrides to ecs gateway so upstream users can pass any env they want to override in the container.

## Summary
Add envs to run_task in ecs_gateway

The format of env should be: {"name": "", "value": ""} and we pass a list of envs to run_task

## Next
1. Add env override support in container service
2. Add env override support in onedocker service.

Differential Revision: D29889149

