### PR TITLE
Simplify PL-Coordinator interface and make sure one-command isn't broken

### DIFF
--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -11,17 +11,17 @@ CLI for running a Private Lift study
 
 Usage:
     pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> [--input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> --num_files_per_mpc_container=<num_files_per_mpc_container>] [options]
-    pl-coordinator id_match <instance_id> --config=<config_file> [--num_containers=<num_containers> --input_path=<input_path> --output_path=<output_path> --server_ips=<server_ips> --hmac_key=<base64_key> --fail_fast --dry_run] [options]
-    pl-coordinator compute <instance_id> --config=<config_file> [(--num_containers=<num_containers> --spine_path=<spine_path> --data_path=<data_path>) --output_path=<output_path> --server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
-    pl-coordinator aggregate <instance_id> --config=<config_file> [(--input_path=<input_path> --num_shards=<num_shards>) --output_path=<output_path> --server_ips=<server_ips> --dry_run] [options]
+    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --fail_fast --dry_run] [options]
+    pl-coordinator compute <instance_id> --config=<config_file> [--server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
+    pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
     pl-coordinator run_post_processing_handlers <instance_id> --config=<config_file> [--aggregated_result_path=<aggregated_result_path> --dry_run] [options]
     pl-coordinator get <instance_id> --config=<config_file> [options]
     pl-coordinator get_server_ips <instance_id> --config=<config_file> [options]
     pl-coordinator get_pid <instance_id> --config=<config_file> [options]
     pl-coordinator get_mpc <instance_id> --config=<config_file> [options]
-    pl-coordinator run_instance <instance_id> --config=<config_file> --input_path=<input_path> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
-    pl-coordinator run_instances <instance_ids> --config=<config_file> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
+    pl-coordinator run_instance <instance_id> --config=<config_file> --input_path=<input_path> --num_shards=<num_shards> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
+    pl-coordinator run_instances <instance_ids> --config=<config_file> --input_paths=<input_paths> --num_shards_list=<num_shards_list> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pl-coordinator run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pl-coordinator cancel_current_stage <instance_id> --config=<config_file> [options]
 
@@ -90,17 +90,16 @@ def main():
             "--objective_ids": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
             "--input_path": schema.Or(None, str),
             "--input_paths": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
-            "--spine_path": schema.Or(None, str),
-            "--data_path": schema.Or(None, str),
-            "--output_path": schema.Or(None, str),
             "--output_dir": schema.Or(None, str),
             "--aggregated_result_path": schema.Or(None, str),
             "--expected_result_path": schema.Or(None, str),
-            "--num_containers": schema.Or(None, schema.Use(int)),
             "--num_pid_containers": schema.Or(None, schema.Use(int)),
             "--num_mpc_containers": schema.Or(None, schema.Use(int)),
             "--num_files_per_mpc_container": schema.Or(None, schema.Use(int)),
             "--num_shards": schema.Or(None, schema.Use(int)),
+            "--num_shards_list": schema.Or(
+                None, schema.Use(lambda arg: arg.split(","))
+            ),
             "--server_ips": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
             "--concurrency": schema.Or(None, schema.Use(int)),
             "--hmac_key": schema.Or(None, str),
@@ -141,9 +140,6 @@ def main():
         id_match(
             config=config,
             instance_id=instance_id,
-            num_containers=arguments["--num_containers"],
-            input_path=arguments["--input_path"],
-            output_path=arguments["--output_path"],
             logger=logger,
             fail_fast=arguments["--fail_fast"],
             server_ips=arguments["--server_ips"],
@@ -155,10 +151,6 @@ def main():
         compute(
             config=config,
             instance_id=instance_id,
-            num_containers=arguments["--num_containers"],
-            spine_path=arguments["--spine_path"],
-            data_path=arguments["--data_path"],
-            output_path=arguments["--output_path"],
             concurrency=arguments["--concurrency"],
             logger=logger,
             server_ips=arguments["--server_ips"],
@@ -189,10 +181,7 @@ def main():
         aggregate(
             config=config,
             instance_id=instance_id,
-            output_path=arguments["--output_path"],
             logger=logger,
-            input_path=arguments["--input_path"],
-            num_shards=arguments["--num_shards"],
             server_ips=arguments["--server_ips"],
             dry_run=arguments["--dry_run"],
         )
@@ -211,6 +200,7 @@ def main():
             config=config,
             instance_id=instance_id,
             input_path=arguments["--input_path"],
+            num_shards=["--num_shards"],
             logger=logger,
             num_tries=arguments["--tries_per_stage"],
             dry_run=arguments["--dry_run"],
@@ -220,6 +210,7 @@ def main():
             config=config,
             instance_ids=arguments["<instance_ids>"],
             input_paths=arguments["--input_paths"],
+            num_shards_list=arguments["--num_shards_list"],
             logger=logger,
             num_tries=arguments["--tries_per_stage"],
             dry_run=arguments["--dry_run"],

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -67,9 +67,6 @@ def id_match(
     instance_id: str,
     logger: logging.Logger,
     fail_fast: bool = False,
-    num_containers: Optional[int] = None,
-    input_path: Optional[str] = None,
-    output_path: Optional[str] = None,
     server_ips: Optional[List[str]] = None,
     hmac_key: Optional[str] = None,
     dry_run: Optional[bool] = False,
@@ -82,9 +79,6 @@ def id_match(
     pl_service.id_match(
         instance_id=instance_id,
         protocol=PIDProtocol.UNION_PID,
-        num_containers=num_containers,
-        input_path=input_path,
-        output_path=output_path,
         fail_fast=fail_fast,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
@@ -110,10 +104,6 @@ def compute(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
-    num_containers: Optional[int] = None,
-    spine_path: Optional[str] = None,
-    data_path: Optional[str] = None,
-    output_path: Optional[str] = None,
     concurrency: Optional[int] = None,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
@@ -125,22 +115,14 @@ def compute(
     # This call is necessary because it could be the case that last compute failed and this is a valid retry,
     # but because it's possible that the "get" command never gets called to update the instance since the last step started,
     # so it appears that the current status is still COMPUTATION_STARTED, which is an invalid status for retry.
-    pl_instance = pl_service.update_instance(instance_id)
+    pl_service.update_instance(instance_id)
 
     # TODO T98578552: Take away the option to specify required fields in the middle of a computation
-    output_path = output_path or pl_instance.compute_stage_output_base_path
-    if not output_path:
-        raise ValueError("Unable to find output path for the compute stage")
-
     pl_service.prepare_data(
         instance_id=instance_id,
-        num_containers=num_containers,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
-        spine_path=spine_path,
-        data_path=data_path,
-        output_path=output_path,
         dry_run=dry_run,
     )
 
@@ -150,8 +132,6 @@ def compute(
         instance_id=instance_id,
         game_name=GAME_NAME,
         concurrency=concurrency or DEFAULT_CONCURRENCY,
-        output_path=output_path,
-        num_containers=num_containers,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
@@ -167,9 +147,6 @@ def aggregate(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
-    input_path: Optional[str] = None,
-    num_shards: Optional[int] = None,
-    output_path: Optional[str] = None,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
@@ -185,9 +162,6 @@ def aggregate(
 
     instance = pl_service.aggregate_metrics(
         instance_id=instance_id,
-        output_path=output_path,
-        input_path=input_path,
-        num_shards=num_shards,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],


### PR DESCRIPTION
Summary:
This diff simplifies the PL-Coordinator interface and makes one-command changes accordingly so PL is not broken. The reason I want to simplify the PL-Coordinator interface is so that I can simplify PrivateLiftService interface, which will make consolidating PrivateLiftService and PrivateAttributionService easy. To get more context, see design doc: https://fb.quip.com/CkYwAbQmX5ty. This diff is the PL-Coordinator part of both How 2. & 3.

How to review this diff:
1. The interface of pl_coordinator.py `id_match`, `compute` and `aggregate` commands has been simplified. The pl_service_wrapper.py is also simplified accordingly. I'm able to delete what I deleted from those 2 files because all those arguments are either passed in at the `create_instance` command or inferred within the service, invisible to users.
2. Before this diff, when running pl_coordinator `run_instances` command, the user do not need to pass in the `num_shards_list` (a list of num_shards, one num_shard per computation) argument because one-command has logic that checks the number of ip addresses returned from Graph API response after the ID_MATCH operation request has been made and use that as num_shards. But because we need num_shards now at pl_coordinator `create_instance` time, we have to add this `--num_shards_list` argument.
2. Because of the interface changes of pl_coordinator, this diff then modifies one-command code, which is the direct user of pl_coordinator, in pl_instance_runner.py and pl_study_runner.py, so that they functions the same as before.
3. Finally, modified test_pl_service_wrapper.py and copy a bunch of test resource files so that the tests still pass. It tests the same things as before, but now it looks more similar to test_pa_coordinator.py. I'm hoping to make them look the same eventually and remove one of them.

Differential Revision: D30629415

