### PR TITLE
aggregate_shards() wrapper function

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
+    id_match,
 )
 
 DEFAULT_HMAC_KEY: str = ""
@@ -95,31 +96,6 @@ def create_instance(
         aggregation_type=aggregation_type,
         k_anonymity_threshold=k_anonymity_threshold,
         fail_fast=fail_fast,
-    )
-
-    logger.info(instance)
-
-
-def id_match(
-    config: Dict[str, Any],
-    instance_id: str,
-    logger: logging.Logger,
-    server_ips: Optional[List[str]] = None,
-    dry_run: Optional[bool] = False,
-) -> None:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    # run pid instance through pid service invoked from pa service
-    instance = private_computation_service.id_match(
-        instance_id=instance_id,
-        pid_config=config["pid"],
-        server_ips=server_ips,
-        dry_run=dry_run,
     )
 
     logger.info(instance)

--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
+    aggregate_shards,
     id_match,
 )
 
@@ -153,33 +154,6 @@ def compute_attribution(
     )
 
     logging.info("Finished running compute stage")
-    logger.info(instance)
-
-
-def aggregate_shards(
-    config: Dict[str, Any],
-    instance_id: str,
-    logger: logging.Logger,
-    server_ips: Optional[List[str]] = None,
-    dry_run: Optional[bool] = False,
-    log_cost_to_s3: bool = False,
-) -> None:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    private_computation_service.update_instance(instance_id)
-
-    instance = private_computation_service.aggregate_shards(
-        instance_id=instance_id,
-        server_ips=server_ips,
-        dry_run=dry_run,
-        log_cost_to_s3=log_cost_to_s3,
-    )
-
     logger.info(instance)
 
 

--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -45,7 +45,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    aggregate,
+    aggregate_shards,
     compute,
     create_instance,
     get,
@@ -188,7 +188,7 @@ def main():
         get_mpc(config, instance_id, logger)
     elif arguments["aggregate"]:
         logger.info(f"Aggregate instance: {instance_id}")
-        aggregate(
+        aggregate_shards(
             config=config,
             instance_id=instance_id,
             logger=logger,

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -26,7 +26,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     create_instance,
     id_match,
     compute,
-    aggregate,
+    aggregate_shards,
     cancel_current_stage,
 )
 
@@ -379,7 +379,7 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
                         dry_run=None,
                     )
                 else:
-                    aggregate(
+                    aggregate_shards(
                         config=self.config,
                         instance_id=self.instance_id,
                         logger=self.logger,

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -91,7 +91,6 @@ class IdMatchStageService(PrivateComputationStageService):
         pc_instance.instances.append(pid_instance)
 
         # Run pid
-        # With the current design, it won't return until everything is done
         await self._pid_svc.run_instance(
             instance_id=pid_instance_id,
             pid_config=self._pid_config,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -150,12 +150,13 @@ def compute(
     logger.info(instance)
 
 
-def aggregate(
+def aggregate_shards(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
+    log_cost_to_s3: bool = False,
 ) -> None:
     pc_service = _build_private_computation_service(
         config["private_computation"],
@@ -177,6 +178,7 @@ def aggregate(
         ],
         server_ips=server_ips,
         dry_run=dry_run,
+        log_cost_to_s3=log_cost_to_s3,
     )
 
     logger.info(instance)

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -80,7 +80,6 @@ def id_match(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
-    fail_fast: bool = False,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
@@ -92,7 +91,7 @@ def id_match(
     )
 
     # run pid instance through pid service invoked from pc service
-    pc_service.id_match(
+    instance = pc_service.id_match(
         instance_id=instance_id,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
@@ -105,11 +104,6 @@ def id_match(
         dry_run=dry_run,
     )
 
-    # At this point, pc instance has a pid instance. Pid dispatcher should have updated
-    # the pid instance to its newest status already, whether FAILED or COMPLETED,
-    # but pc instance has not been updated based on the pid instance.
-    # So make this call here to keep them in sync.
-    instance = pc_service.update_instance(instance_id)
     logger.info(instance)
 
 


### PR DESCRIPTION
Summary: Remove the copy of the aggregate_shards() function from pa_coordinator.py and use the copy from private_computation_service_wrapper.py which is renamed from aggregate() to aggregate_shards() to be more descriptive.

Reviewed By: jrodal98

Differential Revision: D31621630

