### PR TITLE
get rid of docker/terraform interpolation-expression only warning

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -42,11 +42,12 @@ ADD deploy.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/deploy.sh
 ADD aws_terraform_template /terraform_deployment/terraform_scripts
 ADD data_ingestion /terraform_deployment/terraform_scripts/data_ingestion
+ADD semi_automated_data_ingestion /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
 ADD config.yml /terraform_deployment
 
-##########################################
+# #########################################
 # Spring Boot
-##########################################
+# #########################################
 ARG JAR_FILE=server/build/libs/*.jar
 COPY ${JAR_FILE} /server/server.jar
 EXPOSE 8080

--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -26,6 +26,11 @@ resource "aws_iam_role_policy_attachment" "glue_service" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
+resource "aws_iam_role_policy_attachment" "glue_console_access" {
+  role       = "${aws_iam_role.glue_service_role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSGlueConsoleFullAccess"
+}
+
 resource "aws_iam_role_policy" "s3_policy" {
   name   = "s3-policy${var.tag_postfix}"
   role   = "${aws_iam_role.glue_service_role.id}"
@@ -88,7 +93,7 @@ resource "aws_glue_crawler" "mpc_events_crawler" {
 
   s3_target {
     path       = "s3://${var.data_processing_output_bucket}"
-    exclusions = ["processing-failed**"]
+    exclusions = ["processing-failed**", "semi-automated-app-data-ingestion/**"]
   }
 
   schedule = "cron(0 * * * ? *)"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -22,18 +22,18 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "glue_service" {
-  role       = "${aws_iam_role.glue_service_role.id}"
+  role       = aws_iam_role.glue_service_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "glue_console_access" {
-  role       = "${aws_iam_role.glue_service_role.id}"
+  role       = aws_iam_role.glue_service_role.id
   policy_arn = "arn:aws:iam::aws:policy/AWSGlueConsoleFullAccess"
 }
 
 resource "aws_iam_role_policy" "s3_policy" {
   name   = "s3-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.glue_service_role.id}"
+  role   = aws_iam_role.glue_service_role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -55,7 +55,7 @@ EOF
 
 resource "aws_iam_role_policy" "kms_policy_glue" {
   name   = "kms-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.glue_service_role.id}"
+  role   = aws_iam_role.glue_service_role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -16,8 +16,8 @@ data "archive_file" "zip_lambda" {
 }
 
 resource "aws_s3_bucket_object" "upload_lambda" {
-  bucket = "${var.data_processing_lambda_s3_bucket}"
-  key    = "${var.data_processing_lambda_s3_key}"
+  bucket = var.data_processing_lambda_s3_bucket
+  key    = var.data_processing_lambda_s3_key
   source = "lambda.zip"
   etag   = filemd5("data_transformation_lambda.py")
 }
@@ -91,19 +91,19 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_lambda_access" {
-  role       = "${aws_iam_role.firehose_role.id}"
+  role       = aws_iam_role.firehose_role.id
   policy_arn = "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
 }
 
 
 resource "aws_iam_role_policy_attachment" "attach_s3_access" {
-  role       = "${aws_iam_role.firehose_role.id}"
+  role       = aws_iam_role.firehose_role.id
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 resource "aws_iam_role_policy" "kms_policy_firehose" {
   name   = "firehose-kms-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.firehose_role.id}"
+  role   = aws_iam_role.firehose_role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -142,13 +142,13 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_kinesis_role" {
-  role       = "${aws_iam_role.lambda_iam.id}"
+  role       = aws_iam_role.lambda_iam.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
 }
 
 resource "aws_lambda_function" "lambda_processor" {
-  s3_bucket     = "${var.data_processing_lambda_s3_bucket}"
-  s3_key        = "${var.data_processing_lambda_s3_key}"
+  s3_bucket     = var.data_processing_lambda_s3_bucket
+  s3_key        = var.data_processing_lambda_s3_key
   function_name = "cb-data-ingestion-stream-processor${var.tag_postfix}"
   role          = aws_iam_role.lambda_iam.arn
   handler       = "data_transformation_lambda.lambda_handler"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
@@ -1,0 +1,9 @@
+output "data_processing_output_bucket_id" {
+  value       = aws_s3_bucket.bucket.id
+  description = "The id of S3 bucked used to store data processing outputs"
+}
+
+output "data_processing_output_bucket_arn" {
+  value       = aws_s3_bucket.bucket.arn
+  description = "The arn of S3 bucked used to store data processing outputs"
+}

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket_object" "upload_glue_ETL" {
-  bucket = "${var.app_data_input_bucket_id}"
-  key    = "semi-automated-app-data-ingestion/glue_ETL.py"
+  bucket = var.app_data_input_bucket_id
+  key    = "semi-automated-data-ingestion/glue_ETL.py"
   source = "glue_ETL.py"
   etag   = filemd5("glue_ETL.py")
 }
@@ -58,7 +58,7 @@ EOF
 
 resource "aws_iam_role_policy" "kms_policy_glue" {
   name   = "kms-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.glue_ETL_role.id}"
+  role   = aws_iam_role.glue_ETL_role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
@@ -1,12 +1,12 @@
 resource "aws_s3_bucket_object" "upload_glue_ETL" {
-  bucket = "${var.app_data_input_bucket}${var.tag_postfix}"
-  key    = "glue_ETL.py"
+  bucket = "${var.app_data_input_bucket_id}"
+  key    = "semi-automated-app-data-ingestion/glue_ETL.py"
   source = "glue_ETL.py"
   etag   = filemd5("glue_ETL.py")
 }
 
 resource "aws_iam_role" "glue_ETL_role" {
-  name               = "glue-service-role${var.tag_postfix}"
+  name               = "glue-ETL-role${var.tag_postfix}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -25,18 +25,18 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "glue_service" {
-  role       = "${aws_iam_role.glue_ETL_role.id}"
+  role       = aws_iam_role.glue_ETL_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "attach_s3_access" {
-  role       = "${aws_iam_role.glue_ETL_role.id}"
+  role       = aws_iam_role.glue_ETL_role.id
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 resource "aws_iam_role_policy" "s3_policy" {
   name   = "s3-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.glue_ETL_role.id}"
+  role   = aws_iam_role.glue_ETL_role.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -82,6 +82,9 @@ resource "aws_glue_job" "glue_job" {
   role_arn = aws_iam_role.glue_ETL_role.arn
 
   command {
-    script_location = "s3://${var.app_data_input_bucket}${var.tag_postfix}/glue_ETL.py"
+    script_location = "s3://${var.app_data_input_bucket_id}/semi-automated-data-ingestion/glue_ETL.py"
+  }
+  execution_property {
+    max_concurrent_runs = 10
   }
 }

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
@@ -9,9 +9,9 @@ data "archive_file" "zip_lambda" {
 }
 
 resource "aws_s3_bucket_object" "upload_lambda_trigger" {
-  bucket = "${var.app_data_input_bucket_id"
+  bucket = var.app_data_input_bucket_id
   key    = "semi-automated-data-ingestion/${var.lambda_trigger_s3_key}"
-  source = "${var.lambda_trigger_s3_key}"
+  source = "semi-automated-data-ingestion/${var.lambda_trigger_s3_key}"
   etag   = filemd5("lambda_trigger.py")
 
 }
@@ -37,8 +37,8 @@ EOF
 }
 
 resource "aws_lambda_function" "lambda_trigger" {
-  s3_bucket     = "${var.app_data_input_bucket_id}"
-  s3_key        = "${var.lambda_trigger_s3_key}"
+  s3_bucket     = var.app_data_input_bucket_id
+  s3_key        = "semi-automated-data-ingestion/${var.lambda_trigger_s3_key}"
   function_name = "semi-automated-data-ingestion-trigger${var.tag_postfix}"
   role          = aws_iam_role.lambda_iam.arn
   handler       = "lambda_trigger.lambda_handler"
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "lambda_trigger" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = "${var.app_data_input_bucket_id}"
+  bucket = var.app_data_input_bucket_id
   lambda_function {
     lambda_function_arn = aws_lambda_function.lambda_trigger.arn
     events              = ["s3:ObjectCreated:*"]
@@ -65,22 +65,22 @@ resource "aws_lambda_permission" "allow_bucket" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda_trigger.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${var.app_data_input_bucket_arn}"
+  source_arn    = var.app_data_input_bucket_arn
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_glue_service_role" {
-  role       = "${aws_iam_role.lambda_iam.id}"
+  role       = aws_iam_role.lambda_iam.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_cloudwatch" {
-  role       = "${aws_iam_role.lambda_iam.id}"
+  role       = aws_iam_role.lambda_iam.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_role_policy" "kms_policy_lambda" {
   name   = "lambda-kms-policy${var.tag_postfix}"
-  role   = "${aws_iam_role.lambda_iam.id}"
+  role   = aws_iam_role.lambda_iam.id
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
@@ -18,8 +18,7 @@ client = boto3.client("glue")
 
 # Variables for the job:
 # same name as the aws_glue_job resource in glue.tf
-# [TODO]: in deploy.sh replace the hardcoded name with shell edits (i.e., sed i...)
-glueJobName = "glue-ETL"
+glueJobName = 'TO_BE_UPDATED_DURING_DEPLOYMENT'
 
 # Define Lambda function
 def lambda_handler(event, context):
@@ -39,8 +38,7 @@ def lambda_handler(event, context):
         s3_bucket = s3_info["bucket"]["name"]
         s3_object_key = s3_info["object"]["key"]
         s3_read_path = s3_bucket + "/" + s3_object_key
-        # [TODO: current s3_write_path is hardcoded, will be updated when integrating into deploy.sh]
-        s3_write_path = "semi-automated-app-event-ingestion/write/"
+        s3_write_path = 'TO_BE_UPDATED_DURING_DEPLOYMENT'
         logger.info("s3_read_path: " + s3_read_path)
         response = client.start_job_run(
             JobName=glueJobName,

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/variable.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/variable.tf
@@ -8,6 +8,16 @@ variable "app_data_input_bucket" {
   default     = ""
 }
 
+variable "app_data_input_bucket_id" {
+  description = "The ID of the S3 bucket for advertisers to upload app data and necessary python scripts"
+  default     = ""
+}
+
+variable "app_data_input_bucket_arn" {
+  description = "The ARN of the S3 bucket for advertisers to upload app data and necessary python scripts"
+  default     = ""
+}
+
 variable "lambda_trigger_s3_key" {
   description = "Source S3 key for lambda trigger function used in semi-automated data ingestion"
   default     = ""


### PR DESCRIPTION
Summary:
Previously we see the following message:
```Warning: Interpolation-only expressions are deprecated

  on glue.tf line 25, in resource "aws_iam_role_policy_attachment" "glue_service":
  25:   role       = "${aws_iam_role.glue_service_role.id}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```
In this diff, we clean it up by changing
```
"${aws_iam_role.glue_service_role.id}"
```
to
```
aws_iam_role.glue_service_role.id
```

Differential Revision: D30737116

