### PR TITLE
PID don't block if final stage

### DIFF
--- a/fbpmp/data_processing/pid_preparer/preparer.py
+++ b/fbpmp/data_processing/pid_preparer/preparer.py
@@ -9,6 +9,7 @@ import logging
 import pathlib
 from typing import Optional
 
+from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 
@@ -34,7 +35,8 @@ class UnionPIDDataPreparerService(abc.ABC):
         onedocker_svc: OneDockerService,
         binary_version: str,
         tmp_directory: str = "/tmp/",
-    ) -> None:
+        wait_for_container: bool = True,
+    ) -> ContainerInstance:
         pass
 
     @abc.abstractmethod
@@ -46,5 +48,6 @@ class UnionPIDDataPreparerService(abc.ABC):
         onedocker_svc: OneDockerService,
         binary_version: str,
         tmp_directory: str = "/tmp/",
-    ) -> None:
+        wait_for_container: bool = True,
+    ) -> ContainerInstance:
         pass

--- a/fbpmp/data_processing/sharding/sharding.py
+++ b/fbpmp/data_processing/sharding/sharding.py
@@ -8,6 +8,7 @@ import abc
 import enum
 from typing import Optional
 
+from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 
@@ -43,7 +44,8 @@ class ShardingService(abc.ABC):
         binary_version: str,
         tmp_directory: str = "/tmp/",
         hmac_key: Optional[str] = None,
-    ) -> None:
+        wait_for_containers: bool = True,
+    ) -> ContainerInstance:
         pass
 
     @abc.abstractmethod
@@ -58,5 +60,6 @@ class ShardingService(abc.ABC):
         binary_version: str,
         tmp_directory: str = "/tmp/",
         hmac_key: Optional[str] = None,
-    ) -> None:
+        wait_for_containers: bool = True,
+    ) -> ContainerInstance:
         pass

--- a/fbpmp/pid/service/pid_service/pid.py
+++ b/fbpmp/pid/service/pid_service/pid.py
@@ -119,7 +119,7 @@ class PIDService:
         await dispatcher.run_all()
 
         # Return refreshed instance
-        return self.instance_repository.read(instance_id)
+        return self.update_instance(instance_id)
 
     def get_instance(self, instance_id: str) -> PIDInstance:
         self.logger.info(f"Getting PID instance: {instance_id}")

--- a/fbpmp/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpmp/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -5,26 +5,23 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
+from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpmp.data_processing.sharding.sharding import ShardType
 from fbpmp.data_processing.sharding.sharding_cpp import CppShardingService
 from fbpmp.onedocker_binary_config import OneDockerBinaryConfig
 from fbpmp.pcf.tests.async_utils import to_sync
 from fbpmp.pid.entity.pid_instance import PIDStageStatus
 from fbpmp.pid.entity.pid_stages import UnionPIDStage
-from fbpmp.pid.repository.pid_instance_local import LocalPIDInstanceRepository
 from fbpmp.pid.service.pid_service.pid_shard_stage import PIDShardStage
+from fbpmp.pid.service.pid_service.pid_stage import PIDStage
 from fbpmp.pid.service.pid_service.pid_stage_input import PIDStageInput
+from libfb.py.asyncio.unittest import AsyncMock
+from libfb.py.testutil import data_provider
 
 
-CONFIG = {
-    "s3_coordination_file": "ip_config"
-}
-
-
-async def async_wrapper(value):
-    return value
+CONFIG = {"s3_coordination_file": "ip_config"}
 
 
 class TestPIDShardStage(unittest.TestCase):
@@ -51,23 +48,42 @@ class TestPIDShardStage(unittest.TestCase):
             res = await stage._ready(stage_input)
             self.assertTrue(res)
 
-    @patch.object(
-        PIDShardStage,
-        "shard",
-        return_value=async_wrapper(PIDStageStatus.COMPLETED),
+    @data_provider(
+        lambda: ({"wait_for_containers": True}, {"wait_for_containers": False})
     )
+    @patch("fbpmp.data_processing.sharding.sharding_cpp.wait_for_containers_async")
+    @patch("fbpcp.service.storage.StorageService")
+    @patch("fbpcp.service.onedocker.OneDockerService")
+    @patch("fbpmp.pid.repository.pid_instance.PIDInstanceRepository")
     @to_sync
-    async def test_run(self, mock_shard):
-        mock_instance_repo = LocalPIDInstanceRepository(base_dir=".")
-        mock_instance_repo.read = MagicMock()
-        mock_instance_repo.update = MagicMock()
+    async def test_run(
+        self,
+        mock_instance_repo,
+        mock_onedocker_svc,
+        mock_storage_svc,
+        mock_wait_for_containers_async,
+        wait_for_containers: bool,
+    ):
+        ip = "192.0.2.0"
+        container = ContainerInstance(instance_id="123", ip_address=ip)
+        mock_onedocker_svc.start_containers_async = AsyncMock(return_value=[container])
+        container.status = (
+            ContainerInstanceStatus.COMPLETED
+            if wait_for_containers
+            else ContainerInstanceStatus.STARTED
+        )
+        mock_wait_for_containers_async.return_value = [container]
+        test_onedocker_binary_config = OneDockerBinaryConfig(
+            tmp_directory="/test_tmp_directory/",
+            binary_version="latest",
+        )
         stage = PIDShardStage(
             stage=UnionPIDStage.PUBLISHER_SHARD,
             config=CONFIG,
             instance_repository=mock_instance_repo,
-            storage_svc="STORAGE",
-            onedocker_svc="ONEDOCKER",
-            onedocker_binary_config="OD_CONFIG",
+            storage_svc=mock_storage_svc,
+            onedocker_svc=mock_onedocker_svc,
+            onedocker_binary_config=test_onedocker_binary_config,
         )
         instance_id = "444"
         stage_input = PIDStageInput(
@@ -84,20 +100,36 @@ class TestPIDShardStage(unittest.TestCase):
                 stage=UnionPIDStage.PUBLISHER_SHARD,
                 config=CONFIG,
                 instance_repository=mock_instance_repo,
-                storage_svc="STORAGE",
-                onedocker_svc="ONEDOCKER",
-                onedocker_binary_config="OD_CONFIG",
+                storage_svc=mock_storage_svc,
+                onedocker_svc=mock_onedocker_svc,
+                onedocker_binary_config=test_onedocker_binary_config,
             )
-            status = await stage.run(stage_input)
+            status = await stage.run(
+                stage_input, wait_for_containers=wait_for_containers
+            )
+            self.assertEqual(
+                PIDStageStatus.COMPLETED
+                if wait_for_containers
+                else PIDStageStatus.STARTED,
+                status,
+            )
+
+            mock_onedocker_svc.start_containers_async.assert_called_once()
+            if wait_for_containers:
+                mock_wait_for_containers_async.assert_called_once()
+            else:
+                mock_wait_for_containers_async.assert_not_called()
             # instance status is updated to READY, STARTED, then COMPLETED
             mock_instance_repo.read.assert_called_with(instance_id)
-            self.assertEqual(mock_instance_repo.read.call_count, 3)
-            self.assertEqual(mock_instance_repo.update.call_count, 3)
+            self.assertEqual(mock_instance_repo.read.call_count, 4)
+            self.assertEqual(mock_instance_repo.update.call_count, 4)
 
         # Input not ready
         with patch.object(PIDShardStage, "files_exist") as mock_fe:
             mock_fe.return_value = False
-            status = await stage.run(stage_input)
+            status = await stage.run(
+                stage_input, wait_for_containers=wait_for_containers
+            )
             self.assertEqual(PIDStageStatus.FAILED, status)
 
         # Multiple input paths (invariant exception)
@@ -109,52 +141,82 @@ class TestPIDShardStage(unittest.TestCase):
                     stage=UnionPIDStage.PUBLISHER_SHARD,
                     config=CONFIG,
                     instance_repository=mock_instance_repo,
-                    storage_svc="STORAGE",
-                    onedocker_svc="ONEDOCKER",
-                    onedocker_binary_config="OD_CONFIG",
+                    storage_svc=mock_storage_svc,
+                    onedocker_svc=mock_onedocker_svc,
+                    onedocker_binary_config=test_onedocker_binary_config,
                 )
-                status = await stage.run(stage_input)
-                self.assertEqual(PIDStageStatus.COMPLETED, status)
-                mock_shard.assert_called_once_with("in1", "out", 123)
+                status = await stage.run(
+                    stage_input, wait_for_containers=wait_for_containers
+                )
+                self.assertEqual(
+                    PIDStageStatus.COMPLETED
+                    if wait_for_containers
+                    else PIDStageStatus.STARTED,
+                    status,
+                )
 
+    @data_provider(
+        lambda: ({"wait_for_containers": True}, {"wait_for_containers": False})
+    )
     @patch.object(CppShardingService, "shard_on_container_async")
+    @patch("fbpcp.service.storage.StorageService")
+    @patch("fbpcp.service.onedocker.OneDockerService")
     @patch("fbpmp.pid.repository.pid_instance.PIDInstanceRepository")
     @to_sync
-    async def test_shard(self, mock_instance_repo, mock_sharder):
-        test_onedocker_binary_config = OneDockerBinaryConfig(
-            tmp_directory="/test_tmp_directory/",
-            binary_version="latest",
-        )
-        stage = PIDShardStage(
-            stage=UnionPIDStage.PUBLISHER_SHARD,
-            config=CONFIG,
-            instance_repository=mock_instance_repo,
-            storage_svc="STORAGE",
-            onedocker_svc="ONEDOCKER",
-            onedocker_binary_config=test_onedocker_binary_config,
-        )
+    async def test_shard(
+        self,
+        mock_instance_repo,
+        mock_onedocker_svc,
+        mock_storage_svc,
+        mock_sharder,
+        wait_for_containers: bool,
+    ):
+        with patch.object(PIDStage, "update_instance_containers"):
+            test_onedocker_binary_config = OneDockerBinaryConfig(
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+            )
+            stage = PIDShardStage(
+                stage=UnionPIDStage.PUBLISHER_SHARD,
+                config=CONFIG,
+                instance_repository=mock_instance_repo,
+                storage_svc=mock_storage_svc,
+                onedocker_svc=mock_onedocker_svc,
+                onedocker_binary_config=test_onedocker_binary_config,
+            )
 
-        test_input_path = "foo"
-        test_output_path = "bar"
-        test_num_shards = 1
-        test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
+            test_input_path = "foo"
+            test_output_path = "bar"
+            test_num_shards = 1
+            test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
 
-        shard_path = PIDShardStage.get_sharded_filepath(test_output_path, 0)
-        self.assertEqual(f"{test_output_path}_0", shard_path)
+            shard_path = PIDShardStage.get_sharded_filepath(test_output_path, 0)
+            self.assertEqual(f"{test_output_path}_0", shard_path)
 
-        res = await stage.shard(
-            test_input_path, test_output_path, test_num_shards, test_hmac_key
-        )
-        self.assertEqual(PIDStageStatus.COMPLETED, res)
+            res = await stage.shard(
+                "123",
+                test_input_path,
+                test_output_path,
+                test_num_shards,
+                test_hmac_key,
+                wait_for_containers=wait_for_containers,
+            )
+            self.assertEqual(
+                PIDStageStatus.COMPLETED
+                if wait_for_containers
+                else PIDStageStatus.STARTED,
+                res,
+            )
 
-        mock_sharder.assert_called_once_with(
-            ShardType.HASHED_FOR_PID,
-            test_input_path,
-            output_base_path=test_output_path,
-            file_start_index=0,
-            num_output_files=test_num_shards,
-            onedocker_svc=stage.onedocker_svc,
-            binary_version=test_onedocker_binary_config.binary_version,
-            tmp_directory=test_onedocker_binary_config.tmp_directory,
-            hmac_key=test_hmac_key,
-        )
+            mock_sharder.assert_called_once_with(
+                ShardType.HASHED_FOR_PID,
+                test_input_path,
+                output_base_path=test_output_path,
+                file_start_index=0,
+                num_output_files=test_num_shards,
+                onedocker_svc=stage.onedocker_svc,
+                binary_version=test_onedocker_binary_config.binary_version,
+                tmp_directory=test_onedocker_binary_config.tmp_directory,
+                hmac_key=test_hmac_key,
+                wait_for_containers=wait_for_containers,
+            )


### PR DESCRIPTION
Summary:
## What is this diff stack

* Reduces ID Match thrift latency from 96 minutes -> 6 minutes without any thrift level changes or PrivateComputationService changes
* Modifies how PIDDispatcher and PIDStage.run flow works. Specifically, it allows individual stages from the PID DAG to be run (instead of running all) and makes waiting for containers to finish optional

## What is this diff

* The last stage of PID no longer waits for containers to complete, and thus ID match no longer is blocked by PID run
* `run_next` now returns a bool to signify whether or not a stage was run
* `_find_eligible_stages` doesn't return stages who have status "started" since in progress stages aren't eligible to run.

## Why

* A <6 minute thrift latency is better than a >96 minute thrift latency

## Next diff

{F650174314}

Differential Revision: D30417269

