### PR TITLE
E2E test: Adding scripts to run on github actions [3/n]

### DIFF
--- a/fbpcs/tests/github/attribution_check_status.sh
+++ b/fbpcs/tests/github/attribution_check_status.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Check if all status are complete for attribution stages
+set -e
+container_name=$1
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+docker_command="docker exec $container_name $ATTRIBUTION_COORDINATOR"
+
+# check if all the status are COMPLETED, if yes, return true
+function check_status_complete() {
+    $docker_command get_instance "$1" --config="$DOCKER_CLOUD_CONFIG_FILE" || exit 1
+    #filter out "status": "COMPLETED"
+    non_complete_status=$($docker_command get_instance "$1" \
+        --config="$DOCKER_CLOUD_CONFIG_FILE" 2>&1 | \
+        grep -o -E "\"status\": \"[a-zA-Z]+\"" | \
+        awk -F: '$2 != " \"COMPLETED\""')
+    if [ -z "$non_complete_status" ]
+    then
+        echo "$1 status is all complete"
+        return 0
+    else
+        echo "$1 has following status: $non_complete_status"
+        return 1
+    fi
+}
+
+until check_status_complete $"$ATTRIBUTION_PUBLIHSER_NAME" \
+&& check_status_complete $"$ATTRIBUTION_PARTNER_NAME"
+    do echo "Waiting status to complete ..."
+    sleep 60
+done
+
+echo "Stage complets successfully"

--- a/fbpcs/tests/github/attribution_run_stages.sh
+++ b/fbpcs/tests/github/attribution_run_stages.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage:Run attribution different stages: create_instance, id_match, prepare_compute_input, compute_attribution, aggregate_shards
+
+set -e
+
+container_name=$1
+stage=$2
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+docker_command="docker exec $container_name $ATTRIBUTION_COORDINATOR"
+
+case "$stage" in
+    create_instance )
+        echo "Create Attribution Publisher instance"
+        $docker_command create_instance "$ATTRIBUTION_PUBLIHSER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --input_path="$ATTRIBUTION_INPUT_FILE" \
+            --output_dir="$ATTRIBUTION_OUTPUT_DIR" \
+            --role=publisher \
+            --num_pid_containers="$ATTRIBUTION_NUM_PID_CONTAINERS" \
+            --num_mpc_containers="$ATTRIBUTION_NUM_MPC_CONTAINERS" \
+            --num_files_per_mpc_container="$ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER" \
+            --concurrency="$ATTRIBUTION_CONCURRENCY" \
+            --attribution_rule="$ATTRIBUTION_RULE" \
+            --aggregation_type="$ATTRIBUTION_TYPE"
+        echo "Create Attribution Partner instance"
+        $docker_command create_instance "$ATTRIBUTION_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --input_path="$ATTRIBUTION_INPUT_FILE" \
+            --output_dir="$ATTRIBUTION_OUTPUT_DIR" \
+            --role=partner \
+            --num_pid_containers="$ATTRIBUTION_NUM_PID_CONTAINERS" \
+            --num_mpc_containers="$ATTRIBUTION_NUM_MPC_CONTAINERS" \
+            --num_files_per_mpc_container="$ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER" \
+            --concurrency="$ATTRIBUTION_CONCURRENCY" \
+            --attribution_rule="$ATTRIBUTION_RULE" \
+            --aggregation_type="$ATTRIBUTION_TYPE"
+            ;;
+    prepare_compute_input )
+        echo "Attribution Publisher $stage starts"
+        $docker_command "$stage" "$ATTRIBUTION_PUBLIHSER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        echo "Attribution Partner $stage starts"
+        $docker_command "$stage" "$ATTRIBUTION_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        ;;
+    id_match|compute_attribution|aggregate_shards )
+        echo "Attribution Publisher $stage starts"
+        $docker_command "$stage" "$ATTRIBUTION_PUBLIHSER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE"
+        echo "Get Publisher Ips"
+        # get_server_ips returns multiple lines, only the last line is ip address
+        publisher_server_ips=$($docker_command get_server_ips "$ATTRIBUTION_PUBLIHSER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" | sed -E '$!d;s/\r//g')
+        echo "Server IPs are ${publisher_server_ips}"
+        echo "Attribution Partner $stage starts"
+        $docker_command "$stage" "$ATTRIBUTION_PARTNER_NAME" \
+            --config="$DOCKER_CLOUD_CONFIG_FILE" \
+            --server_ips="${publisher_server_ips}"
+        ;;
+
+    * )
+        echo "Not a valid Attribution stage"
+esac

--- a/fbpcs/tests/github/config.sh
+++ b/fbpcs/tests/github/config.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Github e2e configs
+
+## Shared
+export E2E_S3_BUCKET="fbpcs-github-e2e"
+export E2E_GITHUB_S3_URL="https://$E2E_S3_BUCKET.s3.us-west-2.amazonaws.com"
+# Matched with yaml file
+export CLOUD_CONFIG_FILE="fbpcs_e2e_aws.yml"
+export DOCKER_CLOUD_CONFIG_FILE="/$CLOUD_CONFIG_FILE"
+export DOCKER_INSTANCE_REPO="/instances"
+
+## Lift
+# Lift study configs
+export LIFT_PUBLIHSER_NAME="pl_publisher_github"
+export LIFT_PARTNER_NAME="pl_partner_github"
+export LIFT_COORDINATOR="python3.8 -m fbpcs.pl_coordinator.pl_coordinator"
+export LIFT_NUM_MPC_CONTAIENRS=2
+export LIFT_NUM_PID_CONTAINERS=2
+export LIFT_INPUT_FILE=$E2E_GITHUB_S3_URL/lift/inputs/publisher_e2e_input.csv
+export LIFT_OUTPUT_DIR=$E2E_GITHUB_S3_URL/lift/outputs
+
+# Lift result comparision
+export LIFT_OUTPUT_PATH=s3://$E2E_S3_BUCKET/lift/outputs
+export LIFT_PUBLISHER_AGGREGATION_OUTPUT=$LIFT_OUTPUT_PATH/"$LIFT_PUBLIHSER_NAME"_out_dir/shard_aggregation_stage/out.json
+export LIFT_PARTNER_AGGREGATION_OUTPUT=s$LIFT_OUTPUT_PATH/"$LIFT_PARTNER_NAME"_out_dir/shard_aggregation_stage/out.json
+
+export LIFT_RESUKT_PATH=s3://$E2E_S3_BUCKET/lift/results
+export LIFT_PUBLISHER_EXPECTED_RESULT=$LIFT_RESUKT_PATH/publisher_expected_result.json
+export LIFT_PARTNER_EXPECTED_RESULT=$LIFT_RESUKT_PATH/partner_expected_result.json
+
+## Attribution
+# Attribution study configs
+export ATTRIBUTION_PUBLIHSER_NAME="pa_publisher_github"
+export ATTRIBUTION_PARTNER_NAME="pa_partner_github"
+export ATTRIBUTION_COORDINATOR="python3.8 -m fbpcs.pa_coordinator.pa_coordinator"
+
+export ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER=1
+export ATTRIBUTION_CONCURRENCY=1
+export ATTRIBUTION_NUM_PID_CONTAINERS=1
+export ATTRIBUTION_NUM_MPC_CONTAINERS=1
+export ATTRIBUTION_RULE="last_touch_1d"
+export ATTRIBUTION_TYPE="measurement"
+
+export ATTRIBUTION_INPUT_FILE=$E2E_GITHUB_S3_URL/attribution/inputs/publisher_e2e_input.csv
+export ATTRIBUTION_OUTPUT_DIR=$E2E_GITHUB_S3_URL/attribution/outputs
+
+# Attribution result comparision
+export ATTRIBUTION_OUTPUT_PATH=s3://$E2E_S3_BUCKET/attribution/outputs
+export ATTRIBUTION_PUBLISHER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PUBLIHSER_NAME"_out_dir/shard_aggregation_stage/out.json
+export ATTRIBUTION_PARTNER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PARTNER_NAME"_out_dir/shard_aggregation_stage/out.json
+
+export ATTRIBUTION_RESULT_PATH=s3://$E2E_S3_BUCKET/attribution/results
+export ATTRIBUTION_PUBLISHER_EXPECTED_RESULT=$ATTRIBUTION_RESULT_PATH/publisher_expected_result.json
+export ATTRIBUTION_PARTNER_EXPECTED_RESULT=$ATTRIBUTION_RESULT_PATH/partner_expected_result.json

--- a/fbpcs/tests/github/start_container.sh
+++ b/fbpcs/tests/github/start_container.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: Start conatiner and setup directory and files
+set -e
+
+container_name=$1
+image=$2
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+if [ "$(docker ps -q -f name="$container_name")" ]; then
+        # cleanup
+        echo "Stop and remove old container"
+        docker stop "$container_name"
+        docker rm  "$container_name"
+fi
+# run container
+echo "Run container $container_name"
+docker run -td --name "$container_name" "$image"
+
+# setup
+echo "Create base directory for study"
+docker exec "$container_name" mkdir "$DOCKER_INSTANCE_REPO" || exit 1
+
+echo "Copy study yaml file to container"
+docker cp "$CLOUD_CONFIG_FILE" "$container_name":"$DOCKER_CLOUD_CONFIG_FILE" || exit 1
+
+echo "Setup AWS CLI"
+docker exec "$container_name" aws configure set default/region us-west-2 --profile default || exit 1

--- a/fbpcs/tests/github/validate_result.sh
+++ b/fbpcs/tests/github/validate_result.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: ./validate_result.sh lift|attribution, to validate aggregation output is matching with expected results
+
+set -e
+game=$1
+
+# shellcheck disable=SC1091,SC1090
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh" || exit 1
+
+TMP_DIR="/tmp"
+PUBLISHER_EXPECTED_RESULT=$TMP_DIR/publisher_expected_result.json
+PARTNER_EXPECTED_RESULT=$TMP_DIR/partner_expected_result.json
+PUBLISHER_AGGREGATION_OUTPUT=$TMP_DIR/publisher_output.json
+PARTNER_AGGREGATION_OUTPUT=$TMP_DIR/partner_output.json
+
+echo "Remove publisher and partner files"
+rm -f $TMP_DIR/publisher* $TMP_DIR/partner*
+
+if [ "$game" == 'lift' ]
+then
+    aws s3 cp "$LIFT_PUBLISHER_AGGREGATION_OUTPUT" $PUBLISHER_AGGREGATION_OUTPUT
+    aws s3 cp "$LIFT_PARTNER_AGGREGATION_OUTPUT" $PARTNER_AGGREGATION_OUTPUT
+    aws s3 cp "$LIFT_PUBLISHER_EXPECTED_RESULT" $PUBLISHER_EXPECTED_RESULT
+    aws s3 cp "$LIFT_PARTNER_EXPECTED_RESULT" $PARTNER_EXPECTED_RESULT
+    echo "Lift files are copied to $TMP_DIR"
+
+elif [ "$game" == "attribution" ]
+then
+    aws s3 cp "$ATTRIBUTION_PUBLISHER_AGGREGATION_OUTPUT" "$PUBLISHER_AGGREGATION_OUTPUT"
+    aws s3 cp "$ATTRIBUTION_PARTNER_AGGREGATION_OUTPUT" "$PARTNER_AGGREGATION_OUTPUT"
+    aws s3 cp "$ATTRIBUTION_PUBLISHER_EXPECTED_RESULT" "$PUBLISHER_EXPECTED_RESULT"
+    aws s3 cp "$ATTRIBUTION_PARTNER_EXPECTED_RESULT" "$PARTNER_EXPECTED_RESULT"
+    echo "Attribution files are copied to $TMP_DIR"
+
+else
+    echo "Invalid game: $game"
+fi
+# check if there is difference
+function check_results_match() {
+    diff_output=$(diff <(jq -S . "$1") <(jq -S . "$2"))
+    if [ -z "$diff_output" ];
+    then
+        echo "$1 and $2 results are the same"
+        return 0
+    else
+        echo "$1 and $2 results are different"
+        return 1
+    fi
+}
+
+if check_results_match $PUBLISHER_AGGREGATION_OUTPUT $PUBLISHER_EXPECTED_RESULT \
+&& check_results_match $PARTNER_AGGREGATION_OUTPUT $PARTNER_EXPECTED_RESULT
+then
+    echo "$game e2e tests succeed"
+else
+    echo "$game e2e tests failed, results donot not match"
+fi


### PR DESCRIPTION
Summary:
config.sh: config files for both PL and PA
start_container.sh: this is to start containers (both PL and PA)
validate_result.sh: to validate if results match
attribution_check_status.sh and attribution_run_stages.sh are for attribution specially.

Lift checks status and run stages scripts will be added later

Reviewed By: corbantek

Differential Revision: D31590094

