### PR TITLE
Revert `game_type=attribution` I added in D31628424

### DIFF
--- a/fbpcs/pa_coordinator/pa_coordinator.py
+++ b/fbpcs/pa_coordinator/pa_coordinator.py
@@ -52,7 +52,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     id_match,
     prepare_compute_input,
     print_instance,
-    run_next
+    run_next,
 )
 from fbpcs.utils.optional import unwrap_or_default
 


### PR DESCRIPTION
Summary:
I added to D31628424 (https://github.com/facebookresearch/fbpcs/commit/8ce494e04c323c2fab57db50cad7c70d9a5a15b7) without proper testing. That one's landed already.

Now E2E test should be broken because pa_coordinator.py doesn't take this argument https://fburl.com/code/srf8myi9

Differential Revision: D31743993

