### PR TITLE
Separate Deploy Controller from Runner so that the shell can become non-blocking

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -40,6 +40,14 @@ done
 
 tag_postfix="-${pce_id}"
 
+if [ -z ${TF_LOG+x} ]; then
+    echo "Terraform Detailed Error Logging Disabled"
+else
+    echo "Terraform Log Level: $TF_LOG"
+    echo "Terraform Log File: $TF_LOG_PATH"
+    echo
+fi
+
 echo "AWS region is $region."
 echo "The string '$tag_postfix' will be appended after the tag of the AWS resources."
 echo "Your AWS acount ID is $aws_account_id"

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +29,8 @@ public class DeployController {
   private Lock singleProvisioningLock = new ReentrantLock();
   private Process provisioningProcess;
   private final String NO_UPDATES_MESSAGE = "No updates";
+
+  Logger logger = LoggerFactory.getLogger(DeployController.class);
 
   enum DeploymentStatusRunning {
     DEPLOYMENT_NOT_STARTED,
@@ -74,38 +78,61 @@ public class DeployController {
       consumes = "application/json",
       produces = "application/json")
   public DeploymentResult deploymentCreate(@RequestBody DeploymentParams deployment) {
-    if (!deployment.validRegion())
+    logger.info("Received deployment request: " + deployment.toString());
+
+    if (!deployment.validRegion()) {
+      logger.warn("  Invalid region: " + deployment.region);
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED, "Invalid Region: " + deployment.region);
-    if (!deployment.validAccountID())
+    }
+    if (!deployment.validAccountID()) {
+      logger.warn("  Invalid account ID: " + deployment.accountId);
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED, "Invalid Account ID: " + deployment.accountId);
-    if (!deployment.validPubAccountID())
+    }
+    if (!deployment.validPubAccountID()) {
+      logger.warn("  Invalid publisher account ID: " + deployment.pubAccountId);
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED,
           "Invalid Publisher Account ID: " + deployment.pubAccountId);
-    if (!deployment.validVpcID())
+    }
+    if (!deployment.validVpcID()) {
+      logger.warn("  Invalid VPC ID: " + deployment.vpcId);
       return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid VPC: " + deployment.vpcId);
-    if (!deployment.validTagPostfix())
+          DeploymentResultSuccessful.STATUS_FAILED, "Invalid VPC ID: " + deployment.vpcId);
+    }
+    if (!deployment.validTagPostfix()) {
+      logger.warn("  Invalid tag postfix: " + deployment.tag);
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED, "Invalid Tag Postfix: " + deployment.tag);
-    if (!deployment.validStorageID())
+    }
+    if (!deployment.validStorageID()) {
+      logger.warn("  Invalid terraform config storage bucket: " + deployment.storage);
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED,
-          "Invalid S3 storage bucket: " + deployment.storage);
-    if (!deployment.validIngestionOutputID())
+          "Invalid terraform config storage bucket: " + deployment.storage);
+    }
+    if (!deployment.validIngestionOutputID()) {
+      logger.warn("  Invalid data ingestion bucket: " + deployment.ingestionOutput);
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED,
-          "Invalid S3 ingestion output bucket: " + deployment.ingestionOutput);
-    if (!deployment.validAccessKeyId())
+          "Invalid data ingestion bucket: " + deployment.ingestionOutput);
+    }
+    if (!deployment.validAccessKeyId()) {
+      logger.warn("  Invalid AWS access key ID");
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED, "Invalid AWS Access Key ID");
-    if (!deployment.validSecretAccessKey())
+    }
+    if (!deployment.validSecretAccessKey()) {
+      logger.warn("  Invalid AWS secret access key");
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_FAILED, "Invalid AWS Secret Access Key");
+    }
+
+    logger.info("  Validated input");
 
     if (singleProvisioningLock.tryLock()) {
+      logger.info("  No deployment conflicts found");
       deploymentStatus.status = DeploymentStatusRunning.DEPLOYMENT_RUNNING;
       deploymentStatus.message = null;
 
@@ -128,6 +155,7 @@ public class DeployController {
         deployCommand.add("-t");
         deployCommand.add(deployment.tag);
       }
+      logger.info("  Deploy command built: " + deployCommand);
 
       try {
         ProcessBuilder pb = new ProcessBuilder(deployCommand);
@@ -144,27 +172,32 @@ public class DeployController {
         pb.redirectErrorStream(true);
         pb.directory(new File("/terraform_deployment"));
         provisioningProcess = pb.start();
+        logger.info("  Creating deployment process");
         try {
           provisioningProcess.waitFor(30, TimeUnit.MINUTES);
+          logger.info("  Deployment process finished");
 
           synchronized (singleUpdateMutex) {
             deploymentStatus.status = DeploymentStatusRunning.DEPLOYMENT_FINISHED;
           }
           int exitCode = provisioningProcess.exitValue();
           if (exitCode == 0) {
+            logger.info("  Deployment finished successfully");
             return new DeploymentResult(
                 DeploymentResultSuccessful.STATUS_SUCCESS, "Deployed successfully");
           } else {
+            logger.error("  Deployment failed with exit code: " + String.valueOf(exitCode));
             return new DeploymentResult(
                 DeploymentResultSuccessful.STATUS_FAILED,
-                "Deployment failed with exit code: "
-                    + String.valueOf(provisioningProcess.exitValue()));
+                "Deployment failed with exit code: " + String.valueOf(exitCode));
           }
         } catch (InterruptedException e) {
+          logger.error("  Deployment timed out. Message: " + e.getMessage());
           return new DeploymentResult(
               DeploymentResultSuccessful.STATUS_TIMEOUT, "Deployment timed out");
         }
       } catch (IOException e) {
+        logger.error("  Deployment could not be started. Message: " + e.getMessage());
         return new DeploymentResult(
             DeploymentResultSuccessful.STATUS_FAILED, "Could not start deployment");
       } finally {
@@ -173,6 +206,7 @@ public class DeployController {
         singleProvisioningLock.unlock();
       }
     } else {
+      logger.error("  Another deployment is in progress");
       return new DeploymentResult(
           DeploymentResultSuccessful.STATUS_BLOCKED, "Another deployment is in progress");
     }
@@ -180,12 +214,15 @@ public class DeployController {
 
   @GetMapping(path = "/v1/deployment", produces = "application/json")
   public DeploymentStatus deploymentStatus() {
+    logger.info("Received status command");
     if (deploymentStatus.status == DeploymentStatusRunning.DEPLOYMENT_NOT_STARTED) {
+      logger.info("  No deployment is running");
       return new DeploymentStatus(
           DeploymentStatusRunning.DEPLOYMENT_NOT_STARTED, NO_UPDATES_MESSAGE);
     }
 
     if (provisioningProcess == null) {
+      logger.warn("  Deployment process unavailable, with status: " + deploymentStatus.status);
       deploymentStatus = new DeploymentStatus();
       return deploymentStatus;
     }
@@ -202,12 +239,15 @@ public class DeployController {
           sb.append('\n');
         }
       } catch (IOException e) {
+        logger.debug("  Problem reading deployment process logs: " + e.getMessage());
       }
+      logger.trace("  Read " + sb.length() + " chars from deployment process logs");
 
       if (deploymentStatus.status == DeploymentStatusRunning.DEPLOYMENT_RUNNING) {
         deploymentStatus.message = sb.length() == 0 ? NO_UPDATES_MESSAGE : sb.toString();
         return deploymentStatus;
       } else {
+        logger.info("  Deployment finished");
         deploymentStatus = new DeploymentStatus();
         provisioningProcess = null;
         return new DeploymentStatus(DeploymentStatusRunning.DEPLOYMENT_FINISHED, sb.toString());

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -135,6 +135,11 @@ public class DeployController {
         Map<String, String> env = pb.environment();
         env.put("AWS_ACCESS_KEY_ID", deployment.awsAccessKeyId);
         env.put("AWS_SECRET_ACCESS_KEY", deployment.awsSecretAccessKey);
+        if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
+          if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
+          env.put("TF_LOG", deployment.logLevel.getLevel());
+          env.put("TF_LOG_PATH", "/tmp/deploy.log");
+        }
 
         pb.redirectErrorStream(true);
         pb.directory(new File("/terraform_deployment"));

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -12,16 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,33 +26,8 @@ public class DeployController {
 
   private final Logger logger = LoggerFactory.getLogger(DeployController.class);
 
-  private Object singleUpdateMutex = new Object();
-  private Lock singleProvisioningLock = new ReentrantLock();
-
-  private Process provisioningProcess;
-
-  private DeploymentState deploymentState;
-
-  public DeployController() {
-    this.deploymentState = DeploymentState.STATE_NOT_STARTED;
-  }
-
-  enum DeploymentState {
-    STATE_NOT_STARTED("not started"),
-    STATE_RUNNING("running"),
-    STATE_FINISHED("finished");
-
-    private String state;
-
-    private DeploymentState(String state) {
-      this.state = state;
-    }
-
-    @JsonValue
-    public String getState() {
-      return state;
-    }
-  };
+  private DeploymentRunner runner;
+  private Semaphore singleProvisioningLock = new Semaphore(1);
 
   enum APIReturnStatus {
     STATUS_SUCCESS("success"),
@@ -114,132 +80,48 @@ public class DeployController {
     }
     logger.info("  Validated input");
 
-    if (singleProvisioningLock.tryLock()) {
+    try {
+      if (!singleProvisioningLock.tryAcquire()) {
+        String errorMessage = "Another deployment is in progress";
+        logger.error("  " + errorMessage);
+        return new DeploymentAPIReturn(APIReturnStatus.STATUS_FAIL, errorMessage);
+      }
       logger.info("  No deployment conflicts found");
-      deploymentState = DeploymentState.STATE_RUNNING;
 
-      List<String> deployCommand = new ArrayList<String>();
-      deployCommand.add("/bin/sh");
-      deployCommand.add("/terraform_deployment/deploy.sh");
-      deployCommand.add("-r");
-      deployCommand.add(deployment.region);
-      deployCommand.add("-a");
-      deployCommand.add(deployment.accountId);
-      deployCommand.add("-p");
-      deployCommand.add(deployment.pubAccountId);
-      deployCommand.add("-v");
-      deployCommand.add(deployment.vpcId);
-      deployCommand.add("-s");
-      deployCommand.add(deployment.storage);
-      deployCommand.add("-d");
-      deployCommand.add(deployment.ingestionOutput);
-      if (deployment.tag != null && !deployment.tag.isEmpty()) {
-        deployCommand.add("-t");
-        deployCommand.add(deployment.tag);
-      }
-      logger.info("  Deploy command built: " + deployCommand);
-
-      try {
-        ProcessBuilder pb = new ProcessBuilder(deployCommand);
-
-        Map<String, String> env = pb.environment();
-        env.put("AWS_ACCESS_KEY_ID", deployment.awsAccessKeyId);
-        env.put("AWS_SECRET_ACCESS_KEY", deployment.awsSecretAccessKey);
-        if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
-          if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
-          env.put("TF_LOG", deployment.logLevel.getLevel());
-          env.put("TF_LOG_PATH", "/tmp/deploy.log");
-        }
-
-        pb.redirectErrorStream(true);
-        pb.directory(new File("/terraform_deployment"));
-        provisioningProcess = pb.start();
-        logger.info("  Creating deployment process");
-        try {
-          provisioningProcess.waitFor(30, TimeUnit.MINUTES);
-          logger.info("  Deployment process finished");
-
-          synchronized (singleUpdateMutex) {
-            deploymentState = DeploymentState.STATE_FINISHED;
-          }
-          int exitCode = provisioningProcess.exitValue();
-          if (exitCode == 0) {
-            logger.info("  Deployment finished successfully");
-            return new DeploymentAPIReturn(APIReturnStatus.STATUS_SUCCESS, "Deployed successfully");
-          } else {
-            logger.error("  Deployment failed with exit code: " + String.valueOf(exitCode));
-            return new DeploymentAPIReturn(
-                APIReturnStatus.STATUS_ERROR,
-                "Deployment failed with exit code: " + String.valueOf(exitCode));
-          }
-        } catch (InterruptedException e) {
-          logger.error("  Deployment timed out. Message: " + e.getMessage());
-          return new DeploymentAPIReturn(APIReturnStatus.STATUS_ERROR, "Deployment timed out");
-        }
-      } catch (IOException e) {
-        logger.error("  Deployment could not be started. Message: " + e.getMessage());
-        return new DeploymentAPIReturn(APIReturnStatus.STATUS_FAIL, "Could not start deployment");
-      } finally {
-        if (provisioningProcess != null && provisioningProcess.isAlive())
-          provisioningProcess.destroy();
-        singleProvisioningLock.unlock();
-      }
-    } else {
-      logger.error("  Another deployment is in progress");
+      runner =
+          new DeploymentRunner(
+              deployment,
+              () -> {
+                singleProvisioningLock.release();
+              });
+      runner.start();
       return new DeploymentAPIReturn(
-          APIReturnStatus.STATUS_ERROR, "Another deployment is in progress");
+          APIReturnStatus.STATUS_SUCCESS, "Deployment Started Successfully");
+    } catch (DeploymentException ex) {
+      return new DeploymentAPIReturn(APIReturnStatus.STATUS_ERROR, ex.getMessage());
+    } finally {
+      logger.info("  Deployment request finalized");
     }
   }
 
   @GetMapping(path = "/v1/deployment", produces = "application/json")
   public DeploymentAPIReturn deploymentStatus() {
+    logger.info("Received status command");
+
+    if (runner == null
+        || runner.getDeploymentState() == DeploymentRunner.DeploymentState.STATE_NOT_STARTED) {
+      logger.info("  No deployment is running");
+      return new DeploymentAPIReturn(APIReturnStatus.STATUS_SUCCESS, NO_UPDATES_MESSAGE);
+    }
+
+    DeploymentRunner.DeploymentState state = runner.getDeploymentState();
+
     ObjectMapper mapper = new ObjectMapper();
     ObjectNode rootNode = mapper.createObjectNode();
-    rootNode.put("state", deploymentState.getState());
+    rootNode.put("state", state.toString());
+    if (state == DeploymentRunner.DeploymentState.STATE_FINISHED)
+      rootNode.put("exitValue", runner.getExitValue());
 
-    logger.info("Received status command");
-    if (deploymentState == DeploymentState.STATE_NOT_STARTED) {
-      logger.info("  No deployment is running");
-      return new DeploymentAPIReturn(APIReturnStatus.STATUS_SUCCESS, NO_UPDATES_MESSAGE, rootNode);
-    }
-
-    if (provisioningProcess == null) {
-      String stateString =
-          "Deployment process unavailable, with status: " + deploymentState.getState();
-      deploymentState = DeploymentState.STATE_NOT_STARTED;
-      logger.warn("  " + stateString);
-      return new DeploymentAPIReturn(APIReturnStatus.STATUS_ERROR, stateString);
-    }
-
-    synchronized (singleUpdateMutex) {
-      StringBuilder sb = new StringBuilder();
-      BufferedReader stdout =
-          new BufferedReader(new InputStreamReader(provisioningProcess.getInputStream()));
-
-      try {
-        String s;
-        while (stdout.ready() && (s = stdout.readLine()) != null) {
-          sb.append(s);
-          sb.append('\n');
-        }
-      } catch (IOException e) {
-        logger.debug("  Problem reading deployment process logs: " + e.getMessage());
-      }
-      logger.trace("  Read " + sb.length() + " chars from deployment process logs");
-
-      if (deploymentState == DeploymentState.STATE_RUNNING) {
-        String message = sb.length() == 0 ? NO_UPDATES_MESSAGE : sb.toString();
-        return new DeploymentAPIReturn(APIReturnStatus.STATUS_SUCCESS, message, rootNode);
-      } else {
-        logger.info("  Deployment finished");
-
-        provisioningProcess = null;
-
-        deploymentState = DeploymentState.STATE_FINISHED;
-        rootNode.put("state", deploymentState.getState());
-
-        return new DeploymentAPIReturn(APIReturnStatus.STATUS_SUCCESS, sb.toString(), rootNode);
-      }
-    }
+    return new DeploymentAPIReturn(APIReturnStatus.STATUS_SUCCESS, runner.getOutput(), rootNode);
   }
 }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -30,7 +30,7 @@ public class DeployController {
   private Process provisioningProcess;
   private final String NO_UPDATES_MESSAGE = "No updates";
 
-  Logger logger = LoggerFactory.getLogger(DeployController.class);
+  private final Logger logger = LoggerFactory.getLogger(DeployController.class);
 
   enum DeploymentStatusRunning {
     DEPLOYMENT_NOT_STARTED,
@@ -80,55 +80,11 @@ public class DeployController {
   public DeploymentResult deploymentCreate(@RequestBody DeploymentParams deployment) {
     logger.info("Received deployment request: " + deployment.toString());
 
-    if (!deployment.validRegion()) {
-      logger.warn("  Invalid region: " + deployment.region);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid Region: " + deployment.region);
+    try {
+      deployment.validate();
+    } catch (InvalidDeploymentArgumentException ex) {
+      return new DeploymentResult(DeploymentResultSuccessful.STATUS_FAILED, ex.getMessage());
     }
-    if (!deployment.validAccountID()) {
-      logger.warn("  Invalid account ID: " + deployment.accountId);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid Account ID: " + deployment.accountId);
-    }
-    if (!deployment.validPubAccountID()) {
-      logger.warn("  Invalid publisher account ID: " + deployment.pubAccountId);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED,
-          "Invalid Publisher Account ID: " + deployment.pubAccountId);
-    }
-    if (!deployment.validVpcID()) {
-      logger.warn("  Invalid VPC ID: " + deployment.vpcId);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid VPC ID: " + deployment.vpcId);
-    }
-    if (!deployment.validTagPostfix()) {
-      logger.warn("  Invalid tag postfix: " + deployment.tag);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid Tag Postfix: " + deployment.tag);
-    }
-    if (!deployment.validStorageID()) {
-      logger.warn("  Invalid terraform config storage bucket: " + deployment.storage);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED,
-          "Invalid terraform config storage bucket: " + deployment.storage);
-    }
-    if (!deployment.validIngestionOutputID()) {
-      logger.warn("  Invalid data ingestion bucket: " + deployment.ingestionOutput);
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED,
-          "Invalid data ingestion bucket: " + deployment.ingestionOutput);
-    }
-    if (!deployment.validAccessKeyId()) {
-      logger.warn("  Invalid AWS access key ID");
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid AWS Access Key ID");
-    }
-    if (!deployment.validSecretAccessKey()) {
-      logger.warn("  Invalid AWS secret access key");
-      return new DeploymentResult(
-          DeploymentResultSuccessful.STATUS_FAILED, "Invalid AWS Secret Access Key");
-    }
-
     logger.info("  Validated input");
 
     if (singleProvisioningLock.tryLock()) {

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentException.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+public class DeploymentException extends RuntimeException {
+  public DeploymentException(String message) {
+    super(message);
+  }
+
+  private static final long serialVersionUID = 856L;
+}

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -10,6 +10,8 @@ package com.facebook.business.cloudbridge.pl.server;
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DeploymentParams {
   public String region;
@@ -23,6 +25,8 @@ public class DeploymentParams {
 
   public String awsAccessKeyId;
   public String awsSecretAccessKey;
+
+  private final Logger logger = LoggerFactory.getLogger(DeploymentParams.class);
 
   enum LogLevel {
     DISABLED("Disabled"),
@@ -116,6 +120,41 @@ public class DeploymentParams {
 
   public boolean validSecretAccessKey() {
     return awsSecretAccessKey != null && !awsSecretAccessKey.isEmpty();
+  }
+
+  private void logAndThrow(String message) throws InvalidDeploymentArgumentException {
+    logger.error("  " + message);
+    throw new InvalidDeploymentArgumentException(message);
+  }
+
+  public void validate() throws InvalidDeploymentArgumentException {
+    if (!validRegion()) {
+      logAndThrow("Invalid Region: " + region);
+    }
+    if (!validAccountID()) {
+      logAndThrow("Invalid Account ID: " + accountId);
+    }
+    if (!validPubAccountID()) {
+      logAndThrow("Invalid Publisher Account ID: " + pubAccountId);
+    }
+    if (!validVpcID()) {
+      logAndThrow("Invalid VPC ID: " + vpcId);
+    }
+    if (!validTagPostfix()) {
+      logAndThrow("Invalid Tag Postfix: " + tag);
+    }
+    if (!validStorageID()) {
+      logAndThrow("Invalid terraform config storage bucket: " + storage);
+    }
+    if (!validIngestionOutputID()) {
+      logAndThrow("Invalid data ingestion bucket: " + ingestionOutput);
+    }
+    if (!validAccessKeyId()) {
+      logAndThrow("Invalid AWS Access Key ID");
+    }
+    if (!validSecretAccessKey()) {
+      logAndThrow("Invalid AWS Secret Access Key");
+    }
   }
 
   public String toString() {

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -8,6 +8,8 @@
 package com.facebook.business.cloudbridge.pl.server;
 
 import com.amazonaws.regions.Regions;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DeploymentParams {
   public String region;
@@ -17,9 +19,43 @@ public class DeploymentParams {
   public String storage;
   public String ingestionOutput;
   public String tag;
+  public LogLevel logLevel;
 
   public String awsAccessKeyId;
   public String awsSecretAccessKey;
+
+  enum LogLevel {
+    DISABLED("Disabled"),
+    ERROR("ERROR"),
+    WARNING("WARN"),
+    INFORMATION("INFO"),
+    DEBUG("DEBUG"),
+    TRACE("TRACE");
+
+    private final String level;
+
+    LogLevel() {
+      this.level = "DEBUG";
+    }
+
+    LogLevel(final String level) {
+      this.level = level;
+    }
+
+    public String getLevel() {
+      return this.level;
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static LogLevel getLogLevelFromName(@JsonProperty("logLevel") String level) {
+      for (LogLevel l : LogLevel.values()) {
+        if (l.getLevel().equals(level)) {
+          return l;
+        }
+      }
+      return DEBUG;
+    }
+  }
 
   public boolean validRegion() {
     try {
@@ -80,5 +116,30 @@ public class DeploymentParams {
 
   public boolean validSecretAccessKey() {
     return awsSecretAccessKey != null && !awsSecretAccessKey.isEmpty();
+  }
+
+  public String toString() {
+    StringBuilder sb =
+        new StringBuilder()
+            .append("{region: ")
+            .append(region)
+            .append(", account ID: ")
+            .append(accountId)
+            .append(", publisher account ID: ")
+            .append(pubAccountId)
+            .append(", VPC ID: ")
+            .append(vpcId)
+            .append(", Configuration Storage: ")
+            .append(storage)
+            .append(", Ingestion Output Storage: ")
+            .append(ingestionOutput);
+    if (tag != null) {
+      sb.append(", Tag: ").append(tag);
+    }
+    if (logLevel != null) {
+      sb.append(", Terraform Log Level: ").append(logLevel);
+    }
+    sb.append("}");
+    return sb.toString();
   }
 }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeploymentRunner extends Thread {
+  private Logger logger = LoggerFactory.getLogger(DeployController.class);
+  private List<String> deployCommand;
+  private Map<String, String> environmentVariables;
+
+  private Runnable deploymentFinishedCallback;
+  private Process provisioningProcess;
+
+  private int exitValue;
+
+  public int getExitValue() {
+    return exitValue;
+  }
+
+  private Object processOutputMutex = new Object();
+  private String processOutput = new String();
+
+  public String getOutput() {
+    String output;
+    synchronized (processOutputMutex) {
+      output = processOutput;
+      processOutput = new String();
+    }
+
+    if (provisioningProcess == null) deploymentState = DeploymentState.STATE_NOT_STARTED;
+
+    return output;
+  }
+
+  enum DeploymentState {
+    STATE_NOT_STARTED("not started"),
+    STATE_RUNNING("running"),
+    STATE_FINISHED("finished");
+
+    private String state;
+
+    private DeploymentState(String state) {
+      this.state = state;
+    }
+
+    @JsonValue
+    public String toString() {
+      return state;
+    }
+  };
+
+  private DeploymentState deploymentState;
+
+  public DeploymentState getDeploymentState() {
+    return deploymentState;
+  }
+
+  public DeploymentRunner(DeploymentParams deployment, Runnable deploymentFinishedCallback) {
+
+    this.deploymentState = DeploymentState.STATE_NOT_STARTED;
+    this.deploymentFinishedCallback = deploymentFinishedCallback;
+
+    buildDeployCommand(deployment);
+    buildEnvironmentVariables(deployment);
+  }
+
+  private void buildDeployCommand(DeploymentParams deployment) {
+    deployCommand = new ArrayList<String>();
+    deployCommand.add("/bin/sh");
+    deployCommand.add("/terraform_deployment/deploy.sh");
+    deployCommand.add("-r");
+    deployCommand.add(deployment.region);
+    deployCommand.add("-a");
+    deployCommand.add(deployment.accountId);
+    deployCommand.add("-p");
+    deployCommand.add(deployment.pubAccountId);
+    deployCommand.add("-v");
+    deployCommand.add(deployment.vpcId);
+    deployCommand.add("-s");
+    deployCommand.add(deployment.storage);
+    deployCommand.add("-d");
+    deployCommand.add(deployment.ingestionOutput);
+    if (deployment.tag != null && !deployment.tag.isEmpty()) {
+      deployCommand.add("-t");
+      deployCommand.add(deployment.tag);
+    }
+    logger.info("  Deploy command built: " + deployCommand);
+  }
+
+  private void buildEnvironmentVariables(DeploymentParams deployment) {
+    environmentVariables = new HashMap<String, String>();
+    environmentVariables.put("AWS_ACCESS_KEY_ID", deployment.awsAccessKeyId);
+    environmentVariables.put("AWS_SECRET_ACCESS_KEY", deployment.awsSecretAccessKey);
+
+    if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
+      if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
+      environmentVariables.put("TF_LOG", deployment.logLevel.getLevel());
+      environmentVariables.put("TF_LOG_PATH", "/tmp/deploy.log");
+    }
+  }
+
+  private String readOutput() {
+    StringBuilder sb = new StringBuilder();
+    BufferedReader stdout =
+        new BufferedReader(new InputStreamReader(provisioningProcess.getInputStream()));
+
+    try {
+      String s;
+      while (stdout.ready() && (s = stdout.readLine()) != null) {
+        sb.append(s);
+        sb.append('\n');
+      }
+    } catch (IOException e) {
+      logger.debug("  Problem reading deployment process logs: " + e.getMessage());
+    }
+    logger.trace("  Read " + sb.length() + " chars from deployment process logs");
+
+    return sb.toString();
+  }
+
+  private void logOutput(String output) {
+    synchronized (processOutputMutex) {
+      processOutput += output;
+    }
+  }
+
+  public void run() {
+    deploymentState = DeploymentState.STATE_RUNNING;
+
+    try {
+      ProcessBuilder pb = new ProcessBuilder(deployCommand);
+
+      Map<String, String> env = pb.environment();
+      env.putAll(environmentVariables);
+
+      pb.redirectErrorStream(true);
+      pb.directory(new File("/terraform_deployment"));
+      provisioningProcess = pb.start();
+      logger.info("  Creating deployment process");
+
+      while (provisioningProcess.isAlive()) {
+        String output = readOutput();
+        logOutput(output);
+
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+        }
+      }
+
+      exitValue = provisioningProcess.exitValue();
+      logger.info("  Deployment process exited with value: " + exitValue);
+
+    } catch (IOException e) {
+      logger.error("  Deployment could not be started. Message: " + e.getMessage());
+      throw new DeploymentException("Deployment could not be started");
+    } finally {
+      deploymentState = DeploymentState.STATE_FINISHED;
+      if (provisioningProcess.isAlive()) provisioningProcess.destroy();
+      provisioningProcess = null;
+      logger.info("  Deployment finished");
+
+      deploymentFinishedCallback.run();
+    }
+  }
+}

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/InvalidDeploymentArgumentException.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/InvalidDeploymentArgumentException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+public class InvalidDeploymentArgumentException extends Exception {
+  public InvalidDeploymentArgumentException(String message) {
+    super(message);
+  }
+
+  private static final long serialVersionUID = 855L;
+}

--- a/fbpcs/infra/cloud_bridge/server/src/main/resources/logback-spring.xml
+++ b/fbpcs/infra/cloud_bridge/server/src/main/resources/logback-spring.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <property name="LOGS" value="/tmp" />
+
+    <appender name="Console"
+        class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                ${CONSOLE_LOG_PATTERN}
+            </Pattern>
+        </layout>
+    </appender>
+
+    <appender name="RollingFile"
+        class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS}/server.log</file>
+        <encoder
+            class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+        </encoder>
+
+        <rollingPolicy
+            class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- rollover daily and when the file reaches 10 MegaBytes -->
+            <fileNamePattern>${LOGS}/archived/server-%d{yyyy-MM-dd}.%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!-- LOG everything at INFO level -->
+    <root level="info">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </root>
+
+    <!-- LOG "com.facebook*" at TRACE level -->
+    <logger name="com.facebook" level="trace" additivity="false">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </logger>
+
+</configuration>


### PR DESCRIPTION
Summary:
This change effectively breaks the server in two
DeployController and DeploymentRunner

Runner extends Thread and allows for the controller to dissociate with the deployment.
This, in turn, allows for the UI to be non-blocking.

Reviewed By: corbantek, marksliva

Differential Revision: D30484886

