### PR TITLE
semi-automated data ingestion: Initial AWS resource definitions by terraform script

### DIFF
--- a/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
+++ b/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
@@ -1,0 +1,87 @@
+resource "aws_s3_bucket_object" "upload_glue_ETL" {
+  bucket = "${var.app_data_input_bucket}${var.tag_postfix}"
+  key    = "glue_ETL.py"
+  source = "glue_ETL.py"
+  etag   = filemd5("glue_ETL.py")
+}
+
+resource "aws_iam_role" "glue_ETL_role" {
+  name               = "glue-service-role${var.tag_postfix}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "glue.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "glue_service" {
+  role       = "${aws_iam_role.glue_ETL_role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_s3_access" {
+  role       = "${aws_iam_role.glue_ETL_role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role_policy" "s3_policy" {
+  name   = "s3-policy${var.tag_postfix}"
+  role   = "${aws_iam_role.glue_ETL_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${var.app_data_input_bucket}",
+        "arn:aws:s3:::${var.app_data_input_bucket}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "kms_policy_glue" {
+  name   = "kms-policy${var.tag_postfix}"
+  role   = "${aws_iam_role.glue_ETL_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "kms:*",
+      "Resource": [
+        "arn:aws:kms:*:${var.aws_account_id}:key/*",
+        "arn:aws:kms:*:${var.aws_account_id}:alias/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_glue_job" "glue_job" {
+  name     = "glue-ETL${var.tag_postfix}"
+  role_arn = aws_iam_role.glue_ETL_role.arn
+
+  command {
+    script_location = "s3://${var.app_data_input_bucket}${var.tag_postfix}/glue_ETL.py"
+  }
+}

--- a/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
+++ b/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
@@ -1,0 +1,110 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+#########################################
+### IMPORT LIBRARIES AND SET VARIABLES
+#########################################
+
+#Import python modules
+from datetime import datetime
+import sys
+
+#Import pyspark modules
+from pyspark.context import SparkContext
+from pyspark.sql.functions import col,year,month,dayofmonth,hour,to_date,lit,from_unixtime
+from pyspark.sql.types import IntegerType
+
+#Import glue modules
+from awsglue.utils import getResolvedOptions
+from awsglue.context import GlueContext
+from awsglue.dynamicframe import DynamicFrame
+
+
+#Initialize contexts and session
+spark_context = SparkContext.getOrCreate()
+glue_context = GlueContext(spark_context)
+session = glue_context.spark_session
+
+args = getResolvedOptions(sys.argv,
+                          ['JOB_NAME',
+                           's3_read_path',
+                           's3_write_path'])
+
+#Parameters
+
+s3_options = {"paths": ["s3://" + args['s3_read_path']]}
+s3_write_path = "s3://" + args['s3_write_path']
+#########################################
+### EXTRACT (READ DATA)
+#########################################
+
+#Log starting time
+dt_start = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+print("Start time:", dt_start)
+
+# read data from s3 directly
+dynamic_frame_read = glue_context.create_dynamic_frame.from_options(
+    connection_type="s3",
+    connection_options=s3_options,
+    format="csv",
+    format_options={"withHeader": True},
+)  # format_options go by default
+
+# #Convert dynamic frame to data frame to use standard pyspark functions
+data_frame = dynamic_frame_read.toDF()
+
+### debug
+data_frame.show(10)
+
+#########################################
+### TRANSFORM (MODIFY DATA)
+#########################################
+
+# create columns
+augmented_df = (
+    data_frame.withColumn("unixtime", data_frame["timestamp"].cast(IntegerType()))
+    .withColumn("action_source", lit("app"))
+    .withColumn("date_col", to_date(from_unixtime(col("unixtime"))))
+    .withColumn("year", year(col("date_col")))
+    .withColumn("month", month(col("date_col")))
+    .withColumn("day", dayofmonth(col("date_col")))
+    .withColumn("hour", hour(col("date_col")))
+    .drop(col("date_col"))
+    .drop(col("unixtime"))
+    .repartition(1)
+)
+
+#Print result table
+#Note: Show function is an action. Actions force the execution of the data frame plan.
+#With big data the slowdown would be significant without cacching.
+final_df = augmented_df
+final_df.show(10)
+
+#########################################
+### LOAD (WRITE DATA)
+#########################################
+
+#Create just 1 partition, because there is so little data
+final_df = final_df.repartition(1)
+
+#Convert back to dynamic frame
+dynamic_frame_write = DynamicFrame.fromDF(final_df, glue_context, "dynamic_frame_write")
+
+#Write data back to S3
+glue_context.write_dynamic_frame.from_options(
+frame = dynamic_frame_write,
+connection_type = "s3",
+connection_options = {
+"path": s3_write_path,
+#Here you could create S3 prefixes according to a values in specified columns
+"partitionKeys": ["year", "month", "day", "hour"]
+},
+format = "json"
+)
+
+#Log end time
+dt_end = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+print("End time:", dt_end)

--- a/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
+++ b/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
@@ -1,0 +1,117 @@
+resource "aws_kms_key" "s3_kms_key" {
+  description = "This key is used to encrypt bucket objects"
+}
+
+resource "aws_s3_bucket" "app_data_bucket" {
+  bucket = "${var.app_data_input_bucket}${var.tag_postfix}"
+  versioning {
+    enabled = true
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.s3_kms_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+      bucket_key_enabled = true
+    }
+  }
+
+}
+
+data "archive_file" "zip_lambda" {
+  type        = "zip"
+  source_file = "lambda_trigger.py"
+  output_path = "${var.lambda_trigger_s3_key}"
+}
+
+resource "aws_s3_bucket_object" "upload_lambda_trigger" {
+  bucket = "${var.app_data_input_bucket}${var.tag_postfix}"
+  key    = "${var.lambda_trigger_s3_key}"
+  source = "${var.lambda_trigger_s3_key}"
+  etag   = filemd5("lambda_trigger.py")
+
+}
+
+resource "aws_iam_role" "lambda_iam" {
+  name = "lambda-iam${var.tag_postfix}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_lambda_function" "lambda_trigger" {
+  s3_bucket     = "${var.app_data_input_bucket}"
+  s3_key        = "${var.lambda_trigger_s3_key}"
+  function_name = "semi-automated-data-ingestion-trigger${var.tag_postfix}"
+  role          = aws_iam_role.lambda_iam.arn
+  handler       = "lambda_trigger.lambda_handler"
+  runtime       = "python3.8"
+  timeout       = 60
+  environment {
+    variables = {
+      DEBUG = "false"
+    }
+  }
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.app_data_bucket.id
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.lambda_trigger.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_suffix       = ".csv"
+  }
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda_trigger.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.app_data_bucket.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_glue_service_role" {
+  role       = "${aws_iam_role.lambda_iam.id}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_cloudwatch" {
+  role       = "${aws_iam_role.lambda_iam.id}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "kms_policy_lambda" {
+  name   = "lambda-kms-policy${var.tag_postfix}"
+  role   = "${aws_iam_role.lambda_iam.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "kms:*",
+      "Resource": [
+        "arn:aws:kms:*:${var.aws_account_id}:key/*",
+        "arn:aws:kms:*:${var.aws_account_id}:alias/*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
+++ b/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import print_function
+
+# Set up logging
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# Import Boto 3 for AWS Glue
+import boto3
+
+client = boto3.client("glue")
+
+# Variables for the job:
+# same name as the aws_glue_job resource in glue.tf
+# [TODO]: in deploy.sh replace the hardcoded name with shell edits (i.e., sed i...)
+glueJobName = "glue-ETL"
+
+# Define Lambda function
+def lambda_handler(event, context):
+
+    ### should be one single upload (it should be larger than 1 by default)
+    if len(event["Records"]) >= 2:
+        logger.info("multiple csv uploaded. please upload only one csv at a time")
+    elif len(event["Records"]) == 0:
+        logger.info("no csv uploaded to S3. wrong trigger of lambda")
+    else:
+        record = event["Records"][0]
+
+        ### extract s3 bucket and path
+        s3_info = record["s3"]
+        logger.info("s3_info: ")
+        logger.info(s3_info)
+        s3_bucket = s3_info["bucket"]["name"]
+        s3_object_key = s3_info["object"]["key"]
+        s3_read_path = s3_bucket + "/" + s3_object_key
+        # [TODO: current s3_write_path is hardcoded, will be updated when integrating into deploy.sh]
+        s3_write_path = "semi-automated-app-event-ingestion/write/"
+        logger.info("s3_read_path: " + s3_read_path)
+        response = client.start_job_run(
+            JobName=glueJobName,
+            Arguments={
+                "--s3_read_path": s3_read_path,
+                "--s3_write_path": s3_write_path,
+            },
+        )
+        logger.info("## STARTED GLUE JOB: " + glueJobName)
+        logger.info("## GLUE JOB RUN ID: " + response["JobRunId"])
+        return response

--- a/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/main.tf
+++ b/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  profile = "default"
+  region  = var.region
+}
+
+provider "archive" {}
+
+terraform {
+  backend "s3" {}
+}

--- a/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/variable.tf
+++ b/fbpmp/infra/cloud_bridge/semi_automated_data_ingestion/variable.tf
@@ -1,0 +1,24 @@
+variable "region" {
+  description = "region of the aws resources"
+  default     = "us-west-2"
+}
+
+variable "app_data_input_bucket" {
+  description = "S3 bucket for advertisers to upload app data and necessary python scripts"
+  default     = ""
+}
+
+variable "lambda_trigger_s3_key" {
+  description = "Source S3 key for lambda trigger function used in semi-automated data ingestion"
+  default     = ""
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}
+
+variable "aws_account_id" {
+  description = "your aws account id, that's used to read encrypted S3 files"
+  default     = ""
+}


### PR DESCRIPTION
Summary:
**Context**
semi-automated data ingestion is a mitigation to support semi-automated app events ingestion for Cloudbridge. It could also be a generic, semi-automated solution for ingesting any other event types in future.

More details can be found in this design doc: https://docs.google.com/document/d/1fGiwVHVIG3xa5fuQR80d-Z43vpXaE2yZDWoB6F892Hk/edit?usp=sharing

**What**

In this diff, we have two python scripts:
1) `lambda_trigger.py`: a trigger function when a new dataset (in csv format) uploaded to a given S3 bucket.
2) `glue_ETL.py`: the ETL python script to process the data and merge with the same S3 destination of the standard CB data ingestion pipeline.
3) `main.tf`, `lambda.tf`, `glue.tf`, `variable.tf`: `main.tf` contains the necessary init, `lambda.tf` (`glue.tf`) contains all resources related to lambda trigger function (glue etl jobs). `variable.tf` contains all variables being used.

**Next**
1. Integrate these tf scripts and python scripts into deploy.sh
2. load test (maximum data size per dataset)

Differential Revision: D30535385

