### PR TITLE
Make num_files_per_mpc_container required

### DIFF
--- a/fbpmp/pl_coordinator/pl_coordinator.py
+++ b/fbpmp/pl_coordinator/pl_coordinator.py
@@ -10,7 +10,7 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> [--num_containers=<num_containers> --input_path=<input_path> --output_dir=<output_dir>] [options]
+    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> [--num_containers=<num_containers> --input_path=<input_path> --output_dir=<output_dir> --num_files_per_mpc_container=<num_files_per_mpc_container>] [options]
     pl-coordinator id_match <instance_id> --config=<config_file> [--num_containers=<num_containers> --input_path=<input_path> --output_path=<output_path> --server_ips=<server_ips> --hmac_key=<base64_key> --fail_fast --dry_run] [options]
     pl-coordinator compute <instance_id> --config=<config_file> [(--num_containers=<num_containers> --spine_path=<spine_path> --data_path=<data_path>) --output_path=<output_path> --server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
     pl-coordinator aggregate <instance_id> --config=<config_file> [(--input_path=<input_path> --num_shards=<num_shards>) --output_path=<output_path> --server_ips=<server_ips> --dry_run] [options]
@@ -53,7 +53,9 @@ from fbpmp.pl_coordinator.pl_service_wrapper import (
     cancel_current_stage,
 )
 from fbpmp.pl_coordinator.pl_study_runner import run_study
-from fbpmp.private_computation.entity.private_computation_instance import PrivateComputationRole
+from fbpmp.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
 
 
 def main():
@@ -95,6 +97,7 @@ def main():
             "--aggregated_result_path": schema.Or(None, str),
             "--expected_result_path": schema.Or(None, str),
             "--num_containers": schema.Or(None, schema.Use(int)),
+            "--num_files_per_mpc_container": schema.Or(None, schema.Use(int)),
             "--num_shards": schema.Or(None, schema.Use(int)),
             "--server_ips": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
             "--concurrency": schema.Or(None, schema.Use(int)),
@@ -126,6 +129,7 @@ def main():
             role=arguments["--role"],
             logger=logger,
             num_containers=arguments["--num_containers"],
+            num_files_per_mpc_container=arguments["--num_files_per_mpc_container"],
             input_path=arguments["--input_path"],
             output_dir=arguments["--output_dir"],
         )

--- a/fbpmp/private_computation/entity/private_computation_instance.py
+++ b/fbpmp/private_computation/entity/private_computation_instance.py
@@ -61,6 +61,7 @@ class PrivateComputationInstance(InstanceBase):
     instances: List[UnionedPCInstance]
     status: PrivateComputationInstanceStatus
     status_update_ts: int
+    num_files_per_mpc_container: int
     retry_counter: int = 0
     partial_container_retry_enabled: bool = (
         False  # TODO T98578624: once the product is stabilized, we can enable this
@@ -77,7 +78,6 @@ class PrivateComputationInstance(InstanceBase):
     hmac_key: Optional[str] = None
     num_pid_containers: Optional[int] = None
     num_mpc_containers: Optional[int] = None
-    num_files_per_mpc_container: Optional[int] = None
     padding_size: Optional[int] = None
 
     concurrency: int = 1
@@ -93,7 +93,6 @@ class PrivateComputationInstance(InstanceBase):
     compute_output_path: Optional[
         str
     ] = None  # assign when compute; reused by aggregate
-    compute_num_shards: Optional[int] = None  # assign when compute; reused by aggregate
     aggregated_result_path: Optional[
         str
     ] = None  # assign when aggregate; reused by post processing handlers

--- a/fbpmp/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpmp/private_computation/test/repository/test_private_computation_instance_local.py
@@ -39,6 +39,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             instances=[self.test_mpc_instance],
             status=PrivateComputationInstanceStatus.CREATED,
             status_update_ts=1600000000,
+            num_files_per_mpc_container=40,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -54,6 +55,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             instances=[self.test_mpc_instance],
             status=PrivateComputationInstanceStatus.CREATED,
             status_update_ts=1600000000,
+            num_files_per_mpc_container=40,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)


### PR DESCRIPTION
Summary: `num_files_per_mpc_container` is a piece of information that's required to complete a Private Computation. When creating a PA instance, it's already required ([code pointer](https://fburl.com/diffusion/r45hnlpr)) for the user to provide it. For PL, it's not required to be passed in from the user because it always uses a hard-coded value = 40. Either case, it makes sense to save this information in PrivateComputationInstance as a required attribute.

Differential Revision: D30500380

