### PR TITLE
thrift server support multiple regions

### DIFF
--- a/fbpcs/private_lift/entity/pce_config.py
+++ b/fbpcs/private_lift/entity/pce_config.py
@@ -18,8 +18,8 @@ from dataclasses_json import dataclass_json
 class PCEConfig:
     subnets: List[str]
     cluster: str
-    data_processing_task_definition: str
     region: str
+    onedocker_task_definition: str
 
     def __str__(self) -> str:
         # pyre-ignore


### PR DESCRIPTION
Summary:
## What

* Remove data processing task definition from PCEConfig
* Add onedocker task defintion to pceconfig
* Override output_dir passed in during createInstance

## Why

* task definitions: sync with configerator changes made in D31028468
* output_dir: force the output dir to be in the same region as the PCEConfig region

More context: https://fb.workplace.com/groups/164332244998024/permalink/713631653401411/

Reviewed By: gorel

Differential Revision: D31060170

