### PR TITLE
Create better zip_apply function to clean up MPC games

### DIFF
--- a/fbpcs/emp_games/common/Functional.h
+++ b/fbpcs/emp_games/common/Functional.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace private_measurement::functional {
+namespace detail {
+// Logic adapted from https://stackoverflow.com/a/18771618/15625637
+template <class I> void advance(I &&it) { ++it; }
+
+template <class I, class... Is> void advance(I &&it, Is &&...its) {
+  ++it;
+  detail::advance(its...);
+}
+
+// Special template to allow for cases where there *are* no more iterators
+// In this case, zip_apply is no different from std::transform, so it is
+// unlikely anyone would use it, but it could help avoid a frustrating
+// compilation error when testing or debugging something.
+template <class... Is> void advance(Is &&...) { /* empty */; }
+} // namespace detail
+
+/*
+ * Acts as a "zip and map" utility with automatic type deduction
+ * The first iterator must be <= the size of all other passed iterators
+ * otherwise the result is UB caused by iterating beyond end iterators.
+ *
+ * Example usage:
+ * std::vector<int> v1{1, 2, 3, 4, 5};
+ * std::vector<int> v2{5, 6, 7, 8, 9};
+ * std::vector<int> v3{3, 2, 1, 2, 3};
+ * auto res = zip_apply(
+ *     v1.begin(), v1.end(),
+ *     v2.begin(),
+ *     v3.begin(),
+ *     [](auto n1, auto n2, auto n3) {
+ *         return n1 * n2 - n3;
+ *     });
+ * EXPECT_EQ(res, std::vector{2, 10, 20, 30, 42});
+ */
+template <class Function, class I, class... Is>
+auto zip_apply(Function f, I &&begin, I &&end, Is &&...its)
+    -> std::vector<decltype(f(*begin, *(its)...))> {
+  std::vector<decltype(f(*begin, *(its)...))> res;
+  // TODO: Would be better to check *all* iterators instead of just first
+  // This function assumes the first iterator is the only end checked
+  // A better design would take pairs of begin and end iterators
+  for (/* empty */; begin != end; ++begin, detail::advance(its...)) {
+    res.push_back(f(*begin, *(its)...));
+  }
+  return res;
+}
+} // namespace private_measurement::functional

--- a/fbpcs/emp_games/common/test/FunctionalTest.cpp
+++ b/fbpcs/emp_games/common/test/FunctionalTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <vector>
+
+#include "../Functional.h"
+
+namespace private_measurement::functional {
+
+TEST(FunctionalTest, TestZipApplyBasic) {
+  std::vector<int64_t> v{1, 2, 3, 4, 5};
+  auto f = [](auto n) { return n * n; };
+  std::vector<int64_t> expected{1, 4, 9, 16, 25};
+  auto actual = zip_apply(f, v.begin(), v.end());
+
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(FunctionalTest, TestZipApplyAdvancedInputType) {
+  std::vector<int64_t> v1{1, 2, 3, 4, 5};
+  std::vector<int64_t> v2{11, 22, 33, 44, 55};
+  std::vector<int64_t> v3{10, 20, 30, 40, 50};
+  auto f = [](auto n1, auto n2, auto n3) { return n1 + n2 - n3; };
+  std::vector<int64_t> expected{2, 4, 6, 8, 10};
+  auto actual = zip_apply(f, v1.begin(), v1.end(), v2.begin(), v3.begin());
+
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(FunctionalTest, TestZipApplyAdvancedOutputType) {
+  std::vector<int64_t> v{1, 2, 3, 4, 5};
+  auto f = [](auto n) { return std::make_tuple(n, n + 1); };
+  std::vector<std::tuple<int64_t, int64_t>> expected{
+      std::make_tuple(1, 2), std::make_tuple(2, 3), std::make_tuple(3, 4),
+      std::make_tuple(4, 5), std::make_tuple(5, 6)};
+  auto actual = zip_apply(f, v.begin(), v.end());
+
+  EXPECT_EQ(expected, actual);
+}
+} // namespace private_measurement::functional

--- a/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
@@ -7,9 +7,15 @@
 
 #pragma once
 
+#include <sstream>
+#include <vector>
+
+#include <folly/String.h>
+
 #include "../common/GroupedLiftMetrics.h"
 
 namespace private_lift {
+
 /*
  * Simple struct representing the metrics in a Lift computation
  */
@@ -40,6 +46,8 @@ struct OutputMetricsData {
   int64_t controlClickers = 0;
   int64_t reachedConversions = 0;
   int64_t reachedValue = 0;
+  std::vector<int64_t> testConvHistogram;
+  std::vector<int64_t> controlConvHistogram;
 
   OutputMetricsData() = default;
 
@@ -79,6 +87,8 @@ struct OutputMetricsData {
     os << "Control Clickers: " << out.controlClickers << "\n";
     os << "Reached Conversions: " << out.reachedConversions << "\n";
     os << "Reached Value: " << out.reachedValue << "\n";
+    os << "Test Conversion histogram: " << folly::join(',', out.testConvHistogram) << "\n";
+    os << "Control Conversion histogram: " << folly::join(',', out.controlConvHistogram) << "\n";
 
     return os;
   }
@@ -115,6 +125,8 @@ struct OutputMetricsData {
     metrics.controlClickers = controlClickers;
     metrics.reachedConversions = reachedConversions;
     metrics.reachedValue = reachedValue;
+    metrics.testConvHistogram = testConvHistogram;
+    metrics.controlConvHistogram = controlConvHistogram;
     return metrics;
   }
 

--- a/fbpcs/emp_games/lift/common/LiftMetrics.h
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+
 #include "folly/dynamic.h"
 
 namespace private_lift {
@@ -42,6 +43,8 @@ struct LiftMetrics {
   int64_t controlClickers;
   int64_t reachedConversions;
   int64_t reachedValue;
+  std::vector<int64_t> testConvHistogram;
+  std::vector<int64_t> controlConvHistogram;
 
   bool operator==(const LiftMetrics& other) const noexcept;
   LiftMetrics operator+(const LiftMetrics& other) const noexcept;


### PR DESCRIPTION
Summary:
# What
* An iterator-based zip_apply based on a functional approach

# Why
* This stack is implementing histograms for advanced lift support in PL
* Much of the zip_and_map created for PL is quite messy and hard to extend. I created this to help with some of that; as you'll see in the next diff, it helped somewhat, but there's still a lot of room for improvement

If anyone is really strong at C++ template programming, I think this could be even better if we took groups of begin and end iterators; maybe we could accomplish that by explicitly taking tuples, but that seemed a bit heavy-handed.

The other thing I wanted to do was make the function the *last* parameter, but for some reason the template instantiation wasn't working well when I did that

Reviewed By: corbantek

Differential Revision: D30410808

