### PR TITLE
Make the config.yml template for PL and PA the same

### DIFF
--- a/fbpmp/pa_coordinator/config.yml
+++ b/fbpmp/pa_coordinator/config.yml
@@ -1,4 +1,4 @@
-private_attribution:
+private_computation:
   dependency:
     PrivateComputationInstanceRepository:
       class: fbpmp.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository
@@ -48,6 +48,11 @@ pid:
       class: fbpmp.pid.repository.pid_instance_local.LocalPIDInstanceRepository
       constructor:
         base_dir: /fbpmp_instances
+  CloudCredentialService:
+    class: fbpmp.pid.service.credential_service.simple_cloud_credential_service.SimpleCloudCredentialService
+    constructor:
+      access_key_id: TODO
+      access_key_data: TODO
 mpc:
   dependency:
     MPCGameService:
@@ -61,3 +66,5 @@ mpc:
         base_dir: /fbpmp_instances
     ShardingService:
       class: fbpmp.data_processing.sharding.sharding_cpp.CppShardingService
+graphapi:
+  access_token: TODO

--- a/fbpmp/pa_coordinator/pa_coordinator.py
+++ b/fbpmp/pa_coordinator/pa_coordinator.py
@@ -171,15 +171,15 @@ def _build_onedocker_binary_cfg_map(
 
 def get_mpc(config: Dict[str, Any], instance_id: str, logger: logging.Logger) -> None:
     container_service = _build_container_service(
-        config["private_attribution"]["dependency"]["ContainerService"]
+        config["private_computation"]["dependency"]["ContainerService"]
     )
     storage_service = _build_storage_service(
-        config["private_attribution"]["dependency"]["StorageService"]
+        config["private_computation"]["dependency"]["StorageService"]
     )
     mpc_service = _build_mpc_service(
         config["mpc"],
         _build_onedocker_service_cfg(
-            config["private_attribution"]["dependency"]["OneDockerServiceConfig"]
+            config["private_computation"]["dependency"]["OneDockerServiceConfig"]
         ),
         container_service,
         storage_service,
@@ -229,7 +229,7 @@ def create_instance(
     k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
 ) -> None:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
     instance = pa_service.create_instance(
         instance_id=instance_id,
@@ -257,7 +257,7 @@ def id_match(
     dry_run: Optional[bool] = False,
 ) -> None:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
 
     # run pid instance through pid service invoked from pa service
@@ -280,7 +280,7 @@ def prepare_compute_input(
     log_cost_to_s3: bool = False,
 ) -> None:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
 
     pa_service.prepare_data(
@@ -304,7 +304,7 @@ def compute_attribution(
     log_cost_to_s3: bool = False,
 ) -> None:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
     logging.info("Starting compute metrics...")
 
@@ -332,7 +332,7 @@ def aggregate_shards(
     log_cost_to_s3: bool = False,
 ) -> None:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
 
     pa_service.update_instance(instance_id)
@@ -352,7 +352,7 @@ def get_instance(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> PrivateComputationInstance:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
 
     pa_instance = pa_service.update_instance(instance_id)
@@ -365,7 +365,7 @@ def get_server_ips(
     instance_id: str,
 ) -> List[str]:
     pa_service = _build_pa_service(
-        config["private_attribution"], config["mpc"], config["pid"]
+        config["private_computation"], config["mpc"], config["pid"]
     )
 
     pa_instance = pa_service.update_instance(instance_id)

--- a/fbpmp/pl_coordinator/config.yml
+++ b/fbpmp/pl_coordinator/config.yml
@@ -1,4 +1,4 @@
-privatelift:
+private_computation:
   dependency:
     PrivateComputationInstanceRepository:
       class: fbpmp.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository
@@ -7,20 +7,28 @@ privatelift:
     ContainerService:
       class: fbpcp.service.container_aws.AWSContainerService
       constructor:
+        # AWS region - ex. us-west-2
         region: TODO
+        # ECS cluster name - ex. pl-cluster-private-attribution-partner
         cluster: TODO
+        # AWS subnet IDs - ex. [subnet-123456789abcdefgh, subnet-987654321abcdefgh]
         subnets: [TODO]
+        # AWS access key
         access_key_id: TODO
+        # AWS access secret
         access_key_data: TODO
     StorageService:
       class: fbpcp.service.storage_s3.S3StorageService
       constructor:
+        # AWS region - ex. us-west-2
         region: TODO
+        # AWS access key
         access_key_id: TODO
+        # AWS access secret
         access_key_data: TODO
     ValidationConfig:
       is_validating: false
-      synthetic_shard_path: TODO
+      synthetic_shard_path:
     OneDockerBinaryConfig:
       default:
         constructor:
@@ -28,6 +36,9 @@ privatelift:
           binary_version: latest
     OneDockerServiceConfig:
       constructor:
+        # TODO: Change this value with pl-task task definition in the following format (see Container Definitions section inside selected task definition revision):
+        # <task definition name>:<revision>#<container name>
+        # ex. pl-task-private-attribution-partner:1#pl-container-private-attribution-partner
         task_definition: TODO_ONEDOCKER_TASK_DEFINITION
 pid:
   dependency:

--- a/fbpmp/pl_coordinator/pl_service_wrapper.py
+++ b/fbpmp/pl_coordinator/pl_service_wrapper.py
@@ -42,7 +42,9 @@ def create_instance(
     num_mpc_containers: Optional[int] = None,
     num_files_per_mpc_container: Optional[int] = None,
 ) -> PrivateComputationInstance:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
     instance = pl_service.create_instance(
         instance_id=instance_id,
         role=role,
@@ -51,7 +53,7 @@ def create_instance(
         num_pid_containers=num_pid_containers,
         num_mpc_containers=num_mpc_containers,
         num_files_per_mpc_container=num_files_per_mpc_container,
-        is_validating=config["privatelift"]["dependency"]["ValidationConfig"][
+        is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
     )
@@ -72,7 +74,9 @@ def id_match(
     hmac_key: Optional[str] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
 
     # run pid instance through pid service invoked from pl service
     pl_service.id_match(
@@ -82,12 +86,12 @@ def id_match(
         input_path=input_path,
         output_path=output_path,
         fail_fast=fail_fast,
-        is_validating=config["privatelift"]["dependency"]["ValidationConfig"][
+        is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
-        synthetic_shard_path=config["privatelift"]["dependency"]["ValidationConfig"][
-            "synthetic_shard_path"
-        ],
+        synthetic_shard_path=config["private_computation"]["dependency"][
+            "ValidationConfig"
+        ]["synthetic_shard_path"],
         pid_config=config["pid"],
         server_ips=server_ips,
         hmac_key=hmac_key,
@@ -114,7 +118,9 @@ def compute(
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
 
     # This call is necessary because it could be the case that last compute failed and this is a valid retry,
     # but because it's possible that the "get" command never gets called to update the instance since the last step started,
@@ -129,7 +135,7 @@ def compute(
     pl_service.prepare_data(
         instance_id=instance_id,
         num_containers=num_containers,
-        is_validating=config["privatelift"]["dependency"]["ValidationConfig"][
+        is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
         spine_path=spine_path,
@@ -146,7 +152,7 @@ def compute(
         concurrency=concurrency or DEFAULT_CONCURRENCY,
         output_path=output_path,
         num_containers=num_containers,
-        is_validating=config["privatelift"]["dependency"]["ValidationConfig"][
+        is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
         server_ips=server_ips,
@@ -167,7 +173,9 @@ def aggregate(
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
 
     # This call is necessary because it could be the case that last aggregate failed and this is a valid retry,
     # or last compute succeeded and this is a regular aggregate. Either way, because it's possible that
@@ -180,7 +188,7 @@ def aggregate(
         output_path=output_path,
         input_path=input_path,
         num_shards=num_shards,
-        is_validating=config["privatelift"]["dependency"]["ValidationConfig"][
+        is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
         server_ips=server_ips,
@@ -197,7 +205,9 @@ def validate(
     aggregated_result_path: str,
     expected_result_path: str,
 ) -> None:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
     pl_service.validate_metrics(
         instance_id=instance_id,
         aggregated_result_path=aggregated_result_path,
@@ -216,7 +226,9 @@ def run_post_processing_handlers(
         logger.warning(f"No post processing configuration found for {instance_id=}")
         return
 
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
 
     post_processing_handlers = {
         name: reflect.get_class(handler_config["class"])(
@@ -247,7 +259,9 @@ def get(
     MPCInstance to this pl instance. Because pl_service.update_instance() also writes to this pl instance, it could
     accidentally erase that PID or MPCInstance.
     """
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
     instance = pl_service.get_instance(instance_id)
     if instance.status in [
         PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
@@ -262,7 +276,9 @@ def get(
 def get_server_ips(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> None:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
 
     pl_instance = pl_service.instance_repository.read(instance_id)
 
@@ -284,19 +300,19 @@ def get_server_ips(
 
 def get_pid(config: Dict[str, Any], instance_id: str, logger: logging.Logger) -> None:
     container_service = _build_container_service(
-        config["privatelift"]["dependency"]["ContainerService"]
+        config["private_computation"]["dependency"]["ContainerService"]
     )
     onedocker_service_config = _build_onedocker_service_cfg(
-        config["privatelift"]["dependency"]["OneDockerServiceConfig"]
+        config["private_computation"]["dependency"]["OneDockerServiceConfig"]
     )
     onedocker_binary_config_map = _build_onedocker_binary_cfg_map(
-        config["privatelift"]["dependency"]["OneDockerBinaryConfig"]
+        config["private_computation"]["dependency"]["OneDockerBinaryConfig"]
     )
     onedocker_service = _build_onedocker_service(
         container_service, onedocker_service_config.task_definition
     )
     storage_service = _build_storage_service(
-        config["privatelift"]["dependency"]["StorageService"]
+        config["private_computation"]["dependency"]["StorageService"]
     )
     pid_service = _build_pid_service(
         config["pid"],
@@ -310,15 +326,15 @@ def get_pid(config: Dict[str, Any], instance_id: str, logger: logging.Logger) ->
 
 def get_mpc(config: Dict[str, Any], instance_id: str, logger: logging.Logger) -> None:
     container_service = _build_container_service(
-        config["privatelift"]["dependency"]["ContainerService"]
+        config["private_computation"]["dependency"]["ContainerService"]
     )
     storage_service = _build_storage_service(
-        config["privatelift"]["dependency"]["StorageService"]
+        config["private_computation"]["dependency"]["StorageService"]
     )
     mpc_service = _build_mpc_service(
         config["mpc"],
         _build_onedocker_service_cfg(
-            config["privatelift"]["dependency"]["OneDockerServiceConfig"]
+            config["private_computation"]["dependency"]["OneDockerServiceConfig"]
         ),
         container_service,
         storage_service,
@@ -331,7 +347,9 @@ def get_mpc(config: Dict[str, Any], instance_id: str, logger: logging.Logger) ->
 def cancel_current_stage(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> PrivateComputationInstance:
-    pl_service = _build_pl_service(config["privatelift"], config["mpc"], config["pid"])
+    pl_service = _build_pl_service(
+        config["private_computation"], config["mpc"], config["pid"]
+    )
     instance = pl_service.cancel_current_stage(instance_id=instance_id)
     logger.info("Done canceling the current stage")
     return instance
@@ -373,7 +391,9 @@ def _build_mpc_service(
     )
 
     mpc_game_config = config["dependency"]["MPCGameService"]
-    pl_game_repo_config = mpc_game_config["dependency"]["PrivateComputationGameRepository"]
+    pl_game_repo_config = mpc_game_config["dependency"][
+        "PrivateComputationGameRepository"
+    ]
     pl_game_repo_class = reflect.get_class(pl_game_repo_config["class"])
     pl_game_repo = pl_game_repo_class()
     mpc_game_class = reflect.get_class(mpc_game_config["class"])


### PR DESCRIPTION
Summary:
There's 1 copy of config.yml template under PL, and another copy under PA. They were already really similar. This diff makes them the same, so `fbpmp/pa_coordinator/config.yml` and `fbpmp/pl_coordinator/config.yml` are exactly the same now. I also have to change all of the other .ymls we use for testing.

Putting it as RFC because I have not aligned with the team on the changes to the .ymls. Details on what's changed:
1. First row is renamed from `privatelift`/`private_attribution` to `private_computation`
2. Add `CloudCredentialService` to PA config.yml template to match with PL
3. Add `graphapi` to PA config.yml template to match with PL

Doing this should help unblock PA + CB deployment integration based on the discussion happening in D30597753.

Differential Revision: D30676350

