### PR TITLE
Fix fbpcs/onedocker image after migrated to self hosted runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build onedocker image in rc
         run: |
-          ./build-docker.sh onedocker -t rc
+          ./build-docker.sh onedocker -t rc -f
 
       # tests will be added here once we have one script for all tests ready
       #- name: Tests name

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -6,7 +6,8 @@ ARG os_release="latest"
 ARG tag="latest"
 FROM fbpcs/data-processing:${tag} as data_processing
 FROM fbpcs/emp-games:${tag} as emp_games
-FROM ghcr.io/facebookresearch/private-id:${tag} as private_id
+# Tag for private-id is always latest
+FROM ghcr.io/facebookresearch/private-id:latest as private_id
 
 FROM ubuntu:${os_release}
 # Set the timezone


### PR DESCRIPTION
Summary:
The image failed to built:
1.ERROR: Unable to find docker image fbpcf/ubuntu:latest.  Please clone and run https://github.com/facebookresearch/fbpcf/blob/master/build-docker.sh -- Adding a -f so it will download the most recent one
2.During testing, I also notice the tag for private-id always need to be:latest( we cannot tag it as :rc)

Differential Revision: D31508903

