### PR TITLE
Add __init__.py to register cloud folder as a package folder

### DIFF
--- a/fbpcs/cloud/__init__.py
+++ b/fbpcs/cloud/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary: This is to fix the pyre error in Github, for OSS this matters because there is no TARGET and buck to take care of the library registration

Differential Revision: D30251285

