### PR TITLE
Add subnet entity in fbpcs

### DIFF
--- a/fbpcs/entity/subnet.py
+++ b/fbpcs/entity/subnet.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Subnet:
+    id: str
+    availability_zone: str
+    tags: Dict[str, str] = field(default_factory=lambda: {})


### PR DESCRIPTION
Summary:
## Context
We plan to fetch all possible subnets in one specific vpc in our stress test script. So we need this subnet entity to store the subnet information.

## Summary
The subnet entity will container id, az and tags.
Please check the response from ec2 client to see if the fields are reasonable or if we need other variables

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_subnets

## Next
1. Implement subnet mapper
2. Implement describe subnets in ec2 gateway

Differential Revision: D29952426

