### PR TITLE
move status updating logic to stage service

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_base_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_base_stage_flow.py
@@ -6,12 +6,19 @@
 
 # pyre-strict
 
+from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Type, TypeVar, TYPE_CHECKING
 
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+
+if TYPE_CHECKING:
+    from fbpcs.private_computation.service.private_computation_stage_service import (
+        PrivateComputationStageService,
+        PrivateComputationStageServiceArgs,
+    )
 from fbpcs.stage_flow.stage_flow import StageFlow, StageFlowData
 
 C = TypeVar("C", bound="PrivateComputationBaseStageFlow")
@@ -23,9 +30,54 @@ class PrivateComputationStageFlowData(StageFlowData[PrivateComputationInstanceSt
 
 
 class PrivateComputationBaseStageFlow(StageFlow):
+    # TODO(T103297566): [BE] document PrivateComputationBaseStageFlow
     def __init__(self, data: PrivateComputationStageFlowData) -> None:
         super().__init__()
         self.started_status: PrivateComputationInstanceStatus = data.started_status
         self.failed_status: PrivateComputationInstanceStatus = data.failed_status
         self.completed_status: PrivateComputationInstanceStatus = data.completed_status
         self.is_joint_stage: bool = data.is_joint_stage
+
+    @classmethod
+    def cls_name_to_cls(cls: Type[C], name: str) -> Type[C]:
+        """
+        Converts the name of an existing stage flow subclass into the subclass object
+
+        Arguments:
+            name: The name of a PrivateComputationBaseStageFlow subclass
+
+        Returns:
+            A subclass of PrivateComputationBaseStageFlow
+
+        Raises:
+            ValueError: raises when no subclass with the name 'name' is found
+        """
+        for subclass in cls.__subclasses__():
+            if name == subclass.__name__:
+                return subclass
+        raise ValueError(f"No subclass with name {name}")
+
+    @classmethod
+    def get_cls_name(cls: Type[C]) -> str:
+        """Convenience wrapper around cls.__name__"""
+        return cls.__name__
+
+    @abstractmethod
+    def get_stage_service(
+        self, args: "PrivateComputationStageServiceArgs"
+    ) -> "PrivateComputationStageService":
+        """
+        Maps StageFlow instances to StageService instances
+
+        Arguments:
+            args: Common arguments initialized in PrivateComputationService that are consumed by stage services
+
+        Returns:
+            An instantiated StageService object corresponding to the StageFlow enum member caller.
+
+        Raises:
+            NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
+        """
+        raise NotImplementedError(
+            f"get_stage_service not implemented for {self.__class__}"
+        )

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -19,6 +19,9 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
 )
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
+)
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -26,6 +29,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     create_and_start_mpc_instance,
     map_private_computation_role_to_mpc_party,
+    get_updated_pc_status_mpc_game,
 )
 
 
@@ -124,7 +128,9 @@ class AggregateShardsStageService(PrivateComputationStageService):
 
             mpc_instance = await create_and_start_mpc_instance(
                 mpc_svc=self._mpc_service,
-                instance_id=pc_instance.instance_id + "_aggregate_shards" + str(pc_instance.retry_counter),
+                instance_id=pc_instance.instance_id
+                + "_aggregate_shards"
+                + str(pc_instance.retry_counter),
                 game_name=GameNames.SHARD_AGGREGATOR.value,
                 mpc_party=map_private_computation_role_to_mpc_party(pc_instance.role),
                 num_containers=2,
@@ -147,7 +153,9 @@ class AggregateShardsStageService(PrivateComputationStageService):
             ]
             mpc_instance = await create_and_start_mpc_instance(
                 mpc_svc=self._mpc_service,
-                instance_id=pc_instance.instance_id + "_aggregate_shards" + str(pc_instance.retry_counter),
+                instance_id=pc_instance.instance_id
+                + "_aggregate_shards"
+                + str(pc_instance.retry_counter),
                 game_name=GameNames.SHARD_AGGREGATOR.value,
                 mpc_party=map_private_computation_role_to_mpc_party(pc_instance.role),
                 num_containers=1,
@@ -160,3 +168,16 @@ class AggregateShardsStageService(PrivateComputationStageService):
         pc_instance.instances.append(PCSMPCInstance.from_mpc_instance(mpc_instance))
         return pc_instance
 
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """Updates the MPCInstances and gets latest PrivateComputationInstance status
+
+        Arguments:
+            private_computation_instance: The PC instance that is being updated
+
+        Returns:
+            The latest status for private_computation_instance
+        """
+        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -22,6 +22,9 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
 )
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
+)
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )
@@ -33,6 +36,7 @@ from fbpcs.private_computation.service.utils import (
     gen_mpc_game_args_to_retry,
     map_private_computation_role_to_mpc_party,
     ready_for_partial_container_retry,
+    get_updated_pc_status_mpc_game,
 )
 
 
@@ -124,6 +128,19 @@ class ComputeMetricsStageService(PrivateComputationStageService):
         pc_instance.instances.append(PCSMPCInstance.from_mpc_instance(mpc_instance))
         return pc_instance
 
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """Updates the MPCInstances and gets latest PrivateComputationInstance status
+
+        Arguments:
+            private_computation_instance: The PC instance that is being updated
+
+        Returns:
+            The latest status for private_computation_instance
+        """
+        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
 
     # TODO: Make an entity representation for game args that can dump a dict to pass
     # to mpc service. The entity will give us type checking and ensure that all args are

--- a/fbpcs/private_computation/service/dummy_stage_service.py
+++ b/fbpcs/private_computation/service/dummy_stage_service.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List, Optional
+
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+)
+
+
+class DummyStageService(PrivateComputationStageService):
+    """
+    Stage service that does nothing. It is used in stage flows as a dummy node akin
+    to those found in linked list implementions. Having a DummyStageService in the flow
+    reduces the need for special logic
+
+    Per some online wisdom:
+    A dummy node is a node that will not contain any usable value but will always carry the location of the front of the list.
+    """
+
+    async def run_async(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]] = None,
+    ) -> PrivateComputationInstance:
+        """
+        Does nothing except return pc_instance back to caller
+        """
+        return pc_instance
+
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """
+        Does nothing except return pc_instance.status back to caller
+        """
+        return pc_instance.status
+

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -16,6 +16,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_PID_PROTOCOL
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
@@ -36,7 +37,7 @@ class IdMatchStageService(PrivateComputationStageService):
         self,
         pid_svc: PIDService,
         pid_config: Dict[str, Any],
-        protocol: PIDProtocol,
+        protocol: PIDProtocol = DEFAULT_PID_PROTOCOL,
         is_validating: bool = False,
         synthetic_shard_path: Optional[str] = None,
     ) -> None:

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 
+from fbpcs.private_computation.entity.private_computation_instance import PrivateComputationInstanceStatus
 import asyncio
 import logging
 from typing import Dict, List, Optional
@@ -140,3 +141,35 @@ class PostProcessingStageService(PrivateComputationStageService):
                 handler_name
             ] = PostProcessingHandlerStatus.FAILED
             post_processing_instance.status = PostProcessingInstanceStatus.FAILED
+
+
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """Updates the PostProcessingInstances and gets latest PrivateComputationInstance status
+
+        Arguments:
+            private_computation_instance: The PC instance that is being updated
+
+        Returns:
+            The latest status for private_computation_instance
+        """
+        status = pc_instance.status
+        if pc_instance.instances:
+            # Only need to update the last stage/instance
+            last_instance = pc_instance.instances[-1]
+            if not isinstance(last_instance, PostProcessingInstance):
+                return status
+
+            post_processing_instance_status = pc_instance.instances[-1].status
+
+            stage = pc_instance.current_stage
+            if post_processing_instance_status is PostProcessingInstanceStatus.STARTED:
+                status = stage.started_status
+            elif post_processing_instance_status is PostProcessingInstanceStatus.COMPLETED:
+                status = stage.completed_status
+            elif post_processing_instance_status is PostProcessingInstanceStatus.FAILED:
+                status = stage.failed_status
+
+        return status

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -11,7 +11,7 @@ import json
 import logging
 import math
 from datetime import datetime, timezone
-from typing import DefaultDict, Dict, List, Optional, Any, TypeVar
+from typing import DefaultDict, Dict, List, Optional, Any, Type, TypeVar
 
 from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus
 from fbpcp.service.mpc import MPCService
@@ -143,6 +143,9 @@ class PrivateComputationService:
         padding_size: int = DEFAULT_PADDING_SIZE,
         k_anonymity_threshold: int = DEFAULT_K_ANONYMITY_THRESHOLD,
         fail_fast: bool = False,
+        stage_flow_cls: Type[
+            PrivateComputationBaseStageFlow
+        ] = PrivateComputationStageFlow,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -171,6 +174,7 @@ class PrivateComputationService:
             concurrency=concurrency,
             k_anonymity_threshold=k_anonymity_threshold,
             fail_fast=fail_fast,
+            _stage_flow_cls_name=stage_flow_cls.get_cls_name(),
         )
 
         self.instance_repository.create(instance)

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -7,11 +7,33 @@
 # pyre-strict
 
 import abc
+from dataclasses import dataclass
+from typing import Any, Dict, DefaultDict
 from typing import List, Optional
 
+from fbpcp.service.mpc import MPCService
+from fbpcp.service.storage import StorageService
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.pid.service.pid_service.pid import PIDService
+from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
 )
+
+
+@dataclass
+class PrivateComputationStageServiceArgs:
+    """
+    These are all arguments that are guaranteed to exist in the PrivateComputationService at service
+    creation time. A combination of these arguments is used to construct stage private computation stage services.
+    """
+
+    pid_svc: PIDService
+    pid_config: Dict[str, Any]
+    onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig]
+    mpc_svc: MPCService
+    storage_svc: StorageService
+    post_processing_handlers: Dict[str, PostProcessingHandler]
 
 
 class PrivateComputationStageService(abc.ABC):
@@ -20,7 +42,7 @@ class PrivateComputationStageService(abc.ABC):
     Any parameters necessary to run the stage that aren't provided by run_async should be passed to the subclass' constructor.
     """
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     async def run_async(
         self,
         pc_instance: PrivateComputationInstance,

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
+    PrivateComputationInstanceStatus
 )
 
 
@@ -49,4 +50,11 @@ class PrivateComputationStageService(abc.ABC):
         # TODO(T102471612): remove server_ips from run_async, move to subclass constructor instead
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
+        ...
+
+    @abc.abstractmethod
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
         ...


### PR DESCRIPTION
Summary:
## What

* Move status updating logic from private_computation.py into stage service

## Why

* This will enforce that any new stages or flows that are added will implement the business logic for updating their status
* The stage service already knows how to run the stage, so it also knows how to update the status. Might as well have it do both.

## Diff stack context

* Context: https://fb.workplace.com/groups/164332244998024/permalink/727979271966649/

TLDR:

This will make adding stages to private computation easier and safer and will enable the private computation service to switch between arbitrary sets of instructions. For example, you could have a stage flow that PCS uses to run Private lift / attribtution with id match  -> compute -> aggregate as we do now. We can also have stage flows that split id match into PID shard, prepare, and run, a stage flow that splits attribution compute into attribute and aggregate, etc. The stage flows will all coexist and share the same execution engine (PrivateComputationService). PrivateComputationService will use the stage flow to determine what stage to run and what to set the statuses of the instance to.

Some of the reasons we want to do this include...

* Adding more stages to private computations will allow us to...
    * Reduce private lift run time by at least 13 minutes, or roughly ~11% of the two hour PL SLA
    * Decouple attribution and aggregation operations, consistent with the long term goal of creating a horizontal attribution layer (AdConv in cloud)
    * Meet our 5 minute thrift service latency SLA targets
    * Decrease E2E test run time by 40%
    * Support new games in the future that run different stages

## Next diffs

* implement run next

Differential Revision: D31613443

