### PR TITLE
add lambda job that triggers on S3 CSV uploads

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_validation/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_validation/main.tf
@@ -1,0 +1,109 @@
+provider "aws" {
+  profile = "default"
+  region  = var.aws_region
+}
+
+provider "archive" {}
+
+terraform {
+  backend "s3" {}
+}
+
+data "archive_file" "lambda_source_package" {
+  type        = "zip"
+  source_dir  = "validation_utility/"
+  output_path = "validation_lambda${var.tag_postfix}.zip"
+}
+
+resource "aws_s3_bucket_object" "lambda_trigger_object" {
+  bucket = var.upload_and_validation_s3_bucket
+  key    = "data-validation-lambda-package${var.tag_postfix}.zip"
+  source = data.archive_file.lambda_source_package.output_path
+  etag   = filemd5("validation_lambda${var.tag_postfix}.zip")
+}
+
+resource "aws_iam_role" "lambda_iam" {
+  name = "lambda-iam${var.tag_postfix}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "upload_lambda_trigger" {
+  s3_bucket     = var.upload_and_validation_s3_bucket
+  s3_key        = "data-validation-lambda-package${var.tag_postfix}.zip"
+  function_name = "data-validation-lambda-trigger${var.tag_postfix}"
+  role          = aws_iam_role.lambda_iam.arn
+  handler       = "lambda_main.lambda_handler"
+  runtime       = "python3.9"
+  timeout       = 900
+  memory_size   = 1024
+  environment {
+    variables = {
+      VALIDATION_DEBUG_MODE           = var.validation_debug_mode
+      UPLOAD_AND_VALIDATION_S3_BUCKET = var.upload_and_validation_s3_bucket
+      VALIDATION_RESULTS_S3_KEY       = var.validation_results_s3_key
+    }
+  }
+}
+
+resource "aws_lambda_permission" "allow_upload_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.upload_lambda_trigger.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = "arn:aws:s3:::${var.upload_and_validation_s3_bucket}"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = var.upload_and_validation_s3_bucket
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.upload_lambda_trigger.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "${var.events_data_upload_s3_key}/"
+    filter_suffix       = ".csv"
+  }
+
+  depends_on = [aws_lambda_permission.allow_upload_bucket]
+}
+
+resource "aws_iam_role_policy" "s3_policy_lambda" {
+  name   = "lambda-s3-policy${var.tag_postfix}"
+  role   = aws_iam_role.lambda_iam.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+          "arn:aws:s3:::${var.upload_and_validation_s3_bucket}/${var.validation_results_s3_key}",
+          "arn:aws:s3:::${var.upload_and_validation_s3_bucket}/${var.validation_results_s3_key}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+          "arn:aws:s3:::${var.upload_and_validation_s3_bucket}/${var.events_data_upload_s3_key}",
+          "arn:aws:s3:::${var.upload_and_validation_s3_bucket}/${var.events_data_upload_s3_key}/*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/fbpcs/infra/cloud_bridge/data_validation/validation_utility/lambda_main.py
+++ b/fbpcs/infra/cloud_bridge/data_validation/validation_utility/lambda_main.py
@@ -1,0 +1,76 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import boto3
+import os
+import urllib
+import validation
+
+from datetime import datetime
+
+DEBUG_MODE = str(os.environ.get('VALIDATION_DEBUG_MODE')) == '1'
+
+def debug_log(msg: str) -> None:
+    if DEBUG_MODE:
+        print(f'{msg}\n')
+
+def write_result_to_s3(bucket_name: str, bucket_key: str, file_name: str, file_contents: str) -> None:
+    debug_log(
+        '\n'.join([
+            'write_result_to_s3:',
+            f'bucket_name: {bucket_name}',
+            f'bucket_key: {bucket_key}',
+            f'file_name: {file_name}',
+            f'file_contents: {file_contents}',
+        ])
+    )
+    s3_client = boto3.client('s3')
+    key = bucket_key + '/' + file_name
+    response = s3_client.put_object(
+        Body=file_contents.encode('utf-8'),
+        Bucket=bucket_name,
+        Key=key
+    )
+    debug_log(response)
+
+# context type is: awslambdaric.lambda_context.LambdaContext
+def lambda_handler(event, context):
+    output_bucket_name = os.environ.get('UPLOAD_AND_VALIDATION_S3_BUCKET')
+    output_bucket_key = os.environ.get('VALIDATION_RESULTS_S3_KEY')
+    if not (output_bucket_name and output_bucket_key):
+        raise Exception(f'Exception: missing either output_bucket_name: `{output_bucket_name}` or output_bucket_key: `{output_bucket_key}`')
+
+    debug_log(
+        f'output bucket: {output_bucket_name}\noutput key: {output_bucket_key}'
+    )
+
+    try:
+        # todo: loop over all records
+        record = event['Records'][0]
+        input_bucket = record['s3']['bucket']['name']
+        input_key = urllib.parse.unquote_plus(record['s3']['object']['key'], encoding='utf-8')
+        debug_log(
+            f'input bucket: {input_bucket}\ninput key: {input_key}'
+        )
+        validation_results = validation.validate_and_generate_report(input_bucket, input_key)
+
+        input_filename = input_key.split('/')[-1]
+        validation_result_file_path = '_'.join([
+            input_filename,
+            'validation-results',
+            datetime.now().isoformat(),
+        ])
+
+        write_result_to_s3(
+            output_bucket_name,
+            output_bucket_key,
+            validation_result_file_path,
+            validation_results
+        )
+    except BaseException as e:
+        print(f'Unexpected error occurred: {e}')
+
+    debug_log('Finished validation processing')
+    return {'records': []}

--- a/fbpcs/infra/cloud_bridge/data_validation/validation_utility/validation.py
+++ b/fbpcs/infra/cloud_bridge/data_validation/validation_utility/validation.py
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import boto3
+
+def validate_and_generate_report(bucket, key):
+    report = ['Validation Summary:']
+    s3_client = boto3.client('s3')
+    response = s3_client.get_object(Bucket=bucket, Key=key)
+    body = response['Body']
+    lines = 0
+    for _ in body.iter_lines():
+        lines += 1
+    report.append('Total lines: %s' % lines)
+    return '\n'.join(report) + '\n'

--- a/fbpcs/infra/cloud_bridge/data_validation/variable.tf
+++ b/fbpcs/infra/cloud_bridge/data_validation/variable.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  description = "region of the aws resources"
+  default     = "us-west-2"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}
+
+variable "aws_account_id" {
+  description = "your aws account id, that's used to read encrypted S3 files"
+  default     = ""
+}
+
+variable "upload_and_validation_s3_bucket" {
+  description = "the bucket where manually preprocessed event CSVs will be uploaded, and where the validation results will be stored"
+  default     = ""
+}
+
+variable "events_data_upload_s3_key" {
+  description = "the object key where manually preprocessed event CSVs will be uploaded"
+  default     = ""
+}
+
+variable "validation_results_s3_key" {
+  description = "The bucket path where validation results will be stored. This should be a different basepath than the upload directory to avoid an infinite processing loop"
+  default     = ""
+}
+
+variable "validation_debug_mode" {
+  description = "extra logging for debugging/dev purpose"
+  default     = 0
+}


### PR DESCRIPTION
Summary:
Add terraform deployment that processes uploaded events_data CSVs in an
automated lambda processing pipeline.
CSVs uploaded to:
- s3://events_data_upload_s3_bucket/events_data_upload_s3_key
are processed and the result is uploaded to:
- s3://validation_results_s3_bucket/validation_results_s3_key

Differential Revision: D31173407

