### PR TITLE
add compute metrics stage service

### DIFF
--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import logging
+from typing import Any, DefaultDict, Dict, List, Optional
+
+from fbpcp.service.mpc import MPCService
+from fbpcp.util.typing import checked_cast
+from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+)
+from fbpcs.private_computation.entity.private_computation_stage_type import (
+    PrivateComputationStageType,
+)
+from fbpcs.private_computation.service.private_computation_service_data import (
+    PrivateComputationServiceData,
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+)
+from fbpcs.private_computation.service.utils import (
+    create_and_start_mpc_instance,
+    gen_mpc_game_args_to_retry,
+    map_private_computation_role_to_mpc_party,
+    ready_for_partial_container_retry,
+)
+
+
+class ComputeMetricsStageService(PrivateComputationStageService):
+    def __init__(
+        self,
+        onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
+        mpc_service: MPCService,
+        concurrency: Optional[int] = None,
+        attribution_rule: Optional[str] = None,
+        aggregation_type: Optional[str] = None,
+        is_validating: bool = False,
+        log_cost_to_s3: bool = False,
+        container_timeout: Optional[int] = None,
+        skip_partial_container_retry: bool = False,
+    ) -> None:
+        self._onedocker_binary_config_map = onedocker_binary_config_map
+        self._mpc_service = mpc_service
+        self._concurrency = concurrency
+        self._attribution_rule = attribution_rule
+        self._aggregation_type = aggregation_type
+        self._is_validating = is_validating
+        self._log_cost_to_s3 = log_cost_to_s3
+        self._container_timeout = container_timeout
+        self._skip_partial_container_retry = skip_partial_container_retry
+
+    # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
+    # Make an async version of run_async() so that it can be called by Thrift
+    async def run_async(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]] = None,
+    ) -> PrivateComputationInstance:
+        # Prepare arguments for lift game
+        # TODO T101225909: remove the option to pass in concurrency at the compute stage
+        #   instead, always pass in at create_instance
+        pc_instance.concurrency = self._concurrency or pc_instance.concurrency
+        game_args = self._get_compute_metrics_game_args(
+            pc_instance,
+        )
+
+        # We do this check here because depends on how game_args is generated, len(game_args) could be different,
+        #   but we will always expect server_ips == len(game_args)
+        if server_ips and len(server_ips) != len(game_args):
+            raise ValueError(
+                f"Unable to rerun MPC compute because there is a mismatch between the number of server ips given ({len(server_ips)}) and the number of containers ({len(game_args)}) to be spawned."
+            )
+
+        # Create and start MPC instance to run MPC compute
+        logging.info("Starting to run MPC instance.")
+
+        stage_data = PrivateComputationServiceData.get(
+            pc_instance.game_type
+        ).compute_stage
+        binary_name = stage_data.binary_name
+        game_name = checked_cast(str, stage_data.game_name)
+
+        binary_config = self._onedocker_binary_config_map[binary_name]
+        retry_counter_str = str(pc_instance.retry_counter)
+        mpc_instance = await create_and_start_mpc_instance(
+            mpc_svc=self._mpc_service,
+            instance_id=pc_instance.instance_id
+            + "_compute_metrics"
+            + retry_counter_str,
+            game_name=game_name,
+            mpc_party=map_private_computation_role_to_mpc_party(pc_instance.role),
+            num_containers=len(game_args),
+            binary_version=binary_config.binary_version,
+            server_ips=server_ips,
+            game_args=game_args,
+            container_timeout=self._container_timeout,
+        )
+
+        logging.info("MPC instance started running.")
+
+        # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
+        pc_instance.instances.append(PCSMPCInstance.from_mpc_instance(mpc_instance))
+        return pc_instance
+
+    @property
+    def stage_type(self) -> PrivateComputationStageType:
+        return PrivateComputationStageType.COMPUTE
+
+    # TODO: Make an entity representation for game args that can dump a dict to pass
+    # to mpc service. The entity will give us type checking and ensure that all args are
+    # specified.
+    def _get_compute_metrics_game_args(
+        self,
+        private_computation_instance: PrivateComputationInstance,
+    ) -> List[Dict[str, Any]]:
+        game_args = []
+
+        # If this is to recover from a previous MPC compute failure
+        if (
+            ready_for_partial_container_retry(private_computation_instance)
+            and not self._skip_partial_container_retry
+        ):
+            game_args_to_retry = gen_mpc_game_args_to_retry(
+                private_computation_instance
+            )
+            if game_args_to_retry:
+                game_args = game_args_to_retry
+
+        # If this is a normal run, dry_run, or unable to get the game args to retry from mpc service
+        if not game_args:
+            num_containers = private_computation_instance.num_mpc_containers
+            # update num_containers if is_vaildating = true
+            if self._is_validating:
+                num_containers += 1
+
+            common_compute_game_args = {
+                "input_base_path": private_computation_instance.data_processing_output_path,
+                "output_base_path": private_computation_instance.compute_stage_output_base_path,
+                "num_files": private_computation_instance.num_files_per_mpc_container,
+                "concurrency": private_computation_instance.concurrency,
+            }
+
+            # TODO: we eventually will want to get rid of the if-else here, which will be
+            #   easy to do once the Lift and Attribution MPC compute games are consolidated
+            if (
+                private_computation_instance.game_type
+                is PrivateComputationGameType.ATTRIBUTION
+            ):
+                # TODO: we will write aggregation_type, attribution_rule and log_cost_to_s3
+                #   to the instance, so later this function interface will get simplified
+                game_args = self._get_attribution_game_args(
+                    private_computation_instance,
+                    common_compute_game_args,
+                )
+
+            elif (
+                private_computation_instance.game_type
+                is PrivateComputationGameType.LIFT
+            ):
+                game_args = self._get_lift_game_args(
+                    private_computation_instance, common_compute_game_args
+                )
+
+        return game_args
+
+    def _get_lift_game_args(
+        self,
+        private_computation_instance: PrivateComputationInstance,
+        common_compute_game_args: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        game_args = []
+        game_args = [
+            {
+                **common_compute_game_args,
+                **{
+                    "file_start_index": i
+                    * private_computation_instance.num_files_per_mpc_container
+                },
+            }
+            for i in range(private_computation_instance.num_mpc_containers)
+        ]
+        return game_args
+
+    def _get_attribution_game_args(
+        self,
+        private_computation_instance: PrivateComputationInstance,
+        common_compute_game_args: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        game_args = []
+        game_args = [
+            {
+                **common_compute_game_args,
+                **{
+                    "aggregators": self._aggregation_type,
+                    "attribution_rules": self._attribution_rule,
+                    "file_start_index": i
+                    * private_computation_instance.num_files_per_mpc_container,
+                    "use_xor_encryption": True,
+                    "run_name": private_computation_instance.instance_id
+                    if self._log_cost_to_s3
+                    else "",
+                    "max_num_touchpoints": private_computation_instance.padding_size,
+                    "max_num_conversions": private_computation_instance.padding_size,
+                },
+            }
+            for i in range(private_computation_instance.num_mpc_containers)
+        ]
+        return game_args

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from typing import Any, Dict, List, Optional
+
+from fbpcp.entity.container_instance import ContainerInstanceStatus
+from fbpcp.entity.mpc_instance import MPCInstance, MPCParty
+from fbpcp.service.mpc import MPCService
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
+
+"""
+43200 s = 12 hrs
+
+We want to be conservative on this timeout just in case:
+1) partner side is not able to connect in time. This is possible because it's a manual process
+to run partner containers and humans can be slow;
+2) during development, we add logic or complexity to the binaries running inside the containers
+so that they take more than a few hours to run.
+"""
+DEFAULT_CONTAINER_TIMEOUT_IN_SEC = 43200
+
+MAX_ROWS_PER_PID_CONTAINER = 10_000_000
+TARGET_ROWS_PER_MPC_CONTAINER = 250_000
+NUM_NEW_SHARDS_PER_FILE: int = round(
+    MAX_ROWS_PER_PID_CONTAINER / TARGET_ROWS_PER_MPC_CONTAINER
+)
+
+# List of stages with 'STARTED' status.
+STAGE_STARTED_STATUSES: List[PrivateComputationInstanceStatus] = [
+    PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+    PrivateComputationInstanceStatus.COMPUTATION_STARTED,
+    PrivateComputationInstanceStatus.AGGREGATION_STARTED,
+    PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,
+]
+
+# List of stages with 'FAILED' status.
+STAGE_FAILED_STATUSES: List[PrivateComputationInstanceStatus] = [
+    PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+    PrivateComputationInstanceStatus.COMPUTATION_FAILED,
+    PrivateComputationInstanceStatus.AGGREGATION_FAILED,
+    PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
+]
+
+DEFAULT_PADDING_SIZE = 4
+DEFAULT_K_ANONYMITY_THRESHOLD = 100
+
+
+async def create_and_start_mpc_instance(
+    mpc_svc: MPCService,
+    instance_id: str,
+    game_name: str,
+    mpc_party: MPCParty,
+    num_containers: int,
+    binary_version: str,
+    server_ips: Optional[List[str]] = None,
+    game_args: Optional[List[Dict[str, Any]]] = None,
+    container_timeout: Optional[int] = None,
+) -> MPCInstance:
+    mpc_svc.create_instance(
+        instance_id=instance_id,
+        game_name=game_name,
+        mpc_party=mpc_party,
+        num_workers=num_containers,
+        game_args=game_args,
+    )
+
+    return await mpc_svc.start_instance_async(
+        instance_id=instance_id,
+        server_ips=server_ips,
+        timeout=container_timeout or DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
+        version=binary_version,
+    )
+
+
+def map_private_computation_role_to_mpc_party(
+    private_computation_role: PrivateComputationRole,
+) -> MPCParty:
+    """
+    TODO
+    """
+    if private_computation_role is PrivateComputationRole.PUBLISHER:
+        return MPCParty.SERVER
+    elif private_computation_role is PrivateComputationRole.PARTNER:
+        return MPCParty.CLIENT
+    else:
+        raise ValueError(f"No mpc party defined for {private_computation_role}")
+
+
+def ready_for_partial_container_retry(
+    private_computation_instance: PrivateComputationInstance,
+) -> bool:
+    return (
+        private_computation_instance.partial_container_retry_enabled
+        and private_computation_instance.status
+        is PrivateComputationInstanceStatus.COMPUTATION_FAILED
+    )
+
+
+def gen_mpc_game_args_to_retry(
+    private_computation_instance: PrivateComputationInstance,
+) -> Optional[List[Dict[str, Any]]]:
+    # Get the last mpc instance
+    last_mpc_instance = private_computation_instance.instances[-1]
+
+    # Validate the last instance
+    if not isinstance(last_mpc_instance, MPCInstance):
+        raise ValueError(
+            f"The last instance of PrivateComputationInstance {private_computation_instance.instance_id} is NOT an MPCInstance"
+        )
+
+    containers = last_mpc_instance.containers
+    game_args = last_mpc_instance.game_args
+    game_args_to_retry = game_args
+
+    # We have to do the check here because occasionally when containers failed to spawn,
+    #   len(containers) < len(game_args), in which case we should not get game args from
+    #   failed containers; if we do, we will miss game args that belong to those containers
+    #   failed to be spawned
+    if containers and game_args and len(containers) == len(game_args):
+        game_args_to_retry = [
+            game_arg
+            for game_arg, container_instance in zip(game_args, containers)
+            if container_instance.status is not ContainerInstanceStatus.COMPLETED
+        ]
+
+    return game_args_to_retry


### PR DESCRIPTION
Summary:
The line count is misleading, 90% of the code was either moved or deleted. I'll point those out in the diff.

## What

* Implement ComputeMetricsStageService, which has the business logic for calling into MPCService and running compute
* replace inside of PrivateComputationService.compute_metrics function with call to run_stage
* Delete compute metrics test cases that are now covered by the run stage unit tests added in a previous diff

## Why

Context here: https://fb.workplace.com/groups/164332244998024/permalink/711906473573929/

tl;dr is generalizing stage management and stage execution logic will make adding and maintaining stages easier, get rid of a lot of duplicated state checking logic, plus it significantly debloats private_computation.py

## Next diffs

* added docstrings to all of the functions + methods in utils.py and ComputeMetricsStageServices
* some unit tests for compute metrics stage service

Differential Revision: D31295848

