### PR TITLE
Fix missing fbpcs prefix in extract-docker-binaries.sh

### DIFF
--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -9,11 +9,11 @@ set -e
 PROG_NAME=$0
 usage() {
   cat << EOF >&2
-Usage: $PROG_NAME <emp_games|data_processing|fbpcs> [-t TAG]
+Usage: $PROG_NAME <emp_games|data_processing> [-t TAG]
 
 package:
-  emp_games - builds the emp_games docker image
-  data_processing - builds the data_processing docker image
+  emp_games - extracts the binaries from fbpcs/emp-games docker image
+  data_processing - extracts the binaries from fbpcs/data-processing docker image
 -t TAG: uses the image with the given tag (default: latest)
 EOF
   exit 1
@@ -37,12 +37,12 @@ shift "$((OPTIND - 1))"
 
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-    # Run from the root dir of emp_games so the binaries paths exist
+    # Run from the root dir of so the binaries paths exist
     cd "$SCRIPT_DIR" || exit
     mkdir -p binaries_out
 
 if [ "$PACKAGE" = "emp_games" ]; then
-docker create -ti --name temp_container "emp-games:${TAG}"
+docker create -ti --name temp_container "fbpcs/emp-games:${TAG}"
 docker cp temp_container:/usr/local/bin/lift_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/attribution_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/shard_aggregator "$SCRIPT_DIR/binaries_out/."
@@ -50,7 +50,7 @@ docker rm -f temp_container
 fi
 
 if [ "$PACKAGE" = "data_processing" ]; then
-docker create -ti --name temp_container "data-processing:${TAG}"
+docker create -ti --name temp_container "fbpcs/data-processing:${TAG}"
 docker cp temp_container:/usr/local/bin/sharder "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/sharder_hashed_for_pid "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/pid_preparer "$SCRIPT_DIR/binaries_out/."


### PR DESCRIPTION
Summary:
What:
- Add fbpcs prefix to emp-games and data-processing in extract-docker-binaries
- Update usage text

Why:
The script is unable to extract the binaries because the docker image does not exist...

Differential Revision: D31341710

