### PR TITLE
Mark arguments non-optional at create_instance command

### DIFF
--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -10,7 +10,7 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> [--input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> --num_files_per_mpc_container=<num_files_per_mpc_container>] [options]
+    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--num_files_per_mpc_container=<num_files_per_mpc_container>] [options]
     pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --fail_fast --dry_run] [options]
     pl-coordinator compute <instance_id> --config=<config_file> [--server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
     pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]


### PR DESCRIPTION
Summary:
Addressing the issue jrodal98 brought up [here](https://www.internalfb.com/diff/D30629415 (https://github.com/facebookresearch/fbpcs/commit/758ccf42bec7a5146d7adae0d16038c3b4bdf80c)?dst_version_fbid=440175244098695&transaction_fbid=1422140571500942). I should have marked the arguments changed in this diff as non-optional, otherwise we could potentially create an instance but not able to run the computation because of missing arguments at instance creation time. In production nothing should be broken because One-command doesn't interact with the CLI, instead it calls the functions directly, for example, `fbpcs.pl_coordinator.pl_service_wrapper`.

`num_files_per_mpc_container` can stay optional because PrivateLiftService uses a default value when it's not provided.

Reviewed By: jrodal98

Differential Revision: D30971515

