### PR TITLE
run_stage update using self.instance_repository

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -308,14 +308,14 @@ class PrivateComputationService:
         try:
             pc_instance = await stage_svc.run_async(pc_instance, server_ips)
         except Exception as e:
-            self.logger.error(f"Caught exception when running {stage}")
+            self.logger.error(f"Caught exception when running {stage}\n{e}")
             self._update_status(
                 private_computation_instance=pc_instance,
                 new_status=stage.failed_status,
             )
             raise e
         finally:
-            pc_instance = self._update_instance(pc_instance)
+            self.instance_repository.update(pc_instance)
         return pc_instance
 
     # PID stage


### PR DESCRIPTION
Summary:
## What

* replace run_stage _update_instance call with self.instance_repository.update_instance

## Why

Ran into a bizarre edge-case bug today:

* ID match PID Prepare spun up containers
* PIDService ran a get_container(container_ids)[0] call and got a list out of range error
* This exception made it to run_stage, so we enter the Except block
* The status is changed to failed, we re-raise the exception, and then move to the finally block
* _update_status calls pid_svc update to update the container statuses
* For some reason, get_container(container_ids)[0] works this time, so the status of PID is set to STARTED
* Since Pid has a start status, the pc_instance is set to ID MATCHING started
* PID won't actually attempt to start the PID RUN though, since it is currently designed to run everything E2E and that call chain was interrupted by an exception

An immediate solution to prevent this weird failed  -> started bug is to call the instance repository update directly. This is fine, since we don't really need to update the PID/MPC instances immediately after returning from the PIDService/MPCService calls. The instance monitor can take care of it.

Differential Revision: D31703738

