### PR TITLE
BE - refactor onedocker cli show api to make it show all versions and their information

### DIFF
--- a/fbpcs/gateway/s3.py
+++ b/fbpcs/gateway/s3.py
@@ -95,6 +95,15 @@ class S3Gateway:
         return key_list
 
     @error_handler
+    def list_folders(self, bucket: str, key: str) -> List[str]:
+        key = key + "/"
+        response = self.client.list_objects_v2(Bucket=bucket, Prefix=key, Delimiter="/")
+        return [
+            prefix_dict["Prefix"][len(key) : -1]
+            for prefix_dict in response.get("CommonPrefixes")
+        ]
+
+    @error_handler
     def delete_object(self, bucket: str, key: str) -> None:
         self.client.delete_object(Bucket=bucket, Key=key)
 

--- a/fbpcs/service/storage.py
+++ b/fbpcs/service/storage.py
@@ -8,6 +8,7 @@
 
 import abc
 from enum import Enum
+from typing import List
 
 from fbpcs.entity.file_information import FileInfo
 
@@ -47,4 +48,8 @@ class StorageService(abc.ABC):
 
     @abc.abstractmethod
     def get_file_info(self, filename: str) -> FileInfo:
+        pass
+
+    @abc.abstractmethod
+    def list_folders(self, filename: str) -> List[str]:
         pass

--- a/fbpcs/service/storage_s3.py
+++ b/fbpcs/service/storage_s3.py
@@ -9,7 +9,7 @@
 import os
 from os import path
 from os.path import join, normpath, relpath
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from fbpcs.entity.file_information import FileInfo
 from fbpcs.gateway.s3 import S3Gateway
@@ -206,3 +206,7 @@ class S3StorageService(StorageService):
     def get_file_size(self, filename: str) -> int:
         s3_path = S3Path(filename)
         return self.s3_gateway.get_object_size(s3_path.bucket, s3_path.key)
+
+    def list_folders(self, filename: str) -> List[str]:
+        s3_path = S3Path(filename)
+        return self.s3_gateway.list_folders(s3_path.bucket, s3_path.key)


### PR DESCRIPTION
Summary: Add a function get_top_level_sub_folders in S3 gateway to return the top level subfolders. And use this function to alter the show api in onedocker CLI to show all available versions, instead of only the requested one.

Differential Revision: D30030721

