### PR TITLE
Publish fbpcs/coordinator image

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -1,0 +1,59 @@
+name: Publish Coordinator Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'fbpcs/pl_coordinator/**'
+      - 'fbpcs/pa_coordinator/**'
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Manually running this workflow to build a coordinator image'
+        default: 'Run'
+
+
+env:
+  DISTRO: ubuntu
+  REGISTRY: ghcr.io
+  LOCAL_IMAGE_NAME: ${{ github.event.repository.name }}/coordinator
+  LOCAL_IMAGE_TAG: latest
+  REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/coordinator
+
+jobs:
+  push:
+   runs-on: ubuntu-latest
+   name: Build and publish image
+   permissions:
+    contents: read
+    packages: write
+
+   steps:
+     - uses: actions/checkout@v2
+
+     - name: Build image
+       run: |
+        docker build -f ./fbpcs/Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} .
+
+    # Tests will be added here
+
+     - name: Log into registry ${{ env.REGISTRY }}
+       uses: docker/login-action@v1
+       with:
+         registry: ${{ env.REGISTRY }}
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: Set output
+       id: vars
+       run: echo ::set-output name=ref::${GITHUB_REF##*/}
+
+     - name: Tag docker image
+       run: |
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:latest
+
+     - name: Push image to registry
+       run: |
+          docker push --all-tags ${{ env.REGISTRY_IMAGE_NAME }}


### PR DESCRIPTION
Summary:
**Why**: When adding E2E tests on github actions, I need to use pl-coodinator to coordinate different stages.

**What**: Publish fbpcs/coordinator image; image will be like ghcr.io/facebookresearch/fbpcs/coordinator:latest(since pl and pa will both use it, so I change the name to be coordinator)

I didnot create a specific bash script because this is in sync with oncall scripts.  Let me know if you need me create one and I can update oncall scripts accordingly

**Next**: May need to rename the files; or release this to Pypi

Differential Revision: D31176404

