### PR TITLE
update Readme.md

### DIFF
--- a/fbpmp/infra/cloud_bridge/README.md
+++ b/fbpmp/infra/cloud_bridge/README.md
@@ -1,42 +1,59 @@
 This README guide will show you how to run `deploy.sh`.
 
+# Prerequisites
+Install docker and Java
+1. Install docker here: https://www.docker.com/products/docker-desktop
+2. Install Java, and make sure using Java 11.
+  1. go to: https://java.com/en/download/help/download_options.html and following the installation instruction there. Or Use Homebrew. Run the following command:
+         brew install java11 `or` brew cask install java11
+  2. run the following command :
+         java -version
+    you should see the similar messages as follow:
+         openjdk version "11.0.12" 2021-07-20
+         OpenJDK Runtime Environment Homebrew (build 11.0.12+0)
+         OpenJDK 64-Bit Server VM Homebrew (build 11.0.12+0, mixed mode)
+
+
+
+# Run `deploy.sh`
+
 1. Download the `infra` directory
-    * run the following command
+  * run the following command:
 
-        git clone https://github.com/facebookresearch/fbpcs.git
-2. Install docker and Java
-    * https://hub.docker.com/editions/community/docker-ce-desktop-mac
-    * https://java.com/en/download/help/download_options.html
-3. Change to `cloud_bridge` directory
-    * run the following command
+      git clone https://github.com/facebookresearch/fbpcs.git
 
-        cd fbpcs/fbpmp/infra/cloud_bridge
+2. Change to `cloud_bridge` directory
+  * run the following command
+
+      cd fbpcs/fbpmp/infra/cloud_bridge
+  * if encountered permission error, run the following:
+      chmod +x server/gradlew
 4. build the image
-    * run the following command
+  * run the following command
 
-        make image-build
+      make image-build
 5. find your image tag/id:
-    * run one of the following commands
+  * run one of the following commands
 
-        docker image ls
+      docker image ls \
         `or`
-        docker images cloudbridge-private_lift-server
+      docker images cloudbridge-private_lift-server
 6. given the right docker image tag/id, do `docker run`
-    * run the following command
+  * run the following command
 
-        docker run -it <image-tag> /bin/sh
+      docker run -it <image-tag> /bin/sh
 7. initiate helper function
-    * run the following command
+  * run the following command
 
-        /bin/sh ./terraform_deployment/deploy.sh --help
+      /bin/sh ./terraform_deployment/deploy.sh --help
 8. create environment variables on AWS credentials (while be removed eventually)
-    * run the following command
+  * run the following command
 
-        export AWS_ACCESS_KEY_ID=<YOUR_OWN_AWS_ACCESS_KEY>
-        export AWS_SECRET_ACCESS_KEY=<YOUR_OWN_AWS_SECRET_ACCESS_KEY>
-        export TF_LOG=DEBUG
-        export TH_LOG_PATH=/tmp/deploy.log
+      export AWS_ACCESS_KEY_ID=<YOUR_OWN_AWS_ACCESS_KEY> \
+      export AWS_SECRET_ACCESS_KEY=<YOUR_OWN_AWS_SECRET_ACCESS_KEY> \
+      export TF_LOG=DEBUG \
+      export TH_LOG_PATH=/tmp/deploy.log
 9. run `deploy.sh`
-    * run the following command
+ * run the following command
 
-        /bin/sh ./terraform_deployment/deploy.sh -r <> -a <> -p <> -v <> -s <> -d <> -t <>
+      /bin/sh ./terraform_deployment/deploy.sh -r <> -a <> -p <> -v <> -s <> -d <> -t <>


### PR DESCRIPTION
Summary:
as per title. Update Readme.md so that:
1. Adjust indentation It properly displays `commands-to-run`
2. Currently only Java11 is supported. If other Java version installed (e.g. Java16), `make image-build` will complain
3. for the first time running `gradle`, permission error might occur.

Differential Revision: D30794084

