### PR TITLE
Remove usages of emp::Integer::reveal<std::string>()

### DIFF
--- a/fbpmp/emp_games/attribution/Conversion.h
+++ b/fbpmp/emp_games/attribution/Conversion.h
@@ -46,11 +46,11 @@ struct PrivateConversion {
   T reveal(int party = emp::PUBLIC) const {
     std::stringstream out;
     out << "Conv{ts=";
-    out << ts.reveal<std::string>(party);
+    out << ts.reveal<int64_t>(party);
     out << ", value=";
-    out << conv_value.reveal<std::string>(party);
+    out << conv_value.reveal<int64_t>(party);
     out << ", metadata=";
-    out << conv_metadata.reveal<std::string>(party);
+    out << conv_metadata.reveal<int64_t>(party);
     out << "}";
 
     return out.str();

--- a/fbpmp/emp_games/attribution/Touchpoint.h
+++ b/fbpmp/emp_games/attribution/Touchpoint.h
@@ -108,13 +108,13 @@ struct PrivateTouchpoint {
 
     out << (isClick.reveal<bool>(party) ? "Click{" : "View{");
     out << "id=";
-    out << id.reveal<std::string>(party);
+    out << id.reveal<int64_t>(party);
     out << ", adId=";
-    out << adId.reveal<std::string>(party);
+    out << adId.reveal<int64_t>(party);
     out << ", ts=";
-    out << ts.reveal<std::string>(party);
+    out << ts.reveal<int64_t>(party);
     out << ", campaignMetadata=";
-    out << campaignMetadata.reveal<std::string>(party);
+    out << campaignMetadata.reveal<int64_t>(party);
     out << "}";
 
     return out.str();


### PR DESCRIPTION
Summary: In the next version of emp calling `reveal<std::string>()` on an integer will return the string version of all the bits (i.e. 01010101). This is annoying, but we can just do `reveal<int64_t>` and output that to get the same result.

Reviewed By: peking2

Differential Revision: D30442219

