### PR TITLE
fbpcs deprecate container_version for OneDocker Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,10 @@ Add parameter to ContainerService/OneDockerService to allow passing in environme
 
 ### Description of changes
 Add optional task_definition member to OneDockerService and introduce task_definition as a param for start_container functions
+
+## 0.3.2 -> 0.4.0
+### Types of changes
+*  Breaking change
+
+### Description of changes
+Deprecate container_version parameter for OneDockerService start_container functions

--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -52,7 +52,6 @@ class OneDockerService:
     def start_container(
         self,
         package_name: str,
-        container_definition: Optional[str] = None,
         task_definition: Optional[str] = None,
         version: str = DEFAULT_BINARY_VERSION,
         cmd_args: str = "",
@@ -64,7 +63,6 @@ class OneDockerService:
         return asyncio.run(
             self.start_containers_async(
                 package_name,
-                container_definition,
                 task_definition,
                 version,
                 [cmd_args] if cmd_args else None,
@@ -77,7 +75,6 @@ class OneDockerService:
     def start_containers(
         self,
         package_name: str,
-        container_definition: Optional[str] = None,
         task_definition: Optional[str] = None,
         version: str = DEFAULT_BINARY_VERSION,
         cmd_args_list: Optional[List[str]] = None,
@@ -88,7 +85,6 @@ class OneDockerService:
         return asyncio.run(
             self.start_containers_async(
                 package_name,
-                container_definition,
                 task_definition,
                 version,
                 cmd_args_list,
@@ -101,7 +97,6 @@ class OneDockerService:
     async def start_containers_async(
         self,
         package_name: str,
-        container_definition: Optional[str] = None,
         task_definition: Optional[str] = None,
         version: str = DEFAULT_BINARY_VERSION,
         cmd_args_list: Optional[List[str]] = None,
@@ -123,12 +118,10 @@ class OneDockerService:
 
         self.logger.info("Spinning up container instances")
 
-        task_definition = (
-            task_definition or container_definition or self.task_definition
-        )
-        if task_definition is None:
+        task_definition = task_definition or self.task_definition
+        if not task_definition:
             raise ValueError(
-                "task_definition should not be None if self.task_definition is None"
+                "task definition should be specified when spinning up containers"
             )
         container_ids = await self.container_svc.create_instances_async(
             # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", encoding="utf-8") as f:
 
 setup(
     name="fbpcs",
-    version="0.3.2",
+    version="0.4.0",
     description="Facebook Private Computation Service",
     author="Facebook",
     author_email="researchtool-help@fb.com",


### PR DESCRIPTION
Summary:
**What:** Delete `container_definition` as a parameter in `start_containers` in OneDocker Service.  This will reflect version 0.4.0 of fbpcs, given that we are introducing a breaking change

**Why:** We want to replace `container_definition` terminology with `task_definition` for consistency and to be more specific

Differential Revision: D30051309

