### PR TITLE
Fix issue where an exception could cause double deployment

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -163,6 +163,8 @@ public class DeployController {
         return new DeploymentResult(
             DeploymentResultSuccessful.STATUS_FAILED, "Could not start deployment");
       } finally {
+        if (provisioningProcess != null && provisioningProcess.isAlive())
+          provisioningProcess.destroy();
         singleProvisioningLock.unlock();
       }
     } else {
@@ -176,6 +178,11 @@ public class DeployController {
     if (deploymentStatus.status == DeploymentStatusRunning.DEPLOYMENT_NOT_STARTED) {
       return new DeploymentStatus(
           DeploymentStatusRunning.DEPLOYMENT_NOT_STARTED, NO_UPDATES_MESSAGE);
+    }
+
+    if (provisioningProcess == null) {
+      deploymentStatus = new DeploymentStatus();
+      return deploymentStatus;
     }
 
     synchronized (singleUpdateMutex) {


### PR DESCRIPTION
Summary:
This has not been seen in the field, but Process instances, when killed do not terminate the associated subprocesses.
If an exception causes the try-catch loop to exit, effectively releasing the lock preventing multiple deployments, a new one could be started, while the original process keeps going in the background, effectively yielding two deployments

Reviewed By: corbantek, ajaybhargavb

Differential Revision: D30459730

