### PR TITLE
Add PA features to PrivateLiftService

### DIFF
--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -54,6 +54,7 @@ def create_instance(
         output_dir=output_dir,
         num_pid_containers=num_pid_containers,
         num_mpc_containers=num_mpc_containers,
+        concurrency=DEFAULT_CONCURRENCY,
         num_files_per_mpc_container=num_files_per_mpc_container,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -46,6 +46,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             output_dir="out",
             num_pid_containers=4,
             num_mpc_containers=4,
+            concurrency=1,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -67,6 +68,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             output_dir="out",
             num_pid_containers=4,
             num_mpc_containers=4,
+            concurrency=1,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -94,6 +94,9 @@ STAGE_FAILED_STATUSES: List[PrivateComputationInstanceStatus] = [
     PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
 ]
 
+DEFAULT_PADDING_SIZE = 4
+DEFAULT_K_ANONYMITY_THRESHOLD = 100
+
 
 class PrivateLiftService:
     def __init__(
@@ -124,12 +127,16 @@ class PrivateLiftService:
         output_dir: str,
         num_pid_containers: int,
         num_mpc_containers: int,
+        concurrency: int,
         num_files_per_mpc_container: Optional[int] = None,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         breakdown_key: Optional[BreakdownKey] = None,
         pce_config: Optional[PCEConfig] = None,
         is_test: Optional[bool] = False,
+        hmac_key: Optional[str] = None,
+        padding_size: int = DEFAULT_PADDING_SIZE,
+        k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -151,6 +158,10 @@ class PrivateLiftService:
             breakdown_key=breakdown_key,
             pce_config=pce_config,
             is_test=is_test,
+            hmac_key=hmac_key,
+            padding_size=padding_size,
+            concurrency=concurrency,
+            k_anonymity_threshold=k_anonymity_threshold,
         )
 
         self.instance_repository.create(instance)
@@ -200,6 +211,7 @@ class PrivateLiftService:
                 pl_instance=pl_instance, new_status=new_status
             )
             self.instance_repository.update(pl_instance)
+            self.logger.info(f"Finished updating instance: {pl_instance.instance_id}")
 
         return pl_instance
 
@@ -330,7 +342,7 @@ class PrivateLiftService:
         pl_instance = self.get_instance(instance_id)
 
         if pl_instance.role is PrivateComputationRole.PARTNER and not server_ips:
-            raise ValueError("Missing server_ips")
+            raise ValueError("Missing server_ips for Partner")
 
         # default to be an empty string
         retry_counter_str = ""
@@ -354,6 +366,9 @@ class PrivateLiftService:
 
         # Create a new pid instance
         pid_instance_id = instance_id + "_id_match" + retry_counter_str
+        # TODO T101225909: remove the option here to pass in a hmac key at the id match stage
+        #   instead, always pass in at create_instance
+        pl_instance.hmac_key = hmac_key or pl_instance.hmac_key
         pid_instance = self.pid_svc.create_instance(
             instance_id=pid_instance_id,
             protocol=PIDProtocol.UNION_PID,
@@ -363,7 +378,7 @@ class PrivateLiftService:
             output_path=pl_instance.pid_stage_output_base_path,
             is_validating=is_validating,
             synthetic_shard_path=synthetic_shard_path,
-            hmac_key=hmac_key,
+            hmac_key=pl_instance.hmac_key,
         )
 
         # Push PID instance to PrivateComputationInstance.instances and update PL Instance status
@@ -596,9 +611,11 @@ class PrivateLiftService:
             )
 
         # Prepare arguments for lift game
+        # TODO T101225909: remove the option to pass in concurrency at the compute stage
+        #   instead, always pass in at create_instance
+        pl_instance.concurrency = concurrency or pl_instance.concurrency
         game_args = self._get_compute_metrics_game_args(
             pl_instance,
-            concurrency,
             is_validating,
             dry_run,
             container_timeout,
@@ -1124,7 +1141,6 @@ class PrivateLiftService:
     def _get_compute_metrics_game_args(
         self,
         pl_instance: PrivateComputationInstance,
-        concurrency: int,
         is_validating: Optional[bool] = False,
         dry_run: Optional[bool] = None,
         container_timeout: Optional[int] = None,
@@ -1147,7 +1163,7 @@ class PrivateLiftService:
                     "output_base_path": pl_instance.compute_stage_output_base_path,
                     "file_start_index": file_start_index,
                     "num_files": num_files,
-                    "concurrency": concurrency,
+                    "concurrency": pl_instance.concurrency,
                 }
                 for file_start_index, num_files in self.calculate_file_start_index_and_num_shards(
                     num_containers * pl_instance.num_files_per_mpc_container,

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -120,6 +120,7 @@ class TestPrivateLiftService(unittest.TestCase):
         self.test_input_path = "in_path"
         self.test_output_dir = "out_dir"
         self.test_game_type = PrivateComputationGameType.LIFT
+        self.test_concurrency = 1
 
     def test_create_instance(self):
         test_role = PrivateComputationRole.PUBLISHER
@@ -131,6 +132,7 @@ class TestPrivateLiftService(unittest.TestCase):
             output_dir=self.test_output_dir,
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
+            concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
         )
         # check instance_repository.create is called with the correct arguments
@@ -967,6 +969,7 @@ class TestPrivateLiftService(unittest.TestCase):
             status_update_ts=1600000000,
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
+            concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             game_type=PrivateComputationGameType.LIFT,
             input_path=self.test_input_path,


### PR DESCRIPTION
Summary:
**This stack**
Consolidate PA and PL service with the following steps
1. Modify PrivateLiftService, so that PA-Coordinator can use it;
2. Make PA-Coordinator use PrivateLiftService;
3. Delete PrivateAttributionService;
4. Rename PrivateLiftService to PrivateComputationService;
5. Clear the TODOs added as BE tasks

**This diff**
Step 1. PrivateLiftService is kind of "game agnostic". It still knows about Lift and Attribution, but it supports both now, despite being called "PrivateLift"Service still.

Differential Revision: D30836795

