### PR TITLE
split the pl-coordinator `compute` command into `prepare_compute_input` and `compute_metrics`

### DIFF
--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -12,7 +12,8 @@ CLI for running a Private Lift study
 Usage:
     pl-coordinator create_instance <instance_id> --config=<config_file> --role=<pl_role> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--concurrency=<concurrency> --game_type=<game_type> --num_files_per_mpc_container=<num_files_per_mpc_container> --hmac_key=<base64_key> --fail_fast] [options]
     pl-coordinator id_match <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
-    pl-coordinator compute <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
+    pl-coordinator prepare_compute_input <instance_id> --config=<config_file> [--dry_run] [options]
+    pl-coordinator compute_metrics <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator aggregate <instance_id> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pl-coordinator validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
     pl-coordinator run_post_processing_handlers <instance_id> --config=<config_file> [--aggregated_result_path=<aggregated_result_path> --dry_run] [options]
@@ -47,13 +48,14 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     aggregate_shards,
-    compute,
+    compute_metrics,
     create_instance,
     get_instance,
     get_mpc,
     get_pid,
     get_server_ips,
     id_match,
+    prepare_compute_input,
     run_post_processing_handlers,
     validate,
     cancel_current_stage,
@@ -66,7 +68,8 @@ def main():
         {
             "create_instance": bool,
             "id_match": bool,
-            "compute": bool,
+            "prepare_compute_input": bool,
+            "compute_metrics": bool,
             "aggregate": bool,
             "validate": bool,
             "run_post_processing_handlers": bool,
@@ -160,9 +163,17 @@ def main():
             server_ips=arguments["--server_ips"],
             dry_run=arguments["--dry_run"],
         )
-    elif arguments["compute"]:
+    elif arguments["prepare_compute_input"]:
+        logger.info(f"Prepare compute input for instance: {instance_id}")
+        prepare_compute_input(
+            config=config,
+            instance_id=instance_id,
+            logger=logger,
+            dry_run=arguments["--dry_run"],
+        )
+    elif arguments["compute_metrics"]:
         logger.info(f"Compute instance: {instance_id}")
-        compute(
+        compute_metrics(
             config=config,
             instance_id=instance_id,
             logger=logger,

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -23,12 +23,13 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    get_instance,
-    create_instance,
-    id_match,
-    compute,
     aggregate_shards,
     cancel_current_stage,
+    compute_metrics,
+    create_instance,
+    get_instance,
+    id_match,
+    prepare_compute_input,
 )
 
 
@@ -375,7 +376,13 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
                         dry_run=None,
                     )
                 elif stage is PrivateLiftStage.COMPUTE:
-                    compute(
+                    prepare_compute_input(
+                        config=self.config,
+                        instance_id=self.instance_id,
+                        logger=self.logger,
+                        dry_run=None,
+                    )
+                    compute_metrics(
                         config=self.config,
                         instance_id=self.instance_id,
                         logger=self.logger,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -117,26 +117,6 @@ def id_match(
     logger.info(instance)
 
 
-def compute(
-    config: Dict[str, Any],
-    instance_id: str,
-    logger: logging.Logger,
-    server_ips: Optional[List[str]] = None,
-    dry_run: Optional[bool] = False,
-) -> None:
-    prepare_compute_input(
-        config=config, instance_id=instance_id, logger=logger, dry_run=dry_run
-    )
-
-    compute_metrics(
-        config=config,
-        instance_id=instance_id,
-        logger=logger,
-        server_ips=server_ips,
-        dry_run=dry_run,
-    )
-
-
 def prepare_compute_input(
     config: Dict[str, Any],
     instance_id: str,


### PR DESCRIPTION
Summary: So we want to consolidate pl_coordinator.py and pa_coordinator.py. pa_coordinator.py has a `prepare_compute_input` command and a `compute_attribution` command, but pl_coordinator.py only has a `compute` command that does both. We think pa's way is more aligned with the long term goal of having staging all split, so in this diff I'm modifying pl_coordinator to make it more look like pa_coordinator.

Differential Revision: D31630554

