### PR TITLE
Move LocalMPCInstanceRepository to FBPCS

### DIFF
--- a/fbpmp/common/repository/mpc_instance_local.py
+++ b/fbpmp/common/repository/mpc_instance_local.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcp.entity.mpc_instance import MPCInstance
+from fbpcp.repository.instance_local import LocalInstanceRepository
+from fbpcp.repository.mpc_instance import MPCInstanceRepository
+
+
+class LocalMPCInstanceRepository(MPCInstanceRepository):
+    def __init__(self, base_dir: str) -> None:
+        self.repo = LocalInstanceRepository(base_dir)
+
+    def create(self, instance: MPCInstance) -> None:
+        self.repo.create(instance)
+
+    def read(self, instance_id: str) -> MPCInstance:
+        return MPCInstance.loads_schema(self.repo.read(instance_id))
+
+    def update(self, instance: MPCInstance) -> None:
+        self.repo.update(instance)
+
+    def delete(self, instance_id: str) -> None:
+        self.repo.delete(instance_id)

--- a/fbpmp/common/tests/repository/test_instance_local.py
+++ b/fbpmp/common/tests/repository/test_instance_local.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from pathlib import Path
+from unittest.mock import mock_open, MagicMock, patch
+
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpmp.common.repository.instance_local import LocalInstanceRepository
+
+TEST_BASE_DIR = Path("./")
+TEST_INSTANCE_ID = "test-instance-id"
+TEST_GAME_NAME = "lift"
+TEST_MPC_PARTY = MPCParty.SERVER
+TEST_NUM_WORKERS = 1
+TEST_SERVER_IPS = ["192.0.2.0"]
+TEST_GAME_ARGS = [{}]
+ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
+ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
+
+
+class TestLocalInstanceRepository(unittest.TestCase):
+    def setUp(self):
+        self.mpc_instance = MPCInstance.create_instance(
+            instance_id=TEST_INSTANCE_ID,
+            game_name=TEST_GAME_NAME,
+            mpc_party=TEST_MPC_PARTY,
+            num_workers=TEST_NUM_WORKERS,
+            server_ips=TEST_SERVER_IPS,
+            status=MPCInstanceStatus.CREATED,
+            game_args=TEST_GAME_ARGS,
+        )
+        self.local_instance_repo = LocalInstanceRepository(TEST_BASE_DIR)
+
+    def test_create_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=True)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_ALREADY_EXISTS):
+            self.local_instance_repo.create(self.mpc_instance)
+
+    @patch("builtins.open")
+    def test_create_non_existing_instance(self, mock_open):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        self.assertIsNone(self.local_instance_repo.create(self.mpc_instance))
+        mock_open.assert_called_with(path, "w")
+
+    def test_read_non_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.read(TEST_INSTANCE_ID)
+
+    def test_read_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=True)
+        data = self.mpc_instance.dumps_schema()
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        with patch("builtins.open", mock_open(read_data=data)) as mock_file:
+            self.assertEqual(open(path).read().strip(), data)
+            mpc_instance = MPCInstance.loads_schema(
+                self.local_instance_repo.read(TEST_INSTANCE_ID)
+            )
+            self.assertEqual(self.mpc_instance, mpc_instance)
+            mock_file.assert_called_with(path, "r")
+
+    def test_update_non_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.update(self.mpc_instance)
+
+    @patch("builtins.open")
+    def test_update_existing_instance(self, mock_open):
+        self.local_instance_repo._exist = MagicMock(return_value=True)
+        new_mpc_instance = copy.deepcopy(self.mpc_instance)
+        new_mpc_instance.game_name = "aggregator"
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        self.assertIsNone(self.local_instance_repo.update(new_mpc_instance))
+        mock_open.assert_called_with(path, "w")
+
+    def test_exists(self):
+        self.assertFalse(self.local_instance_repo._exist(TEST_INSTANCE_ID))
+        with patch.object(Path, "exists"):
+            self.assertTrue(self.local_instance_repo._exist(TEST_INSTANCE_ID))
+
+    def test_delete_non_existing_instance(self):
+        self.local_instance_repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.delete(TEST_INSTANCE_ID)
+
+    def test_delete_existing_instance(self):
+        with patch.object(Path, "joinpath") as mock_join:
+            with patch.object(Path, "unlink") as mock_unlink:
+                mock_unlink.return_value = None
+                self.assertIsNone(self.local_instance_repo.delete(TEST_INSTANCE_ID))
+                mock_join.assert_called_with(TEST_INSTANCE_ID)

--- a/fbpmp/common/tests/repository/test_instance_s3.py
+++ b/fbpmp/common/tests/repository/test_instance_s3.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import uuid
+from unittest.mock import MagicMock
+
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcp.service.storage_s3 import S3StorageService
+from fbpmp.common.repository.instance_s3 import S3InstanceRepository
+
+
+class TestS3InstanceRepository(unittest.TestCase):
+    TEST_BASE_DIR = "./"
+    TEST_INSTANCE_ID = str(uuid.uuid4())
+    TEST_GAME_NAME = "lift"
+    TEST_MPC_PARTY = MPCParty.SERVER
+    TEST_NUM_WORKERS = 1
+    TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
+    TEST_GAME_ARGS = [{}]
+    ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
+    ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
+
+    def setUp(self):
+        storage_svc = S3StorageService("us-west-1")
+        self.s3_storage_repo = S3InstanceRepository(storage_svc, self.TEST_BASE_DIR)
+        self.mpc_instance = MPCInstance.create_instance(
+            instance_id=self.TEST_INSTANCE_ID,
+            game_name=self.TEST_GAME_NAME,
+            mpc_party=self.TEST_MPC_PARTY,
+            num_workers=self.TEST_NUM_WORKERS,
+            server_ips=self.TEST_SERVER_IPS,
+            status=MPCInstanceStatus.CREATED,
+            game_args=self.TEST_GAME_ARGS,
+        )
+
+    def test_create_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=False)
+        self.s3_storage_repo.s3_storage_svc.write = MagicMock(return_value=None)
+        self.s3_storage_repo.create(self.mpc_instance)
+        self.s3_storage_repo.s3_storage_svc.write.assert_called()
+
+    def test_create_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_ALREADY_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_ALREADY_EXISTS):
+            self.s3_storage_repo.create(self.mpc_instance)
+
+    def test_read_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_NOT_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_NOT_EXISTS):
+            self.s3_storage_repo.read(self.TEST_INSTANCE_ID)
+
+    def test_read_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=True)
+        self.s3_storage_repo.s3_storage_svc.read = MagicMock(
+            return_value=self.mpc_instance.dumps_schema()
+        )
+        instance = MPCInstance.loads_schema(
+            self.s3_storage_repo.read(self.mpc_instance)
+        )
+        self.assertEqual(self.mpc_instance, instance)
+
+    def test_update_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_NOT_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_NOT_EXISTS):
+            self.s3_storage_repo.update(self.mpc_instance)
+
+    def test_update_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=True)
+        self.s3_storage_repo.s3_storage_svc.write = MagicMock(return_value=None)
+        self.s3_storage_repo.update(self.mpc_instance)
+        self.s3_storage_repo.s3_storage_svc.write.assert_called()
+
+    def test_delete_non_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(
+            side_effect=RuntimeError(self.ERROR_MSG_NOT_EXISTS)
+        )
+        with self.assertRaisesRegex(RuntimeError, self.ERROR_MSG_NOT_EXISTS):
+            self.s3_storage_repo.delete(self.TEST_INSTANCE_ID)
+
+    def test_delete_existing_instance(self):
+        self.s3_storage_repo._exist = MagicMock(return_value=True)
+        self.s3_storage_repo.s3_storage_svc.delete = MagicMock(return_value=None)
+        self.s3_storage_repo.delete(self.TEST_INSTANCE_ID)
+        self.s3_storage_repo.s3_storage_svc.delete.assert_called()
+
+    def test_exists(self):
+        self.s3_storage_repo.s3_storage_svc.file_exists = MagicMock(return_value=True)
+        self.assertTrue(self.s3_storage_repo._exist(self.TEST_INSTANCE_ID))

--- a/fbpmp/common/tests/repository/test_mpc_instance_local.py
+++ b/fbpmp/common/tests/repository/test_mpc_instance_local.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from pathlib import Path
+from unittest.mock import mock_open, MagicMock, patch
+
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpmp.common.repository.mpc_instance_local import LocalMPCInstanceRepository
+
+TEST_BASE_DIR = Path("./")
+TEST_INSTANCE_ID = "test-instance-id"
+TEST_GAME_NAME = "lift"
+TEST_MPC_PARTY = MPCParty.SERVER
+TEST_NUM_WORKERS = 1
+TEST_SERVER_IPS = ["192.0.2.0"]
+TEST_GAME_ARGS = [{}]
+ERROR_MSG_ALREADY_EXISTS = f"{TEST_INSTANCE_ID} already exists"
+ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
+
+
+class TestLocalMPCInstanceRepository(unittest.TestCase):
+    def setUp(self):
+        self.mpc_instance = MPCInstance.create_instance(
+            instance_id=TEST_INSTANCE_ID,
+            game_name=TEST_GAME_NAME,
+            mpc_party=TEST_MPC_PARTY,
+            num_workers=TEST_NUM_WORKERS,
+            server_ips=TEST_SERVER_IPS,
+            status=MPCInstanceStatus.CREATED,
+            game_args=TEST_GAME_ARGS,
+        )
+        self.local_instance_repo = LocalMPCInstanceRepository(TEST_BASE_DIR)
+
+    def test_create_existing_instance(self):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=True)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_ALREADY_EXISTS):
+            self.local_instance_repo.create(self.mpc_instance)
+
+    @patch("builtins.open")
+    def test_create_non_existing_instance(self, mock_open):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=False)
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        self.assertIsNone(self.local_instance_repo.create(self.mpc_instance))
+        mock_open.assert_called_with(path, "w")
+
+    def test_read_non_existing_instance(self):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.read(TEST_INSTANCE_ID)
+
+    def test_read_existing_instance(self):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=True)
+        data = self.mpc_instance.dumps_schema()
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        with patch("builtins.open", mock_open(read_data=data)) as mock_file:
+            self.assertEqual(open(path).read().strip(), data)
+            mpc_instance = self.local_instance_repo.read(TEST_INSTANCE_ID)
+            self.assertEqual(self.mpc_instance, mpc_instance)
+            mock_file.assert_called_with(path, "r")
+
+    def test_update_non_existing_instance(self):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.update(self.mpc_instance)
+
+    @patch("builtins.open")
+    def test_update_existing_instance(self, mock_open):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=True)
+        new_mpc_instance = copy.deepcopy(self.mpc_instance)
+        new_mpc_instance.game_name = "aggregator"
+        path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
+        self.assertIsNone(self.local_instance_repo.update(new_mpc_instance))
+        mock_open.assert_called_with(path, "w")
+
+    def test_delete_non_existing_instance(self):
+        self.local_instance_repo.repo._exist = MagicMock(return_value=False)
+        with self.assertRaisesRegex(RuntimeError, ERROR_MSG_NOT_EXISTS):
+            self.local_instance_repo.delete(TEST_INSTANCE_ID)
+
+    def test_delete_existing_instance(self):
+        with patch.object(Path, "joinpath") as mock_join:
+            with patch.object(Path, "unlink") as mock_unlink:
+                mock_unlink.return_value = None
+                self.assertIsNone(self.local_instance_repo.delete(TEST_INSTANCE_ID))
+                mock_join.assert_called_with(TEST_INSTANCE_ID)

--- a/fbpmp/pa_coordinator/config.yml
+++ b/fbpmp/pa_coordinator/config.yml
@@ -56,7 +56,7 @@ mpc:
         PrivateAttributionGameRepository:
           class: fbpmp.private_attribution.repository.private_attribution_game.PrivateAttributionGameRepository
     MPCInstanceRepository:
-      class: fbpcp.repository.mpc_instance_local.LocalMPCInstanceRepository
+      class: fbpmp.common.repository.mpc_instance_local.LocalMPCInstanceRepository
       constructor:
         base_dir: /fbpmp_instances
     ShardingService:

--- a/fbpmp/pl_coordinator/config.yml
+++ b/fbpmp/pl_coordinator/config.yml
@@ -50,7 +50,7 @@ mpc:
         PrivateLiftGameRepository:
           class: fbpmp.private_lift.repository.private_lift_game.PrivateLiftGameRepository
     MPCInstanceRepository:
-      class: fbpcp.repository.mpc_instance_local.LocalMPCInstanceRepository
+      class: fbpmp.common.repository.mpc_instance_local.LocalMPCInstanceRepository
       constructor:
         base_dir: /fbpmp_instances
     ShardingService:

--- a/fbpmp/private_lift/test/service/test_privatelift.py
+++ b/fbpmp/private_lift/test/service/test_privatelift.py
@@ -46,7 +46,7 @@ class TestPrivateLiftService(unittest.TestCase):
         container_svc_patcher = patch("fbpcp.service.container_aws.AWSContainerService")
         storage_svc_patcher = patch("fbpcp.service.storage_s3.S3StorageService")
         mpc_instance_repo_patcher = patch(
-            "fbpcp.repository.mpc_instance_local.LocalMPCInstanceRepository"
+            "fbpmp.common.repository.mpc_instance_local.LocalMPCInstanceRepository"
         )
         pid_instance_repo_patcher = patch(
             "fbpmp.pid.repository.pid_instance_local.LocalPIDInstanceRepository"


### PR DESCRIPTION
Summary:
This diff is to move LocalMPCInstanceRepository to FBPCS completely.

Next: Decouple MPCInstance

Differential Revision: D30418309

