### PR TITLE
PCS update pip requirements

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -10,4 +10,4 @@ tqdm ~= 4.55
 networkx ~= 2.5
 requests ~= 2.25
 psutil ~= 5.8
-fbpcp ~= 0.1.5
+fbpcp ~= 0.1.6


### PR DESCRIPTION
Summary:
## What

Update fbpcp requirement to 0.1.6

## Why

This version fixes a bug with one docker that allows you to specify the version of the binaries being run, which we need for our weekly E2E test.

Reviewed By: Olivia-liu

Differential Revision: D31588172

