### PR TITLE
Add logging to PL deployment service

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -40,6 +40,14 @@ done
 
 tag_postfix="-${pce_id}"
 
+if [ -z ${TF_LOG+x} ]; then
+    echo "Terraform Detailed Error Logging Disabled"
+else
+    echo "Terraform Log Level: $TF_LOG"
+    echo "Terraform Log File: $TF_LOG_PATH"
+    echo
+fi
+
 echo "AWS region is $region."
 echo "The string '$tag_postfix' will be appended after the tag of the AWS resources."
 echo "Your AWS acount ID is $aws_account_id"

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -135,6 +135,11 @@ public class DeployController {
         Map<String, String> env = pb.environment();
         env.put("AWS_ACCESS_KEY_ID", deployment.awsAccessKeyId);
         env.put("AWS_SECRET_ACCESS_KEY", deployment.awsSecretAccessKey);
+        if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
+          if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
+          env.put("TF_LOG", deployment.logLevel.getLevel());
+          env.put("TF_LOG_PATH", "/tmp/deploy.log");
+        }
 
         pb.redirectErrorStream(true);
         pb.directory(new File("/terraform_deployment"));

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -8,6 +8,8 @@
 package com.facebook.business.cloudbridge.pl.server;
 
 import com.amazonaws.regions.Regions;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DeploymentParams {
   public String region;
@@ -17,9 +19,43 @@ public class DeploymentParams {
   public String storage;
   public String ingestionOutput;
   public String tag;
+  public LogLevel logLevel;
 
   public String awsAccessKeyId;
   public String awsSecretAccessKey;
+
+  enum LogLevel {
+    DISABLED("Disabled"),
+    ERROR("ERROR"),
+    WARNING("WARN"),
+    INFORMATION("INFO"),
+    DEBUG("DEBUG"),
+    TRACE("TRACE");
+
+    private final String level;
+
+    LogLevel() {
+      this.level = "DEBUG";
+    }
+
+    LogLevel(final String level) {
+      this.level = level;
+    }
+
+    public String getLevel() {
+      return this.level;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static LogLevel getLogLevelFromName(@JsonProperty("logLevel") String level) {
+      for (LogLevel l : LogLevel.values()) {
+        if (l.getLevel().equals(level)) {
+          return l;
+        }
+      }
+      return DEBUG;
+    }
+  }
 
   public boolean validRegion() {
     try {
@@ -80,5 +116,30 @@ public class DeploymentParams {
 
   public boolean validSecretAccessKey() {
     return awsSecretAccessKey != null && !awsSecretAccessKey.isEmpty();
+  }
+
+  public String toString() {
+    StringBuilder sb =
+        new StringBuilder()
+            .append("{region: ")
+            .append(region)
+            .append(", account ID: ")
+            .append(accountId)
+            .append(", publisher account ID: ")
+            .append(pubAccountId)
+            .append(", VPC ID: ")
+            .append(vpcId)
+            .append(", Configuration Storage: ")
+            .append(storage)
+            .append(", Ingestion Output Storage: ")
+            .append(ingestionOutput);
+    if (tag != null) {
+      sb.append(", Tag: ").append(tag);
+    }
+    if (logLevel != null) {
+      sb.append(", Terraform Log Level: ").append(logLevel);
+    }
+    sb.append("}");
+    return sb.toString();
   }
 }


### PR DESCRIPTION
Summary:
Enable flag TF_LOG in Terraform that actually enables debugging output.
Adding TL_LOG_PATH that automatically dumps to given file, if logging is enabled.
Also adding support in Cloudbridge's PL Shell for it

Reviewed By: corbantek

Differential Revision: D30350879

