### PR TITLE
add run_next to private computation service

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -173,3 +173,14 @@ class PrivateComputationInstance(InstanceBase):
         return PrivateComputationBaseStageFlow.cls_name_to_cls(
             self._stage_flow_cls_name
         ).get_stage_from_status(self.status)
+
+    def get_next_runnable_stage(self) -> Optional[PrivateComputationBaseStageFlow]:
+        """Returns the next runnable stage in the instance's stage flow
+
+        * If the instance has a start status, return None
+        * If the instance has a failed status, return the current stage in the flow
+        * If the instance has a completed status, return the next stage in the flow (which could be None)
+        """
+        return PrivateComputationBaseStageFlow.cls_name_to_cls(
+            self._stage_flow_cls_name
+        ).get_next_runnable_stage_from_status(self.status)

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -297,6 +297,42 @@ class TestPrivateComputationService(unittest.TestCase):
             },
         )()
 
+    def test_get_next_runnable_stage_completed_status(self) -> None:
+        flow = PrivateComputationStageFlow
+        status  = PrivateComputationInstanceStatus.CREATED
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.assertEqual(flow.ID_MATCH, instance.get_next_runnable_stage())
+
+    def test_get_next_runnable_stage_failed_status(self) -> None:
+        flow = PrivateComputationStageFlow
+        status  = PrivateComputationInstanceStatus.ID_MATCHING_FAILED
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.assertEqual(flow.ID_MATCH, instance.get_next_runnable_stage())
+
+    def test_get_next_runnable_stage_started_status(self) -> None:
+        flow = PrivateComputationStageFlow
+        status  = PrivateComputationInstanceStatus.ID_MATCHING_STARTED
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.assertEqual(None, instance.get_next_runnable_stage())
+
+    def test_get_next_runnable_stage_nothing_left(self) -> None:
+        flow = PrivateComputationStageFlow
+        status  = PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.assertEqual(None, instance.get_next_runnable_stage())
+
     @data_provider(_get_valid_stages_data)
     def test_run_stage_correct_stage_order(
         self,


### PR DESCRIPTION
Summary:
## What

* implement get_next_runnable_stage convenience wrapper on PrivateComputationInstance
* Implement run_next in PrivateComputationService
* Add basic tests for get_next_runnable_stage

## Why

* Final step in PrivateComputationService to support run_next, which we can use run run arbitrary stage flows E2E

## Diff stack context

* Context: https://fb.workplace.com/groups/164332244998024/permalink/727979271966649/

TLDR:

This will make adding stages to private computation easier and safer and will enable the private computation service to switch between arbitrary sets of instructions. For example, you could have a stage flow that PCS uses to run Private lift / attribtution with id match  -> compute -> aggregate as we do now. We can also have stage flows that split id match into PID shard, prepare, and run, a stage flow that splits attribution compute into attribute and aggregate, etc. The stage flows will all coexist and share the same execution engine (PrivateComputationService). PrivateComputationService will use the stage flow to determine what stage to run and what to set the statuses of the instance to.

Some of the reasons we want to do this include...

* Adding more stages to private computations will allow us to...
    * Reduce private lift run time by at least 13 minutes, or roughly ~11% of the two hour PL SLA
    * Decouple attribution and aggregation operations, consistent with the long term goal of creating a horizontal attribution layer (AdConv in cloud)
    * Meet our 5 minute thrift service latency SLA targets
    * Decrease E2E test run time by 40%
    * Support new games in the future that run different stages

## Next diffs

* implement run next in thrift and pc coordinator
* Integrate run next into fbpcs e2e runner

Differential Revision: D31659518

