### PR TITLE
Get stage data based on game_type

### DIFF
--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -25,9 +25,10 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_lift.service.privatelift import PrivateLiftService
 
-GAME_NAME = "lift"
+GAME_NAME = GameNames.LIFT.value
 DEFAULT_CONCURRENCY = 4
 
 

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from enum import Enum
 from typing import List
 
 from fbpcp.entity.mpc_game_config import MPCGameArgument, MPCGameConfig
@@ -11,8 +12,15 @@ from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 
 
+class GameNames(Enum):
+    LIFT = "lift"
+    SHARD_AGGREGATOR = "shard_aggregator"
+    ATTRIBUTION_COMPUTE = "attribution_compute"
+    ATTRIBUTION_SHARD_AGGREGATOR = "attribution_shard_aggregator"
+
+
 PRIVATE_COMPUTATION_GAME_CONFIG = {
-    "lift": {
+    GameNames.LIFT.value: {
         "onedocker_package_name": OneDockerBinaryNames.LIFT_COMPUTE.value,
         "arguments": [
             {"name": "input_base_path", "required": True},
@@ -22,7 +30,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG = {
             {"name": "concurrency", "required": True},
         ],
     },
-    "shard_aggregator": {
+    GameNames.SHARD_AGGREGATOR.value: {
         "onedocker_package_name": OneDockerBinaryNames.SHARD_AGGREGATOR.value,
         "arguments": [
             {"name": "input_base_path", "required": True},
@@ -32,7 +40,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG = {
             {"name": "first_shard_index", "required": False},
         ],
     },
-    "attribution_compute": {
+    GameNames.ATTRIBUTION_COMPUTE.value: {
         "onedocker_package_name": OneDockerBinaryNames.ATTRIBUTION_COMPUTE.value,
         "arguments": [
             {"name": "aggregators", "required": True},
@@ -45,7 +53,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG = {
             {"name": "use_xor_encryption", "required": True},
         ],
     },
-    "attribution_shard_aggregator": {
+    GameNames.ATTRIBUTION_SHARD_AGGREGATOR.value: {
         "onedocker_package_name": OneDockerBinaryNames.SHARD_AGGREGATOR.value,
         "arguments": [
             {"name": "input_base_path", "required": True},

--- a/fbpcs/private_computation/service/private_computation_service_data.py
+++ b/fbpcs/private_computation/service/private_computation_service_data.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+from fbpcs.data_processing.attribution_id_combiner.attribution_id_spine_combiner_cpp import (
+    CppAttributionIdSpineCombinerService,
+)
+from fbpcs.data_processing.lift_id_combiner.lift_id_spine_combiner_cpp import (
+    CppLiftIdSpineCombinerService,
+)
+from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation.repository.private_computation_game import (
+    PRIVATE_COMPUTATION_GAME_CONFIG,
+)
+
+
+# TODO T100288161: create super class to extend from to avoid using Union
+UnionedStageServices = Union[
+    CppAttributionIdSpineCombinerService, CppLiftIdSpineCombinerService
+]
+
+""" This is to get a mapping from onedocker_package_name to game name
+{
+    "private_attribution/compute":"attribution_compute",
+    "private_lift/lift":"lift",
+    ...
+}
+"""
+BINARY_NAME_TO_GAME_NAME: Dict[str, str] = {
+    v["onedocker_package_name"]: k for k, v in PRIVATE_COMPUTATION_GAME_CONFIG.items()
+}
+
+
+@dataclass
+class StageData:
+    binary_name: str
+    game_name: Optional[str] = None
+    service: Optional[UnionedStageServices] = None
+
+
+@dataclass
+class PrivateComputationServiceData:
+    """
+    This class groups data necessary to run each stage for all supported stages
+    by the service. The service needs to provide the type of game (lift, attribution, etc.)
+    because each game_type requires different data to run.
+
+    Currently, this get function is directly used by PrivateComputationService.
+    We plan to implement a PrivateComputationStageService which abstracts the
+    business logic of each stage so that PrivateComputationService is not bloated with it.
+    PrivateComputationStageService will be calling this function in the future to
+    get data from each stage.
+    """
+
+    combiner_stage: StageData
+    compute_stage: StageData
+
+    LIFT_COMBINER_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.LIFT_ID_SPINE_COMBINER.value,
+        game_name=None,
+        service=CppLiftIdSpineCombinerService(),
+    )
+
+    LIFT_COMPUTE_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.LIFT_COMPUTE.value,
+        game_name=BINARY_NAME_TO_GAME_NAME[OneDockerBinaryNames.LIFT_COMPUTE.value],
+        service=None,
+    )
+
+    ATTRIBUTION_COMBINER_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.ATTRIBUTION_ID_SPINE_COMBINER.value,
+        game_name=None,
+        service=CppAttributionIdSpineCombinerService(),
+    )
+
+    ATTRIBUTION_COMPUTE_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.ATTRIBUTION_COMPUTE.value,
+        game_name=BINARY_NAME_TO_GAME_NAME[
+            OneDockerBinaryNames.ATTRIBUTION_COMPUTE.value
+        ],
+        service=None,
+    )
+
+    @classmethod
+    def get(
+        cls, game_type: PrivateComputationGameType
+    ) -> "PrivateComputationServiceData":
+        if game_type is PrivateComputationGameType.LIFT:
+            return cls(
+                combiner_stage=PrivateComputationServiceData.LIFT_COMBINER_STAGE_DATA,
+                compute_stage=PrivateComputationServiceData.LIFT_COMPUTE_STAGE_DATA,
+            )
+        elif game_type is PrivateComputationGameType.ATTRIBUTION:
+            return cls(
+                combiner_stage=PrivateComputationServiceData.ATTRIBUTION_COMBINER_STAGE_DATA,
+                compute_stage=PrivateComputationServiceData.ATTRIBUTION_COMPUTE_STAGE_DATA,
+            )
+        else:
+            raise ValueError("Unknown game type")

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -35,6 +35,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
     UnionedPCInstance,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_lift.service.errors import PLServiceValidationError
 from fbpcs.private_lift.service.privatelift import (
     PrivateLiftService,
@@ -192,7 +193,7 @@ class TestPrivateLiftService(unittest.TestCase):
         test_mpc_id = "test_mpc_id"
         mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
-            game_name="lift",
+            game_name=GameNames.LIFT.value,
             mpc_party=MPCParty.SERVER,
             num_workers=2,
         )
@@ -396,7 +397,7 @@ class TestPrivateLiftService(unittest.TestCase):
     def test_compute_metrics(self):
         test_pl_id = "test_pl_id"
         test_mpc_id = test_pl_id + "_compute_metrics"
-        test_game_name = "lift"
+        test_game_name = GameNames.LIFT.value
         test_num_containers = 2
         test_mpc_party = MPCParty.CLIENT
         test_concurrency = 2
@@ -481,7 +482,7 @@ class TestPrivateLiftService(unittest.TestCase):
     def test_compute_metrics_rerun(self):
         # construct a pl_instance
         test_mpc_id = self.test_pl_id + "_compute_metrics"
-        test_game_name = "lift"
+        test_game_name = GameNames.LIFT.value
 
         mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
@@ -522,7 +523,7 @@ class TestPrivateLiftService(unittest.TestCase):
 
     def test_partner_missing_server_ips(self):
         test_pl_id = "test_pl_id"
-        test_game_name = "lift"
+        test_game_name = GameNames.LIFT.value
         test_concurrency = 2
 
         pl_instance = self.create_sample_instance(
@@ -550,7 +551,7 @@ class TestPrivateLiftService(unittest.TestCase):
         test_mpc_id = self.test_pl_id + "_compute_metrics"
         mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_mpc_id,
-            game_name="lift",
+            game_name=GameNames.LIFT.value,
             mpc_party=MPCParty.SERVER,
             num_workers=self.test_num_containers,
             status=MPCInstanceStatus.COMPLETED,
@@ -580,7 +581,7 @@ class TestPrivateLiftService(unittest.TestCase):
         ]
         # check a new MPC instance handling metrics aggregation was to be created
         self.assertEqual(
-            "shard_aggregator",
+            GameNames.SHARD_AGGREGATOR.value,
             self.pl_service._create_and_start_mpc_instance.call_args[1]["game_name"],
         )
         self.assertEqual(
@@ -597,7 +598,7 @@ class TestPrivateLiftService(unittest.TestCase):
         test_pl_id = "test_pl_id"
         mpc_instance = PCSMPCInstance.create_instance(
             instance_id=test_pl_id + "_aggregate_metrics",
-            game_name="shard_aggregator",
+            game_name=GameNames.SHARD_AGGREGATOR.value,
             mpc_party=MPCParty.SERVER,
             num_workers=2,
             status=MPCInstanceStatus.FAILED,
@@ -659,7 +660,7 @@ class TestPrivateLiftService(unittest.TestCase):
         # check a new MPC instance handling metrics aggregation was to be created
         # with the overwritten input_path and num_shards
         self.assertEqual(
-            "shard_aggregator",
+            GameNames.SHARD_AGGREGATOR.value,
             self.pl_service._create_and_start_mpc_instance.call_args[1]["game_name"],
         )
         self.assertEqual(
@@ -677,7 +678,7 @@ class TestPrivateLiftService(unittest.TestCase):
         self.pl_service.mpc_svc.start_instance_async = AsyncMock()
 
         instance_id = "test_instance_id"
-        game_name = "lift"
+        game_name = GameNames.LIFT.value
         mpc_party = MPCParty.CLIENT
         num_containers = 4
         input_file = "input_file"
@@ -753,7 +754,7 @@ class TestPrivateLiftService(unittest.TestCase):
         # Test get status from an MPC stage
         mpc_instance = PCSMPCInstance.create_instance(
             instance_id="test_mpc_id",
-            game_name="shard_aggregator",
+            game_name=GameNames.SHARD_AGGREGATOR.value,
             mpc_party=MPCParty.SERVER,
             num_workers=2,
             status=MPCInstanceStatus.FAILED,
@@ -852,7 +853,7 @@ class TestPrivateLiftService(unittest.TestCase):
 
     def test_cancel_current_stage(self):
         test_mpc_id = self.test_pl_id + "_compute_metrics"
-        test_game_name = "lift"
+        test_game_name = GameNames.LIFT.value
         test_mpc_party = MPCParty.CLIENT
 
         # prepare the pl instance that will be read in to memory from the repository
@@ -922,7 +923,7 @@ class TestPrivateLiftService(unittest.TestCase):
         test_input = "test_input_retry"
         mpc_instance = PCSMPCInstance.create_instance(
             instance_id="mpc_instance",
-            game_name="lift",
+            game_name=GameNames.LIFT.value,
             mpc_party=MPCParty.SERVER,
             num_workers=2,
             status=MPCInstanceStatus.FAILED,


### PR DESCRIPTION
Summary:
Get combiner service, lift binary name and game name from `game_type` so it's no longer lift specific. This will make turning PrivateLiftService into PrivateComputationService possible later in this stack. PrivateAttributionService will be replaced by PrivateComputationService.

Design doc: https://fburl.com/93kmb0hk

Differential Revision: D30978299

