### PR TITLE
PPH stage service

### DIFF
--- a/fbpcs/post_processing_handler/post_processing_handler.py
+++ b/fbpcs/post_processing_handler/post_processing_handler.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
     from fbpcs.private_computation.entity.private_computation_instance import (
         PrivateComputationInstance,
     )
-    from fbpcs.private_computation.service.private_computation import (
-        PrivateComputationService,
-    )
+from fbpcp.service.storage import StorageService
 
 
 class PostProcessingHandlerStatus(Enum):
@@ -30,7 +28,7 @@ class PostProcessingHandler(abc.ABC):
     @abc.abstractmethod
     async def run(
         self,
-        private_computation_service: "PrivateComputationService",
+        storage_svc: StorageService,
         private_computation_instance: "PrivateComputationInstance",
     ) -> None:
         raise NotImplementedError

--- a/fbpcs/post_processing_handler/tests/dummy_handler.py
+++ b/fbpcs/post_processing_handler/tests/dummy_handler.py
@@ -13,14 +13,11 @@ from typing import TYPE_CHECKING
 
 from fbpcs.post_processing_handler.exception import PostProcessingHandlerRuntimeError
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
-
 if TYPE_CHECKING:
     from fbpcs.private_computation.entity.private_computation_instance import (
         PrivateComputationInstance,
     )
-    from fbpcs.private_computation.service.private_computation import (
-        PrivateComputationService,
-    )
+from fbpcp.service.storage import StorageService
 
 
 class PostProcessingDummyHandler(PostProcessingHandler):
@@ -33,7 +30,7 @@ class PostProcessingDummyHandler(PostProcessingHandler):
 
     async def run(
         self,
-        private_computation_service: "PrivateComputationService",
+        storage_svc: StorageService,
         private_computation_instance: "PrivateComputationInstance",
     ) -> None:
         if random.random() >= self.probability_of_failure:

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import asyncio
+import logging
+from typing import Dict, List, Optional
+
+from fbpcp.service.storage import StorageService
+from fbpcs.post_processing_handler.post_processing_handler import (
+    PostProcessingHandler,
+    PostProcessingHandlerStatus,
+)
+from fbpcs.post_processing_handler.post_processing_instance import (
+    PostProcessingInstance,
+    PostProcessingInstanceStatus,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+)
+from fbpcs.private_computation.entity.private_computation_stage_type import (
+    PrivateComputationStageType,
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+)
+
+
+class PostProcessingStageService(PrivateComputationStageService):
+    """Handles business logic for the private computation post processing stage
+
+    Private attributes:
+        _storage_svc: Used to read/write files during private computation runs, e.g. read the final results from S3
+        _post_processing_handlers: maps handler name to handler instance. Handler instance defines the business logic of the handler
+        _aggregated_result_path: Optional path to private computation final results JSON file
+    """
+
+    def __init__(
+        self,
+        storage_svc: StorageService,
+        post_processing_handlers: Dict[str, PostProcessingHandler],
+        aggregated_result_path: Optional[str] = None,
+    ) -> None:
+        self._storage_svc = storage_svc
+        self._post_processing_handlers = post_processing_handlers
+        self._aggregated_result_path = aggregated_result_path
+        self._logger: logging.Logger = logging.getLogger(__name__)
+
+    # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
+    # Make an async version of run_async() so that it can be called by Thrift
+    async def run_async(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]] = None,
+    ) -> PrivateComputationInstance:
+        """Runs the private computation post processing handlers stage
+
+        Post processing handlers are designed to run after final results are available. You can write
+        post processing handlers to download results from cloud storage, send you an email, etc.
+
+        Args:
+            pc_instance: the private computation instance to run post processing handlers with
+            server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
+
+        Returns:
+            An updated version of pc_instance that stores a post processing instance
+        """
+
+        post_processing_handlers_statuses = None
+        if pc_instance.instances:
+            last_instance = pc_instance.instances[-1]
+            if (
+                isinstance(last_instance, PostProcessingInstance)
+                and last_instance.handler_statuses.keys()
+                == self._post_processing_handlers.keys()
+            ):
+                self._logger.info("Copying statuses from last instance")
+                post_processing_handlers_statuses = (
+                    last_instance.handler_statuses.copy()
+                )
+
+        post_processing_instance = PostProcessingInstance.create_instance(
+            instance_id=pc_instance.instance_id
+            + "_post_processing"
+            + str(pc_instance.retry_counter),
+            handlers=self._post_processing_handlers,
+            handler_statuses=post_processing_handlers_statuses,
+            status=PostProcessingInstanceStatus.STARTED,
+        )
+
+        pc_instance.instances.append(post_processing_instance)
+
+        # if any handlers fail, then the post_processing_instance status will be
+        # set to failed, as will the pc_instance status
+        await asyncio.gather(
+            *[
+                self._run_post_processing_handler(
+                    pc_instance,
+                    post_processing_instance,
+                    name,
+                    handler,
+                )
+                for name, handler in self._post_processing_handlers.items()
+                if post_processing_instance.handler_statuses[name]
+                != PostProcessingHandlerStatus.COMPLETED
+            ]
+        )
+
+        # if any of the handlers failed, then the status of the post processing instance would have
+        # been set to failed. If none of them failed, then tht means all of the handlers completed, so
+        # we can set the status to completed.
+        if post_processing_instance.status != PostProcessingInstanceStatus.FAILED:
+            post_processing_instance.status = PostProcessingInstanceStatus.COMPLETED
+        return pc_instance
+
+    @property
+    def stage_type(self) -> PrivateComputationStageType:
+        return PrivateComputationStageType.POST_PROCESSING_HANDLERS
+
+    async def _run_post_processing_handler(
+        self,
+        private_computation_instance: PrivateComputationInstance,
+        post_processing_instance: PostProcessingInstance,
+        handler_name: str,
+        handler: PostProcessingHandler,
+    ) -> None:
+        self._logger.info(f"Starting post processing handler: {handler_name=}")
+        post_processing_instance.handler_statuses[
+            handler_name
+        ] = PostProcessingHandlerStatus.STARTED
+        try:
+            await handler.run(self._storage_svc, private_computation_instance)
+            self._logger.info(f"Completed post processing handler: {handler_name=}")
+            post_processing_instance.handler_statuses[
+                handler_name
+            ] = PostProcessingHandlerStatus.COMPLETED
+        except Exception as e:
+            self._logger.exception(e)
+            self._logger.error(f"Failed post processing handler: {handler_name=}")
+            post_processing_instance.handler_statuses[
+                handler_name
+            ] = PostProcessingHandlerStatus.FAILED
+            post_processing_instance.status = PostProcessingInstanceStatus.FAILED

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -716,7 +716,7 @@ class PrivateComputationService:
             handler_name
         ] = PostProcessingHandlerStatus.STARTED
         try:
-            await handler.run(self, private_computation_instance)
+            await handler.run(self.storage_svc, private_computation_instance)
             self.logger.info(f"Completed post processing handler: {handler_name=}")
             post_processing_instance.handler_statuses[
                 handler_name


### PR DESCRIPTION
Summary:
The line count is misleading, 90% of the code was either moved or deleted. I'll point those out in the diff.

## What

* ImplementPostProcessingStageService, which has the business logic for running post processing handlers such as export to scribe
* replace inside of PrivateComputationService.run_post_processing_handlers function with call to run_stage

## Why

Context here: https://fb.workplace.com/groups/164332244998024/permalink/711906473573929/

tl;dr is generalizing stage management and stage execution logic will make adding and maintaining stages easier, get rid of a lot of duplicated state checking logic, plus it significantly debloats private_computation.py

## Next diff

* unit test for post processing stage service

Differential Revision: D31385296

