### PR TITLE
fbpcs/onedocker Add a step in docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Remove unused images
+        run: |
+         docker image prune -af
+
       - name: Build onedocker image in rc
         run: |
           ./build-docker.sh onedocker -t rc -f


### PR DESCRIPTION
Summary: After migrating to self hosted runner(EC2 host) the unused image need to get cleanup before new images are built; otherwise, the new image will carry all the past commit tags

Differential Revision: D31592886

