### PR TITLE
Add cost estimation to decoupled attribution

### DIFF
--- a/fbpmp/emp_games/attribution/CostEstimation.h
+++ b/fbpmp/emp_games/attribution/CostEstimation.h
@@ -43,6 +43,9 @@ class CostEstimation {
     if (app == "attribution") {
       s3Path_ = "pa-logs";
     }
+    else if (app == "attribution_experimental") {
+      s3Path_ = "attr-logs";
+    }
     else if (app == "data_processing") {
       s3Path_ = "dp-logs";
     }


### PR DESCRIPTION
Summary: Add cost estimation to decoupled attribution for enabling performance tests.

Reviewed By: elliottlawrence

Differential Revision: D30736002

