### PR TITLE
Adding a test.yml to test building docker script when pushed to main and pull from main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test building image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  building_image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build image
+      run: |
+        ./build-docker.sh onedocker


### PR DESCRIPTION
Summary:
Since current github workflow is only triggered per day, we want to add a test.yml to track if each commit can build image successfully

This is to only build an image, without publishing it

Differential Revision: D31253179

