### PR TITLE
integrate semi-automated data ingestion pipeline to CB deployment stage

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -42,11 +42,12 @@ ADD deploy.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/deploy.sh
 ADD aws_terraform_template /terraform_deployment/terraform_scripts
 ADD data_ingestion /terraform_deployment/terraform_scripts/data_ingestion
+ADD semi_automated_data_ingestion /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
 ADD config.yml /terraform_deployment
 
-##########################################
+# #########################################
 # Spring Boot
-##########################################
+# #########################################
 ARG JAR_FILE=server/build/libs/*.jar
 COPY ${JAR_FILE} /server/server.jar
 EXPOSE 8080

--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -26,6 +26,11 @@ resource "aws_iam_role_policy_attachment" "glue_service" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
+resource "aws_iam_role_policy_attachment" "glue_console_access" {
+  role       = "${aws_iam_role.glue_service_role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSGlueConsoleFullAccess"
+}
+
 resource "aws_iam_role_policy" "s3_policy" {
   name   = "s3-policy${var.tag_postfix}"
   role   = "${aws_iam_role.glue_service_role.id}"
@@ -88,7 +93,7 @@ resource "aws_glue_crawler" "mpc_events_crawler" {
 
   s3_target {
     path       = "s3://${var.data_processing_output_bucket}"
-    exclusions = ["processing-failed**"]
+    exclusions = ["processing-failed**", "semi-automated-app-data-ingestion/**"]
   }
 
   schedule = "cron(0 * * * ? *)"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
@@ -1,0 +1,9 @@
+output "data_processing_output_bucket_id" {
+  value       = aws_s3_bucket.bucket.id
+  description = "The id of S3 bucked used to store data processing outputs"
+}
+
+output "data_processing_output_bucket_arn" {
+  value       = aws_s3_bucket.bucket.arn
+  description = "The arn of S3 bucked used to store data processing outputs"
+}

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
@@ -1,12 +1,12 @@
 resource "aws_s3_bucket_object" "upload_glue_ETL" {
-  bucket = "${var.app_data_input_bucket}${var.tag_postfix}"
-  key    = "glue_ETL.py"
+  bucket = "${var.app_data_input_bucket_id}"
+  key    = "semi-automated-app-data-ingestion/glue_ETL.py"
   source = "glue_ETL.py"
   etag   = filemd5("glue_ETL.py")
 }
 
 resource "aws_iam_role" "glue_ETL_role" {
-  name               = "glue-service-role${var.tag_postfix}"
+  name               = "glue-ETL-role${var.tag_postfix}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -25,18 +25,18 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "glue_service" {
-  role       = "${aws_iam_role.glue_ETL_role.id}"
+  role       = aws_iam_role.glue_ETL_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_s3_access" {
-  role       = "${aws_iam_role.glue_ETL_role.id}"
+  role       = aws_iam_role.glue_ETL_role.id
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 resource "aws_iam_role_policy" "s3_policy" {
   name   = "s3-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.glue_ETL_role.id}"
+  role   = aws_iam_role.glue_ETL_role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -82,6 +82,9 @@ resource "aws_glue_job" "glue_job" {
   role_arn = aws_iam_role.glue_ETL_role.arn
 
   command {
-    script_location = "s3://${var.app_data_input_bucket}${var.tag_postfix}/glue_ETL.py"
+    script_location = "s3://${var.app_data_input_bucket_id}/semi-automated-data-ingestion/glue_ETL.py"
+  }
+  execution_property {
+    max_concurrent_runs = 10
   }
 }

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
@@ -18,8 +18,7 @@ client = boto3.client("glue")
 
 # Variables for the job:
 # same name as the aws_glue_job resource in glue.tf
-# [TODO]: in deploy.sh replace the hardcoded name with shell edits (i.e., sed i...)
-glueJobName = "glue-ETL"
+glueJobName = 'TO_BE_UPDATED_DURING_DEPLOYMENT'
 
 # Define Lambda function
 def lambda_handler(event, context):
@@ -39,8 +38,7 @@ def lambda_handler(event, context):
         s3_bucket = s3_info["bucket"]["name"]
         s3_object_key = s3_info["object"]["key"]
         s3_read_path = s3_bucket + "/" + s3_object_key
-        # [TODO: current s3_write_path is hardcoded, will be updated when integrating into deploy.sh]
-        s3_write_path = "semi-automated-app-event-ingestion/write/"
+        s3_write_path = 'TO_BE_UPDATED_DURING_DEPLOYMENT'
         logger.info("s3_read_path: " + s3_read_path)
         response = client.start_job_run(
             JobName=glueJobName,

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/variable.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/variable.tf
@@ -8,6 +8,16 @@ variable "app_data_input_bucket" {
   default     = ""
 }
 
+variable "app_data_input_bucket_id" {
+  description = "The ID of the S3 bucket for advertisers to upload app data and necessary python scripts"
+  default     = ""
+}
+
+variable "app_data_input_bucket_arn" {
+  description = "The ARN of the S3 bucket for advertisers to upload app data and necessary python scripts"
+  default     = ""
+}
+
 variable "lambda_trigger_s3_key" {
   description = "Source S3 key for lambda trigger function used in semi-automated data ingestion"
   default     = ""


### PR DESCRIPTION
Summary:
**Context**

1. We have completed the initial AWS configuration through tf scripts in the stacked diffs. So we want to integrate the semi-automated data ingestion pipeline into the deployment stage.

**What**
1. This diff enable terraform creating data ingestion resources in `deploy.sh`. This diff add `terraform init/apply` for `data ingestion` component in `deploy.sh`
2. related load test results: https://fb.quip.com/rOvGA31qQLLr

**Next**
* in Sep, add tests to `deploy.sh`

Differential Revision: D30705920

