### PR TITLE
PPH stage fixes

### DIFF
--- a/fbpcs/post_processing_handler/post_processing_handler.py
+++ b/fbpcs/post_processing_handler/post_processing_handler.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
     from fbpcs.private_computation.entity.private_computation_instance import (
         PrivateComputationInstance,
     )
-    from fbpcs.private_computation.service.private_computation import (
-        PrivateComputationService,
-    )
+from fbpcp.service.storage import StorageService
 
 
 class PostProcessingHandlerStatus(Enum):
@@ -30,7 +28,7 @@ class PostProcessingHandler(abc.ABC):
     @abc.abstractmethod
     async def run(
         self,
-        private_computation_service: "PrivateComputationService",
+        storage_svc: StorageService,
         private_computation_instance: "PrivateComputationInstance",
     ) -> None:
         raise NotImplementedError

--- a/fbpcs/post_processing_handler/tests/dummy_handler.py
+++ b/fbpcs/post_processing_handler/tests/dummy_handler.py
@@ -13,14 +13,11 @@ from typing import TYPE_CHECKING
 
 from fbpcs.post_processing_handler.exception import PostProcessingHandlerRuntimeError
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
-
 if TYPE_CHECKING:
     from fbpcs.private_computation.entity.private_computation_instance import (
         PrivateComputationInstance,
     )
-    from fbpcs.private_computation.service.private_computation import (
-        PrivateComputationService,
-    )
+from fbpcp.service.storage import StorageService
 
 
 class PostProcessingDummyHandler(PostProcessingHandler):
@@ -33,7 +30,7 @@ class PostProcessingDummyHandler(PostProcessingHandler):
 
     async def run(
         self,
-        private_computation_service: "PrivateComputationService",
+        storage_svc: StorageService,
         private_computation_instance: "PrivateComputationInstance",
     ) -> None:
         if random.random() >= self.probability_of_failure:

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -716,7 +716,7 @@ class PrivateComputationService:
             handler_name
         ] = PostProcessingHandlerStatus.STARTED
         try:
-            await handler.run(self, private_computation_instance)
+            await handler.run(self.storage_svc, private_computation_instance)
             self.logger.info(f"Completed post processing handler: {handler_name=}")
             post_processing_instance.handler_statuses[
                 handler_name


### PR DESCRIPTION
Summary:
## What

* Post processing handler now accepts storage service as an argument instead of the entire private computation service.
* export to scribe post processing handler checks if the game type is lift or something else (e.g. attribution). If it's LIFT, the results are written to scribe. Otherwise, it does nothing

## Why

* I can't think of a compelling reason for giving the post processing handler access to the entire private computation service. Especially now that I am moving the stages out of the private computation class and into separate classes.
* Post consolidation, we don't want to try writing attribution results into our lift dataswarm pipeline, as that could result in some clowny behavior. As a follow up, someone from PCS team will write the export to scribe logic for attribution.

## Next diffs

* Post processing handler stage service
* post processing handlers unit tests
* Start splitting compute metrics into multiple stages

Differential Revision: D31356551

