### PR TITLE
E2E test: fix typo for script name

### DIFF
--- a/.github/workflows/pa-e2e.yml
+++ b/.github/workflows/pa-e2e.yml
@@ -89,9 +89,9 @@ jobs:
         ./attribution_check_status.sh ${{ env.CONTAINER_NAME }}
        working-directory: ./fbpcs/tests/github/
 
-     - name: Attribution - Validate Results
+     - name: Attribution - Validate Result
        run: |
-        ./validate_results.sh attribution
+        ./validate_result.sh attribution
        working-directory: ./fbpcs/tests/github/
 
      - name: Cleanup


### PR DESCRIPTION
Summary:
Just notice there is a typo in script name when running e2e tests for PA;
Script name is validate_result.sh, not validate_results.sh

Differential Revision: D31627170

