### PR TITLE
rename PrivateComputationStageFlow -> LegacyStageFlow

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -120,7 +120,7 @@ class PrivateComputationInstance(InstanceBase):
     is_test: Optional[bool] = False  # set to be true for testing account ID
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name
-    _stage_flow_cls_name: str = "PrivateComputationStageFlow"
+    _stage_flow_cls_name: str = "PrivateComputationLegacyStageFlow"
 
     def get_instance_id(self) -> str:
         return self.instance_id

--- a/fbpcs/private_computation/entity/private_computation_legacy_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_legacy_stage_flow.py
@@ -30,7 +30,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 
 
-class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
+class PrivateComputationLegacyStageFlow(PrivateComputationBaseStageFlow):
     """
     This enum lists all of the supported stage types and maps to their possible statuses.
     It also provides methods to get information about the next or previous stage.
@@ -81,7 +81,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         self, args: PrivateComputationStageServiceArgs
     ) -> PrivateComputationStageService:
         """
-        Maps PrivateComputationStageFlow instances to StageService instances
+        Maps PrivateComputationLegacyStageFlow instances to StageService instances
 
         Arguments:
             args: Common arguments initialized in PrivateComputationService that are consumed by stage services

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -35,8 +35,8 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
     UnionedPCInstance,
 )
-from fbpcs.private_computation.entity.private_computation_stage_flow import (
-    PrivateComputationStageFlow,
+from fbpcs.private_computation.entity.private_computation_legacy_stage_flow import (
+    PrivateComputationLegacyStageFlow,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.errors import (
@@ -63,12 +63,12 @@ from libfb.py.asyncio.mock import AsyncMock
 from libfb.py.testutil import data_provider
 
 
-def _get_valid_stages_data() -> List[Tuple[PrivateComputationStageFlow]]:
+def _get_valid_stages_data() -> List[Tuple[PrivateComputationLegacyStageFlow]]:
     return [
-        (PrivateComputationStageFlow.ID_MATCH,),
-        (PrivateComputationStageFlow.COMPUTE,),
-        (PrivateComputationStageFlow.AGGREGATE,),
-        (PrivateComputationStageFlow.POST_PROCESSING_HANDLERS,),
+        (PrivateComputationLegacyStageFlow.ID_MATCH,),
+        (PrivateComputationLegacyStageFlow.COMPUTE,),
+        (PrivateComputationLegacyStageFlow.AGGREGATE,),
+        (PrivateComputationLegacyStageFlow.POST_PROCESSING_HANDLERS,),
     ]
 
 
@@ -298,8 +298,8 @@ class TestPrivateComputationService(unittest.TestCase):
         )()
 
     def test_get_next_runnable_stage_completed_status(self) -> None:
-        flow = PrivateComputationStageFlow
-        status  = PrivateComputationInstanceStatus.CREATED
+        flow = PrivateComputationLegacyStageFlow
+        status = PrivateComputationInstanceStatus.CREATED
 
         instance = self.create_sample_instance(status)
         instance._stage_flow_cls_name = flow.get_cls_name()
@@ -307,8 +307,8 @@ class TestPrivateComputationService(unittest.TestCase):
         self.assertEqual(flow.ID_MATCH, instance.get_next_runnable_stage())
 
     def test_get_next_runnable_stage_failed_status(self) -> None:
-        flow = PrivateComputationStageFlow
-        status  = PrivateComputationInstanceStatus.ID_MATCHING_FAILED
+        flow = PrivateComputationLegacyStageFlow
+        status = PrivateComputationInstanceStatus.ID_MATCHING_FAILED
 
         instance = self.create_sample_instance(status)
         instance._stage_flow_cls_name = flow.get_cls_name()
@@ -316,8 +316,8 @@ class TestPrivateComputationService(unittest.TestCase):
         self.assertEqual(flow.ID_MATCH, instance.get_next_runnable_stage())
 
     def test_get_next_runnable_stage_started_status(self) -> None:
-        flow = PrivateComputationStageFlow
-        status  = PrivateComputationInstanceStatus.ID_MATCHING_STARTED
+        flow = PrivateComputationLegacyStageFlow
+        status = PrivateComputationInstanceStatus.ID_MATCHING_STARTED
 
         instance = self.create_sample_instance(status)
         instance._stage_flow_cls_name = flow.get_cls_name()
@@ -325,8 +325,8 @@ class TestPrivateComputationService(unittest.TestCase):
         self.assertEqual(None, instance.get_next_runnable_stage())
 
     def test_get_next_runnable_stage_nothing_left(self) -> None:
-        flow = PrivateComputationStageFlow
-        status  = PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED
+        flow = PrivateComputationLegacyStageFlow
+        status = PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED
 
         instance = self.create_sample_instance(status)
         instance._stage_flow_cls_name = flow.get_cls_name()
@@ -336,7 +336,7 @@ class TestPrivateComputationService(unittest.TestCase):
     @data_provider(_get_valid_stages_data)
     def test_run_stage_correct_stage_order(
         self,
-        stage: PrivateComputationStageFlow,
+        stage: PrivateComputationLegacyStageFlow,
     ) -> None:
         """
         tests that run_stage runs stage_svc when the stage_svc is the next stage in the sequence
@@ -360,7 +360,7 @@ class TestPrivateComputationService(unittest.TestCase):
     @data_provider(_get_valid_stages_data)
     def test_run_stage_status_already_started(
         self,
-        stage: PrivateComputationStageFlow,
+        stage: PrivateComputationLegacyStageFlow,
     ) -> None:
         """
         tests that run_stage does not run stage_svc when the instance status is already started
@@ -381,7 +381,7 @@ class TestPrivateComputationService(unittest.TestCase):
     @data_provider(_get_valid_stages_data)
     def test_run_stage_out_of_order_with_dry_run(
         self,
-        stage: PrivateComputationStageFlow,
+        stage: PrivateComputationLegacyStageFlow,
     ) -> None:
         """
         tests that run_stage runs stage_svc out of order when dry run is passed
@@ -404,7 +404,7 @@ class TestPrivateComputationService(unittest.TestCase):
     @data_provider(_get_valid_stages_data)
     def test_run_stage_out_of_order_without_dry_run(
         self,
-        stage: PrivateComputationStageFlow,
+        stage: PrivateComputationLegacyStageFlow,
     ) -> None:
         """
         tests that run_stage does not run stage_svc out of order when dry run is not passed
@@ -427,7 +427,7 @@ class TestPrivateComputationService(unittest.TestCase):
     @data_provider(_get_valid_stages_data)
     def test_run_stage_partner_no_server_ips(
         self,
-        stage: PrivateComputationStageFlow,
+        stage: PrivateComputationLegacyStageFlow,
     ) -> None:
         """
         if it's a joint stage (partner requires server ips) but partner doesn't provide server ips, value error is thrown.
@@ -458,7 +458,7 @@ class TestPrivateComputationService(unittest.TestCase):
     @data_provider(_get_valid_stages_data)
     def test_run_stage_fails(
         self,
-        stage: PrivateComputationStageFlow,
+        stage: PrivateComputationLegacyStageFlow,
     ) -> None:
         """
         tests that statuses are set properly when a run fails


### PR DESCRIPTION
Summary:
## What

* Rename PrivateComputationStageFlow -> PrivateComputationLegacyStageFlow

## Why

* I plan on adding create a new stage flow that starts to include more stages than we currently use.
* The legacy id_match -> compute -> aggregate stage flow is esoteric because compute is actually a combination of prepare AND compute. Because of this, it isn't supported by run_next - prepare must be its own stage.
* We can keep the id_match -> compute -> aggregate stage flow for legacy reasons so that the old way of running lift and attribution continues to work as expected. This will help ensure there are no disruptions to production while run_next is productionized and tested with new stages for the first time.

## Diff stack context

* Context: https://fb.workplace.com/groups/164332244998024/permalink/727979271966649/

TLDR:

This will make adding stages to private computation easier and safer and will enable the private computation service to switch between arbitrary sets of instructions. For example, you could have a stage flow that PCS uses to run Private lift / attribtution with id match  -> compute -> aggregate as we do now. We can also have stage flows that split id match into PID shard, prepare, and run, a stage flow that splits attribution compute into attribute and aggregate, etc. The stage flows will all coexist and share the same execution engine (PrivateComputationService). PrivateComputationService will use the stage flow to determine what stage to run and what to set the statuses of the instance to.

Some of the reasons we want to do this include...

* Adding more stages to private computations will allow us to...
    * Reduce private lift run time by at least 13 minutes, or roughly ~11% of the two hour PL SLA
    * Decouple attribution and aggregation operations, consistent with the long term goal of creating a horizontal attribution layer (AdConv in cloud)
    * Meet our 5 minute thrift service latency SLA targets
    * Decrease E2E test run time by 40%
    * Support new games in the future that run different stages

## Next diffs

* Create prepare data stage service
* Rename PrivateComputationStageFlow -> PrivateComputationLegacyStageFlow
* Integrate run next into fbpcs e2e runner

Differential Revision: D31696994

