### PR TITLE
Reorder constructor arguments in Timestamp class

### DIFF
--- a/fbpmp/emp_games/attribution/Timestamp.cpp
+++ b/fbpmp/emp_games/attribution/Timestamp.cpp
@@ -25,7 +25,7 @@ emp::Bit Timestamp::equal(const Timestamp& rhs) const {
 }
 
 emp::Bit Timestamp::operator<(const int64_t rhs) const {
-  return !geq(Timestamp{rhs, minValue_, maxValue_, precision_});
+  return !geq(Timestamp{rhs, emp::PUBLIC, minValue_, maxValue_, precision_});
 }
 
 emp::Bit operator>(int64_t lhs, const Timestamp& rhs) {

--- a/fbpmp/emp_games/attribution/Timestamp.h
+++ b/fbpmp/emp_games/attribution/Timestamp.h
@@ -81,10 +81,10 @@ class Timestamp : public emp::Swappable<Timestamp>,
  public:
   explicit Timestamp(
       int64_t ts,
+      int party = emp::PUBLIC,
       int64_t minValue = kDefaultMinValue,
       int64_t maxValue = kDefaultMaxValue,
-      Precision p = kDefaultPrecision,
-      int party = emp::PUBLIC)
+      Precision p = kDefaultPrecision)
       : Timestamp{
             minValue,
             maxValue,

--- a/fbpmp/emp_games/attribution/test/TimestampTest.cpp
+++ b/fbpmp/emp_games/attribution/test/TimestampTest.cpp
@@ -20,7 +20,7 @@ TEST(TimestampTest, TestLength) {
     Timestamp ts1{86400};
     EXPECT_EQ(ts1.length(), 64);
 
-    Timestamp ts2{100, 0, 15359, Precision::MINUTES};
+    Timestamp ts2{100, emp::PUBLIC, 0, 15359, Precision::MINUTES};
     EXPECT_EQ(ts2.length(), 8);
   });
 }
@@ -62,7 +62,7 @@ TEST(TimestampTest, TestReveal) {
     EXPECT_EQ(ts1.reveal<int64_t>(), 1000);
     EXPECT_EQ(ts1.reveal<std::string>(), "1000");
 
-    Timestamp ts2{3000, -65536, 65535, Precision::MINUTES};
+    Timestamp ts2{3000, emp::PUBLIC, -65536, 65535, Precision::MINUTES};
     EXPECT_EQ(ts2.reveal<int64_t>(), 3000);
     EXPECT_EQ(ts2.reveal<std::string>(), "3000");
   });


### PR DESCRIPTION
Summary: In a future diff I'll pass the `party` into the `Timestamp` constructor. This is just a simple reordering so we don't need to explicitly specify the min/max/precision when we do that.

Reviewed By: gorel

Differential Revision: D30432065

