### PR TITLE
Handle histograms in shard aggregator

### DIFF
--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
@@ -87,7 +87,7 @@ TEST_F(AggMetricsTest, TestParseLift) {
 
   ASSERT_EQ(metrics.getAtKey("cohortMetrics")->getAsList().size(), 2);
   ASSERT_EQ(metrics.getAtKey("publisherBreakdowns")->getAsList().size(), 2);
-  ASSERT_EQ(metrics.getAtKey("metrics")->getAsMap().size(), 26);
+  ASSERT_EQ(metrics.getAtKey("metrics")->getAsMap().size(), 28);
 
   // check a few values
   EXPECT_EQ(

--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp
@@ -26,11 +26,21 @@ void applyLiftThresholdCondition(
           liftMetrics->getAtKey("controlConverters")->getEmpIntValue() >=
       kAnonymityLevel;
   for (const auto& [key, value] : liftMetrics->getAsMap()) {
+    // TODO: Use std::string operator== instead of compare
     if (!key.compare("controlPopulation") || !key.compare("testPopulation")) {
+      // These two values are always revealed
       continue;
     }
-    value->setEmpIntValue(
-        emp::If(condition, value->getEmpIntValue(), hiddenMetric));
+    else if (key == "controlConvHistogram" || key == "testConvHistogram") {
+      auto& innerList = value->getAsList();
+      for (auto& innerValue : innerList) {
+        innerValue->setEmpIntValue(
+          emp::If(condition, innerValue->getEmpIntValue(), hiddenMetric));
+      }
+    } else {
+      value->setEmpIntValue(
+          emp::If(condition, value->getEmpIntValue(), hiddenMetric));
+    }
   }
 }
 } // namespace

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_alice_0
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_alice_0
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -29,6 +31,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -87,6 +93,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 1247379003,
         "controlValueSquared": 405497006,
         "testNumConvSquared": 247379003,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_alice_1
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_alice_1
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3350441960,
             "controlNumConvSquared": 350441960,
             "testValueSquared": 2014985121,
@@ -29,6 +31,8 @@
             "reachedValue": 2908667381
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 236216478,
             "testValueSquared": 3942206104,
             "controlNumConvSquared": 36216478,
@@ -57,6 +61,8 @@
             "reachedValue": 2361916971
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 36216478,
             "testValueSquared": 942206104,
             "controlNumConvSquared": 6216478,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3350441960,
             "controlNumConvSquared": 350441960,
             "testValueSquared": 2014985121,
@@ -115,6 +123,8 @@
             "reachedValue": 2908667381
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 236216478,
             "testValueSquared": 3942206104,
             "controlNumConvSquared": 36216478,
@@ -143,6 +153,8 @@
             "reachedValue": 2361916971
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 36216478,
             "testValueSquared": 942206104,
             "controlNumConvSquared": 6216478,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 4205949011,
         "controlValueSquared": 3724585762,
         "testNumConvSquared": 205949011,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_alice_2
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_alice_2
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3947481434,
             "testValueSquared": 1842109010,
             "controlNumConvSquared": 947481434,
@@ -29,6 +31,8 @@
             "reachedValue": 3410190073
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 211392546,
             "testValueSquared": 3474056566,
             "testNumConvSquared": 474056566,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3947481434,
             "testValueSquared": 1842109010,
             "controlNumConvSquared": 947481434,
@@ -87,6 +93,8 @@
             "reachedValue": 3410190073
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 211392546,
             "testValueSquared": 3474056566,
             "testNumConvSquared": 474056566,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 2949102338,
         "controlValueSquared": 2259601706,
         "testNumConvSquared": 949102338,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_bob_0
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_bob_0
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 4087915581,
             "testValueSquared": 1772237085,
             "controlNumConvSquared": 87915581,
@@ -29,6 +31,8 @@
             "reachedValue": 2037188277
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3792338230,
             "controlValueSquared": 607756327,
             "testNumConvSquared": 792338230,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 4087915581,
             "testValueSquared": 1772237085,
             "controlNumConvSquared": 87915581,
@@ -87,6 +93,8 @@
             "reachedValue": 2037188277
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3792338230,
             "controlValueSquared": 607756327,
             "testNumConvSquared": 792338230,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "controlValueSquared": 656633916,
         "testValueSquared": 2225859069,
         "controlNumConvSquared": 56633916,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_bob_1
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_bob_1
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3606004712,
             "testValueSquared": 2815807925,
             "testNumConvSquared": 815807925,
@@ -29,6 +31,8 @@
             "reachedValue": 3881859274
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2504736058,
             "testValueSquared": 3205654685,
             "controlNumConvSquared": 504736058,
@@ -57,6 +61,8 @@
             "reachedValue": 1975128278
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 504736058,
             "testValueSquared": 205654685,
             "controlNumConvSquared": 4736058,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3606004712,
             "testValueSquared": 2815807925,
             "testNumConvSquared": 815807925,
@@ -115,6 +123,8 @@
             "reachedValue": 3881859274
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2504736058,
             "testValueSquared": 3205654685,
             "controlNumConvSquared": 504736058,
@@ -143,6 +153,8 @@
             "reachedValue": 1975128278
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 504736058,
             "testValueSquared": 205654685,
             "controlNumConvSquared": 4736058,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 3217340599,
         "controlValueSquared": 1536294960,
         "testNumConvSquared": 217340599,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_bob_2
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_bob_2
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3978546583,
             "testValueSquared": 3733041961,
             "controlNumConvSquared": 978546583,
@@ -29,6 +31,8 @@
             "reachedValue": 3437788024
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 345616773,
             "controlValueSquared": 3249935587,
             "controlNumConvSquared": 249935587,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3978546583,
             "testValueSquared": 3733041961,
             "controlNumConvSquared": 978546583,
@@ -87,6 +93,8 @@
             "reachedValue": 3437788024
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 345616773,
             "controlValueSquared": 3249935587,
             "controlNumConvSquared": 249935587,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "controlValueSquared": 2689546300,
         "testValueSquared": 836055183,
         "controlNumConvSquared": 689546300,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_metrics
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_metrics
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 1498345844,
             "testValueSquared": 8688508308,
             "controlNumConvSquared": 1929258356,
@@ -29,6 +31,8 @@
             "reachedValue": 1605304674
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 7273179529,
             "testValueSquared": 6165631040,
             "controlNumConvSquared": 1539991433,
@@ -57,6 +61,8 @@
             "reachedValue": 10662098835
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 473773988,
             "testValueSquared": 879420933,
             "controlNumConvSquared": 1482532,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 1498345844,
             "testValueSquared": 8688508308,
             "controlNumConvSquared": 1929258356,
@@ -115,6 +123,8 @@
             "reachedValue": 1605304674
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 7273179529,
             "testValueSquared": 6165631040,
             "controlNumConvSquared": 1539991433,
@@ -143,6 +153,8 @@
             "reachedValue": 10662098835
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 473773988,
             "testValueSquared": 879420933,
             "controlNumConvSquared": 1482532,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [0,0,0,0],
+        "testConvHistogram": [0,0,0,0],
         "testValueSquared": 7289318455,
         "controlValueSquared": 3950817466,
         "testNumConvSquared": 1060095031,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_metrics_kanon
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_metrics_kanon
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 1498345844,
             "testValueSquared": 8688508308,
             "controlNumConvSquared": 1929258356,
@@ -29,6 +31,8 @@
             "reachedValue": 1605304674
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 7273179529,
             "testValueSquared": 6165631040,
             "controlNumConvSquared": 1539991433,
@@ -57,6 +61,8 @@
             "reachedValue": 10662098835
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 473773988,
             "testValueSquared": 879420933,
             "controlNumConvSquared": 1482532,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 1498345844,
             "testValueSquared": 8688508308,
             "controlNumConvSquared": 1929258356,
@@ -115,6 +123,8 @@
             "reachedValue": 1605304674
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 7273179529,
             "testValueSquared": 6165631040,
             "controlNumConvSquared": 1539991433,
@@ -143,6 +153,8 @@
             "reachedValue": 10662098835
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 473773988,
             "testValueSquared": 879420933,
             "controlNumConvSquared": 1482532,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [0,0,0,0],
+        "testConvHistogram": [0,0,0,0],
         "controlValue": 11138262435,
         "testValueSquared": 7289318455,
         "controlValueSquared": 3950817466,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_metrics_kanon_anonymous
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/aggregator_metrics_kanon_anonymous
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [-1,-1,-1,-1],
+            "testConvHistogram": [-1,-1,-1,-1],
             "controlClicks": -1,
             "controlImpressions": -1,
             "controlMatchCount": -1,
@@ -29,6 +31,8 @@
             "reachedValue": -1
         },
         {
+            "controlConvHistogram": [-1,-1,-1,-1],
+            "testConvHistogram": [-1,-1,-1,-1],
             "controlClicks": -1,
             "testMatchCount": -1,
             "controlImpressions": -1,
@@ -57,6 +61,8 @@
             "reachedValue": -1
         },
         {
+            "controlConvHistogram": [-1,-1,-1,-1],
+            "testConvHistogram": [-1,-1,-1,-1],
             "controlClicks": -1,
             "testMatchCount": -1,
             "controlImpressions": -1,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [-1,-1,-1,-1],
+            "testConvHistogram": [-1,-1,-1,-1],
             "controlClicks": -1,
             "controlImpressions": -1,
             "controlMatchCount": -1,
@@ -115,6 +123,8 @@
             "reachedValue": -1
         },
         {
+            "controlConvHistogram": [-1,-1,-1,-1],
+            "testConvHistogram": [-1,-1,-1,-1],
             "controlClicks": -1,
             "testMatchCount": -1,
             "controlImpressions": -1,
@@ -143,6 +153,8 @@
             "reachedValue": -1
         },
         {
+            "controlConvHistogram": [-1,-1,-1,-1],
+            "testConvHistogram": [-1,-1,-1,-1],
             "controlClicks": -1,
             "testMatchCount": -1,
             "controlImpressions": -1,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [-1,-1,-1,-1],
+        "testConvHistogram": [-1,-1,-1,-1],
         "controlClicks": -1,
         "controlImpressions": -1,
         "controlMatchCount": -1,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/lift/zero_metrics
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/lift/zero_metrics
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 0,
             "controlNumConvSquared": 0,
             "testValueSquared": 0,
@@ -29,6 +31,8 @@
             "reachedValue": 0
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 0,
             "testValueSquared": 0,
             "controlNumConvSquared": 0,
@@ -57,6 +61,8 @@
             "reachedValue": 0
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 0,
             "testValueSquared": 0,
             "controlNumConvSquared": 0,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 0,
             "controlNumConvSquared": 0,
             "testValueSquared": 0,
@@ -115,6 +123,8 @@
             "reachedValue": 0
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 0,
             "testValueSquared": 0,
             "controlNumConvSquared": 0,
@@ -143,6 +153,8 @@
             "reachedValue": 0
         },
         {
+            "controlConvHistogram": [0,0,0,0],
+            "testConvHistogram": [0,0,0,0],
             "controlValueSquared": 0,
             "testValueSquared": 0,
             "controlNumConvSquared": 0,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [0,0,0,0],
+        "testConvHistogram": [0,0,0,0],
         "testValueSquared": 0,
         "controlValueSquared": 0,
         "testNumConvSquared": 0,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_extra_cohort_metric.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_extra_cohort_metric.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -29,6 +31,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -60,6 +64,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -88,6 +94,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -118,6 +126,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 1247379003,
         "controlValueSquared": 405497006,
         "testNumConvSquared": 247379003,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_extra_metric.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_extra_metric.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 4087915581,
             "testValueSquared": 1772237085,
             "controlNumConvSquared": 87915581,
@@ -29,6 +31,8 @@
             "reachedValue": 2037188277
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3792338230,
             "controlValueSquared": 607756327,
             "testNumConvSquared": 792338230,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 4087915581,
             "testValueSquared": 1772237085,
             "controlNumConvSquared": 87915581,
@@ -87,6 +93,8 @@
             "reachedValue": 2037188277
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3792338230,
             "controlValueSquared": 607756327,
             "testNumConvSquared": 792338230,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "notAMetric": 23235253,
         "controlValueSquared": 656633916,
         "testValueSquared": 2225859069,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_fake_cohort_metric.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_fake_cohort_metric.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquaredFake": 3350441960,
             "controlNumConvSquared": 350441960,
             "testValueSquared": 2014985121,
@@ -29,6 +31,8 @@
             "reachedValue": 2908667381
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 236216478,
             "testValueSquared": 3942206104,
             "controlNumConvSquared": 36216478,
@@ -57,6 +61,8 @@
             "reachedValue": 2361916971
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 36216478,
             "testValueSquared": 942206104,
             "controlNumConvSquared": 6216478,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquaredFake": 3350441960,
             "controlNumConvSquared": 350441960,
             "testValueSquared": 2014985121,
@@ -115,6 +123,8 @@
             "reachedValue": 2908667381
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 236216478,
             "testValueSquared": 3942206104,
             "controlNumConvSquared": 36216478,
@@ -143,6 +153,8 @@
             "reachedValue": 2361916971
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 36216478,
             "testValueSquared": 942206104,
             "controlNumConvSquared": 6216478,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 4205949011,
         "controlValueSquared": 3724585762,
         "testNumConvSquared": 205949011,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_fake_metric.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_fake_metric.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -29,6 +31,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -87,6 +93,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquaredFake": 1247379003,
         "controlValueSquared": 405497006,
         "testNumConvSquared": 247379003,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_input.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_input.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -29,6 +31,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -87,6 +93,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 1247379003,
         "controlValueSquared": 405497006,
         "testNumConvSquared": 247379003,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_missing_cohort_metric.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_missing_cohort_metric.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 1772237085,
             "controlNumConvSquared": 87915581,
             "testNumConvSquared": 772237085,
@@ -28,6 +30,8 @@
             "reachedValue": 2037188277
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3792338230,
             "controlValueSquared": 607756327,
             "testNumConvSquared": 792338230,
@@ -58,6 +62,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 1772237085,
             "controlNumConvSquared": 87915581,
             "testNumConvSquared": 772237085,
@@ -85,6 +91,8 @@
             "reachedValue": 2037188277
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3792338230,
             "controlValueSquared": 607756327,
             "testNumConvSquared": 792338230,
@@ -114,6 +122,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "controlValueSquared": 656633916,
         "testValueSquared": 2225859069,
         "controlNumConvSquared": 56633916,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_missing_metric.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_missing_metric.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3606004712,
             "testValueSquared": 2815807925,
             "testNumConvSquared": 815807925,
@@ -29,6 +31,8 @@
             "reachedValue": 3881859274
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2504736058,
             "testValueSquared": 3205654685,
             "controlNumConvSquared": 504736058,
@@ -57,6 +61,8 @@
             "reachedValue": 1975128278
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 504736058,
             "testValueSquared": 205654685,
             "controlNumConvSquared": 4736058,
@@ -87,6 +93,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3606004712,
             "testValueSquared": 2815807925,
             "testNumConvSquared": 815807925,
@@ -115,6 +123,8 @@
             "reachedValue": 3881859274
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2504736058,
             "testValueSquared": 3205654685,
             "controlNumConvSquared": 504736058,
@@ -143,6 +153,8 @@
             "reachedValue": 1975128278
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 504736058,
             "testValueSquared": 205654685,
             "controlNumConvSquared": 4736058,
@@ -172,6 +184,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "controlValueSquared": 1536294960,
         "testNumConvSquared": 217340599,
         "controlNumConvSquared": 536294960,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_no_metrics.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/invalid_lift_no_metrics.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3978546583,
             "testValueSquared": 3733041961,
             "controlNumConvSquared": 978546583,
@@ -29,6 +31,8 @@
             "reachedValue": 3437788024
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 345616773,
             "controlValueSquared": 3249935587,
             "controlNumConvSquared": 249935587,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 3978546583,
             "testValueSquared": 3733041961,
             "controlNumConvSquared": 978546583,
@@ -87,6 +93,8 @@
             "reachedValue": 3437788024
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 345616773,
             "controlValueSquared": 3249935587,
             "controlNumConvSquared": 249935587,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/valid_lift_input.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/valid_lift_input.json
@@ -1,6 +1,8 @@
 {
     "cohortMetrics": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -29,6 +31,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -59,6 +63,8 @@
     ],
     "publisherBreakdowns": [
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "controlValueSquared": 2988483738,
             "testValueSquared": 459307800,
             "controlNumConvSquared": 988483738,
@@ -87,6 +93,8 @@
             "reachedValue": 1957171223
         },
         {
+            "controlConvHistogram": [1,2,3,4],
+            "testConvHistogram": [4,3,2,1],
             "testValueSquared": 3691439230,
             "testNumConvSquared": 691439230,
             "controlValueSquared": 1825398531,
@@ -116,6 +124,8 @@
         }
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 1247379003,
         "controlValueSquared": 405497006,
         "testNumConvSquared": 247379003,

--- a/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/valid_lift_no_cohort_metrics.json
+++ b/fbpcs/emp_games/attribution/shard_aggregator/test/shard_validation_test/valid_lift_no_cohort_metrics.json
@@ -4,6 +4,8 @@
     "publisherBreakdowns": [
     ],
     "metrics": {
+        "controlConvHistogram": [1,2,3,4],
+        "testConvHistogram": [4,3,2,1],
         "testValueSquared": 2949102338,
         "controlValueSquared": 2259601706,
         "testNumConvSquared": 949102338,


### PR DESCRIPTION
Summary: Histograms need to be handled by a special case in the shard aggregator because apparently it's not completely generic :(

Reviewed By: jrodal98

Differential Revision: D31447173

