### PR TITLE
Remove dead code in SecretSharing

### DIFF
--- a/fbpmp/emp_games/common/SecretSharing.h
+++ b/fbpmp/emp_games/common/SecretSharing.h
@@ -65,25 +65,6 @@ const std::vector<PrivateBit<MY_ROLE>> privatelyShareBits(
     std::optional<int64_t> numVals = std::nullopt);
 
 /*
- * Share emp::Integers from SOURCE_ROLE to the opposite party
- * numVals = number of items to share
- */
-template <int MY_ROLE, int SOURCE_ROLE>
-const std::vector<emp::Integer> privatelyShareIntsFrom(
-    const std::vector<int64_t>& in,
-    int64_t numVals,
-    int32_t bitLen = INT_SIZE);
-
-/*
- * Share emp::Bits from SOURCE_ROLE to the opposite party
- * numVals = number of items to share
- */
-template <int MY_ROLE, int SOURCE_ROLE>
-const std::vector<emp::Bit> privatelyShareBitsFrom(
-    const std::vector<int64_t>& in,
-    int64_t numVals);
-
-/*
  * Share an array of type T from SOURCE_ROLE to the opposite party,
  * return an array of type O.
  *
@@ -97,9 +78,42 @@ const std::vector<emp::Bit> privatelyShareBitsFrom(
  * numVals = number of items to share
  * nullValue = value to initialize for the non-source role.
  */
-template <int MY_ROLE, int SOURCE_ROLE, typename T, typename O>
-const std::vector<O>
-privatelyShareArrayFrom(const std::vector<T>& in, int64_t numVals, T nullValue);
+template <
+    int MY_ROLE,
+    int SOURCE_ROLE,
+    typename T,
+    typename O,
+    typename... BatcherArgs>
+const std::vector<O> privatelyShareArrayFrom(
+    const std::vector<T>& in,
+    int64_t numVals,
+    T nullValue,
+    BatcherArgs... batcherArgs);
+
+/*
+ * Share emp::Integers from SOURCE_ROLE to the opposite party
+ * numVals = number of items to share
+ */
+template <int MY_ROLE, int SOURCE_ROLE>
+const std::vector<emp::Integer> privatelyShareIntsFrom(
+    const std::vector<int64_t>& in,
+    int64_t numVals,
+    int32_t bitLen = INT_SIZE) {
+  return privatelyShareArrayFrom<MY_ROLE, SOURCE_ROLE, int64_t, emp::Integer>(
+      in, numVals, 0, bitLen);
+}
+
+/*
+ * Share emp::Bits from SOURCE_ROLE to the opposite party
+ * numVals = number of items to share
+ */
+template <int MY_ROLE, int SOURCE_ROLE>
+const std::vector<emp::Bit> privatelyShareBitsFrom(
+    const std::vector<int64_t>& in,
+    int64_t numVals) {
+  return privatelyShareArrayFrom<MY_ROLE, SOURCE_ROLE, int64_t, emp::Bit>(
+      in, numVals, 0);
+}
 
 /*
  * Share an array of T arrays from SOURCE_ROLE to the opposite party,

--- a/fbpmp/emp_games/common/SecretSharing.h
+++ b/fbpmp/emp_games/common/SecretSharing.h
@@ -19,50 +19,11 @@
 
 namespace private_measurement::secret_sharing {
 
-/**
- * Custom emp::Integer that can be used with these functions to allow
- * integers to be passed without providing an explicit length.
- */
-class Integer64 : public emp::Integer {
- public:
-  Integer64(int64_t input, int32_t party = emp::PUBLIC)
-      : emp::Integer{INT_SIZE, input, party} {}
-  Integer64(int32_t len, const void* b) : emp::Integer{len, b} {}
-
-  // batcher
-  template <typename... Args>
-  static size_t bool_size(Args... args) {
-    return emp::Integer::bool_size(INT_SIZE, std::forward<Args>(args)...);
-  }
-  static void bool_data(bool* data, long long num) {
-    return emp::Integer::bool_data(data, INT_SIZE, num);
-  }
-};
-
 /*
  * Share one emp::Integer bidirectionally between both parties
  */
 template <int MY_ROLE>
 PrivateInt<MY_ROLE> privatelyShareInt(int64_t in);
-
-/*
- * Share emp::Integers bidirectionally between both parties
- * numVals = number of items to share (if std::nullopt, use in.size())
- */
-template <int MY_ROLE>
-const std::vector<PrivateInt<MY_ROLE>> privatelyShareInts(
-    const std::vector<int64_t>& in,
-    std::optional<int64_t> numVals = std::nullopt,
-    int32_t bitLen = INT_SIZE);
-
-/*
- * Share emp::Bits bidirectionally between both parties
- * numVals = number of items to share (if std::nullopt, use in.size())
- */
-template <int MY_ROLE>
-const std::vector<PrivateBit<MY_ROLE>> privatelyShareBits(
-    const std::vector<int64_t>& in,
-    std::optional<int64_t> numVals = std::nullopt);
 
 /*
  * Share an array of type T from SOURCE_ROLE to the opposite party,

--- a/fbpmp/emp_games/common/SecretSharing.hpp
+++ b/fbpmp/emp_games/common/SecretSharing.hpp
@@ -29,67 +29,6 @@ PrivateInt<MY_ROLE> privatelyShareInt(int64_t in) {
   return PrivateInt<MY_ROLE>{myInt, theirInt};
 }
 
-template <int MY_ROLE>
-const std::vector<PrivateInt<MY_ROLE>> privatelyShareInts(
-    const std::vector<int64_t>& in,
-    std::optional<int64_t> numVals,
-    int32_t bitLen) {
-  // Batch transfer inputs
-  emp::Batcher myBatcher;
-  emp::Batcher theirBatcher;
-
-  // We create two batchers since we're sharing data bidirectionally
-  // Note that we must add an integer to both sides even though the data
-  // transfer happens in one direction. This is so the underlying
-  // library knows how much space to allocate. It's not exactly clear
-  // from the API that this is a requirement.
-  for (auto i = 0; i < numVals.value_or(in.size()); ++i) {
-    myBatcher.add<emp::Integer>(bitLen, i < in.size() ? in.at(i) : 0);
-    theirBatcher.add<emp::Integer>(bitLen, i < in.size() ? in.at(i) : 0);
-  }
-  myBatcher.make_semi_honest(MY_ROLE);
-  theirBatcher.make_semi_honest(otherRole(MY_ROLE));
-
-  // Convert to vectors
-  std::vector<PrivateInt<MY_ROLE>> out;
-  for (auto i = 0; i < numVals.value_or(in.size()); ++i) {
-    out.push_back(PrivateInt<MY_ROLE>{
-        myBatcher.next<emp::Integer>(), theirBatcher.next<emp::Integer>()});
-  }
-
-  return out;
-}
-
-template <int MY_ROLE>
-const std::vector<PrivateBit<MY_ROLE>> privatelyShareBits(
-    const std::vector<int64_t>& in,
-    std::optional<int64_t> numVals) {
-  // Batch transfer inputs
-  emp::Batcher myBatcher;
-  emp::Batcher theirBatcher;
-
-  // We create two batchers since we're sharing data bidirectionally
-  // Note that we must add a bit to both sides even though the data
-  // transfer happens in one direction. This is so the underlying
-  // library knows how much space to allocate. It's not exactly clear
-  // from the API that this is a requirement.
-  for (auto i = 0; i < numVals.value_or(in.size()); ++i) {
-    myBatcher.add<emp::Bit>(i < in.size() ? in.at(i) : 0);
-    theirBatcher.add<emp::Bit>(i < in.size() ? in.at(i) : 0);
-  }
-  myBatcher.make_semi_honest(MY_ROLE);
-  theirBatcher.make_semi_honest(otherRole(MY_ROLE));
-
-  // Convert to vectors
-  std::vector<PrivateBit<MY_ROLE>> out;
-  for (auto i = 0; i < numVals.value_or(in.size()); ++i) {
-    out.push_back(PrivateBit<MY_ROLE>{
-        myBatcher.next<emp::Bit>(), theirBatcher.next<emp::Bit>()});
-  }
-
-  return out;
-}
-
 template <
     int MY_ROLE,
     int SOURCE_ROLE,


### PR DESCRIPTION
Summary: As far as I can tell this is dead code. `privatelyShare___` in particular seems to be replaced with `privatelyShare___From`.

Reviewed By: leegross

Differential Revision: D30399694

