### PR TITLE
Use size() instead of length on emp::Integer

### DIFF
--- a/fbpmp/emp_games/attribution/Timestamp.cpp
+++ b/fbpmp/emp_games/attribution/Timestamp.cpp
@@ -11,7 +11,7 @@
 namespace measurement::private_attribution {
 
 int Timestamp::length() const {
-  return ts_.length;
+  return ts_.size();
 }
 
 emp::Bit Timestamp::geq(const Timestamp& rhs) const {


### PR DESCRIPTION
Summary: The latest version of emp deprecates the `length` field. `size()` returns the same thing, so this diff just future proofs the code.

Reviewed By: leegross

Differential Revision: D30413481

