### PR TITLE
Add pce id in the tf scripts

### DIFF
--- a/fbpmp/infra/pce/aws_terraform_template/common/pce/compute.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce/compute.tf
@@ -2,7 +2,8 @@ resource "aws_ecs_cluster" "main" {
   name = "onedocker-cluster${var.tag_postfix}"
 
   tags = {
-    pce-tag = "cluster${var.tag_postfix}"
+    pce-tag      = "cluster${var.tag_postfix}"
+    "pce:pce-id" = var.pce_id
   }
 
   capacity_providers = ["FARGATE"]

--- a/fbpmp/infra/pce/aws_terraform_template/common/pce/networking.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce/networking.tf
@@ -3,7 +3,8 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "onedocker-vpc${var.tag_postfix}"
+    Name         = "onedocker-vpc${var.tag_postfix}"
+    "pce:pce-id" = var.pce_id
   }
 }
 
@@ -26,7 +27,8 @@ resource "aws_subnet" "subnets" {
   availability_zone       = local.az_names[each.key]
   map_public_ip_on_launch = true
   tags = {
-    Name = "onedocker-subnet${var.tag_postfix}"
+    Name         = "onedocker-subnet${var.tag_postfix}"
+    "pce:pce-id" = var.pce_id
   }
 }
 
@@ -34,7 +36,8 @@ resource "aws_internet_gateway" "default" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "onedocker-igw${var.tag_postfix}"
+    Name         = "onedocker-igw${var.tag_postfix}"
+    "pce:pce-id" = var.pce_id
   }
 }
 
@@ -81,6 +84,7 @@ resource "aws_default_security_group" "default" {
   }
 
   tags = {
-    Name = "onedocker-security-group${var.tag_postfix}"
+    Name         = "onedocker-security-group${var.tag_postfix}"
+    "pce:pce-id" = var.pce_id
   }
 }

--- a/fbpmp/infra/pce/aws_terraform_template/common/pce/variable.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce/variable.tf
@@ -29,3 +29,8 @@ variable "ingress_rules" {
   }))
   description = "Security group ingress rules"
 }
+
+variable "pce_id" {
+  type        = string
+  description = "The identifier for marking the cloud resources are in PCE"
+}

--- a/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/cloudwatch.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/cloudwatch.tf
@@ -1,3 +1,6 @@
 resource "aws_cloudwatch_log_group" "onedocker_cloudwatch_log_group" {
   name = "/ecs/onedocker-container${var.tag_postfix}"
+  tags = {
+    "pce:pce-id" = var.pce_id
+  }
 }

--- a/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/compute.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/compute.tf
@@ -14,7 +14,10 @@ resource "aws_ecs_task_definition" "onedocker_task_def" {
   task_role_arn            = data.aws_arn.ecs_task_role.arn
   execution_role_arn       = data.aws_arn.ecs_task_execution_role_arn.arn
   requires_compatibilities = ["FARGATE"]
-  container_definitions    = <<DEFINITION
+  tags = {
+    "pce:pce-id" = var.pce_id
+  }
+  container_definitions = <<DEFINITION
 [
   {
     "name": "onedocker-container${var.tag_postfix}",

--- a/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/iam.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/iam.tf
@@ -1,5 +1,8 @@
 resource "aws_iam_role" "onedocker_ecs_task_execution_role" {
   name = "onedocker-ecs-task-execution-role${var.tag_postfix}"
+  tags = {
+    "pce:pce-id" = var.pce_id
+  }
 
   assume_role_policy = <<EOF
 {
@@ -20,6 +23,9 @@ EOF
 
 resource "aws_iam_role" "onedocker_ecs_task_role" {
   name = "onedocker-ecs-task-role${var.tag_postfix}"
+  tags = {
+    "pce:pce-id" = var.pce_id
+  }
 
   assume_role_policy = <<EOF
 {

--- a/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/variable.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/common/pce_shared/variable.tf
@@ -17,3 +17,8 @@ variable "aws_account_id" {
   description = "your aws account id, that's used to create the task_execution_role and task_role"
   default     = ""
 }
+
+variable "pce_id" {
+  type        = string
+  description = "The identifier for marking the cloud resources are in PCE"
+}

--- a/fbpmp/infra/pce/aws_terraform_template/partner/vpc_peering/main.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/partner/vpc_peering/main.tf
@@ -13,6 +13,7 @@ resource "aws_vpc_peering_connection" "vpc_peering_conn" {
   vpc_id        = var.vpc_id
 
   tags = {
-    Name = "onedocker-vpc-peering${var.tag_postfix}"
+    Name         = "onedocker-vpc-peering${var.tag_postfix}"
+    "pce:pce-id" = var.pce_id
   }
 }

--- a/fbpmp/infra/pce/aws_terraform_template/partner/vpc_peering/variable.tf
+++ b/fbpmp/infra/pce/aws_terraform_template/partner/vpc_peering/variable.tf
@@ -32,3 +32,8 @@ variable "destination_cidr_block" {
   description = "The CIDR block of the peer VPC"
   default     = "10.0.0.0/16"
 }
+
+variable "pce_id" {
+  type        = string
+  description = "The identifier for marking the cloud resources are in PCE"
+}


### PR DESCRIPTION
Summary:
**Background:** We define the PCE ID as a identifier to get PCE resources in the cloud. More details in https://fb.quip.com/FTvwAjLeiQrt

**What:** Add the PCE id as a mandatory input variable in tf scripts to pass in the PCE id at provisioning phase. With the given id, we create a tag for all PCE resouces with the Key is "pce-id", value is the user input value.

Reviewed By: peking2

Differential Revision: D30454531

