### PR TITLE
Implement subnet mapper

### DIFF
--- a/fbpcs/entity/subnet.py
+++ b/fbpcs/entity/subnet.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Subnet:
+    id: str
+    availability_zone: str
+    tags: Dict[str, str] = field(default_factory=lambda: {})

--- a/fbpcs/mapper/aws.py
+++ b/fbpcs/mapper/aws.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List
 
 from fbpcs.entity.cluster_instance import Cluster, ClusterStatus
 from fbpcs.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcs.entity.subnet import Subnet
 from fbpcs.entity.vpc_instance import Vpc, VpcState
 
 
@@ -65,6 +66,17 @@ def map_ec2vpc_to_vpcinstance(vpc: Dict[str, Any]) -> Vpc:
     )
 
     return Vpc(vpc_id, state, tags)
+
+
+def map_ec2subnet_to_subnet(subnet: Dict[str, Any]) -> Subnet:
+    availability_zone = subnet["AvailabilityZone"]
+    subnet_id = subnet["SubnetId"]
+    tags = (
+        _convert_aws_tags_to_dict(subnet["Tags"], "Key", "Value")
+        if "Tags" in subnet
+        else {}
+    )
+    return Subnet(subnet_id, availability_zone, tags)
 
 
 def _convert_aws_tags_to_dict(

--- a/tests/mapper/test_aws.py
+++ b/tests/mapper/test_aws.py
@@ -8,9 +8,11 @@ import unittest
 
 from fbpcs.entity.cluster_instance import ClusterStatus, Cluster
 from fbpcs.entity.container_instance import ContainerInstanceStatus, ContainerInstance
+from fbpcs.entity.subnet import Subnet
 from fbpcs.mapper.aws import (
     map_ecstask_to_containerinstance,
     map_esccluster_to_clusterinstance,
+    map_ec2subnet_to_subnet,
 )
 
 
@@ -177,3 +179,19 @@ class TestAWSMapper(unittest.TestCase):
         ]
 
         self.assertEqual(cluster_list, expected_cluster_list)
+
+    def test_map_es2subnet_to_subnet(self):
+        test_subnet_id = "subnet-a0b1c3d4e5"
+        test_az = "us-west-2a"
+        test_tag_key = "Name"
+        test_tag_value = "test_value"
+        ec2_client_response = {
+            "AvailabilityZone": test_az,
+            "SubnetId": test_subnet_id,
+            "Tags": [{"Key": test_tag_key, "Value": test_tag_value}],
+        }
+        expected_subnet = Subnet(
+            test_subnet_id, test_az, {test_tag_key: test_tag_value}
+        )
+
+        self.assertEqual(map_ec2subnet_to_subnet(ec2_client_response), expected_subnet)


### PR DESCRIPTION
Summary:
## Context
We need to mapper the information we need to a new subnet object from EC2 Client response.

EC2 client response:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_subnets

## Summary
1. Implement the subnet mapper
2. Implement its unit test

## Next
Implement describe_subnets in ec2 gateway.

Differential Revision: D29952424

