### PR TITLE
PA-coordinator calls PrivateLiftService.prepare_data()

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -320,11 +320,16 @@ def prepare_compute_input(
     dry_run: Optional[bool] = False,
     log_cost_to_s3: bool = False,
 ) -> None:
-    pa_service = _build_pa_service(
+    private_computation_service = _build_private_computation_service(
         config["private_computation"], config["mpc"], config["pid"]
     )
 
-    pa_service.prepare_data(
+    # Because it's possible that the "get" command never gets called to update the instance since the last step started,
+    # so it could appear that the current status is still XXX_STARTED when it should be XXX_FAILED or XXX_COMPLETED,
+    # so we need to explicitly call update_instance() here to get the current status.
+    private_computation_service.update_instance(instance_id)
+
+    private_computation_service.prepare_data(
         instance_id=instance_id,
         dry_run=dry_run,
         log_cost_to_s3=log_cost_to_s3,

--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -10,8 +10,8 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container>] [options]
-    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --fail_fast --dry_run] [options]
+    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container> --fail_fast] [options]
+    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --dry_run] [options]
     pl-coordinator compute <instance_id> --config=<config_file> [--server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
     pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
@@ -144,6 +144,7 @@ def main():
             num_mpc_containers=arguments["--num_mpc_containers"],
             num_files_per_mpc_container=arguments["--num_files_per_mpc_container"],
             game_type=arguments["--game_type"],
+            fail_fast=arguments["--fail_fast"],
         )
     elif arguments["id_match"]:
         logger.info(f"Run id match on instance: {instance_id}")
@@ -151,7 +152,6 @@ def main():
             config=config,
             instance_id=instance_id,
             logger=logger,
-            fail_fast=arguments["--fail_fast"],
             server_ips=arguments["--server_ips"],
             hmac_key=arguments["--hmac_key"],
             dry_run=arguments["--dry_run"],

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -42,6 +42,7 @@ def create_instance(
     num_mpc_containers: int,
     num_files_per_mpc_container: Optional[int] = None,
     game_type: Optional[PrivateComputationGameType] = None,
+    fail_fast: bool = False,
 ) -> PrivateComputationInstance:
     pl_service = _build_pl_service(
         config["private_computation"], config["mpc"], config["pid"]
@@ -59,6 +60,7 @@ def create_instance(
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
+        fail_fast=fail_fast,
     )
 
     logger.info(instance)
@@ -82,7 +84,6 @@ def id_match(
     pl_service.id_match(
         instance_id=instance_id,
         protocol=PIDProtocol.UNION_PID,
-        fail_fast=fail_fast,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -54,6 +54,7 @@ def create_instance(
         output_dir=output_dir,
         num_pid_containers=num_pid_containers,
         num_mpc_containers=num_mpc_containers,
+        concurrency=DEFAULT_CONCURRENCY,
         num_files_per_mpc_container=num_files_per_mpc_container,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"

--- a/fbpcs/private_attribution/service/private_attribution.py
+++ b/fbpcs/private_attribution/service/private_attribution.py
@@ -78,44 +78,6 @@ class PrivateAttributionService:
         self.onedocker_binary_config_map = onedocker_binary_config_map
         self.logger: logging.Logger = logging.getLogger(__name__)
 
-    def create_instance(
-        self,
-        instance_id: str,
-        role: PrivateComputationRole,
-        input_path: str,
-        output_dir: str,
-        hmac_key: str,
-        num_pid_containers: int,
-        num_mpc_containers: int,
-        num_files_per_mpc_container: int,
-        padding_size: int,
-        logger: logging.Logger,
-        concurrency: int = 1,
-        k_anonymity_threshold: int = 0,
-    ) -> PrivateComputationInstance:
-        self.logger.info(f"Creating instance: {instance_id}")
-
-        instance = PrivateComputationInstance(
-            instance_id=instance_id,
-            role=role,
-            instances=[],
-            status=PrivateComputationInstanceStatus.CREATED,
-            status_update_ts=0,  # placeholder, not used by PA, will be used after PL+PA consolidation
-            input_path=input_path,
-            output_dir=output_dir,
-            hmac_key=hmac_key,
-            num_pid_containers=num_pid_containers,
-            num_mpc_containers=num_mpc_containers,
-            num_files_per_mpc_container=num_files_per_mpc_container,
-            game_type=PrivateComputationGameType.ATTRIBUTION,
-            padding_size=padding_size,
-            concurrency=concurrency,
-            k_anonymity_threshold=k_anonymity_threshold,
-        )
-
-        self.instance_repository.create(instance)
-        return instance
-
     def update_instance(self, instance_id: str) -> PrivateComputationInstance:
         pa_instance = self.instance_repository.read(instance_id)
 

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -89,6 +89,13 @@ class PrivateComputationInstance(InstanceBase):
     k_anonymity_threshold: int = 0
     retry_counter: int = 0
 
+    # This boolean is used to determine whether auto retry will be performed at any data processing step
+    #   of the computation. For now, when fail_fast = False, the pid preparer step
+    #   will retry up to MAX_RETRY times, which is set to be 0, because almost all problems
+    #   we've seen so far won't get resolved by just retrying. In the future, when the product is more stable,
+    #   we will increase MAX_RETRY and allow other steps to auto retry as well.
+    fail_fast: bool = False
+
     breakdown_key: Optional[BreakdownKey] = None
     pce_config: Optional[PCEConfig] = None
     is_test: Optional[bool] = False  # set to be true for testing account ID

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -46,6 +46,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             output_dir="out",
             num_pid_containers=4,
             num_mpc_containers=4,
+            concurrency=1,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -67,6 +68,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             output_dir="out",
             num_pid_containers=4,
             num_mpc_containers=4,
+            concurrency=1,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -47,6 +47,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             num_pid_containers=4,
             num_mpc_containers=4,
             concurrency=1,
+            fail_fast=True,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -69,6 +70,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             num_pid_containers=4,
             num_mpc_containers=4,
             concurrency=1,
+            fail_fast=True,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -137,6 +137,7 @@ class PrivateLiftService:
         hmac_key: Optional[str] = None,
         padding_size: int = DEFAULT_PADDING_SIZE,
         k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
+        fail_fast: bool = False,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -162,6 +163,7 @@ class PrivateLiftService:
             padding_size=padding_size,
             concurrency=concurrency,
             k_anonymity_threshold=k_anonymity_threshold,
+            fail_fast=fail_fast,
         )
 
         self.instance_repository.create(instance)
@@ -301,7 +303,6 @@ class PrivateLiftService:
         instance_id: str,
         protocol: PIDProtocol,
         pid_config: Dict[str, Any],
-        fail_fast: bool,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
@@ -313,7 +314,6 @@ class PrivateLiftService:
                 instance_id,
                 protocol,
                 pid_config,
-                fail_fast,
                 is_validating,
                 synthetic_shard_path,
                 server_ips,
@@ -329,7 +329,6 @@ class PrivateLiftService:
         instance_id: str,
         protocol: PIDProtocol,
         pid_config: Dict[str, Any],
-        fail_fast: bool,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
@@ -396,7 +395,7 @@ class PrivateLiftService:
         await self.pid_svc.run_instance(
             instance_id=pid_instance_id,
             pid_config=pid_config,
-            fail_fast=fail_fast,
+            fail_fast=pl_instance.fail_fast,
             server_ips=server_ips,
         )
 

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -94,6 +94,9 @@ STAGE_FAILED_STATUSES: List[PrivateComputationInstanceStatus] = [
     PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
 ]
 
+DEFAULT_PADDING_SIZE = 4
+DEFAULT_K_ANONYMITY_THRESHOLD = 100
+
 
 class PrivateLiftService:
     def __init__(
@@ -124,12 +127,16 @@ class PrivateLiftService:
         output_dir: str,
         num_pid_containers: int,
         num_mpc_containers: int,
+        concurrency: int,
         num_files_per_mpc_container: Optional[int] = None,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         breakdown_key: Optional[BreakdownKey] = None,
         pce_config: Optional[PCEConfig] = None,
         is_test: Optional[bool] = False,
+        hmac_key: Optional[str] = None,
+        padding_size: int = DEFAULT_PADDING_SIZE,
+        k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -151,6 +158,10 @@ class PrivateLiftService:
             breakdown_key=breakdown_key,
             pce_config=pce_config,
             is_test=is_test,
+            hmac_key=hmac_key,
+            padding_size=padding_size,
+            concurrency=concurrency,
+            k_anonymity_threshold=k_anonymity_threshold,
         )
 
         self.instance_repository.create(instance)
@@ -200,6 +211,7 @@ class PrivateLiftService:
                 pl_instance=pl_instance, new_status=new_status
             )
             self.instance_repository.update(pl_instance)
+            self.logger.info(f"Finished updating instance: {pl_instance.instance_id}")
 
         return pl_instance
 
@@ -330,7 +342,7 @@ class PrivateLiftService:
         pl_instance = self.get_instance(instance_id)
 
         if pl_instance.role is PrivateComputationRole.PARTNER and not server_ips:
-            raise ValueError("Missing server_ips")
+            raise ValueError("Missing server_ips for Partner")
 
         # default to be an empty string
         retry_counter_str = ""
@@ -354,6 +366,9 @@ class PrivateLiftService:
 
         # Create a new pid instance
         pid_instance_id = instance_id + "_id_match" + retry_counter_str
+        # TODO T101225909: remove the option here to pass in a hmac key at the id match stage
+        #   instead, always pass in at create_instance
+        pl_instance.hmac_key = hmac_key or pl_instance.hmac_key
         pid_instance = self.pid_svc.create_instance(
             instance_id=pid_instance_id,
             protocol=PIDProtocol.UNION_PID,
@@ -363,7 +378,7 @@ class PrivateLiftService:
             output_path=pl_instance.pid_stage_output_base_path,
             is_validating=is_validating,
             synthetic_shard_path=synthetic_shard_path,
-            hmac_key=hmac_key,
+            hmac_key=pl_instance.hmac_key,
         )
 
         # Push PID instance to PrivateComputationInstance.instances and update PL Instance status
@@ -596,9 +611,11 @@ class PrivateLiftService:
             )
 
         # Prepare arguments for lift game
+        # TODO T101225909: remove the option to pass in concurrency at the compute stage
+        #   instead, always pass in at create_instance
+        pl_instance.concurrency = concurrency or pl_instance.concurrency
         game_args = self._get_compute_metrics_game_args(
             pl_instance,
-            concurrency,
             is_validating,
             dry_run,
             container_timeout,
@@ -1124,7 +1141,6 @@ class PrivateLiftService:
     def _get_compute_metrics_game_args(
         self,
         pl_instance: PrivateComputationInstance,
-        concurrency: int,
         is_validating: Optional[bool] = False,
         dry_run: Optional[bool] = None,
         container_timeout: Optional[int] = None,
@@ -1147,7 +1163,7 @@ class PrivateLiftService:
                     "output_base_path": pl_instance.compute_stage_output_base_path,
                     "file_start_index": file_start_index,
                     "num_files": num_files,
-                    "concurrency": concurrency,
+                    "concurrency": pl_instance.concurrency,
                 }
                 for file_start_index, num_files in self.calculate_file_start_index_and_num_shards(
                     num_containers * pl_instance.num_files_per_mpc_container,

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -120,6 +120,7 @@ class TestPrivateLiftService(unittest.TestCase):
         self.test_input_path = "in_path"
         self.test_output_dir = "out_dir"
         self.test_game_type = PrivateComputationGameType.LIFT
+        self.test_concurrency = 1
 
     def test_create_instance(self):
         test_role = PrivateComputationRole.PUBLISHER
@@ -131,6 +132,7 @@ class TestPrivateLiftService(unittest.TestCase):
             output_dir=self.test_output_dir,
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
+            concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
         )
         # check instance_repository.create is called with the correct arguments
@@ -967,6 +969,7 @@ class TestPrivateLiftService(unittest.TestCase):
             status_update_ts=1600000000,
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
+            concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             game_type=PrivateComputationGameType.LIFT,
             input_path=self.test_input_path,

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -241,7 +241,6 @@ class TestPrivateLiftService(unittest.TestCase):
         test_pid_role = PIDRole.PUBLISHER
         test_pid_config = {"key": "value"}
         test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
-        test_fail_fast = True
 
         pl_instance = self.create_sample_instance(
             status=PrivateComputationInstanceStatus.CREATED
@@ -267,7 +266,6 @@ class TestPrivateLiftService(unittest.TestCase):
             instance_id=self.test_pl_id,
             protocol=test_pid_protocol,
             pid_config=test_pid_config,
-            fail_fast=test_fail_fast,
             server_ips=["192.0.2.0", "192.0.2.1"],
             hmac_key=test_hmac_key,
         )
@@ -309,10 +307,6 @@ class TestPrivateLiftService(unittest.TestCase):
             test_pid_config,
             self.pid_service.run_instance.call_args[1]["pid_config"],
         )
-        self.assertEqual(
-            test_fail_fast,
-            self.pid_service.run_instance.call_args[1]["fail_fast"],
-        )
 
         self.pl_service.instance_repository.update.assert_called()
 
@@ -345,7 +339,6 @@ class TestPrivateLiftService(unittest.TestCase):
             instance_id=self.test_pl_id,
             protocol=test_pid_protocol,
             pid_config={"key": "value"},
-            fail_fast=False,
         )
 
         # check that the retry counter has been incremented
@@ -378,7 +371,6 @@ class TestPrivateLiftService(unittest.TestCase):
                 instance_id=test_pl_id,
                 protocol=PIDProtocol.UNION_PID,
                 pid_config={"key": "value"},
-                fail_fast=True,
             )
 
     def test_id_match_rerun_fail(self):
@@ -395,7 +387,6 @@ class TestPrivateLiftService(unittest.TestCase):
                 instance_id=test_pl_id,
                 protocol=PIDProtocol.UNION_PID,
                 pid_config={"key": "value"},
-                fail_fast=True,
             )
 
     def test_compute_metrics(self):
@@ -974,4 +965,5 @@ class TestPrivateLiftService(unittest.TestCase):
             game_type=PrivateComputationGameType.LIFT,
             input_path=self.test_input_path,
             output_dir=self.test_output_dir,
+            fail_fast=True,
         )


### PR DESCRIPTION
Summary:
**This stack**
Consolidate PA and PL service with the following steps
1. Modify PrivateLiftService and make PA-Coordinator use it;
3. Delete PrivateAttributionService;
4. Rename PrivateLiftService to PrivateComputationService;
5. Clear the TODOs added along the way as BE tasks.

**This diff**
Part of Step 1. In this diff, pa-coordinator uses `PrivateLiftService.prepare_data()`; and `PrivateAttributionService.prepare_data()` is no longer used. This diff should not break any part of the E2E flow for either PL or PA.

Differential Revision: D31098991

