### PR TITLE
Add task definition attribute to OneDockerService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,11 @@
 *  New feature (non-breaking change which adds functionality)
 
 ### Description of changes
-Add parameter to ContainerService/OneDockerService to allow passing in envionment variables
+Add parameter to ContainerService/OneDockerService to allow passing in environment variables
+
+## 0.3.1 -> 0.3.2
+### Types of changes
+*  New feature (non-breaking change which adds functionality)
+
+### Description of changes
+Add optional task_definition member to OneDockerService and introduce task_definition as a param for start_container functions

--- a/fbpcs/service/mpc.py
+++ b/fbpcs/service/mpc.py
@@ -61,7 +61,7 @@ class MPCService:
         self.mpc_game_svc: MPCGameService = mpc_game_svc
         self.logger: logging.Logger = logging.getLogger(__name__)
 
-        self.onedocker_svc = OneDockerService(self.container_svc)
+        self.onedocker_svc = OneDockerService(self.container_svc, self.task_definition)
 
     """
     The game_args should be consistent with the game_config, which should be
@@ -270,7 +270,7 @@ class MPCService:
         cmd_args_list = [cmd_args for (package_name, cmd_args) in cmd_tuple_list]
 
         return await self.onedocker_svc.start_containers_async(
-            container_definition=self.task_definition,
+            task_definition=self.task_definition,
             package_name=cmd_tuple_list[0][0],
             version=version,
             cmd_args_list=cmd_args_list,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcs",
-    version="0.3.1",
+    version="0.3.2",
     description="Facebook Private Computation Service",
     author="Facebook",
     author_email="researchtool-help@fb.com",

--- a/tests/service/test_onedocker.py
+++ b/tests/service/test_onedocker.py
@@ -16,7 +16,7 @@ class TestOneDockerService(unittest.TestCase):
     @patch("fbpcs.service.container.ContainerService")
     def setUp(self, MockContainerService):
         container_svc = MockContainerService()
-        self.onedocker_svc = OneDockerService(container_svc)
+        self.onedocker_svc = OneDockerService(container_svc, "task_def")
 
     def test_start_container(self):
         mocked_container_info = ContainerInstance(
@@ -28,7 +28,7 @@ class TestOneDockerService(unittest.TestCase):
             return_value=[mocked_container_info]
         )
         returned_container_info = self.onedocker_svc.start_container(
-            container_definition="task_def",
+            task_definition="task_def",
             package_name="project/exe_name",
             cmd_args="cmd_args",
         )
@@ -51,7 +51,7 @@ class TestOneDockerService(unittest.TestCase):
             return_value=mocked_container_info
         )
         returned_container_info = self.onedocker_svc.start_containers(
-            container_definition="task_def",
+            task_definition="task_def",
             package_name="project/exe_name",
             cmd_args_list=["--k1=v1", "--k2=v2"],
         )


### PR DESCRIPTION
Summary:
**What:** Add optional task_definition member to OneDockerService

**Why:** We no longer want to have to pass in task definition every time we start a container.  instead, we can construct OneDockerService with a task definition and use that to start containers.  This is possible now that we have consolidated task definitions for data processing and PID.

Differential Revision: D29998590

