### PR TITLE
Remove the option to pass `protocol` to PrivateComputationService.id_match() because we already only use a hard-coded value

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -42,7 +42,7 @@ from fbpcp.service.storage import StorageService
 from fbpcp.util import reflect, yaml
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_service_config import OneDockerServiceConfig
-from fbpcs.pid.entity.pid_instance import PIDInstance, PIDProtocol
+from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
@@ -263,7 +263,6 @@ def id_match(
     # run pid instance through pid service invoked from pa service
     instance = private_computation_service.id_match(
         instance_id=instance_id,
-        protocol=PIDProtocol.UNION_PID,
         pid_config=config["pid"],
         server_ips=server_ips,
         dry_run=dry_run,

--- a/fbpcs/pl_coordinator/pl_service_wrapper.py
+++ b/fbpcs/pl_coordinator/pl_service_wrapper.py
@@ -86,7 +86,6 @@ def id_match(
     # run pid instance through pid service invoked from pl service
     pl_service.id_match(
         instance_id=instance_id,
-        protocol=PIDProtocol.UNION_PID,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
         ],

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -8,6 +8,7 @@
 
 from typing import List
 
+from fbpcs.pid.entity.pid_instance import PIDProtocol
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
@@ -48,3 +49,4 @@ STAGE_FAILED_STATUSES: List[PrivateComputationInstanceStatus] = [
 
 DEFAULT_PADDING_SIZE = 4
 DEFAULT_K_ANONYMITY_THRESHOLD = 100
+DEFAULT_PID_PROTOCOL: PIDProtocol = PIDProtocol.UNION_PID

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -30,7 +30,6 @@ from fbpcs.data_processing.sharding.sharding_cpp import CppShardingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.pid.entity.pid_instance import PIDInstance, PIDInstanceStatus
-from fbpcs.pid.entity.pid_instance import PIDProtocol
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.post_processing_handler.post_processing_handler import (
@@ -62,8 +61,9 @@ from fbpcs.private_computation.service.constants import (
     NUM_NEW_SHARDS_PER_FILE,
     STAGE_STARTED_STATUSES,
     STAGE_FAILED_STATUSES,
-    DEFAULT_PADDING_SIZE,
     DEFAULT_K_ANONYMITY_THRESHOLD,
+    DEFAULT_PADDING_SIZE,
+    DEFAULT_PID_PROTOCOL,
 )
 from fbpcs.private_computation.service.errors import (
     PrivateComputationServiceValidationError,
@@ -299,7 +299,6 @@ class PrivateComputationService:
     def id_match(
         self,
         instance_id: str,
-        protocol: PIDProtocol,
         pid_config: Dict[str, Any],
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
@@ -309,7 +308,6 @@ class PrivateComputationService:
         return asyncio.run(
             self.id_match_async(
                 instance_id,
-                protocol,
                 pid_config,
                 is_validating,
                 synthetic_shard_path,
@@ -322,7 +320,6 @@ class PrivateComputationService:
     async def id_match_async(
         self,
         instance_id: str,
-        protocol: PIDProtocol,
         pid_config: Dict[str, Any],
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
@@ -334,7 +331,7 @@ class PrivateComputationService:
             IdMatchStageService(
                 self.pid_svc,
                 pid_config,
-                protocol,
+                DEFAULT_PID_PROTOCOL,
                 is_validating or False,
                 synthetic_shard_path,
             ),

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -24,7 +24,6 @@ from fbpcs.pcf.tests.async_utils import to_sync
 from fbpcs.pid.entity.pid_instance import (
     PIDInstance,
     PIDInstanceStatus,
-    PIDProtocol,
     PIDRole,
 )
 from fbpcs.pid.service.pid_service.pid import PIDService
@@ -46,6 +45,7 @@ from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
     NUM_NEW_SHARDS_PER_FILE,
     DEFAULT_K_ANONYMITY_THRESHOLD,
+    DEFAULT_PID_PROTOCOL,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -174,14 +174,13 @@ class TestPrivateComputationService(unittest.TestCase):
 
     def test_update_instance(self):
         test_pid_id = self.test_private_computation_id + "_id_match"
-        test_pid_protocol = PIDProtocol.UNION_PID
         test_pid_role = PIDRole.PUBLISHER
         test_input_path = "pid_in"
         test_output_path = "pid_out"
         # create one PID instance to be put into PrivateComputationInstance
         pid_instance = PIDInstance(
             instance_id=test_pid_id,
-            protocol=test_pid_protocol,
+            protocol=DEFAULT_PID_PROTOCOL,
             pid_role=test_pid_role,
             num_shards=self.test_num_containers,
             input_path=test_input_path,
@@ -683,7 +682,7 @@ class TestPrivateComputationService(unittest.TestCase):
         # Test get status from the PID stage
         pid_instance = PIDInstance(
             instance_id="test_pid_id",
-            protocol=PIDProtocol.UNION_PID,
+            protocol=DEFAULT_PID_PROTOCOL,
             pid_role=PIDRole.PUBLISHER,
             num_shards=4,
             input_path="input",


### PR DESCRIPTION
Summary:
I was talking with Jacob the other day and he pointed out to me that the protocol parameter passed in to the PrivateComputationService is actually ignored. In fact, we always just use UNION_PID because that's the only protocol supported: https://fburl.com/code/1qu6orva

This diff removes the option to pass protocol to PrivateComputationService.id_match().

In the future if more protocol is supported, we can explore other ways to pass the protocol parameter in. For example, passing in at PC instance creation time and save in the instance to be consumed by the id match stage.

Differential Revision: D31209707

