### PR TITLE
de-dup private computation service wrapper functions, part 1

### DIFF
--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -39,7 +39,12 @@ import schema
 from docopt import docopt
 from fbpcp.util import yaml
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
-from fbpcs.pl_coordinator.pl_service_wrapper import (
+from fbpcs.pl_coordinator.pl_study_runner import run_study
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     aggregate,
     compute,
     create_instance,
@@ -51,11 +56,6 @@ from fbpcs.pl_coordinator.pl_service_wrapper import (
     run_post_processing_handlers,
     validate,
     cancel_current_stage,
-)
-from fbpcs.pl_coordinator.pl_study_runner import run_study
-from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationRole,
-    PrivateComputationGameType,
 )
 
 

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -17,17 +17,17 @@ from fbpcs.pl_coordinator.pl_graphapi_utils import (
     PLGraphAPIClient,
     GRAPHAPI_INSTANCE_STATUSES,
 )
-from fbpcs.pl_coordinator.pl_service_wrapper import (
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     get,
     create_instance,
     id_match,
     compute,
     aggregate,
     cancel_current_stage,
-)
-from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationRole,
-    PrivateComputationInstanceStatus,
 )
 
 


### PR DESCRIPTION
Summary:
This stack focuses on consolidating the PL and PA coordinators into one single CLI.

This diff does 2 things (and some functions/variables renaming that should be self-explanatory)
1. Move pl_service_wrapper.py to private_computation_service_wrapper.py because it contains wrapper functions of pcs, not pl service anymore (which doesn't exist anymore);
2. Remove the functions from pa_coordinator.py that are complete duplicates of functions in private_computation_service_wrapper.py

Next, I'll move the remaining functions in pa_coordinator.py to private_computation_service_wrapper.py. Intentionally not doing it here so that I'm not over-complicating this diff; the remaining functions are not complete duplicates, so I cannot just delete them like how I did with those in this diff.

Differential Revision: D31585359

