### PR TITLE
Pass in hmac_key at PL instance creation time

### DIFF
--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -10,8 +10,8 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container> --fail_fast] [options]
-    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --hmac_key=<base64_key> --dry_run] [options]
+    pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container> --hmac_key=<base64_key> --fail_fast] [options]
+    pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator compute <instance_id> --config=<config_file> [--server_ips=<server_ips> --concurrency=<concurrency> --dry_run] [options]
     pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
@@ -144,6 +144,7 @@ def main():
             num_mpc_containers=arguments["--num_mpc_containers"],
             num_files_per_mpc_container=arguments["--num_files_per_mpc_container"],
             game_type=arguments["--game_type"],
+            hmac_key=arguments["--hmac_key"],
             fail_fast=arguments["--fail_fast"],
         )
     elif arguments["id_match"]:
@@ -153,7 +154,6 @@ def main():
             instance_id=instance_id,
             logger=logger,
             server_ips=arguments["--server_ips"],
-            hmac_key=arguments["--hmac_key"],
             dry_run=arguments["--dry_run"],
         )
     elif arguments["compute"]:

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -42,6 +42,7 @@ def create_instance(
     output_dir: str,
     num_pid_containers: int,
     num_mpc_containers: int,
+    hmac_key: Optional[str] = None,
     num_files_per_mpc_container: Optional[int] = None,
     game_type: Optional[PrivateComputationGameType] = None,
     fail_fast: bool = False,
@@ -62,6 +63,7 @@ def create_instance(
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],
+        hmac_key=hmac_key,
         fail_fast=fail_fast,
     )
 
@@ -75,7 +77,6 @@ def id_match(
     logger: logging.Logger,
     fail_fast: bool = False,
     server_ips: Optional[List[str]] = None,
-    hmac_key: Optional[str] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
     pl_service = _build_pl_service(
@@ -94,7 +95,6 @@ def id_match(
         ]["synthetic_shard_path"],
         pid_config=config["pid"],
         server_ips=server_ips,
-        hmac_key=hmac_key,
         dry_run=dry_run,
     )
 

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -7,14 +7,14 @@
 # pyre-strict
 
 from typing import Any, Dict, List, Optional
-from fbpcs.pid.service.pid_service.pid import PIDService
-from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationRole,
-)
 
 from fbpcs.pid.entity.pid_instance import PIDInstanceStatus, PIDProtocol, PIDRole
+from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.private_computation_stage_type import (
     PrivateComputationStageType,
@@ -33,7 +33,6 @@ class IdMatchStageService(PrivateComputationStageService):
         _protocol: An enum consumed by PIDService to determine which protocol to use, e.g. UNION_PID.
         _is_validating: TODO
         _synthetic_shard_path: TODO
-        _hmac_key: A base64 encoded string containing an hmac salt. Used to transform each id into a HMAC_SHA256 hash
     """
 
     def __init__(
@@ -43,14 +42,12 @@ class IdMatchStageService(PrivateComputationStageService):
         protocol: PIDProtocol,
         is_validating: bool = False,
         synthetic_shard_path: Optional[str] = None,
-        hmac_key: Optional[str] = None,
     ) -> None:
         self._pid_svc = pid_svc
         self._pid_config = pid_config
         self._protocol = protocol
         self._is_validating = is_validating
         self._synthetic_shard_path = synthetic_shard_path
-        self._hmac_key = hmac_key
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of run_async() so that it can be called by Thrift
@@ -84,7 +81,7 @@ class IdMatchStageService(PrivateComputationStageService):
             is_validating=self._is_validating or pc_instance.is_validating,
             synthetic_shard_path=self._synthetic_shard_path
             or pc_instance.synthetic_shard_path,
-            hmac_key=self._hmac_key or pc_instance.hmac_key,
+            hmac_key=pc_instance.hmac_key,
         )
 
         # Push PID instance to PrivateComputationInstance.instances and update PL Instance status

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -304,7 +304,6 @@ class PrivateComputationService:
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
-        hmac_key: Optional[str] = None,
         dry_run: Optional[bool] = False,
     ) -> PrivateComputationInstance:
         return asyncio.run(
@@ -315,7 +314,6 @@ class PrivateComputationService:
                 is_validating,
                 synthetic_shard_path,
                 server_ips,
-                hmac_key,
                 dry_run,
             )
         )
@@ -329,7 +327,6 @@ class PrivateComputationService:
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         server_ips: Optional[List[str]] = None,
-        hmac_key: Optional[str] = None,
         dry_run: Optional[bool] = False,
     ) -> PrivateComputationInstance:
         return await self.run_stage_async(
@@ -340,7 +337,6 @@ class PrivateComputationService:
                 protocol,
                 is_validating or False,
                 synthetic_shard_path,
-                hmac_key,
             ),
             server_ips,
             dry_run or False,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -50,17 +50,16 @@ from fbpcs.private_computation.service.private_computation import (
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
-
-# TODO T94666166: libfb won't work in OSS
-from libfb.py.asyncio.mock import AsyncMock
-from libfb.py.testutil import data_provider
-
 from fbpcs.private_computation.service.utils import (
     create_and_start_mpc_instance,
     gen_mpc_game_args_to_retry,
     map_private_computation_role_to_mpc_party,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
 )
+
+# TODO T94666166: libfb won't work in OSS
+from libfb.py.asyncio.mock import AsyncMock
+from libfb.py.testutil import data_provider
 
 
 def _get_valid_stages_data() -> List[Tuple[PrivateComputationStageType]]:
@@ -148,6 +147,7 @@ class TestPrivateComputationService(unittest.TestCase):
         self.test_output_dir = "out_dir"
         self.test_game_type = PrivateComputationGameType.LIFT
         self.test_concurrency = 1
+        self.test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
 
     def test_create_instance(self):
         test_role = PrivateComputationRole.PUBLISHER
@@ -161,6 +161,7 @@ class TestPrivateComputationService(unittest.TestCase):
             num_mpc_containers=self.test_num_containers,
             concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
+            hmac_key=self.test_hmac_key,
         )
         # check instance_repository.create is called with the correct arguments
         self.private_computation_service.instance_repository.create.assert_called()
@@ -429,7 +430,6 @@ class TestPrivateComputationService(unittest.TestCase):
             )
 
         self.assertEqual(pl_instance.status, stage_type.failed_status)
-
 
     def test_partner_missing_server_ips(self):
         test_private_computation_id = "test_private_computation_id"
@@ -855,9 +855,7 @@ class TestPrivateComputationService(unittest.TestCase):
             instances=[mpc_instance],
         )
 
-        game_args = gen_mpc_game_args_to_retry(
-            private_computation_instance
-        )
+        game_args = gen_mpc_game_args_to_retry(private_computation_instance)
 
         self.assertEqual(1, len(game_args))  # only 1 failed container
         self.assertEqual(test_input, game_args[0]["input_filenames"])
@@ -883,4 +881,5 @@ class TestPrivateComputationService(unittest.TestCase):
             output_dir=self.test_output_dir,
             fail_fast=True,
             k_anonymity_threshold=DEFAULT_K_ANONYMITY_THRESHOLD,
+            hmac_key=self.test_hmac_key,
         )


### PR DESCRIPTION
Summary: Remove the option to pass in hmac_key at the the id_match stage for PL. Instead, take it at create_instance and save it to instance. PA is already only taking it at create_instance and not at id_match. No Thrift layer change because the publisher side do not need the hmac_key to do id match.

Reviewed By: jrodal98

Differential Revision: D31156925

