### PR TITLE
Add conv histograms into LiftMetrics

### DIFF
--- a/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
@@ -7,9 +7,15 @@
 
 #pragma once
 
+#include <sstream>
+#include <vector>
+
+#include <folly/String.h>
+
 #include "../common/GroupedLiftMetrics.h"
 
 namespace private_lift {
+
 /*
  * Simple struct representing the metrics in a Lift computation
  */
@@ -40,6 +46,8 @@ struct OutputMetricsData {
   int64_t controlClickers = 0;
   int64_t reachedConversions = 0;
   int64_t reachedValue = 0;
+  std::vector<int64_t> testConvHistogram;
+  std::vector<int64_t> controlConvHistogram;
 
   OutputMetricsData() = default;
 
@@ -79,6 +87,8 @@ struct OutputMetricsData {
     os << "Control Clickers: " << out.controlClickers << "\n";
     os << "Reached Conversions: " << out.reachedConversions << "\n";
     os << "Reached Value: " << out.reachedValue << "\n";
+    os << "Test Conversion histogram: " << folly::join(',', out.testConvHistogram) << "\n";
+    os << "Control Conversion histogram: " << folly::join(',', out.controlConvHistogram) << "\n";
 
     return os;
   }
@@ -115,6 +125,8 @@ struct OutputMetricsData {
     metrics.controlClickers = controlClickers;
     metrics.reachedConversions = reachedConversions;
     metrics.reachedValue = reachedValue;
+    metrics.testConvHistogram = testConvHistogram;
+    metrics.controlConvHistogram = controlConvHistogram;
     return metrics;
   }
 

--- a/fbpcs/emp_games/lift/common/LiftMetrics.h
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+
 #include "folly/dynamic.h"
 
 namespace private_lift {
@@ -42,6 +43,8 @@ struct LiftMetrics {
   int64_t controlClickers;
   int64_t reachedConversions;
   int64_t reachedValue;
+  std::vector<int64_t> testConvHistogram;
+  std::vector<int64_t> controlConvHistogram;
 
   bool operator==(const LiftMetrics& other) const noexcept;
   LiftMetrics operator+(const LiftMetrics& other) const noexcept;


### PR DESCRIPTION
Summary:
# What
* Define four new metrics for PL
  * test conversion histogram
  * control conversion histogram
  * test sales histogram
  * control sales histogram

# Why
* This stack is implementing histograms for advanced lift support in PL

Reviewed By: corbantek, peking2

Differential Revision: D30361851

