### PR TITLE
remove instance repo update in run_stage

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -292,7 +292,6 @@ class PrivateComputationService:
             private_computation_instance=pc_instance,
             new_status=stage_svc.stage_type.start_status,
         )
-        self.instance_repository.update(pc_instance)
         try:
             pc_instance = await stage_svc.run_async(pc_instance, server_ips)
         except Exception as e:


### PR DESCRIPTION
Summary:
## What

Remove an unneccessary update to the instance repository in run_stage

## Why

I noticed while working on another diff stack that this line could theoretically lead to a race condition. If we update the status in the instance repository to XXX_STARTED, then the instance monitor will start updating the instance. Since we update the instance again 10 lines down, it's possible they could do the update at the same time.

Thus, we should update the status in the instance repository only once. The update at the bottom will catch exceptions and set the status to failed, so it makes the most sense to update it here. There are unit tests to simulate this.

Differential Revision: D31591182

