### PR TITLE
Add isValid bit to Touchpoint class

### DIFF
--- a/fbpmp/emp_games/attribution/Attribution.hpp
+++ b/fbpmp/emp_games/attribution/Attribution.hpp
@@ -195,7 +195,7 @@ const std::vector<PrivateAttribution> computeAttributionsForId(
       // and it is preferred over the existing touchpoint
       auto isNewTouchpointAttributable =
           attributionRule.isAttributable(tp, conv);
-      auto isNewTouchpointValid = tp.isValid();
+      auto isNewTouchpointValid = tp.isValid;
       auto isExistingTouchpointInvalid = !attribution.hasAttributedTouchpoint;
       auto isNewTouchpointPreferred = isExistingTouchpointInvalid |
           attributionRule.isNewTouchpointPreferred(tp, attribution.tp);


### PR DESCRIPTION
Summary:
Every time we run an attribution rule, we have to calculate `isNewTouchpointValid`, which is a greater-than-or-equal comparison between `emp::Integers`. My hunch was that it'd be faster to pre-compute this and replace it with just an `emp::Bit` check.

Indeed it looks like this does improve performance slightly, with a 6% reduction in runtime, a 0.8% reduction in network traffic, and a 1.2% reduction in cost. (Though I'd take these numbers with a grain of salt since there is variability every time we run the perf script.)

Reviewed By: gorel

Differential Revision: D30123838

