### PR TITLE
Add game_type Enum to PrivateComputationInstance

### DIFF
--- a/fbpcs/private_attribution/service/private_attribution.py
+++ b/fbpcs/private_attribution/service/private_attribution.py
@@ -29,6 +29,7 @@ from fbpcs.pid.entity.pid_instance import PIDProtocol, PIDRole
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -106,6 +107,7 @@ class PrivateAttributionService:
             num_pid_containers=num_pid_containers,
             num_mpc_containers=num_mpc_containers,
             num_files_per_mpc_container=num_files_per_mpc_container,
+            game_type=PrivateComputationGameType.ATTRIBUTION,
             padding_size=padding_size,
             concurrency=concurrency,
             k_anonymity_threshold=k_anonymity_threshold,

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -48,6 +48,11 @@ class PrivateComputationInstanceStatus(Enum):
     PROCESSING_REQUEST = "PROCESSING_REQUEST"
 
 
+class PrivateComputationGameType(Enum):
+    LIFT = "LIFT"
+    ATTRIBUTION = "ATTRIBUTION"
+
+
 UnionedPCInstance = Union[PIDInstance, PCSMPCInstance, PostProcessingInstance]
 UnionedPCInstanceStatus = Union[
     PIDInstanceStatus, MPCInstanceStatus, PostProcessingInstanceStatus
@@ -62,6 +67,8 @@ class PrivateComputationInstance(InstanceBase):
     status: PrivateComputationInstanceStatus
     status_update_ts: int
     num_files_per_mpc_container: int
+    game_type: PrivateComputationGameType
+
     retry_counter: int = 0
     partial_container_retry_enabled: bool = (
         False  # TODO T98578624: once the product is stabilized, we can enable this

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -11,6 +11,7 @@ import unittest
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -40,6 +41,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             status=PrivateComputationInstanceStatus.CREATED,
             status_update_ts=1600000000,
             num_files_per_mpc_container=40,
+            game_type=PrivateComputationGameType.LIFT,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -56,6 +58,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             status=PrivateComputationInstanceStatus.CREATED,
             status_update_ts=1600000000,
             num_files_per_mpc_container=40,
+            game_type=PrivateComputationGameType.LIFT,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -40,6 +40,7 @@ from fbpcs.post_processing_handler.post_processing_instance import (
     PostProcessingInstanceStatus,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -134,6 +135,7 @@ class PrivateLiftService:
             status_update_ts=PrivateLiftService.get_ts_now(),
             num_files_per_mpc_container=num_files_per_mpc_container
             or NUM_NEW_SHARDS_PER_FILE,
+            game_type=PrivateComputationGameType.LIFT,
             is_validating=is_validating,
             synthetic_shard_path=synthetic_shard_path,
             num_pid_containers=num_pid_containers,

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -29,6 +29,7 @@ from fbpcs.pid.entity.pid_instance import (
 )
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -969,6 +970,7 @@ class TestPrivateLiftService(unittest.TestCase):
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
+            game_type=PrivateComputationGameType.LIFT,
             input_path=self.test_input_path,
             output_dir=self.test_output_dir,
         )


### PR DESCRIPTION
Summary:
We need to store a `game_type` attribution in PrivateComputationInstance for PrivateComputationService to use to figure out what binaries to run. See [2/n] and [3/n] in this stack for how I plan to use it.

It's a little crazy that such a small change requires so many lines of unit test changes. I will clean up the unit tests in a later diff.

Differential Revision: D30681076

