### PR TITLE
Add request_counter decorator

### DIFF
--- a/fbpcs/decorator/metrics.py
+++ b/fbpcs/decorator/metrics.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+import functools
+from typing import Callable
+
+
+def request_counter(metrics_name: str) -> Callable:
+    def wrap(f: Callable):
+        @functools.wraps(f)
+        def wrapper_sync(self, *args, **kwargs):
+            if self.metrics:
+                self.metrics.count(metrics_name, 1)
+            return f(self, *args, **kwargs)
+
+        @functools.wraps(f)
+        async def wrapper_async(self, *args, **kwargs):
+            if self.metrics:
+                self.metrics.count(metrics_name, 1)
+            return await f(self, *args, **kwargs)
+
+        if asyncio.iscoroutinefunction(f):
+            return wrapper_async
+        else:
+            return wrapper_sync
+
+    return wrap
+
+
+# def error_counter(metrics_name: str) -> Callable:
+#     pass
+
+
+# def duration_timer(metrics_name: str) -> Callable:
+#     pass

--- a/fbpcs/service/onedocker.py
+++ b/fbpcs/service/onedocker.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 from typing import Dict, List, Optional, Final
 
+from fbpcs.decorator.metrics import request_counter
 from fbpcs.entity.container_instance import ContainerInstance
 from fbpcs.error.pcs import PcsError
 from fbpcs.metrics.emitter import MetricsEmitter
@@ -25,6 +26,7 @@ ONEDOCKER_CMD_PREFIX = (
 DEFAULT_BINARY_VERSION = "latest"
 
 METRICS_CONTAINER_COUNT = "onedocker.container.count"
+METRICS_START_CONTAINERS_COUNT = "onedocker.start_containers.count"
 
 
 class OneDockerService:
@@ -94,6 +96,7 @@ class OneDockerService:
             )
         )
 
+    @request_counter(METRICS_START_CONTAINERS_COUNT)
     async def start_containers_async(
         self,
         package_name: str,

--- a/tests/decorator/test_metrics.py
+++ b/tests/decorator/test_metrics.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from fbpcs.decorator.metrics import request_counter
+
+
+METRICS_NAME = "test_metrics"
+
+
+class TestMetrics:
+    def __init__(self, metrics):
+        self.metrics = metrics
+
+    @request_counter(METRICS_NAME)
+    def test_sync(self):
+        pass
+
+    @request_counter(METRICS_NAME)
+    async def test_async(self):
+        pass
+
+
+class TestMetricsDecoratorSync(unittest.TestCase):
+    @patch("fbpcs.metrics.emitter.MetricsEmitter")
+    def test_request_count_sync(self, MockMetricsEmitter):
+        metrics = MockMetricsEmitter()
+        test_metrics = TestMetrics(metrics)
+        test_metrics.test_sync()
+        metrics.count.assert_called_with(METRICS_NAME, 1)
+
+
+class TestMetricsDecoratorAsync(IsolatedAsyncioTestCase):
+    @patch("fbpcs.metrics.emitter.MetricsEmitter")
+    async def test_request_count_async(self, MockMetricsEmitter):
+        metrics = MockMetricsEmitter()
+        test_metrics = TestMetrics(metrics)
+        await test_metrics.test_async()
+        metrics.count.assert_called_with(METRICS_NAME, 1)


### PR DESCRIPTION
Summary:
This diff is to add request_counter, so we can track throughput of OneDocker. It's also a generic metric counter, so we can use it in other places.

Next: implement error_counter and duration_time.

Differential Revision: D30177202

