### PR TITLE
Integrate MetricsEmitter into OneDocker

### DIFF
--- a/fbpcs/metrics/__init__.py
+++ b/fbpcs/metrics/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
This diff is to integrate MetricsEmitter into OneDocker

Next: write an integration test to emit some sample events. Then add some unit tests.

Differential Revision: D30030324

