### PR TITLE
Implement describe_subnets in ec2 gateway

### DIFF
--- a/fbpcs/gateway/ec2.py
+++ b/fbpcs/gateway/ec2.py
@@ -10,8 +10,9 @@ from typing import Any, Dict, List, Optional
 
 import boto3
 from fbpcs.decorator.error_handler import error_handler
+from fbpcs.entity.subnet import Subnet
 from fbpcs.entity.vpc_instance import Vpc
-from fbpcs.mapper.aws import map_ec2vpc_to_vpcinstance
+from fbpcs.mapper.aws import map_ec2vpc_to_vpcinstance, map_ec2subnet_to_subnet
 
 
 class EC2Gateway:
@@ -47,3 +48,12 @@ class EC2Gateway:
     def list_vpcs(self) -> List[str]:
         all_vpcs = self.client.describe_vpcs()
         return [vpc["VpcId"] for vpc in all_vpcs["Vpcs"]]
+
+    @error_handler
+    def describe_subnets(
+        self,
+        vpc_id: Optional[str] = None,
+    ) -> List[Subnet]:
+        filters = [{"Name": "vpc-id", "Values": [vpc_id]}] if vpc_id else []
+        response = self.client.describe_subnets(Filters=filters)
+        return [map_ec2subnet_to_subnet(subnet) for subnet in response["Subnets"]]

--- a/tests/gateway/test_ec2.py
+++ b/tests/gateway/test_ec2.py
@@ -7,6 +7,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from fbpcs.entity.subnet import Subnet
 from fbpcs.entity.vpc_instance import Vpc, VpcState
 from fbpcs.gateway.ec2 import EC2Gateway
 
@@ -63,3 +64,25 @@ class TestEC2Gateway(unittest.TestCase):
         expected_vpcs = [TEST_VPC_ID]
         self.assertEqual(vpcs, expected_vpcs)
         self.gw.client.describe_vpcs.assert_called()
+
+    def test_describe_subnets(self):
+        test_subnet_id = "subnet-a0b1c3d4e5"
+        test_az = "us-west-2a"
+        test_tag_key = "Name"
+        test_tag_value = "test_value"
+        client_return_response = {
+            "Subnets": [
+                {
+                    "AvailabilityZone": test_az,
+                    "SubnetId": test_subnet_id,
+                    "Tags": [{"Key": test_tag_key, "Value": test_tag_value}],
+                }
+            ]
+        }
+        self.gw.client.describe_subnets = MagicMock(return_value=client_return_response)
+        subnets = self.gw.describe_subnets()
+        expected_subnets = [
+            Subnet(test_subnet_id, test_az, {test_tag_key: test_tag_value}),
+        ]
+        self.assertEqual(subnets, expected_subnets)
+        self.gw.client.describe_subnets.assert_called()


### PR DESCRIPTION
Summary:
Implement describe_subnets in ec2_gateway.

The ec2 client api is here:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_subnets

Differential Revision: D29953114

