### PR TITLE
Remove unneeded ignore for passing task_definition to create container instance

### DIFF
--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -124,7 +124,6 @@ class OneDockerService:
                 "task definition should be specified when spinning up containers"
             )
         container_ids = await self.container_svc.create_instances_async(
-            # type: ignore
             task_definition,
             cmds,
             env_vars,


### PR DESCRIPTION
Summary:
**What:** Remove unneeded ignore for passing task_definition to create container instance

**Why:** We want to ensure that we catch any linting issues, and that means we don't want to have unecessary type ignores

Reviewed By: jrodal98

Differential Revision: D30104972

