### PR TITLE
Remove LocalMPCInstanceRepository dependency from FBPCP (#128)

### DIFF
--- a/fbpmp/common/tests/repository/test_instance_local.py
+++ b/fbpmp/common/tests/repository/test_instance_local.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from pathlib import Path
+from unittest.mock import mock_open, MagicMock, patch
+
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpmp.common.repository.instance_local import LocalInstanceRepository
+
+TEST_BASE_DIR = Path("./")
+TEST_INSTANCE_ID = "test-instance-id"
+TEST_GAME_NAME = "lift"
+TEST_MPC_PARTY = MPCParty.SERVER
+TEST_NUM_WORKERS = 1
+TEST_SERVER_IPS = ["192.0.2.0"]
+TEST_GAME_ARGS = [{}]
+ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
+ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
+
+
+class TestLocalInstanceRepository(unittest.TestCase):
+    def setUp(self):
+        self.mpc_instance = MPCInstance.create_instance(
+            instance_id=TEST_INSTANCE_ID,
+            game_name=TEST_GAME_NAME,
+            mpc_party=TEST_MPC_PARTY,
+            num_workers=TEST_NUM_WORKERS,
+            server_ips=TEST_SERVER_IPS,
+            status=MPCInstanceStatus.CREATED,
+            game_args=TEST_GAME_ARGS,
+        )
+        self.local_instance_repo = LocalInstanceRepository(TEST_BASE_DIR)
+
+    def test_create_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=True)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_ALREADY_EXISTS):
+            self.local_instance_repo.create(self.mpc_instance)
+
+    @patch("builtins.open")
+    def test_create_non_existing_instance(self, mock_open):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        self.assertIsNone(self.local_instance_repo.create(self.mpc_instance))
+        mock_open.assert_called_with(path, "w")
+
+    def test_read_non_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.read(TEST_INSTANCE_ID)
+
+    def test_read_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=True)
+        data = self.mpc_instance.dumps_schema()
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        with patch("builtins.open", mock_open(read_data=data)) as mock_file:
+            self.assertEqual(open(path).read().strip(), data)
+            mpc_instance = MPCInstance.loads_schema(
+                self.local_instance_repo.read(TEST_INSTANCE_ID)
+            )
+            self.assertEqual(self.mpc_instance, mpc_instance)
+            mock_file.assert_called_with(path, "r")
+
+    def test_update_non_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.update(self.mpc_instance)
+
+    @patch("builtins.open")
+    def test_update_existing_instance(self, mock_open):
+        self.local_instance_repo._exist = MagicMock(return_value=True)
+        new_mpc_instance = copy.deepcopy(self.mpc_instance)
+        new_mpc_instance.game_name = "aggregator"
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        self.assertIsNone(self.local_instance_repo.update(new_mpc_instance))
+        mock_open.assert_called_with(path, "w")
+
+    def test_exists(self):
+        self.assertFalse(self.local_instance_repo._exist(TEST_INSTANCE_ID))
+        with patch.object(Path, "exists"):
+            self.assertTrue(self.local_instance_repo._exist(TEST_INSTANCE_ID))
+
+    def test_delete_non_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.delete(TEST_INSTANCE_ID)
+
+    def test_delete_existing_instance(self):
+        with patch.object(Path, "joinpath") as mock_join:
+            with patch.object(Path, "unlink") as mock_unlink:
+                mock_unlink.return_value = None
+                self.assertIsNone(self.local_instance_repo.delete(TEST_INSTANCE_ID))
+                mock_join.assert_called_with(TEST_INSTANCE_ID)

--- a/fbpmp/common/tests/repository/test_instance_s3.py
+++ b/fbpmp/common/tests/repository/test_instance_s3.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import uuid
+from unittest.mock import MagicMock
+
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcp.service.storage_s3 import S3StorageService
+from fbpmp.common.repository.instance_s3 import S3InstanceRepository
+
+
+class TestS3InstanceRepository(unittest.TestCase):
+    TEST_BASE_DIR = "./"
+    TEST_INSTANCE_ID = str(uuid.uuid4())
+    TEST_GAME_NAME = "lift"
+    TEST_MPC_PARTY = MPCParty.SERVER
+    TEST_NUM_WORKERS = 1
+    TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
+    TEST_GAME_ARGS = [{}]
+    ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
+    ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
+
+    def setUp(self):
+        storage_svc = S3StorageService("us-west-1")
+        self.s3_storage_repo = S3InstanceRepository(storage_svc, self.TEST_BASE_DIR)
+        self.mpc_instance = MPCInstance.create_instance(
+            instance_id=self.TEST_INSTANCE_ID,
+            game_name=self.TEST_GAME_NAME,
+            mpc_party=self.TEST_MPC_PARTY,
+            num_workers=self.TEST_NUM_WORKERS,
+            server_ips=self.TEST_SERVER_IPS,
+            status=MPCInstanceStatus.CREATED,
+            game_args=self.TEST_GAME_ARGS,
+        )
+
+    def test_create_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=False)
+        self.s3_storage_repo.s3_storage_svc.write = MagicMock(return_value=None)
+        self.s3_storage_repo.create(self.mpc_instance)
+        self.s3_storage_repo.s3_storage_svc.write.assert_called()
+
+    def test_create_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_ALREADY_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_ALREADY_EXISTS):
+            self.s3_storage_repo.create(self.mpc_instance)
+
+    def test_read_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_NOT_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_NOT_EXISTS):
+            self.s3_storage_repo.read(self.TEST_INSTANCE_ID)
+
+    def test_read_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=True)
+        self.s3_storage_repo.s3_storage_svc.read = MagicMock(
+            return_value=self.mpc_instance.dumps_schema()
+        )
+        instance = MPCInstance.loads_schema(
+            self.s3_storage_repo.read(self.mpc_instance)
+        )
+        self.assertEqual(self.mpc_instance, instance)
+
+    def test_update_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_NOT_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_NOT_EXISTS):
+            self.s3_storage_repo.update(self.mpc_instance)
+
+    def test_update_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=True)
+        self.s3_storage_repo.s3_storage_svc.write = MagicMock(return_value=None)
+        self.s3_storage_repo.update(self.mpc_instance)
+        self.s3_storage_repo.s3_storage_svc.write.assert_called()
+
+    def test_delete_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_NOT_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_NOT_EXISTS):
+            self.s3_storage_repo.delete(self.TEST_INSTANCE_ID)
+
+    def test_delete_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=True)
+        self.s3_storage_repo.s3_storage_svc.delete = MagicMock(return_value=None)
+        self.s3_storage_repo.delete(self.TEST_INSTANCE_ID)
+        self.s3_storage_repo.s3_storage_svc.delete.assert_called()
+
+    def test_exists(self):
+        self.s3_storage_repo.s3_storage_svc.file_exists = MagicMock(return_value=True)
+        self.assertTrue(self.s3_storage_repo._exist(self.TEST_INSTANCE_ID))


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcp/pull/128

Before moving LocalMPCInstanceRepository to FBPCS, we'd like to remove the dependency from FBPCP. Fortunately, it's just used in one unit test.

Next: move LocalMPCInstanceRepository to FBPCS.

Differential Revision: D30418018

