### PR TITLE
Add script for deploying shared PCE resources

### DIFF
--- a/fbpcs/infra/publisher/Dockerfile
+++ b/fbpcs/infra/publisher/Dockerfile
@@ -45,8 +45,10 @@ RUN terraform --version
 ##########################################
 RUN mkdir /terraform_deployment
 ADD deploy.sh /terraform_deployment
+ADD deploy-shared.sh /terraform_deployment
 ADD util.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/deploy.sh
+RUN chmod +x /terraform_deployment/deploy-shared.sh
 RUN chmod +x /terraform_deployment/util.sh
 ADD aws_terraform_template /terraform_deployment/terraform_scripts
 CMD ["/bin/bash"]

--- a/fbpcs/infra/publisher/deploy-shared.sh
+++ b/fbpcs/infra/publisher/deploy-shared.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+# shellcheck disable=SC1091
+source ./util.sh
+
+usage() {
+    echo "Usage: deploy-shared.sh <deploy|undeploy>
+        [ -t, --tag | A unique identifier to identify resources in this deployment]
+        [ -r, --region | AWS region, e.g. us-west-2 ]
+        [ -a, --account_id | Publisher's AWS account ID ]
+        [ -i, --onedocker_image | OneDocker ecs container image ]
+        [ -b, --bucket | S3 bucket name for storing tfstate ]
+        [ -s, --bucket_region | The region of the tfstate storage bucket ]"
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+undeploy=false
+case "$1" in
+    deploy) ;;
+    undeploy) undeploy=true ;;
+    *) usage ;;
+esac
+shift
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t|--tag) pce_id="$2" ;;
+        -r|--region) region="$2" ;;
+        -a|--account_id) aws_account_id="$2" ;;
+        -i|--onedocker_image) onedocker_ecs_container_image="$2" ;;
+        -b|--bucket) s3_bucket_for_storage="$2" ;;
+        -s|--bucket_region) s3_bucket_region="$2" ;;
+        *) usage ;;
+    esac
+    shift
+    shift
+done
+
+tag_postfix="-${pce_id}"
+
+echo "AWS region is $region."
+echo "The string '$tag_postfix' will be appended after the name of the AWS resources."
+echo "Publisher's AWS acount ID is $aws_account_id"
+echo "The S3 bucket for storing the Terraform state file is $s3_bucket_for_storage and it is in region $s3_bucket_region"
+
+undeploy_aws_resources () {
+    echo "Start undeploying..."
+    echo "########################Check tfstate files########################"
+    check_s3_object_exist "$s3_bucket_for_storage" "tfstate/pce$tag_postfix.tfstate" "$aws_account_id"
+    echo "All tfstate files exist. Continue..."
+
+    echo "########################Delete PCE resources########################"
+    cd /terraform_deployment/terraform_scripts/common/pce_shared
+    terraform init \
+        -backend-config "bucket=$s3_bucket_for_storage" \
+        -backend-config "region=$s3_bucket_region" \
+        -backend-config "key=tfstate/pce$tag_postfix.tfstate"
+    terraform destroy \
+        -auto-approve \
+        -var "aws_region=$region" \
+        -var "tag_postfix=$tag_postfix" \
+        -var "pce_id=$pce_id"
+}
+
+deploy_aws_resources () {
+    echo "########################Started AWS Infrastructure Deployment########################"
+    create_s3_bucket "$s3_bucket_for_storage" "$region" "$aws_account_id"
+
+    # Deploy PCE Terraform scripts
+    cd /terraform_deployment/terraform_scripts/common/pce_shared
+    terraform init \
+        -backend-config "bucket=$s3_bucket_for_storage" \
+        -backend-config "region=$s3_bucket_region" \
+        -backend-config "key=tfstate/pce$tag_postfix.tfstate"
+    terraform apply \
+        -auto-approve \
+        -var "aws_region=$region" \
+        -var "tag_postfix=$tag_postfix" \
+        -var "onedocker_ecs_container_image=$onedocker_ecs_container_image" \
+        -var "aws_account_id=$aws_account_id" \
+        -var "pce_id=$pce_id"
+
+    # Print the output
+    echo "######################## PCE terraform output ########################"
+    terraform output
+
+    echo "########################Finished AWS Infrastructure Deployment########################"
+}
+
+##########################################
+# Main
+##########################################
+
+if "$undeploy"
+then
+    echo "Undeploying the AWS resources..."
+    undeploy_aws_resources
+else
+    deploy_aws_resources
+fi
+exit 0


### PR DESCRIPTION
Summary:
PCE shared resources are shared across a single region. So we only need to manually run this script once per region and the resources will be shared across all advertisers in that region.
Note: PCE service library will have the logic to understand shared PCE resources and it will automatically use it on the publisher side

Next: Add a wiki page with instructions on how to deploy shared resources

Differential Revision: D31322556

