### PR TITLE
set stage status based on container status

### DIFF
--- a/fbpcs/pid/service/pid_service/pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_prepare_stage.py
@@ -87,12 +87,9 @@ class PIDPrepareStage(PIDStage):
 
         # Wait for all coroutines to finish
         containers = await asyncio.gather(*coroutines)
-        # it thinks containers is Tuple[any], when in fact in is List[ContainerInstance]
-        # pyre-ignore
+        containers = list(containers)
+
         await self.update_instance_containers(instance_id, containers)
-        if wait_for_containers:
-            # already waited in preparer.prepare_on_container_async
-            self.logger.info(f"[{self}] All sharded instances prepared")
-            return PIDStageStatus.COMPLETED
-        self.logger.info(f"[{self}] All shard instance containers started")
-        return PIDStageStatus.STARTED
+        status = self.get_stage_status_from_containers(containers)
+        self.logger.info(f"PIDPrepareStatus is {status}")
+        return status

--- a/fbpcs/pid/service/pid_service/pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_shard_stage.py
@@ -98,13 +98,9 @@ class PIDShardStage(PIDStage):
             return PIDStageStatus.FAILED
 
         await self.update_instance_containers(instance_id, [container])
-        if wait_for_containers:
-            self.logger.info("All shards copied to destination path")
-            return PIDStageStatus.COMPLETED
-        self.logger.info(
-            f"[{self}] Started CppShardingService on container {container}"
-        )
-        return PIDStageStatus.STARTED
+        status = self.get_stage_status_from_containers([container])
+        self.logger.info(f"PIDShardStatus is {status}")
+        return status
 
     async def _ready(
         self,


### PR DESCRIPTION
Summary:
## What

* In PIDShard and PIDPrepare, derive a PIDStageStatus from the status of the containers instead of an if-else for complete or started
* Added a new test case to make sure the proper PIDStage status is set
* PIDRun is already doing this, so no need to add anything there

## Why

* The PIDStage status is set to COMPLETED even if one of the containers failed
* Yutong informed me of this bug she found when creating tests for CICD:

"stages_containers":
            {
                "UnionPIDStage.ADV_SHARD":
                [
                    {
                        "instance_id": "arn:aws:ecs:us-west-2:592513842793:task/cicd/195c23de360d4290a70856eab6641053",
                        "ip_address": "10.0.0.82",
                        "status": "COMPLETED"
                    }
                ],
                "UnionPIDStage.ADV_PREPARE":
                [
                    {
                        "instance_id": "arn:aws:ecs:us-west-2:592513842793:task/cicd/c890662107e54314a9d546c4729bb683",
                        "ip_address": "10.0.0.17",
                        "status": "COMPLETED"
                    },
                    {
                        "instance_id": "arn:aws:ecs:us-west-2:592513842793:task/cicd/575934bd966f4e9c98c9d4f93386a2d3",
                        "ip_address": "10.0.0.106",
                        "status": "FAILED" <-------------- We continue to PID RUN after this ... CLOWNTOWN
                    }
                ],
                "UnionPIDStage.ADV_RUN_PID":
                [
                    {
                        "instance_id": "arn:aws:ecs:us-west-2:592513842793:task/cicd/b0d42863bc994d93a4074cb331df0dc2",
                        "ip_address": "10.0.0.121",
                        "status": "COMPLETED"
                    },
                    {
                        "instance_id": "arn:aws:ecs:us-west-2:592513842793:task/cicd/4de272df25c2461187e5e1d5e2f54e34",
                        "ip_address": "10.0.0.47",
                        "status": "COMPLETED"
                    }
                ]
            },

Reviewed By: peking2

Differential Revision: D31157011

