### PR TITLE
shorten lambda trigger name to avoid exceed 64-character limit

### DIFF
--- a/fbpcs/infra/cloud_bridge/README.md
+++ b/fbpcs/infra/cloud_bridge/README.md
@@ -5,55 +5,71 @@ Install docker and Java
 1. Install docker here: https://www.docker.com/products/docker-desktop
 2. Install Java, and make sure using Java 11.
   1. go to: https://java.com/en/download/help/download_options.html and following the installation instruction there. Or Use Homebrew. Run the following command:
-         brew install java11 `or` brew cask install java11
+  ```
+  brew install java11 `or` brew cask install java11
+  ```
   2. run the following command :
-         java -version
+```
+ java -version
+```
     you should see the similar messages as follow:
-         openjdk version "11.0.12" 2021-07-20
-         OpenJDK Runtime Environment Homebrew (build 11.0.12+0)
-         OpenJDK 64-Bit Server VM Homebrew (build 11.0.12+0, mixed mode)
-
+```
+openjdk version "11.0.12" 2021-07-20
+OpenJDK Runtime Environment Homebrew (build 11.0.12+0)
+OpenJDK 64-Bit Server VM Homebrew (build 11.0.12+0, mixed mode)
+```
 
 
 # Run `deploy.sh`
 
 1. Download the `infra` directory
   * run the following command:
-
-      git clone https://github.com/facebookresearch/fbpcs.git
-
+```
+git clone https://github.com/facebookresearch/fbpcs.git
+```
 2. Change to `cloud_bridge` directory
   * run the following command
-
-      cd fbpcs/fbpcs/infra/cloud_bridge
+```
+cd fbpcs/fbpcs/infra/cloud_bridge
+```
   * if encountered permission error, run the following:
-      chmod +x server/gradlew
+```
+chmod +x server/gradlew
+```
 4. build the image
   * run the following command
-
-      make image-build
+```
+make image-build
+```
 5. find your image tag/id:
   * run one of the following commands
-
-      docker image ls \
-        `or`
-      docker images cloudbridge-private_lift-server
+```
+docker image ls
+```
+`or`
+```
+docker images cloudbridge-private_lift-server
+```
 6. given the right docker image tag/id, do `docker run`
   * run the following command
-
-      docker run -it <image-tag> /bin/sh
+```
+docker run -it <image-tag> /bin/sh
+```
 7. initiate helper function
   * run the following command
-
-      /bin/sh ./terraform_deployment/deploy.sh --help
+```
+/bin/sh ./terraform_deployment/deploy.sh --help
+```
 8. create environment variables on AWS credentials (while be removed eventually)
   * run the following command
-
-      export AWS_ACCESS_KEY_ID=<YOUR_OWN_AWS_ACCESS_KEY> \
-      export AWS_SECRET_ACCESS_KEY=<YOUR_OWN_AWS_SECRET_ACCESS_KEY> \
-      export TF_LOG=DEBUG \
-      export TH_LOG_PATH=/tmp/deploy.log
+```
+export AWS_ACCESS_KEY_ID=<YOUR_OWN_AWS_ACCESS_KEY> \
+export AWS_SECRET_ACCESS_KEY=<YOUR_OWN_AWS_SECRET_ACCESS_KEY> \
+export TF_LOG=DEBUG \
+export TH_LOG_PATH=/tmp/deploy.log
+```
 9. run `deploy.sh`
  * run the following command
-
-      /bin/sh ./terraform_deployment/deploy.sh -r <> -a <> -p <> -v <> -s <> -d <> -t <>
+```
+/bin/sh ./terraform_deployment/deploy.sh -r <> -a <> -p <> -v <> -s <> -d <> -t <>
+```

--- a/fbpcs/infra/cloud_bridge/README.md
+++ b/fbpcs/infra/cloud_bridge/README.md
@@ -73,3 +73,6 @@ export TH_LOG_PATH=/tmp/deploy.log
 ```
 /bin/sh ./terraform_deployment/deploy.sh -r <> -a <> -p <> -v <> -s <> -d <> -t <>
 ```
+
+# Notes
+parameter tag (`-t`) cannot be too long. AWS function/variable name must have length less than or equal to 64.

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
@@ -39,7 +39,7 @@ EOF
 resource "aws_lambda_function" "lambda_trigger" {
   s3_bucket     = var.app_data_input_bucket_id
   s3_key        = "semi-automated-data-ingestion/${var.lambda_trigger_s3_key}"
-  function_name = "semi-automated-data-ingestion-trigger${var.tag_postfix}"
+  function_name = "manual-upload-trigger${var.tag_postfix}"
   role          = aws_iam_role.lambda_iam.arn
   handler       = "lambda_trigger.lambda_handler"
   runtime       = "python3.8"


### PR DESCRIPTION
Summary:
**Context**

One teammate on PAPA team encountered following error when running `deploy.sh`:

{F666891311}

**What**
We shorten Lambda trigger functionName to avoid going over AWS character limit.

**Next**
We should consider adding a validation service to avoid such error?

Differential Revision: D31240436

