### PR TITLE
add run_next to pa/pl coordinator

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -16,6 +16,7 @@ Usage:
     pa-coordinator prepare_compute_input <instance_id> --config=<config_file> [--dry_run --log_cost_to_s3] [options]
     pa-coordinator compute_attribution <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run --log_cost_to_s3] [options]
     pa-coordinator aggregate_shards <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run --log_cost_to_s3] [options]
+    pa-coordinator run_next <instance_id> --config=<config_file> [--server_ips=<server_ips>] [options]
     pa-coordinator get_server_ips  <instance_id> --config=<config_file> [options]
     pa-coordinator get_instance <instance_id> --config=<config_file> [options]
     pa-coordinator print_instance <instance_id> --config=<config_file> [options]
@@ -51,6 +52,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     id_match,
     prepare_compute_input,
     print_instance,
+    run_next
 )
 
 DEFAULT_HMAC_KEY: str = ""
@@ -114,6 +116,7 @@ def main() -> None:
             "prepare_compute_input": bool,
             "compute_attribution": bool,
             "aggregate_shards": bool,
+            "run_next": bool,
             "get_server_ips": bool,
             "<instance_id>": schema.Or(None, str),
             "--config": schema.And(schema.Use(PurePath), os.path.exists),
@@ -230,6 +233,14 @@ def main() -> None:
             logger=logger,
             dry_run=arguments["--dry_run"],
             log_cost_to_s3=arguments["--log_cost_to_s3"],
+        )
+    elif arguments["run_next"]:
+        logger.info(f"run_next instance: {instance_id}")
+        run_next(
+            config=config,
+            instance_id=instance_id,
+            logger=logger,
+            server_ips=arguments["--server_ips"],
         )
     elif arguments["get_server_ips"]:
         get_server_ips(

--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -16,6 +16,7 @@ Usage:
     pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
     pl-coordinator run_post_processing_handlers <instance_id> --config=<config_file> [--aggregated_result_path=<aggregated_result_path> --dry_run] [options]
+    pl-coordinator run_next <instance_id> --config=<config_file> [--server_ips=<server_ips>] [options]
     pl-coordinator get <instance_id> --config=<config_file> [options]
     pl-coordinator get_server_ips <instance_id> --config=<config_file> [options]
     pl-coordinator get_pid <instance_id> --config=<config_file> [options]
@@ -56,6 +57,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     run_post_processing_handlers,
     validate,
     cancel_current_stage,
+    run_next
 )
 
 
@@ -69,6 +71,7 @@ def main():
             "validate": bool,
             "run_post_processing_handlers": bool,
             "get": bool,
+            "run_next": bool,
             "get_server_ips": bool,
             "get_pid": bool,
             "get_mpc": bool,
@@ -174,6 +177,14 @@ def main():
             logger=logger,
             aggregated_result_path=arguments["--aggregated_result_path"],
             dry_run=arguments["--dry_run"],
+        )
+    elif arguments["run_next"]:
+        logger.info(f"run_next instance: {instance_id}")
+        run_next(
+            config=config,
+            instance_id=instance_id,
+            logger=logger,
+            server_ips=arguments["--server_ips"],
         )
     elif arguments["get"]:
         logger.info(f"Get instance: {instance_id}")

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -281,6 +281,32 @@ def run_post_processing_handlers(
 
     logger.info(instance)
 
+def run_next(
+    config: Dict[str, Any],
+    instance_id: str,
+    logger: logging.Logger,
+    server_ips: Optional[List[str]] = None,
+) -> None:
+
+    pc_service = _build_private_computation_service(
+        config["private_computation"],
+        config["mpc"],
+        config["pid"],
+        config.get("post_processing_handlers", {}),
+    )
+
+    # Because it's possible that the "get" command never gets called to update the instance since the last step started,
+    # so it could appear that the current status is still XXX_STARTED when it should be XXX_FAILED or XXX_COMPLETED,
+    # so we need to explicitly call update_instance() here to get the current status.
+    pc_service.update_instance(instance_id)
+
+    instance = pc_service.run_next(
+        instance_id=instance_id,
+        server_ips=server_ips
+    )
+
+    logger.info(instance)
+
 
 def get_instance(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger


### PR DESCRIPTION
Summary:
## What

* Implement pa/pl coordinator run_next api

## Why

* We can use run_next to run arbitrary stage flows E2E

## Diff stack context

* Context: https://fb.workplace.com/groups/164332244998024/permalink/727979271966649/

TLDR:

This will make adding stages to private computation easier and safer and will enable the private computation service to switch between arbitrary sets of instructions. For example, you could have a stage flow that PCS uses to run Private lift / attribtution with id match  -> compute -> aggregate as we do now. We can also have stage flows that split id match into PID shard, prepare, and run, a stage flow that splits attribution compute into attribute and aggregate, etc. The stage flows will all coexist and share the same execution engine (PrivateComputationService). PrivateComputationService will use the stage flow to determine what stage to run and what to set the statuses of the instance to.

Some of the reasons we want to do this include...

* Adding more stages to private computations will allow us to...
    * Reduce private lift run time by at least 13 minutes, or roughly ~11% of the two hour PL SLA
    * Decouple attribution and aggregation operations, consistent with the long term goal of creating a horizontal attribution layer (AdConv in cloud)
    * Meet our 5 minute thrift service latency SLA targets
    * Decrease E2E test run time by 40%
    * Support new games in the future that run different stages

## Next diffs

* Create prepare data stage service
* Rename PrivateComputationStageFlow -> PrivateComputationLegacyStageFlow
* Create PrivateComputationStageFlow again, but this one will call Prepare data stage service and will be capable of running run_next e2e
* Integrate run next into fbpcs e2e runner

Differential Revision: D31694468

