### PR TITLE
id_match() wrapper function

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
+    id_match,
 )
 
 DEFAULT_HMAC_KEY: str = ""
@@ -95,31 +96,6 @@ def create_instance(
         aggregation_type=aggregation_type,
         k_anonymity_threshold=k_anonymity_threshold,
         fail_fast=fail_fast,
-    )
-
-    logger.info(instance)
-
-
-def id_match(
-    config: Dict[str, Any],
-    instance_id: str,
-    logger: logging.Logger,
-    server_ips: Optional[List[str]] = None,
-    dry_run: Optional[bool] = False,
-) -> None:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    # run pid instance through pid service invoked from pa service
-    instance = private_computation_service.id_match(
-        instance_id=instance_id,
-        pid_config=config["pid"],
-        server_ips=server_ips,
-        dry_run=dry_run,
     )
 
     logger.info(instance)

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -91,7 +91,6 @@ class IdMatchStageService(PrivateComputationStageService):
         pc_instance.instances.append(pid_instance)
 
         # Run pid
-        # With the current design, it won't return until everything is done
         await self._pid_svc.run_instance(
             instance_id=pid_instance_id,
             pid_config=self._pid_config,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -80,7 +80,6 @@ def id_match(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
-    fail_fast: bool = False,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
@@ -92,7 +91,7 @@ def id_match(
     )
 
     # run pid instance through pid service invoked from pc service
-    pc_service.id_match(
+    instance = pc_service.id_match(
         instance_id=instance_id,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
@@ -105,11 +104,6 @@ def id_match(
         dry_run=dry_run,
     )
 
-    # At this point, pc instance has a pid instance. Pid dispatcher should have updated
-    # the pid instance to its newest status already, whether FAILED or COMPLETED,
-    # but pc instance has not been updated based on the pid instance.
-    # So make this call here to keep them in sync.
-    instance = pc_service.update_instance(instance_id)
     logger.info(instance)
 
 


### PR DESCRIPTION
Summary: Remove the copy of the id_match() function from pa_coordinator.py and use the copy from private_computation_service_wrapper.py.

Reviewed By: jrodal98

Differential Revision: D31616293

