### PR TITLE
validate metrics use result path on instance

### DIFF
--- a/fbpcs/private_lift/entity/pce_config.py
+++ b/fbpcs/private_lift/entity/pce_config.py
@@ -18,8 +18,8 @@ from dataclasses_json import dataclass_json
 class PCEConfig:
     subnets: List[str]
     cluster: str
-    data_processing_task_definition: str
     region: str
+    onedocker_task_definition: str
 
     def __str__(self) -> str:
         # pyre-ignore

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -704,13 +704,16 @@ class PrivateLiftService:
     def validate_metrics(
         self,
         instance_id: str,
-        aggregated_result_path: str,
         expected_result_path: str,
+        aggregated_result_path: Optional[str] = None,
     ) -> None:
+        pl_instance = self.get_instance(instance_id)
         storage_service = self.mpc_svc.storage_svc
         expected_results_dict = json.loads(storage_service.read(expected_result_path))
         aggregated_results_dict = json.loads(
-            storage_service.read(aggregated_result_path)
+            storage_service.read(
+                aggregated_result_path or pl_instance.shard_aggregate_stage_output_path
+            )
         )
         if expected_results_dict == aggregated_results_dict:
             self.logger.info(


### PR DESCRIPTION
Summary:
## What

* aggregated_result_path is now optional for lift validate metrics

## Why

* the variable is stored on the private computation instance and thus doesn't need to be specified

Differential Revision: D31066842

