### PR TITLE
remove tags from bucket names

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -54,7 +54,7 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.data_processing_output_bucket}${var.tag_postfix}"
+  bucket = var.data_processing_output_bucket
   versioning {
     enabled = true
   }


### PR DESCRIPTION
Summary:
**Context**
PL installation improvements for Private Computation: https://docs.google.com/document/d/1kAhjjEoMaWEnXuptSDk-q1qMwTAIAt7_U6g378Bh-AQ/edit

**What**
In this diff, we improve the deploy.sh by adding the following input validation:

**Why**
 We did not find a good reason/motivation to add tags for buckets.
As of now, we add tags for the config bucket, but not the data storage bucket.

1. according to zehuali, bucket name is will not be used for PCE validation.
2. Since tag and bucket name are two separate command line inputs, and we don't delete/destory buckets in the `undeploy` function. It's better to make the name straightforward, so that advertisers can clean up the buckets later on, if they wanted to.
3. We still pce-id/tags for all other AWS resources except for buckets.

Differential Revision: D31659223

