### PR TITLE
Output traffic statistics

### DIFF
--- a/fbpcs/emp_games/attribution/CostEstimation.h
+++ b/fbpcs/emp_games/attribution/CostEstimation.h
@@ -169,7 +169,7 @@ class CostEstimation {
   std::string writeToS3(std::string run_name, folly::dynamic costDynamic){
 
     std::string costData = folly::toPrettyJson(costDynamic);
-    std::string s3FullPath = "https://" + s3Bucket_ + ".s3.us-west-2.amazonaws.com/" + s3Path_ + "/";
+    std::string s3FullPath = folly::to<std::string>("https://", s3Bucket_, ".s3.us-west-2.amazonaws.com/", s3Path_, "/");
     std::string filePath = folly::to<std::string>(s3FullPath, run_name, ".json");
 
     try{


### PR DESCRIPTION
Summary:
- Change attribution code to output traffic statistics (sent and received bytes) from the scheduler. These are also written to the cost estimation in S3.
- Both publisher and partner write the cost estimation to S3. Previously, only the publisher does this. The publisher's cost includes a (somewhat constant) overhead time for the partner to connect, which is significant when the runtimes are small.

Reviewed By: RuiyuZhu

Differential Revision: D31387587

