### PR TITLE
copyright header for new dockerfile

### DIFF
--- a/docker/pce_deployment/Dockerfile.ubuntu
+++ b/docker/pce_deployment/Dockerfile.ubuntu
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 ARG os_release="latest"
 
 FROM ubuntu:${os_release}


### PR DESCRIPTION
Summary:
Got a high-pri task today saying that some file in the fbpcs repo is missing the copyright header.

I went to the [automated check up](https://www.internalfb.com/intern/opensource/github/repo/232509348613701/checkup) page and clicked the "Run Automated Checkup" green button, got an email with this paste P462617773, which indicates that the following file doesn't have the header.

Linter should have caught it (linter rule added in D30141706), but I guess it didn't work because this file is in the public_tld folder and we did some complicated mapping in the shipit config for this folder. I don't have time to look into it today, so leave that as a task.

Reviewed By: jrodal98

Differential Revision: D31659591

