### PR TITLE
Add tests for AttributionRule

### DIFF
--- a/fbpmp/emp_games/attribution/Conversion.h
+++ b/fbpmp/emp_games/attribution/Conversion.h
@@ -26,7 +26,8 @@ struct Conversion {
     return a.ts == b.ts && a.conv_value == b.conv_value;
   }
   friend std::ostream& operator<<(std::ostream& os, const Conversion& conv) {
-    return os << "Conv{ts=" << conv.ts << ", value=" << conv.conv_value << ", metadata=" << conv.conv_metadata << "}";
+    return os << "Conv{ts=" << conv.ts << ", value=" << conv.conv_value
+              << ", metadata=" << conv.conv_metadata << "}";
   }
 };
 
@@ -34,6 +35,12 @@ struct PrivateConversion {
   Timestamp ts;
   emp::Integer conv_value;
   emp::Integer conv_metadata;
+
+  PrivateConversion(
+      const Timestamp& _ts,
+      const emp::Integer& _conv_value,
+      const emp::Integer& _conv_metadata)
+      : ts{_ts}, conv_value{_conv_value}, conv_metadata{_conv_metadata} {}
 
   // emp::batcher based construction support
   PrivateConversion(int len, const emp::block* b)

--- a/fbpmp/emp_games/attribution/test/AttributionRuleTest.cpp
+++ b/fbpmp/emp_games/attribution/test/AttributionRuleTest.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <fbpcf/mpc/EmpTestUtil.h>
+
+#include "../AttributionRule.h"
+
+namespace measurement::private_attribution {
+
+PrivateTouchpoint createTouchpoint(bool isClick, int64_t ts) {
+  return PrivateTouchpoint{
+      emp::Bit{/*isValid*/ true},
+      emp::Bit{isClick},
+      emp::Integer{INT_SIZE, /*adID*/ 100},
+      Timestamp{ts},
+      emp::Integer{INT_SIZE, /*id*/ 101},
+      emp::Integer{INT_SIZE, /*campaignMetadata*/ 102}};
+}
+
+PrivateConversion createConversion(int64_t ts) {
+  return PrivateConversion{
+      Timestamp{ts},
+      emp::Integer{INT_SIZE, /*conv_value*/ 1000},
+      emp::Integer{INT_SIZE, /*conv_metadata*/ 1001}};
+}
+
+class AttributionRuleTest
+    : public testing::TestWithParam<std::pair<int64_t, int64_t>> {};
+
+TEST_P(AttributionRuleTest, TestIsAttributable) {
+  fbpcf::mpc::wrapTest<std::function<void()>>([]() {
+    auto [clickWindowDurationInDays, impWindowDurationInDays] = GetParam();
+    auto isClickOnlyAttributionRule = impWindowDurationInDays == 0;
+    auto attributionRule = AttributionRule::fromNameOrThrow(
+        (isClickOnlyAttributionRule ? "last_click_" : "last_touch_") +
+        std::to_string(clickWindowDurationInDays) + "d");
+
+    auto tpTime = 100;
+    auto validClickConvTime = tpTime + clickWindowDurationInDays * 86400 - 1;
+
+    // Valid click conversion
+    auto tp = createTouchpoint(/*isClick*/ true, tpTime);
+    auto conv = createConversion(validClickConvTime);
+
+    EXPECT_TRUE(attributionRule.isAttributable(tp, conv).reveal<bool>());
+
+    if (isClickOnlyAttributionRule) {
+      // Not click conversion
+      tp = createTouchpoint(/*isClick*/ false, tpTime);
+      conv = createConversion(validClickConvTime);
+
+      EXPECT_FALSE(attributionRule.isAttributable(tp, conv).reveal<bool>());
+    } else {
+      // Valid impression conversion
+      tp = createTouchpoint(/*isClick*/ false, tpTime);
+      conv = createConversion(tpTime + impWindowDurationInDays * 86400 - 1);
+
+      EXPECT_TRUE(attributionRule.isAttributable(tp, conv).reveal<bool>());
+    }
+
+    // Conversion did not occur after touchpoint
+    tp = createTouchpoint(/*isClick*/ true, tpTime);
+    conv = createConversion(tpTime);
+
+    EXPECT_FALSE(attributionRule.isAttributable(tp, conv).reveal<bool>());
+
+    // Click conversion occurred after window ended
+    tp = createTouchpoint(/*isClick*/ true, tpTime);
+    conv = createConversion(tpTime + clickWindowDurationInDays * 86400);
+
+    EXPECT_FALSE(attributionRule.isAttributable(tp, conv).reveal<bool>());
+
+    // Impression conversion occurred after window ended
+    tp = createTouchpoint(/*isClick*/ false, tpTime);
+    conv = createConversion(tpTime + impWindowDurationInDays * 86400);
+
+    EXPECT_FALSE(attributionRule.isAttributable(tp, conv).reveal<bool>());
+  });
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AttributionRules,
+    AttributionRuleTest,
+    testing::Values(
+        std::make_pair(1, 0),
+        std::make_pair(28, 0),
+        std::make_pair(1, 1),
+        std::make_pair(28, 1)));
+
+} // namespace measurement::private_attribution


### PR DESCRIPTION
Summary:
I know at least last_click_1d is covered by integration tests, but since these are pretty core functions I think it'd be good to have unit tests too.

This diff just adds tests for the `isAttributable` method on `AttributionRule`. I may also add a test for `isNewTouchpointPreferred` in a follow-up diff.

Reviewed By: gorel

Differential Revision: D30498106

