### PR TITLE
PA-coordinator calls PrivateLiftService.compute_metrics()

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -320,11 +320,16 @@ def prepare_compute_input(
     dry_run: Optional[bool] = False,
     log_cost_to_s3: bool = False,
 ) -> None:
-    pa_service = _build_pa_service(
+    private_computation_service = _build_private_computation_service(
         config["private_computation"], config["mpc"], config["pid"]
     )
 
-    pa_service.prepare_data(
+    # Because it's possible that the "get" command never gets called to update the instance since the last step started,
+    # so it could appear that the current status is still XXX_STARTED when it should be XXX_FAILED or XXX_COMPLETED,
+    # so we need to explicitly call update_instance() here to get the current status.
+    private_computation_service.update_instance(instance_id)
+
+    private_computation_service.prepare_data(
         instance_id=instance_id,
         dry_run=dry_run,
         log_cost_to_s3=log_cost_to_s3,

--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -349,14 +349,13 @@ def compute_attribution(
     dry_run: Optional[bool] = False,
     log_cost_to_s3: bool = False,
 ) -> None:
-    pa_service = _build_pa_service(
+    private_computation_service = _build_private_computation_service(
         config["private_computation"], config["mpc"], config["pid"]
     )
     logging.info("Starting compute metrics...")
 
-    instance = pa_service.compute_attribute(
+    instance = private_computation_service.compute_metrics(
         instance_id=instance_id,
-        game_name=game,
         attribution_rule=attribution_rule,
         aggregation_type=aggregation_type,
         server_ips=server_ips,

--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -10,8 +10,8 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container>] [options]
-    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --fail_fast --dry_run] [options]
+    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container> --fail_fast] [options]
+    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --dry_run] [options]
     pl-coordinator compute <instance_id> --config=<config_file> [--server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
     pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
@@ -144,6 +144,7 @@ def main():
             num_mpc_containers=arguments["--num_mpc_containers"],
             num_files_per_mpc_container=arguments["--num_files_per_mpc_container"],
             game_type=arguments["--game_type"],
+            fail_fast=arguments["--fail_fast"],
         )
     elif arguments["id_match"]:
         logger.info(f"Run id match on instance: {instance_id}")
@@ -151,7 +152,6 @@ def main():
             config=config,
             instance_id=instance_id,
             logger=logger,
-            fail_fast=arguments["--fail_fast"],
             server_ips=arguments["--server_ips"],
             hmac_key=arguments["--hmac_key"],
             dry_run=arguments["--dry_run"],

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -42,6 +42,7 @@ def create_instance(
     num_mpc_containers: int,
     num_files_per_mpc_container: Optional[int] = None,
     game_type: Optional[PrivateComputationGameType] = None,
+    fail_fast: bool = False,
 ) -> PrivateComputationInstance:
     pl_service = _build_pl_service(
         config["private_computation"], config["mpc"], config["pid"]
@@ -59,6 +60,7 @@ def create_instance(
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
+        fail_fast=fail_fast,
     )
 
     logger.info(instance)
@@ -82,7 +84,6 @@ def id_match(
     pl_service.id_match(
         instance_id=instance_id,
         protocol=PIDProtocol.UNION_PID,
-        fail_fast=fail_fast,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -54,6 +54,7 @@ def create_instance(
         output_dir=output_dir,
         num_pid_containers=num_pid_containers,
         num_mpc_containers=num_mpc_containers,
+        concurrency=DEFAULT_CONCURRENCY,
         num_files_per_mpc_container=num_files_per_mpc_container,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"

--- a/fbpcs/private_attribution/service/private_attribution.py
+++ b/fbpcs/private_attribution/service/private_attribution.py
@@ -78,44 +78,6 @@ class PrivateAttributionService:
         self.onedocker_binary_config_map = onedocker_binary_config_map
         self.logger: logging.Logger = logging.getLogger(__name__)
 
-    def create_instance(
-        self,
-        instance_id: str,
-        role: PrivateComputationRole,
-        input_path: str,
-        output_dir: str,
-        hmac_key: str,
-        num_pid_containers: int,
-        num_mpc_containers: int,
-        num_files_per_mpc_container: int,
-        padding_size: int,
-        logger: logging.Logger,
-        concurrency: int = 1,
-        k_anonymity_threshold: int = 0,
-    ) -> PrivateComputationInstance:
-        self.logger.info(f"Creating instance: {instance_id}")
-
-        instance = PrivateComputationInstance(
-            instance_id=instance_id,
-            role=role,
-            instances=[],
-            status=PrivateComputationInstanceStatus.CREATED,
-            status_update_ts=0,  # placeholder, not used by PA, will be used after PL+PA consolidation
-            input_path=input_path,
-            output_dir=output_dir,
-            hmac_key=hmac_key,
-            num_pid_containers=num_pid_containers,
-            num_mpc_containers=num_mpc_containers,
-            num_files_per_mpc_container=num_files_per_mpc_container,
-            game_type=PrivateComputationGameType.ATTRIBUTION,
-            padding_size=padding_size,
-            concurrency=concurrency,
-            k_anonymity_threshold=k_anonymity_threshold,
-        )
-
-        self.instance_repository.create(instance)
-        return instance
-
     def update_instance(self, instance_id: str) -> PrivateComputationInstance:
         pa_instance = self.instance_repository.read(instance_id)
 

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -89,6 +89,13 @@ class PrivateComputationInstance(InstanceBase):
     k_anonymity_threshold: int = 0
     retry_counter: int = 0
 
+    # This boolean is used to determine whether auto retry will be performed at any data processing step
+    #   of the computation. For now, when fail_fast = False, the pid preparer step
+    #   will retry up to MAX_RETRY times, which is set to be 0, because almost all problems
+    #   we've seen so far won't get resolved by just retrying. In the future, when the product is more stable,
+    #   we will increase MAX_RETRY and allow other steps to auto retry as well.
+    fail_fast: bool = False
+
     breakdown_key: Optional[BreakdownKey] = None
     pce_config: Optional[PCEConfig] = None
     is_test: Optional[bool] = False  # set to be true for testing account ID

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -85,7 +85,7 @@ class PrivateComputationInstance(InstanceBase):
     hmac_key: Optional[str] = None
     padding_size: Optional[int] = None
 
-    concurrency: int = 1
+    concurrency: int = 1  # used only by MPC compute metrics stage. TODO: renamed it to compute_metrics_concurrency
     k_anonymity_threshold: int = 0
     retry_counter: int = 0
 

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -46,6 +46,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             output_dir="out",
             num_pid_containers=4,
             num_mpc_containers=4,
+            concurrency=1,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -67,6 +68,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             output_dir="out",
             num_pid_containers=4,
             num_mpc_containers=4,
+            concurrency=1,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -47,6 +47,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             num_pid_containers=4,
             num_mpc_containers=4,
             concurrency=1,
+            fail_fast=True,
         )
         self.repo.create(test_read_private_computation_instance)
         self.assertEqual(
@@ -69,6 +70,7 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
             num_pid_containers=4,
             num_mpc_containers=4,
             concurrency=1,
+            fail_fast=True,
         )
         # Create a new MPC instance to be added to instances
         self.repo.create(test_update_private_computation_instance)

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -137,6 +137,7 @@ class PrivateLiftService:
         hmac_key: Optional[str] = None,
         padding_size: int = DEFAULT_PADDING_SIZE,
         k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
+        fail_fast: bool = False,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -162,6 +163,7 @@ class PrivateLiftService:
             padding_size=padding_size,
             concurrency=concurrency,
             k_anonymity_threshold=k_anonymity_threshold,
+            fail_fast=fail_fast,
         )
 
         self.instance_repository.create(instance)
@@ -301,7 +303,6 @@ class PrivateLiftService:
         instance_id: str,
         protocol: PIDProtocol,
         pid_config: Dict[str, Any],
-        fail_fast: bool,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
@@ -313,7 +314,6 @@ class PrivateLiftService:
                 instance_id,
                 protocol,
                 pid_config,
-                fail_fast,
                 is_validating,
                 synthetic_shard_path,
                 server_ips,
@@ -329,7 +329,6 @@ class PrivateLiftService:
         instance_id: str,
         protocol: PIDProtocol,
         pid_config: Dict[str, Any],
-        fail_fast: bool,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
@@ -396,7 +395,7 @@ class PrivateLiftService:
         await self.pid_svc.run_instance(
             instance_id=pid_instance_id,
             pid_config=pid_config,
-            fail_fast=fail_fast,
+            fail_fast=pl_instance.fail_fast,
             server_ips=server_ips,
         )
 

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -94,6 +94,9 @@ STAGE_FAILED_STATUSES: List[PrivateComputationInstanceStatus] = [
     PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
 ]
 
+DEFAULT_PADDING_SIZE = 4
+DEFAULT_K_ANONYMITY_THRESHOLD = 100
+
 
 class PrivateLiftService:
     def __init__(
@@ -124,12 +127,16 @@ class PrivateLiftService:
         output_dir: str,
         num_pid_containers: int,
         num_mpc_containers: int,
+        concurrency: int,
         num_files_per_mpc_container: Optional[int] = None,
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         breakdown_key: Optional[BreakdownKey] = None,
         pce_config: Optional[PCEConfig] = None,
         is_test: Optional[bool] = False,
+        hmac_key: Optional[str] = None,
+        padding_size: int = DEFAULT_PADDING_SIZE,
+        k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -151,6 +158,10 @@ class PrivateLiftService:
             breakdown_key=breakdown_key,
             pce_config=pce_config,
             is_test=is_test,
+            hmac_key=hmac_key,
+            padding_size=padding_size,
+            concurrency=concurrency,
+            k_anonymity_threshold=k_anonymity_threshold,
         )
 
         self.instance_repository.create(instance)
@@ -200,6 +211,7 @@ class PrivateLiftService:
                 pl_instance=pl_instance, new_status=new_status
             )
             self.instance_repository.update(pl_instance)
+            self.logger.info(f"Finished updating instance: {pl_instance.instance_id}")
 
         return pl_instance
 
@@ -330,7 +342,7 @@ class PrivateLiftService:
         pl_instance = self.get_instance(instance_id)
 
         if pl_instance.role is PrivateComputationRole.PARTNER and not server_ips:
-            raise ValueError("Missing server_ips")
+            raise ValueError("Missing server_ips for Partner")
 
         # default to be an empty string
         retry_counter_str = ""
@@ -354,6 +366,9 @@ class PrivateLiftService:
 
         # Create a new pid instance
         pid_instance_id = instance_id + "_id_match" + retry_counter_str
+        # TODO T101225909: remove the option here to pass in a hmac key at the id match stage
+        #   instead, always pass in at create_instance
+        pl_instance.hmac_key = hmac_key or pl_instance.hmac_key
         pid_instance = self.pid_svc.create_instance(
             instance_id=pid_instance_id,
             protocol=PIDProtocol.UNION_PID,
@@ -363,7 +378,7 @@ class PrivateLiftService:
             output_path=pl_instance.pid_stage_output_base_path,
             is_validating=is_validating,
             synthetic_shard_path=synthetic_shard_path,
-            hmac_key=hmac_key,
+            hmac_key=pl_instance.hmac_key,
         )
 
         # Push PID instance to PrivateComputationInstance.instances and update PL Instance status
@@ -596,9 +611,11 @@ class PrivateLiftService:
             )
 
         # Prepare arguments for lift game
+        # TODO T101225909: remove the option to pass in concurrency at the compute stage
+        #   instead, always pass in at create_instance
+        pl_instance.concurrency = concurrency or pl_instance.concurrency
         game_args = self._get_compute_metrics_game_args(
             pl_instance,
-            concurrency,
             is_validating,
             dry_run,
             container_timeout,
@@ -1124,7 +1141,6 @@ class PrivateLiftService:
     def _get_compute_metrics_game_args(
         self,
         pl_instance: PrivateComputationInstance,
-        concurrency: int,
         is_validating: Optional[bool] = False,
         dry_run: Optional[bool] = None,
         container_timeout: Optional[int] = None,
@@ -1147,7 +1163,7 @@ class PrivateLiftService:
                     "output_base_path": pl_instance.compute_stage_output_base_path,
                     "file_start_index": file_start_index,
                     "num_files": num_files,
-                    "concurrency": concurrency,
+                    "concurrency": pl_instance.concurrency,
                 }
                 for file_start_index, num_files in self.calculate_file_start_index_and_num_shards(
                     num_containers * pl_instance.num_files_per_mpc_container,

--- a/fbpcs/private_lift/service/privatelift.py
+++ b/fbpcs/private_lift/service/privatelift.py
@@ -483,53 +483,41 @@ class PrivateLiftService:
     def compute_metrics(
         self,
         instance_id: str,
-        concurrency: int,
+        concurrency: Optional[int] = None,
+        attribution_rule: Optional[str] = None,
+        aggregation_type: Optional[str] = None,
         is_validating: Optional[bool] = False,
         server_ips: Optional[List[str]] = None,
         dry_run: Optional[bool] = None,
+        log_cost_to_s3: bool = False,
         container_timeout: Optional[int] = None,
     ) -> PrivateComputationInstance:
         return asyncio.run(
             self.compute_metrics_async(
                 instance_id,
                 concurrency,
+                attribution_rule,
+                aggregation_type,
                 is_validating,
                 server_ips,
                 dry_run,
+                log_cost_to_s3,
                 container_timeout,
             )
         )
-
-    def calculate_file_start_index_and_num_shards(
-        self,
-        num_input_files: int,
-        num_containers: int,
-    ) -> Iterator[Tuple[int, int]]:
-        """
-        Calculate the file start index and number of shards to run per worker
-        Examples:
-        num_input_files = 4, num_containers = 4 -> [(0, 1), (1, 1), (2, 1), (3, 1)]
-        num_input_files = 5, num_containers = 4 -> [(0, 2), (2, 1), (3, 1), (4, 1)]
-        num_input_files = 6, num_containers = 4 -> [(0, 2), (2, 2), (4, 1), (5, 1)]
-        num_input_files = 7, num_containers = 4 -> [(0, 2), (2, 2), (4, 2), (6, 1)]
-        num_input_files = 8, num_containers = 4 -> [(0, 2), (2, 2), (4, 2), (6, 2)]
-        """
-        input_files = ["tmp"] * num_input_files
-        file_start_index = 0
-        for i in range(num_containers):
-            num_files = len(input_files[i::num_containers])
-            yield file_start_index, num_files
-            file_start_index += num_files
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of compute_metrics() so that it can be called by Thrift
     async def compute_metrics_async(
         self,
         instance_id: str,
-        concurrency: int,
+        concurrency: Optional[int] = None,
+        attribution_rule: Optional[str] = None,
+        aggregation_type: Optional[str] = None,
         is_validating: Optional[bool] = False,
         server_ips: Optional[List[str]] = None,
         dry_run: Optional[bool] = None,
+        log_cost_to_s3: bool = False,
         container_timeout: Optional[int] = None,
     ) -> PrivateComputationInstance:
         # It's expected that the pl instance is in an updated status because:
@@ -566,8 +554,11 @@ class PrivateLiftService:
         pl_instance.concurrency = concurrency or pl_instance.concurrency
         game_args = self._get_compute_metrics_game_args(
             pl_instance,
+            attribution_rule,
+            aggregation_type,
             is_validating,
             dry_run,
+            log_cost_to_s3,
             container_timeout,
         )
 
@@ -1008,6 +999,7 @@ class PrivateLiftService:
     ) -> Optional[PrivateComputationInstanceStatus]:
         MPC_GAME_TO_STAGE_MAPPER: Dict[str, str] = {
             GameNames.LIFT.value: "computation",
+            GameNames.ATTRIBUTION_COMPUTE.value: "computation",
             GameNames.SHARD_AGGREGATOR.value: "aggregation",
         }
 
@@ -1091,14 +1083,20 @@ class PrivateLiftService:
     def _get_compute_metrics_game_args(
         self,
         pl_instance: PrivateComputationInstance,
+        attribution_rule: Optional[str] = None,
+        aggregation_type: Optional[str] = None,
         is_validating: Optional[bool] = False,
         dry_run: Optional[bool] = None,
+        log_cost_to_s3: bool = False,
         container_timeout: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         game_args = []
+
         # If this is to recover from a previous MPC compute failure
         if self._ready_for_partial_container_retry(pl_instance) and not dry_run:
-            game_args = self._gen_game_args_to_retry(pl_instance)
+            game_args_to_retry = self._gen_game_args_to_retry(pl_instance)
+            if game_args_to_retry:
+                game_args = game_args_to_retry
 
         # If this is a normal run, dry_run, or unable to get the game args to retry from mpc service
         if not game_args:
@@ -1107,19 +1105,30 @@ class PrivateLiftService:
             if is_validating:
                 num_containers += 1
 
-            game_args = [
-                {
-                    "input_base_path": pl_instance.data_processing_output_path,
-                    "output_base_path": pl_instance.compute_stage_output_base_path,
-                    "file_start_index": file_start_index,
-                    "num_files": num_files,
-                    "concurrency": pl_instance.concurrency,
-                }
-                for file_start_index, num_files in self.calculate_file_start_index_and_num_shards(
-                    num_containers * pl_instance.num_files_per_mpc_container,
-                    num_containers,
+            common_compute_game_args = {
+                "input_base_path": pl_instance.data_processing_output_path,
+                "output_base_path": pl_instance.compute_stage_output_base_path,
+                "num_files": pl_instance.num_files_per_mpc_container,
+                "concurrency": pl_instance.concurrency,
+            }
+
+            # TODO: we eventually will want to get rid of the if-else here, which will be
+            #   easy to do once the Lift and Attribution MPC compute games are consolidated
+            if pl_instance.game_type is PrivateComputationGameType.ATTRIBUTION:
+                # TODO: we will write aggregation_type, attribution_rule and log_cost_to_s3
+                #   to the instance, so later this function interface will get simplified
+                game_args = self._get_attribution_game_args(
+                    pl_instance,
+                    common_compute_game_args,
+                    checked_cast(str, aggregation_type),
+                    checked_cast(str, attribution_rule),
+                    log_cost_to_s3,
                 )
-            ]
+
+            elif pl_instance.game_type is PrivateComputationGameType.LIFT:
+                game_args = self._get_lift_game_args(
+                    pl_instance, common_compute_game_args
+                )
 
         return game_args
 
@@ -1256,3 +1265,44 @@ class PrivateLiftService:
         # Wait for all coroutines to finish
         await asyncio.gather(*coros)
         self.logger.info("All sharding coroutines finished")
+
+    def _get_attribution_game_args(
+        self,
+        pl_instance: PrivateComputationInstance,
+        common_compute_game_args: Dict[str, Any],
+        aggregation_type: str,
+        attribution_rule: str,
+        log_cost_to_s3: bool,
+    ) -> List[Dict[str, Any]]:
+        game_args = []
+        game_args = [
+            {
+                **common_compute_game_args,
+                **{
+                    "aggregators": aggregation_type,
+                    "attribution_rules": attribution_rule,
+                    "file_start_index": i * pl_instance.num_files_per_mpc_container,
+                    "use_xor_encryption": True,
+                    "run_name": pl_instance.instance_id if log_cost_to_s3 else "",
+                    "max_num_touchpoints": pl_instance.padding_size,
+                    "max_num_conversions": pl_instance.padding_size,
+                },
+            }
+            for i in range(pl_instance.num_mpc_containers)
+        ]
+        return game_args
+
+    def _get_lift_game_args(
+        self,
+        pl_instance: PrivateComputationInstance,
+        common_compute_game_args: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        game_args = []
+        game_args = [
+            {
+                **common_compute_game_args,
+                **{"file_start_index": i * pl_instance.num_files_per_mpc_container},
+            }
+            for i in range(pl_instance.num_mpc_containers)
+        ]
+        return game_args

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -120,6 +120,7 @@ class TestPrivateLiftService(unittest.TestCase):
         self.test_input_path = "in_path"
         self.test_output_dir = "out_dir"
         self.test_game_type = PrivateComputationGameType.LIFT
+        self.test_concurrency = 1
 
     def test_create_instance(self):
         test_role = PrivateComputationRole.PUBLISHER
@@ -131,6 +132,7 @@ class TestPrivateLiftService(unittest.TestCase):
             output_dir=self.test_output_dir,
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
+            concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
         )
         # check instance_repository.create is called with the correct arguments
@@ -967,6 +969,7 @@ class TestPrivateLiftService(unittest.TestCase):
             status_update_ts=1600000000,
             num_pid_containers=self.test_num_containers,
             num_mpc_containers=self.test_num_containers,
+            concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             game_type=PrivateComputationGameType.LIFT,
             input_path=self.test_input_path,

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -241,7 +241,6 @@ class TestPrivateLiftService(unittest.TestCase):
         test_pid_role = PIDRole.PUBLISHER
         test_pid_config = {"key": "value"}
         test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
-        test_fail_fast = True
 
         pl_instance = self.create_sample_instance(
             status=PrivateComputationInstanceStatus.CREATED
@@ -267,7 +266,6 @@ class TestPrivateLiftService(unittest.TestCase):
             instance_id=self.test_pl_id,
             protocol=test_pid_protocol,
             pid_config=test_pid_config,
-            fail_fast=test_fail_fast,
             server_ips=["192.0.2.0", "192.0.2.1"],
             hmac_key=test_hmac_key,
         )
@@ -309,10 +307,6 @@ class TestPrivateLiftService(unittest.TestCase):
             test_pid_config,
             self.pid_service.run_instance.call_args[1]["pid_config"],
         )
-        self.assertEqual(
-            test_fail_fast,
-            self.pid_service.run_instance.call_args[1]["fail_fast"],
-        )
 
         self.pl_service.instance_repository.update.assert_called()
 
@@ -345,7 +339,6 @@ class TestPrivateLiftService(unittest.TestCase):
             instance_id=self.test_pl_id,
             protocol=test_pid_protocol,
             pid_config={"key": "value"},
-            fail_fast=False,
         )
 
         # check that the retry counter has been incremented
@@ -378,7 +371,6 @@ class TestPrivateLiftService(unittest.TestCase):
                 instance_id=test_pl_id,
                 protocol=PIDProtocol.UNION_PID,
                 pid_config={"key": "value"},
-                fail_fast=True,
             )
 
     def test_id_match_rerun_fail(self):
@@ -395,7 +387,6 @@ class TestPrivateLiftService(unittest.TestCase):
                 instance_id=test_pl_id,
                 protocol=PIDProtocol.UNION_PID,
                 pid_config={"key": "value"},
-                fail_fast=True,
             )
 
     def test_compute_metrics(self):
@@ -974,4 +965,5 @@ class TestPrivateLiftService(unittest.TestCase):
             game_type=PrivateComputationGameType.LIFT,
             input_path=self.test_input_path,
             output_dir=self.test_output_dir,
+            fail_fast=True,
         )

--- a/fbpcs/private_lift/test/service/test_privatelift.py
+++ b/fbpcs/private_lift/test/service/test_privatelift.py
@@ -887,28 +887,6 @@ class TestPrivateLiftService(unittest.TestCase):
             PrivateComputationInstanceStatus.COMPUTATION_FAILED, pl_instance.status
         )
 
-    def test_calculate_file_start_index_and_num_shards(self):
-        self.assertEqual(
-            list(self.pl_service.calculate_file_start_index_and_num_shards(4, 4)),
-            [(0, 1), (1, 1), (2, 1), (3, 1)],
-        )
-        self.assertEqual(
-            list(self.pl_service.calculate_file_start_index_and_num_shards(5, 4)),
-            [(0, 2), (2, 1), (3, 1), (4, 1)],
-        )
-        self.assertEqual(
-            list(self.pl_service.calculate_file_start_index_and_num_shards(6, 4)),
-            [(0, 2), (2, 2), (4, 1), (5, 1)],
-        )
-        self.assertEqual(
-            list(self.pl_service.calculate_file_start_index_and_num_shards(7, 4)),
-            [(0, 2), (2, 2), (4, 2), (6, 1)],
-        )
-        self.assertEqual(
-            list(self.pl_service.calculate_file_start_index_and_num_shards(8, 4)),
-            [(0, 2), (2, 2), (4, 2), (6, 2)],
-        )
-
     def test_gen_game_args_to_retry(self):
         test_input = "test_input_retry"
         mpc_instance = PCSMPCInstance.create_instance(


### PR DESCRIPTION
Summary:
**This stack**
Consolidate PA and PL service with the following steps
1. Modify PrivateLiftService and make PA-Coordinator use it;
3. Delete PrivateAttributionService;
4. Rename PrivateLiftService to PrivateComputationService;
5. Clear the TODOs added along the way as BE tasks.

**This diff**
Part of Step 1. In this diff, pa-coordinator uses `PrivateLiftService.compute_metrics()`; and `PrivateAttributionService.compute_attribute()` is no longer used. This diff should not break any part of the E2E flow for either PL or PA.

Differential Revision: D31106166

