### PR TITLE
print_instance()

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -42,12 +42,12 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationInstance,
     PrivateComputationGameType,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
     aggregate_shards,
+    get_instance,
     id_match,
 )
 
@@ -155,21 +155,6 @@ def compute_attribution(
 
     logging.info("Finished running compute stage")
     logger.info(instance)
-
-
-def get_instance(
-    config: Dict[str, Any], instance_id: str, logger: logging.Logger
-) -> PrivateComputationInstance:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    pa_instance = private_computation_service.update_instance(instance_id)
-    logger.info(pa_instance)
-    return pa_instance
 
 
 def get_server_ips(

--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -33,9 +33,7 @@ from typing import Any, Dict, List, Optional
 
 import schema
 from docopt import docopt
-from fbpcp.entity.mpc_instance import MPCInstance
 from fbpcp.util import yaml
-from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -48,6 +46,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
     aggregate_shards,
     get_instance,
+    get_server_ips,
     id_match,
 )
 
@@ -155,30 +154,6 @@ def compute_attribution(
 
     logging.info("Finished running compute stage")
     logger.info(instance)
-
-
-def get_server_ips(
-    config: Dict[str, Any],
-    instance_id: str,
-) -> List[str]:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    pa_instance = private_computation_service.update_instance(instance_id)
-
-    server_ips_list = None
-    last_instance = pa_instance.instances[-1]
-    if isinstance(last_instance, (PIDInstance, MPCInstance)):
-        server_ips_list = last_instance.server_ips
-
-    if not server_ips_list:
-        server_ips_list = []
-    print(*server_ips_list, sep=",")
-    return server_ips_list
 
 
 def print_instance(
@@ -318,6 +293,7 @@ def main() -> None:
         get_server_ips(
             config=config,
             instance_id=instance_id,
+            logger=logger,
         )
     elif arguments["print_instance"]:
         print_instance(

--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -48,6 +48,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     get_instance,
     get_server_ips,
     id_match,
+    print_instance,
 )
 
 DEFAULT_HMAC_KEY: str = ""
@@ -154,12 +155,6 @@ def compute_attribution(
 
     logging.info("Finished running compute stage")
     logger.info(instance)
-
-
-def print_instance(
-    config: Dict[str, Any], instance_id: str, logger: logging.Logger
-) -> None:
-    print(get_instance(config, instance_id, logger))
 
 
 def main() -> None:

--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
+    id_match,
 )
 
 DEFAULT_HMAC_KEY: str = ""
@@ -95,31 +96,6 @@ def create_instance(
         aggregation_type=aggregation_type,
         k_anonymity_threshold=k_anonymity_threshold,
         fail_fast=fail_fast,
-    )
-
-    logger.info(instance)
-
-
-def id_match(
-    config: Dict[str, Any],
-    instance_id: str,
-    logger: logging.Logger,
-    server_ips: Optional[List[str]] = None,
-    dry_run: Optional[bool] = False,
-) -> None:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    # run pid instance through pid service invoked from pa service
-    instance = private_computation_service.id_match(
-        instance_id=instance_id,
-        pid_config=config["pid"],
-        server_ips=server_ips,
-        dry_run=dry_run,
     )
 
     logger.info(instance)

--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
+    aggregate_shards,
     id_match,
 )
 
@@ -153,33 +154,6 @@ def compute_attribution(
     )
 
     logging.info("Finished running compute stage")
-    logger.info(instance)
-
-
-def aggregate_shards(
-    config: Dict[str, Any],
-    instance_id: str,
-    logger: logging.Logger,
-    server_ips: Optional[List[str]] = None,
-    dry_run: Optional[bool] = False,
-    log_cost_to_s3: bool = False,
-) -> None:
-    private_computation_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-    )
-
-    private_computation_service.update_instance(instance_id)
-
-    instance = private_computation_service.aggregate_shards(
-        instance_id=instance_id,
-        server_ips=server_ips,
-        dry_run=dry_run,
-        log_cost_to_s3=log_cost_to_s3,
-    )
-
     logger.info(instance)
 
 

--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -45,7 +45,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    aggregate,
+    aggregate_shards,
     compute,
     create_instance,
     get,
@@ -188,7 +188,7 @@ def main():
         get_mpc(config, instance_id, logger)
     elif arguments["aggregate"]:
         logger.info(f"Aggregate instance: {instance_id}")
-        aggregate(
+        aggregate_shards(
             config=config,
             instance_id=instance_id,
             logger=logger,

--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -48,7 +48,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     aggregate_shards,
     compute,
     create_instance,
-    get,
+    get_instance,
     get_mpc,
     get_pid,
     get_server_ips,
@@ -177,7 +177,7 @@ def main():
         )
     elif arguments["get"]:
         logger.info(f"Get instance: {instance_id}")
-        get(config, instance_id, logger)
+        get_instance(config, instance_id, logger)
     elif arguments["get_server_ips"]:
         get_server_ips(config, instance_id, logger)
     elif arguments["get_pid"]:

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -22,7 +22,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    get,
+    get_instance,
     create_instance,
     id_match,
     compute,
@@ -335,7 +335,9 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
         self.input_path: str = input_path
         self.output_dir: str = self.get_output_dir_from_input_path(input_path)
         try:
-            self.status = get(self.config, self.instance_id, self.logger).status
+            self.status = get_instance(
+                self.config, self.instance_id, self.logger
+            ).status
         except RuntimeError:
             self.logger.info(f"Creating new partner instance {self.instance_id}")
             self.status = create_instance(
@@ -351,7 +353,7 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
         self.wait_valid_status(WAIT_VALID_STATUS_TIMEOUT)
 
     def update_instance(self) -> None:
-        self.status = get(self.config, self.instance_id, self.logger).status
+        self.status = get_instance(self.config, self.instance_id, self.logger).status
 
     def cancel_current_stage(self) -> None:
         cancel_current_stage(self.config, self.instance_id, self.logger)

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -26,7 +26,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     create_instance,
     id_match,
     compute,
-    aggregate,
+    aggregate_shards,
     cancel_current_stage,
 )
 
@@ -379,7 +379,7 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
                         dry_run=None,
                     )
                 else:
-                    aggregate(
+                    aggregate_shards(
                         config=self.config,
                         instance_id=self.instance_id,
                         logger=self.logger,

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -91,7 +91,6 @@ class IdMatchStageService(PrivateComputationStageService):
         pc_instance.instances.append(pid_instance)
 
         # Run pid
-        # With the current design, it won't return until everything is done
         await self._pid_svc.run_instance(
             instance_id=pid_instance_id,
             pid_config=self._pid_config,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -25,8 +25,8 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
     PrivateComputationRole,
     PrivateComputationInstance,
-    PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import STAGE_STARTED_STATUSES
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )
@@ -241,11 +241,11 @@ def run_post_processing_handlers(
     logger.info(instance)
 
 
-def get(
+def get_instance(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> PrivateComputationInstance:
     """
-    The purpose of `get` is to get the updated status of the pc instance with id instance_id.
+    To get the updated status of the pc instance with id instance_id.
     We only call pc_service.update_instance() under XXX_STARTED status because otherwise we could run into
     a race condition: when status is not XXX_STARTED, PrivateComputationService might be writing a new PID or
     MPCInstance to this pc instance. Because pc_service.update_instance() also writes to this pc instance, it could
@@ -258,11 +258,7 @@ def get(
         config.get("post_processing_handlers", {}),
     )
     instance = pc_service.get_instance(instance_id)
-    if instance.status in [
-        PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
-        PrivateComputationInstanceStatus.COMPUTATION_STARTED,
-        PrivateComputationInstanceStatus.AGGREGATION_STARTED,
-    ]:
+    if instance.status in STAGE_STARTED_STATUSES:
         instance = pc_service.update_instance(instance_id)
     logger.info(instance)
     return instance

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -266,7 +266,7 @@ def get_instance(
 
 def get_server_ips(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
-) -> None:
+) -> List[str]:
     pc_service = _build_private_computation_service(
         config["private_computation"],
         config["mpc"],
@@ -277,9 +277,9 @@ def get_server_ips(
     pc_instance = pc_service.instance_repository.read(instance_id)
 
     # This utility should only be used to get ips from a publisher instance
-    if pc_instance.role != PrivateComputationRole.PUBLISHER:
+    if pc_instance.role is not PrivateComputationRole.PUBLISHER:
         logger.warning("Unable to get server ips from a partner instance")
-        return
+        return []
 
     server_ips_list = None
     last_instance = pc_instance.instances[-1]
@@ -290,6 +290,7 @@ def get_server_ips(
         server_ips_list = []
 
     print(*server_ips_list, sep=",")
+    return server_ips_list
 
 
 def get_pid(config: Dict[str, Any], instance_id: str, logger: logging.Logger) -> None:

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -150,12 +150,13 @@ def compute(
     logger.info(instance)
 
 
-def aggregate(
+def aggregate_shards(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
+    log_cost_to_s3: bool = False,
 ) -> None:
     pc_service = _build_private_computation_service(
         config["private_computation"],
@@ -177,6 +178,7 @@ def aggregate(
         ],
         server_ips=server_ips,
         dry_run=dry_run,
+        log_cost_to_s3=log_cost_to_s3,
     )
 
     logger.info(instance)

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -353,6 +353,12 @@ def cancel_current_stage(
     return instance
 
 
+def print_instance(
+    config: Dict[str, Any], instance_id: str, logger: logging.Logger
+) -> None:
+    print(get_instance(config, instance_id, logger))
+
+
 def _build_container_service(config: Dict[str, Any]) -> ContainerService:
     container_class = reflect.get_class(config["class"])
     return container_class(**config["constructor"])

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -80,7 +80,6 @@ def id_match(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
-    fail_fast: bool = False,
     server_ips: Optional[List[str]] = None,
     dry_run: Optional[bool] = False,
 ) -> None:
@@ -92,7 +91,7 @@ def id_match(
     )
 
     # run pid instance through pid service invoked from pc service
-    pc_service.id_match(
+    instance = pc_service.id_match(
         instance_id=instance_id,
         is_validating=config["private_computation"]["dependency"]["ValidationConfig"][
             "is_validating"
@@ -105,11 +104,6 @@ def id_match(
         dry_run=dry_run,
     )
 
-    # At this point, pc instance has a pid instance. Pid dispatcher should have updated
-    # the pid instance to its newest status already, whether FAILED or COMPLETED,
-    # but pc instance has not been updated based on the pid instance.
-    # So make this call here to keep them in sync.
-    instance = pc_service.update_instance(instance_id)
     logger.info(instance)
 
 


### PR DESCRIPTION
Summary: This is just...well, moving a function. The reason I want to do this is that I want to consolidate pa_coordinator.py and pl_coordinator.py into private_computation_cli.py. If you look at pl_coordinator.py, you'll notice that it only has 1 function, which is the main function. However, pa_coordinator.py still has functions other than main, like this print_instance() function. So I consider this diff as a small step towards to goal of eventually having a private_computation_cli.py that just have a main function.

Reviewed By: marksliva

Differential Revision: D31628215

