### PR TITLE
Compute conversion histograms

### DIFF
--- a/fbpcs/emp_games/common/Functional.h
+++ b/fbpcs/emp_games/common/Functional.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace private_measurement::functional {
+namespace detail {
+// Logic adapted from https://stackoverflow.com/a/18771618/15625637
+template <class I> void advance(I &&it) { ++it; }
+
+template <class I, class... Is> void advance(I &&it, Is &&...its) {
+  ++it;
+  detail::advance(its...);
+}
+
+// Special template to allow for cases where there *are* no more iterators
+// In this case, zip_apply is no different from std::transform, so it is
+// unlikely anyone would use it, but it could help avoid a frustrating
+// compilation error when testing or debugging something.
+template <class... Is> void advance(Is &&...) { /* empty */; }
+} // namespace detail
+
+/*
+ * Acts as a "zip and map" utility with automatic type deduction
+ * The first iterator must be <= the size of all other passed iterators
+ * otherwise the result is UB caused by iterating beyond end iterators.
+ *
+ * Example usage:
+ * std::vector<int> v1{1, 2, 3, 4, 5};
+ * std::vector<int> v2{5, 6, 7, 8, 9};
+ * std::vector<int> v3{3, 2, 1, 2, 3};
+ * auto res = zip_apply(
+ *     v1.begin(), v1.end(),
+ *     v2.begin(),
+ *     v3.begin(),
+ *     [](auto n1, auto n2, auto n3) {
+ *         return n1 * n2 - n3;
+ *     });
+ * EXPECT_EQ(res, std::vector{2, 10, 20, 30, 42});
+ */
+template <class Function, class I, class... Is>
+auto zip_apply(Function f, I &&begin, I &&end, Is &&...its)
+    -> std::vector<decltype(f(*begin, *(its)...))> {
+  std::vector<decltype(f(*begin, *(its)...))> res;
+  // TODO: Would be better to check *all* iterators instead of just first
+  // This function assumes the first iterator is the only end checked
+  // A better design would take pairs of begin and end iterators
+  for (/* empty */; begin != end; ++begin, detail::advance(its...)) {
+    res.push_back(f(*begin, *(its)...));
+  }
+  return res;
+}
+} // namespace private_measurement::functional

--- a/fbpcs/emp_games/common/test/FunctionalTest.cpp
+++ b/fbpcs/emp_games/common/test/FunctionalTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <vector>
+
+#include "../Functional.h"
+
+namespace private_measurement::functional {
+
+TEST(FunctionalTest, TestZipApplyBasic) {
+  std::vector<int64_t> v{1, 2, 3, 4, 5};
+  auto f = [](auto n) { return n * n; };
+  std::vector<int64_t> expected{1, 4, 9, 16, 25};
+  auto actual = zip_apply(f, v.begin(), v.end());
+
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(FunctionalTest, TestZipApplyAdvancedInputType) {
+  std::vector<int64_t> v1{1, 2, 3, 4, 5};
+  std::vector<int64_t> v2{11, 22, 33, 44, 55};
+  std::vector<int64_t> v3{10, 20, 30, 40, 50};
+  auto f = [](auto n1, auto n2, auto n3) { return n1 + n2 - n3; };
+  std::vector<int64_t> expected{2, 4, 6, 8, 10};
+  auto actual = zip_apply(f, v1.begin(), v1.end(), v2.begin(), v3.begin());
+
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(FunctionalTest, TestZipApplyAdvancedOutputType) {
+  std::vector<int64_t> v{1, 2, 3, 4, 5};
+  auto f = [](auto n) { return std::make_tuple(n, n + 1); };
+  std::vector<std::tuple<int64_t, int64_t>> expected{
+      std::make_tuple(1, 2), std::make_tuple(2, 3), std::make_tuple(3, 4),
+      std::make_tuple(4, 5), std::make_tuple(5, 6)};
+  auto actual = zip_apply(f, v.begin(), v.end());
+
+  EXPECT_EQ(expected, actual);
+}
+} // namespace private_measurement::functional

--- a/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
@@ -7,9 +7,15 @@
 
 #pragma once
 
+#include <sstream>
+#include <vector>
+
+#include <folly/String.h>
+
 #include "../common/GroupedLiftMetrics.h"
 
 namespace private_lift {
+
 /*
  * Simple struct representing the metrics in a Lift computation
  */
@@ -40,6 +46,8 @@ struct OutputMetricsData {
   int64_t controlClickers = 0;
   int64_t reachedConversions = 0;
   int64_t reachedValue = 0;
+  std::vector<int64_t> testConvHistogram;
+  std::vector<int64_t> controlConvHistogram;
 
   OutputMetricsData() = default;
 
@@ -79,6 +87,8 @@ struct OutputMetricsData {
     os << "Control Clickers: " << out.controlClickers << "\n";
     os << "Reached Conversions: " << out.reachedConversions << "\n";
     os << "Reached Value: " << out.reachedValue << "\n";
+    os << "Test Conversion histogram: " << folly::join(',', out.testConvHistogram) << "\n";
+    os << "Control Conversion histogram: " << folly::join(',', out.controlConvHistogram) << "\n";
 
     return os;
   }
@@ -115,6 +125,8 @@ struct OutputMetricsData {
     metrics.controlClickers = controlClickers;
     metrics.reachedConversions = reachedConversions;
     metrics.reachedValue = reachedValue;
+    metrics.testConvHistogram = testConvHistogram;
+    metrics.controlConvHistogram = controlConvHistogram;
     return metrics;
   }
 

--- a/fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp
@@ -169,6 +169,15 @@ OutputMetricsData LiftCalculator::compute(
     eventTimestamps =
         parseArray(partsPartner.at(colNameToIndex.at("event_timestamps")));
 
+    // We can't initialize the convHistograms until we know how many events we
+    // will see. If we ever have a weird input where the rows have different
+    // lengths, doing this sort of "new max" will ensure this still works.
+    // Also remember to go one *past* the size to leave a bucket for 0 convs
+    for (size_t i = out.testConvHistogram.size(); i <= eventTimestamps.size(); ++i) {
+      out.testConvHistogram.push_back(0);
+      out.controlConvHistogram.push_back(0);
+    }
+
     auto valuesIdx = colNameToIndex.find("values") != colNameToIndex.end()
         ? colNameToIndex.at("values")
         : -1;
@@ -223,6 +232,7 @@ OutputMetricsData LiftCalculator::compute(
         out.testSpend += totalSpend;
         out.testReach += (numImpressions > 0 ? 1 : 0);
         out.testClickers += (numClicks > 0 ? 1 : 0);
+        ++out.testConvHistogram[convCount];
       } else {
         ++out.controlPopulation;
         for (auto i = 0; i < eventTimestamps.size(); ++i) {
@@ -254,6 +264,7 @@ OutputMetricsData LiftCalculator::compute(
         out.controlSpend += totalSpend;
         out.controlReach += (numImpressions > 0 ? 1 : 0);
         out.controlClickers += (numClicks > 0 ? 1 : 0);
+        ++out.controlConvHistogram[convCount];
       }
     }
   }

--- a/fbpcs/emp_games/lift/common/LiftMetrics.h
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+
 #include "folly/dynamic.h"
 
 namespace private_lift {
@@ -42,6 +43,8 @@ struct LiftMetrics {
   int64_t controlClickers;
   int64_t reachedConversions;
   int64_t reachedValue;
+  std::vector<int64_t> testConvHistogram;
+  std::vector<int64_t> controlConvHistogram;
 
   bool operator==(const LiftMetrics& other) const noexcept;
   LiftMetrics operator+(const LiftMetrics& other) const noexcept;


### PR DESCRIPTION
Summary:
# What
* Compute conversion histograms in Lift calculator
* Expand calculator test to calculate histograms "in the clear"
* Lots of new comments in the code since this is pretty tricky to calculate in MPC cleanly. There's some room for optimization here, but given how clever the code already is, I'm hesitant to immediately introduce that. Truthfully, that kind of hardcore optimization should be applied at the engine layer if we can deterministically say that due to some sort of MECE principle, we can compute a metric by working off other calculations (in this case, bin zero is just the valid population less people bucketed into other bins).

# Why
* For Advanced Lift support, conversion histograms are a hard requirement

NOTE: In-depth performance analysis below. TL;DR: +14% runtime

Reviewed By: corbantek, peking2

Differential Revision: D30419041

