### PR TITLE
Integrate OneDocker metrics into PL Thrift service

### DIFF
--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -130,7 +130,10 @@ class OneDockerService:
         )
 
         if self.metrics:
-            self.metrics.count(f"{METRICS_CONTAINER_COUNT}.{tag}", len(cmds))
+            name = (
+                f"{METRICS_CONTAINER_COUNT}.{tag}" if tag else METRICS_CONTAINER_COUNT
+            )
+            self.metrics.count(name, len(container_ids))
 
         return container_ids
 


### PR DESCRIPTION
Summary:
This diff is to integrate OneDocker metrics emitter into PL Thrift service, so we can gather some metrics.

Next: fix code coverage

Differential Revision: D30074693

