### PR TITLE
Remove duplicate logic in SecretSharing.hpp

### DIFF
--- a/fbpmp/emp_games/common/SecretSharing.h
+++ b/fbpmp/emp_games/common/SecretSharing.h
@@ -65,25 +65,6 @@ const std::vector<PrivateBit<MY_ROLE>> privatelyShareBits(
     std::optional<int64_t> numVals = std::nullopt);
 
 /*
- * Share emp::Integers from SOURCE_ROLE to the opposite party
- * numVals = number of items to share
- */
-template <int MY_ROLE, int SOURCE_ROLE>
-const std::vector<emp::Integer> privatelyShareIntsFrom(
-    const std::vector<int64_t>& in,
-    int64_t numVals,
-    int32_t bitLen = INT_SIZE);
-
-/*
- * Share emp::Bits from SOURCE_ROLE to the opposite party
- * numVals = number of items to share
- */
-template <int MY_ROLE, int SOURCE_ROLE>
-const std::vector<emp::Bit> privatelyShareBitsFrom(
-    const std::vector<int64_t>& in,
-    int64_t numVals);
-
-/*
  * Share an array of type T from SOURCE_ROLE to the opposite party,
  * return an array of type O.
  *
@@ -97,9 +78,42 @@ const std::vector<emp::Bit> privatelyShareBitsFrom(
  * numVals = number of items to share
  * nullValue = value to initialize for the non-source role.
  */
-template <int MY_ROLE, int SOURCE_ROLE, typename T, typename O>
-const std::vector<O>
-privatelyShareArrayFrom(const std::vector<T>& in, int64_t numVals, T nullValue);
+template <
+    int MY_ROLE,
+    int SOURCE_ROLE,
+    typename T,
+    typename O,
+    typename... BatcherArgs>
+const std::vector<O> privatelyShareArrayFrom(
+    const std::vector<T>& in,
+    int64_t numVals,
+    T nullValue,
+    BatcherArgs... batcherArgs);
+
+/*
+ * Share emp::Integers from SOURCE_ROLE to the opposite party
+ * numVals = number of items to share
+ */
+template <int MY_ROLE, int SOURCE_ROLE>
+const std::vector<emp::Integer> privatelyShareIntsFrom(
+    const std::vector<int64_t>& in,
+    int64_t numVals,
+    int32_t bitLen = INT_SIZE) {
+  return privatelyShareArrayFrom<MY_ROLE, SOURCE_ROLE, int64_t, emp::Integer>(
+      in, numVals, 0, bitLen);
+}
+
+/*
+ * Share emp::Bits from SOURCE_ROLE to the opposite party
+ * numVals = number of items to share
+ */
+template <int MY_ROLE, int SOURCE_ROLE>
+const std::vector<emp::Bit> privatelyShareBitsFrom(
+    const std::vector<int64_t>& in,
+    int64_t numVals) {
+  return privatelyShareArrayFrom<MY_ROLE, SOURCE_ROLE, int64_t, emp::Bit>(
+      in, numVals, 0);
+}
 
 /*
  * Share an array of T arrays from SOURCE_ROLE to the opposite party,


### PR DESCRIPTION
Summary: `privatelyShareIntsFrom` and `privatelyShareBitsFrom` both use similar logic to the more general `privatelyShareArrayFrom`. This diff merges those all together.

Differential Revision: D30399915

