### PR TITLE
Add metrics interface

### DIFF
--- a/fbpcs/metrics/emitter.py
+++ b/fbpcs/metrics/emitter.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+
+
+class MetricsEmitter(abc.ABC):
+    @abc.abstractmethod
+    def count(
+        self,
+        name: str,
+        value: int,
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    def gauge(
+        self,
+        name: str,
+        value: int,
+    ) -> None:
+        pass


### PR DESCRIPTION
Summary:
Going forward, we need to emit metrics in many use cases. For example, we need to emit metrics for OneDocker. This diff is to define a common interface for metrics emitter.

Next: implement ODSEmitter for internal use

Differential Revision: D29954987

