### PR TITLE
Add AWS region to PCEConfig

### DIFF
--- a/fbpcs/private_lift/entity/pce_config.py
+++ b/fbpcs/private_lift/entity/pce_config.py
@@ -19,6 +19,7 @@ class PCEConfig:
     subnets: List[str]
     cluster: str
     data_processing_task_definition: str
+    region: str
 
     def __str__(self) -> str:
         # pyre-ignore


### PR DESCRIPTION
Summary:
## What

Add a region variable to PCEConfig and use it in the private lift thrift server instead of a hardcoded us-west-2

## Why

* Not all of our advertisers are using us-west-2, so we need to make this change in order to run with them

Reviewed By: peking2, Olivia-liu

Differential Revision: D30969252

