### PR TITLE
add is_joint_stage to PCS StageType

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_stage_type.py
+++ b/fbpcs/private_computation/entity/private_computation_stage_type.py
@@ -4,10 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from enum import Enum
+
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
-from enum import Enum
 
 
 class PrivateComputationStageType(Enum):
@@ -20,7 +21,6 @@ class PrivateComputationStageType(Enum):
     An exception is raised at runtime if _order_ is inconsistent with the actual member order.
     """
 
-
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
     _order_ = "UNKNOWN CREATED ID_MATCH COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
@@ -32,31 +32,37 @@ class PrivateComputationStageType(Enum):
         PrivateComputationInstanceStatus.UNKNOWN,
         PrivateComputationInstanceStatus.UNKNOWN,
         PrivateComputationInstanceStatus.UNKNOWN,
+        False,
     )
     CREATED = (
         PrivateComputationInstanceStatus.UNKNOWN,
         PrivateComputationInstanceStatus.CREATED,
         PrivateComputationInstanceStatus.UNKNOWN,
+        False,
     )
     ID_MATCH = (
         PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
         PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+        True,
     )
     COMPUTE = (
         PrivateComputationInstanceStatus.COMPUTATION_STARTED,
         PrivateComputationInstanceStatus.COMPUTATION_COMPLETED,
         PrivateComputationInstanceStatus.COMPUTATION_FAILED,
+        True,
     )
     AGGREGATE = (
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.AGGREGATION_FAILED,
+        True,
     )
     POST_PROCESSING_HANDLERS = (
         PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,
         PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED,
         PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
+        False,
     )
 
     def __init__(
@@ -64,10 +70,12 @@ class PrivateComputationStageType(Enum):
         start_status: PrivateComputationInstanceStatus,
         completed_status: PrivateComputationInstanceStatus,
         failed_status: PrivateComputationInstanceStatus,
+        is_joint_stage: bool,
     ) -> None:
         self.start_status = start_status
         self.completed_status = completed_status
         self.failed_status = failed_status
+        self.is_joint_stage = is_joint_stage
 
     @property
     def next_stage(self) -> "PrivateComputationStageType":

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -245,7 +245,11 @@ class PrivateComputationService:
         stage service
         """
         pc_instance = self.get_instance(instance_id)
-        if pc_instance.role is PrivateComputationRole.PARTNER and not server_ips:
+        if (
+            stage_svc.stage_type.is_joint_stage
+            and pc_instance.role is PrivateComputationRole.PARTNER
+            and not server_ips
+        ):
             raise ValueError("Missing server_ips")
 
         # if the instance status is the complete status of the previous stage, then we can run the target stage

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -7,12 +7,14 @@
 # pyre-strict
 
 import abc
-
 from typing import List, Optional
+
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
 )
-from fbpcs.private_computation.entity.private_computation_stage_type import PrivateComputationStageType
+from fbpcs.private_computation.entity.private_computation_stage_type import (
+    PrivateComputationStageType,
+)
 
 
 class PrivateComputationStageService(abc.ABC):
@@ -25,6 +27,7 @@ class PrivateComputationStageService(abc.ABC):
     async def run_async(
         self,
         pc_instance: PrivateComputationInstance,
+        # TODO(T102471612): remove server_ips from run_async, move to subclass constructor instead
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         ...


### PR DESCRIPTION
Summary:
## What

Added is_joint_stage flag to PrivateComputationStageType, which is used in private_computation.py to distinguish between stages that require server ips (joint calculations) and those that do not

## Why

There was a bad assumption in private_computation.py and stage services that stages require server ips. This isn't true, as post processing handlers don't require server ips, nor does data preparation or instance creation.

More context here:  https://www.internalfb.com/diff/D31385296 (https://github.com/facebookresearch/fbpcs/commit/e13f00b210c98132adef8ef5871aece0c10cb737)?dst_version_fbid=1846156245569327&transaction_fbid=601146891015471

Reviewed By: Olivia-liu

Differential Revision: D31445209

