### PR TITLE
Decouple MPCInstance (#131)

### DIFF
--- a/fbpmp/common/entity/pcs_mpc_instance.py
+++ b/fbpmp/common/entity/pcs_mpc_instance.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, List, Optional
+
+from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.mpc_instance import (
+    MPCInstance,
+    MPCParty,
+    MPCInstanceStatus,
+)
+from fbpmp.common.entity.instance_base import InstanceBase
+
+
+class PCSMPCInstance(MPCInstance, InstanceBase):
+    @classmethod
+    def create_instance(
+        cls,
+        instance_id: str,
+        game_name: str,
+        mpc_party: MPCParty,
+        num_workers: int,
+        server_ips: Optional[List[str]] = None,
+        containers: Optional[List[ContainerInstance]] = None,
+        status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
+        game_args: Optional[List[Dict[str, Any]]] = None,
+    ) -> "PCSMPCInstance":
+        return cls(
+            instance_id,
+            game_name,
+            mpc_party,
+            num_workers,
+            server_ips,
+            containers or [],
+            status,
+            game_args,
+        )
+
+    @classmethod
+    def from_mpc_instance(cls, mpc_instance: MPCInstance) -> "PCSMPCInstance":
+        return cls(
+            mpc_instance.instance_id,
+            mpc_instance.game_name,
+            mpc_instance.mpc_party,
+            mpc_instance.num_workers,
+            mpc_instance.server_ips,
+            mpc_instance.containers,
+            mpc_instance.status,
+            mpc_instance.game_args,
+        )

--- a/fbpmp/common/repository/mpc_instance_local.py
+++ b/fbpmp/common/repository/mpc_instance_local.py
@@ -6,9 +6,11 @@
 
 # pyre-strict
 
+
 from fbpcp.entity.mpc_instance import MPCInstance
-from fbpcp.repository.instance_local import LocalInstanceRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
+from fbpmp.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpmp.common.repository.instance_local import LocalInstanceRepository
 
 
 class LocalMPCInstanceRepository(MPCInstanceRepository):
@@ -16,13 +18,13 @@ class LocalMPCInstanceRepository(MPCInstanceRepository):
         self.repo = LocalInstanceRepository(base_dir)
 
     def create(self, instance: MPCInstance) -> None:
-        self.repo.create(instance)
+        self.repo.create(PCSMPCInstance.from_mpc_instance(instance))
 
-    def read(self, instance_id: str) -> MPCInstance:
-        return MPCInstance.loads_schema(self.repo.read(instance_id))
+    def read(self, instance_id: str) -> PCSMPCInstance:
+        return PCSMPCInstance.loads_schema(self.repo.read(instance_id))
 
     def update(self, instance: MPCInstance) -> None:
-        self.repo.update(instance)
+        self.repo.update(PCSMPCInstance.from_mpc_instance(instance))
 
     def delete(self, instance_id: str) -> None:
         self.repo.delete(instance_id)

--- a/fbpmp/common/tests/repository/test_instance_local.py
+++ b/fbpmp/common/tests/repository/test_instance_local.py
@@ -9,7 +9,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import mock_open, MagicMock, patch
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcp.entity.mpc_instance import MPCInstanceStatus, MPCParty
+from fbpmp.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpmp.common.repository.instance_local import LocalInstanceRepository
 
 TEST_BASE_DIR = Path("./")
@@ -25,7 +26,7 @@ ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
 class TestLocalInstanceRepository(unittest.TestCase):
     def setUp(self):
-        self.mpc_instance = MPCInstance.create_instance(
+        self.mpc_instance = PCSMPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_party=TEST_MPC_PARTY,
@@ -59,7 +60,7 @@ class TestLocalInstanceRepository(unittest.TestCase):
         path = TEST_BASE_DIR.joinpath(TEST_INSTANCE_ID)
         with patch("builtins.open", mock_open(read_data=data)) as mock_file:
             self.assertEqual(open(path).read().strip(), data)
-            mpc_instance = MPCInstance.loads_schema(
+            mpc_instance = PCSMPCInstance.loads_schema(
                 self.local_instance_repo.read(TEST_INSTANCE_ID)
             )
             self.assertEqual(self.mpc_instance, mpc_instance)

--- a/fbpmp/common/tests/repository/test_instance_s3.py
+++ b/fbpmp/common/tests/repository/test_instance_s3.py
@@ -8,8 +8,9 @@ import unittest
 import uuid
 from unittest.mock import MagicMock
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcp.entity.mpc_instance import MPCInstanceStatus, MPCParty
 from fbpcp.service.storage_s3 import S3StorageService
+from fbpmp.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpmp.common.repository.instance_s3 import S3InstanceRepository
 
 
@@ -27,7 +28,7 @@ class TestS3InstanceRepository(unittest.TestCase):
     def setUp(self):
         storage_svc = S3StorageService("us-west-1")
         self.s3_storage_repo = S3InstanceRepository(storage_svc, self.TEST_BASE_DIR)
-        self.mpc_instance = MPCInstance.create_instance(
+        self.mpc_instance = PCSMPCInstance.create_instance(
             instance_id=self.TEST_INSTANCE_ID,
             game_name=self.TEST_GAME_NAME,
             mpc_party=self.TEST_MPC_PARTY,
@@ -62,7 +63,7 @@ class TestS3InstanceRepository(unittest.TestCase):
         self.s3_storage_repo.s3_storage_svc.read = MagicMock(
             return_value=self.mpc_instance.dumps_schema()
         )
-        instance = MPCInstance.loads_schema(
+        instance = PCSMPCInstance.loads_schema(
             self.s3_storage_repo.read(self.mpc_instance)
         )
         self.assertEqual(self.mpc_instance, instance)

--- a/fbpmp/common/tests/repository/test_mpc_instance_local.py
+++ b/fbpmp/common/tests/repository/test_mpc_instance_local.py
@@ -9,7 +9,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import mock_open, MagicMock, patch
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcp.entity.mpc_instance import MPCInstanceStatus, MPCParty
+from fbpmp.common.entity.pcs_mpc_instance import (
+    PCSMPCInstance,
+)
 from fbpmp.common.repository.mpc_instance_local import LocalMPCInstanceRepository
 
 TEST_BASE_DIR = Path("./")
@@ -25,7 +28,7 @@ ERROR_MSG_NOT_EXISTS = f"{TEST_INSTANCE_ID} does not exist"
 
 class TestLocalMPCInstanceRepository(unittest.TestCase):
     def setUp(self):
-        self.mpc_instance = MPCInstance.create_instance(
+        self.mpc_instance = PCSMPCInstance.create_instance(
             instance_id=TEST_INSTANCE_ID,
             game_name=TEST_GAME_NAME,
             mpc_party=TEST_MPC_PARTY,

--- a/fbpmp/private_computation/entity/private_computation_instance.py
+++ b/fbpmp/private_computation/entity/private_computation_instance.py
@@ -11,17 +11,18 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Union, Optional
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus
+from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpmp.common.entity.instance_base import InstanceBase
+from fbpmp.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpmp.pid.entity.pid_instance import PIDInstance, PIDInstanceStatus
+from fbpmp.pid.entity.pid_stages import UnionPIDStage
+from fbpmp.pid.service.pid_service.pid_stage_mapper import STAGE_TO_FILE_FORMAT_MAP
 from fbpmp.post_processing_handler.post_processing_instance import (
     PostProcessingInstance,
     PostProcessingInstanceStatus,
 )
 from fbpmp.private_lift.entity.breakdown_key import BreakdownKey
 from fbpmp.private_lift.entity.pce_config import PCEConfig
-from fbpmp.pid.entity.pid_stages import UnionPIDStage
-from fbpmp.pid.service.pid_service.pid_stage_mapper import STAGE_TO_FILE_FORMAT_MAP
 
 
 class PrivateComputationRole(Enum):
@@ -47,7 +48,7 @@ class PrivateComputationInstanceStatus(Enum):
     PROCESSING_REQUEST = "PROCESSING_REQUEST"
 
 
-UnionedPCInstance = Union[PIDInstance, MPCInstance, PostProcessingInstance]
+UnionedPCInstance = Union[PIDInstance, PCSMPCInstance, PostProcessingInstance]
 UnionedPCInstanceStatus = Union[
     PIDInstanceStatus, MPCInstanceStatus, PostProcessingInstanceStatus
 ]
@@ -61,7 +62,9 @@ class PrivateComputationInstance(InstanceBase):
     status: PrivateComputationInstanceStatus
     status_update_ts: int
     retry_counter: int = 0
-    partial_container_retry_enabled: bool = False  # TODO T98578624: once the product is stabilized, we can enable this
+    partial_container_retry_enabled: bool = (
+        False  # TODO T98578624: once the product is stabilized, we can enable this
+    )
     is_validating: Optional[bool] = False
     synthetic_shard_path: Optional[str] = None
 
@@ -134,7 +137,6 @@ class PrivateComputationInstance(InstanceBase):
     @property
     def data_processing_output_path(self) -> Optional[str]:
         return self._get_stage_output_path("data_processing_stage", "csv")
-
 
     @property
     def compute_stage_output_base_path(self) -> Optional[str]:

--- a/fbpmp/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpmp/private_computation/test/repository/test_private_computation_instance_local.py
@@ -8,7 +8,8 @@ import random
 import string
 import unittest
 
-from fbpcp.entity.mpc_instance import MPCInstance, MPCParty
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpmp.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpmp.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -23,7 +24,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
     def setUp(self):
         instance_id = self._get_random_id()
         self.repo = LocalPrivateComputationInstanceRepository("./")
-        self.test_mpc_instance = MPCInstance.create_instance(
+        self.test_mpc_instance = PCSMPCInstance.create_instance(
             instance_id=instance_id,
             game_name="conversion_lift",
             mpc_party=MPCParty.SERVER,
@@ -40,7 +41,9 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             status_update_ts=1600000000,
         )
         self.repo.create(test_read_private_computation_instance)
-        self.assertEqual(self.repo.read(instance_id), test_read_private_computation_instance)
+        self.assertEqual(
+            self.repo.read(instance_id), test_read_private_computation_instance
+        )
         self.repo.delete(instance_id)
 
     def test_update(self):
@@ -54,7 +57,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)
-        test_mpc_instance_new = MPCInstance.create_instance(
+        test_mpc_instance_new = PCSMPCInstance.create_instance(
             instance_id=instance_id,
             game_name="aggregation",
             mpc_party=MPCParty.SERVER,

--- a/fbpmp/private_lift/test/service/test_privatelift.py
+++ b/fbpmp/private_lift/test/service/test_privatelift.py
@@ -9,8 +9,9 @@ from collections import defaultdict
 from unittest.mock import MagicMock, call, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
-from fbpcp.service.mpc import MPCInstance, MPCInstanceStatus, MPCParty, MPCService
+from fbpcp.service.mpc import MPCInstanceStatus, MPCParty, MPCService
 from fbpcp.service.onedocker import OneDockerService
+from fbpmp.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpmp.data_processing.lift_id_combiner.lift_id_spine_combiner_cpp import (
     CppLiftIdSpineCombinerService,
 )
@@ -179,7 +180,7 @@ class TestPrivateLiftService(unittest.TestCase):
 
         # create one MPC instance to be put into PrivateComputationInstance
         test_mpc_id = "test_mpc_id"
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
             game_name="lift",
             mpc_party=MPCParty.SERVER,
@@ -466,7 +467,7 @@ class TestPrivateLiftService(unittest.TestCase):
         self.pl_service.instance_repository.read = MagicMock(return_value=pl_instance)
 
         # construct an MPC instance as the mocked object returned by _create_and_start_mpc_instance
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
             game_name=test_game_name,
             mpc_party=test_mpc_party,
@@ -528,7 +529,7 @@ class TestPrivateLiftService(unittest.TestCase):
         test_mpc_id = test_pl_id + "_compute_metrics"
         test_game_name = "lift"
         test_num_containers = 2
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
             game_name=test_game_name,
             mpc_party=MPCParty.CLIENT,
@@ -611,7 +612,7 @@ class TestPrivateLiftService(unittest.TestCase):
         test_output_file = "test_output_file"
         test_num_containers = 2
         test_num_shards = 80
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
             game_name="lift",
             mpc_party=MPCParty.SERVER,
@@ -665,7 +666,7 @@ class TestPrivateLiftService(unittest.TestCase):
         # construct a pl_instance
         test_pl_id = "test_pl_id"
         test_compute_output_path = "test_output_file"
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_pl_id + "_aggregate_metrics",
             game_name="shard_aggregator",
             mpc_party=MPCParty.SERVER,
@@ -837,7 +838,7 @@ class TestPrivateLiftService(unittest.TestCase):
 
     def test_get_status_from_stage(self):
         # Test get status from an MPC stage
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id="test_mpc_id",
             game_name="shard_aggregator",
             mpc_party=MPCParty.SERVER,
@@ -978,7 +979,7 @@ class TestPrivateLiftService(unittest.TestCase):
 
         # prepare the pl instance that will be read in to memory from the repository
         # at the beginning of the cancel_current_stage function
-        mpc_instance_started = MPCInstance.create_instance(
+        mpc_instance_started = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
             game_name=test_game_name,
             mpc_party=test_mpc_party,
@@ -995,7 +996,7 @@ class TestPrivateLiftService(unittest.TestCase):
         self.pl_service.instance_repository.read = MagicMock(return_value=pl_instance)
 
         # prepare the mpc instance that's returned from mpc_service.stop_instance()
-        mpc_instance_canceled = MPCInstance.create_instance(
+        mpc_instance_canceled = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
             game_name=test_game_name,
             mpc_party=test_mpc_party,
@@ -1043,7 +1044,7 @@ class TestPrivateLiftService(unittest.TestCase):
 
     def test_gen_game_args_to_retry(self):
         test_input = "test_input_retry"
-        mpc_instance = MPCInstance.create_instance(
+        mpc_instance = PCSMPCInstance.create_instance(
             instance_id="mpc_instance",
             game_name="lift",
             mpc_party=MPCParty.SERVER,


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcp/pull/131

Some design principles
1. core entity should be a plain object which represents data only.
2. repository should maintain a different entity which takes care of serialization/deserialization
3. a mapper should be implemented to transform between entities. That's how we can decouple data and business logic.

This diff is made to reflect the above principles. Basically MPCInstance is very basic and PCSMPCInstance will take care of serialization/deserialization for persistence.

Differential Revision: D30446532

