### PR TITLE
Rename FBPCS to FBPCP in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# FBPCS (Facebook Private Computation Service)
+# FBPCP (Facebook Private Computation Platform)
 [Secure multi-party computation](https://en.wikipedia.org/wiki/Secure_multi-party_computation) (also known as secure computation, multi-party computation (MPC), or privacy-preserving computation) is a subfield of cryptography with the goal of creating methods for parties to jointly compute a function over their inputs while keeping those inputs private.
 
-FBPCS (Facebook Private Computation Service) is a secure, privacy safe and scalable architecture to deploy MPC (Multi Party Computation) applications in a distributed way on virtual private clouds. [FBPCF](https://github.com/facebookresearch/fbpcf) (Facebook Private Computation Framework) is for scaling MPC computation up via threading, while FBPCS is for scaling MPC computation out via [Private Scaling](https://github.com/facebookresearch/FBPCS/blob/main/docs/PrivateScaling.md) architecture. FBPCS consists of various services, interfaces that enable various private measurement solutions, e.g. [Private Lift](https://github.com/facebookresearch/fbpcf/blob/master/docs/PrivateLift.md).
+FBPCP (Facebook Private Computation Platform) is a secure, privacy safe and scalable architecture to deploy MPC (Multi Party Computation) applications in a distributed way on virtual private clouds. [FBPCP](https://github.com/facebookresearch/fbpcf) (Facebook Private Computation Framework) is for scaling MPC computation up via threading, while FBPCP is for scaling MPC computation out via [Private Scaling](https://github.com/facebookresearch/FBPCS/blob/main/docs/PrivateScaling.md) architecture. FBPCP consists of various services, interfaces that enable various private measurement solutions, e.g. [Private Lift](https://github.com/facebookresearch/fbpcf/blob/master/docs/PrivateLift.md).
 
 [Private Scaling](https://github.com/facebookresearch/FBPCS/blob/main/docs/PrivateScaling.md) resembles the map/reduce architecture and is secure against a semi-honest adversary who tries to learn the inputs of the computation. The goal is to secure the intermediate output of each shard to prevent potential privacy leak.
 
 ## Installation Requirements:
 ### Prerequisites for working on Ubuntu 18.04:
-* An AWS account (Access Key ID, Secret Access Key) to use AWS SDK (boto3 API) in FBPCS
+* An AWS account (Access Key ID, Secret Access Key) to use AWS SDK (boto3 API) in FBPCP
 * python >= 3.8
 * python3-pip
 
@@ -20,7 +20,7 @@ sudo apt-get install -y python3.8
 ```sh
 sudo apt-get install -y python3-pip
 ```
-## Installing fbpcs
+## Installing fbpcp
 ```sh
 python3.8 -m pip install 'git+https://github.com/facebookresearch/FBPCS.git'
 # (add --user if you don't have permission)
@@ -34,15 +34,15 @@ python3.8 -m pip install -e FBPCS
 python3.8 -m pip install fbpcs
 ```
 
-## Upgrading fbpcs
+## Upgrading fbpcp
 * To latest version in github main branch
 ```sh
 python3.8 -m pip uninstall fbpcs
-# uninstall fbpcs first
+# uninstall fbpcp first
 
 python3.8 -m pip install 'git+https://github.com/facebookresearch/FBPCS.git'
 # (add --user if you don't have permission)
-# re-install fbpcs from github repository
+# re-install fbpcp from github repository
 ```
 
 * To latest version in Pypi
@@ -60,9 +60,9 @@ python3.8 -m pip install fbpcs --upgrade
 
 ### [Other components](https://github.com/facebookresearch/FBPCS/blob/main/docs/FBPCSComponents.md)
 
-## Join the FBPCS community
+## Join the FBPCP community
 * Website: https://github.com/facebookresearch/fbpcs
 * See the [CONTRIBUTING](https://github.com/facebookresearch/FBPCS/blob/main/CONTRIBUTING.md) file for how to help out.
 
 ## License
-FBPCS is [MIT](https://github.com/facebookresearch/FBPCS/blob/main/LICENSE) licensed, as found in the LICENSE file.
+FBPCP is [MIT](https://github.com/facebookresearch/FBPCS/blob/main/LICENSE) licensed, as found in the LICENSE file.


### PR DESCRIPTION
Summary:
We decided to rename some projects. Basically
FBPCS -> FBPCP
FBPMP -> FBPCS

We originally picked up fbpcp, but we had to change it to fbpcs due to some concerns. However, it doesn't make sense that a platform layer is built on top of a service layer, so we want to fix them altogether.

zhuang-93 will work on following items
- Release FBPCP and deprecate FBPCS
- Move to fbpcp repo

Reviewed By: gorel

Differential Revision: D30259784

