### PR TITLE
Add region and cluster into the metrics key

### DIFF
--- a/fbpcs/service/container.py
+++ b/fbpcs/service/container.py
@@ -15,6 +15,18 @@ from fbpcs.error.pcs import PcsError
 
 class ContainerService(abc.ABC):
     @abc.abstractmethod
+    def get_region(
+        self,
+    ) -> str:
+        pass
+
+    @abc.abstractmethod
+    def get_cluster(
+        self,
+    ) -> str:
+        pass
+
+    @abc.abstractmethod
     def create_instance(
         self,
         container_definition: str,

--- a/fbpcs/service/container_aws.py
+++ b/fbpcs/service/container_aws.py
@@ -33,6 +33,16 @@ class AWSContainerService(ContainerService):
         self.subnets = subnets
         self.ecs_gateway = ECSGateway(region, access_key_id, access_key_data, config)
 
+    def get_region(
+        self,
+    ) -> str:
+        return self.region
+
+    def get_cluster(
+        self,
+    ) -> str:
+        return self.cluster
+
     def create_instance(
         self,
         container_definition: str,

--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -130,9 +130,8 @@ class OneDockerService:
         )
 
         if self.metrics:
-            name = (
-                f"{METRICS_CONTAINER_COUNT}.{tag}" if tag else METRICS_CONTAINER_COUNT
-            )
+            name = f"{METRICS_CONTAINER_COUNT}.{self.container_svc.get_region()}.{self.container_svc.get_cluster()}"
+            name = f"{METRICS_CONTAINER_COUNT}.{tag}" if tag else name
             self.metrics.count(name, len(container_ids))
 
         return container_ids


### PR DESCRIPTION
Summary: I found it's not easy to add a tag in PL Thrift, so I added region and cluster in OneDocker. In this way, we can monitor each region and each advertiser.

Differential Revision: D30175617

