### PR TITLE
Update the terraform script to add tags for route table

### DIFF
--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/compute.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/compute.tf
@@ -2,8 +2,7 @@ resource "aws_ecs_cluster" "main" {
   name = "onedocker-cluster${var.tag_postfix}"
 
   tags = {
-    pce-tag      = "cluster${var.tag_postfix}"
-    "pce:pce-id" = var.pce_id
+    pce-tag = "cluster${var.tag_postfix}"
   }
 
   capacity_providers = ["FARGATE"]

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/main.tf
@@ -1,6 +1,11 @@
 provider "aws" {
   profile = "default"
   region  = var.aws_region
+  default_tags {
+    tags = {
+      "pce:pce-id" = var.pce_id
+    }
+  }
 }
 
 terraform {

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf
@@ -3,8 +3,7 @@ resource "aws_vpc" "main" {
   enable_dns_hostnames = true
 
   tags = {
-    Name         = "onedocker-vpc${var.tag_postfix}"
-    "pce:pce-id" = var.pce_id
+    Name = "onedocker-vpc${var.tag_postfix}"
   }
 }
 
@@ -27,8 +26,7 @@ resource "aws_subnet" "subnets" {
   availability_zone       = local.az_names[each.key]
   map_public_ip_on_launch = true
   tags = {
-    Name         = "onedocker-subnet${var.tag_postfix}"
-    "pce:pce-id" = var.pce_id
+    Name = "onedocker-subnet${var.tag_postfix}"
   }
 }
 
@@ -36,9 +34,12 @@ resource "aws_internet_gateway" "default" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name         = "onedocker-igw${var.tag_postfix}"
-    "pce:pce-id" = var.pce_id
+    Name = "onedocker-igw${var.tag_postfix}"
   }
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = aws_vpc.main.main_route_table_id
 }
 
 resource "aws_route" "internet_access" {
@@ -84,7 +85,6 @@ resource "aws_default_security_group" "default" {
   }
 
   tags = {
-    Name         = "onedocker-security-group${var.tag_postfix}"
-    "pce:pce-id" = var.pce_id
+    Name = "onedocker-security-group${var.tag_postfix}"
   }
 }


### PR DESCRIPTION
Summary:
What:
1. Use default tag to setup the PCE id
2. Touch the default vpc route table to apply tags to route table.

Why:
The VPC create a default route table, so in tf script, we don't create a new route table. The default route table doesn't have the PCE id tag because it's not created by terraform. In the diff, we touch the default route table, so it will apply tags to it.

Differential Revision: D31544460

