### PR TITLE
Change the key type of stages_containers and stage_status from string to UnionPIDStage

### DIFF
--- a/fbpcs/common/entity/instance_base.py
+++ b/fbpcs/common/entity/instance_base.py
@@ -20,7 +20,7 @@ class InstanceBase(DataClassJsonMixin):
         pass
 
     def __str__(self) -> str:
-        return self.to_json()
+        return self.dumps_schema()
 
     def dumps_schema(self) -> str:
         return self.schema().dumps(self)

--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcs.common.entity.instance_base import InstanceBase
+from fbpcs.pid.entity.pid_stages import UnionPIDStage
 
 
 class PIDRole(IntEnum):
@@ -62,8 +63,8 @@ class PIDInstance(InstanceBase):
     data_path: Optional[str] = None
     spine_path: Optional[str] = None
     hmac_key: Optional[str] = None
-    stages_containers: Dict[str, List[ContainerInstance]] = field(default_factory=dict)
-    stages_status: Dict[str, PIDStageStatus] = field(default_factory=dict)
+    stages_containers: Dict[UnionPIDStage, List[ContainerInstance]] = field(default_factory=dict)
+    stages_status: Dict[UnionPIDStage, PIDStageStatus] = field(default_factory=dict)
     status: PIDInstanceStatus = PIDInstanceStatus.UNKNOWN
     server_ips: List[str] = field(default_factory=list)
 

--- a/fbpcs/pid/service/pid_service/pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/pid_dispatcher.py
@@ -121,7 +121,7 @@ class PIDDispatcher(Dispatcher):
         # an instance is done later on.
         if not instance.stages_status:
             instance.stages_status = {
-                str(stage.stage_type): PIDStageStatus.UNKNOWN
+                stage.stage_type: PIDStageStatus.UNKNOWN
                 for stage in enum_to_stage_map.values()
             }
             self.instance_repository.update(instance)
@@ -137,7 +137,7 @@ class PIDDispatcher(Dispatcher):
             raise PIDStageFailureError(f"{stage} is not yet eligible to be run.")
         instance = self.instance_repository.read(self.instance_id)
         if (
-            instance.stages_status.get(str(stage.stage_type), None)
+            instance.stages_status.get(stage.stage_type, None)
             is PIDStageStatus.STARTED
         ):
             raise PIDStageFailureError(f"{stage} already has status STARTED")
@@ -194,7 +194,7 @@ class PIDDispatcher(Dispatcher):
             # started are eligible to be ran
             if (
                 self.dag.in_degree(node) == 0
-                and instance.stages_status.get(str(node.stage_type), None)
+                and instance.stages_status.get(node.stage_type, None)
                 is not PIDStageStatus.STARTED
             ):
                 run_ready_stages.append(node)
@@ -220,7 +220,7 @@ class PIDDispatcher(Dispatcher):
                 node
                 for node in self.dag.nodes
                 if self.dag.in_degree(node) == 0
-                and instance.stages_status.get(str(node.stage_type), None)
+                and instance.stages_status.get(node.stage_type, None)
                 is PIDStageStatus.COMPLETED
             ]
         for stage in finished_stages:

--- a/fbpcs/pid/service/pid_service/pid_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_stage.py
@@ -161,7 +161,7 @@ class PIDStage(abc.ABC):
             instance = self.instance_repository.read(instance_id)
 
             # update instance.stages_containers
-            instance.stages_containers[str(self.stage_type)] = containers
+            instance.stages_containers[self.stage_type] = containers
 
             # write updated instance to repo
             self.instance_repository.update(instance)
@@ -180,7 +180,7 @@ class PIDStage(abc.ABC):
             instance = self.instance_repository.read(instance_id)
 
             # add stage status to instance
-            instance.stages_status[str(self.stage_type)] = status
+            instance.stages_status[self.stage_type] = status
 
             # update the instance status to be FAILED if stage status is FAILED
             if status is PIDStageStatus.FAILED:

--- a/fbpcs/pid/service/pid_service/tests/test_pid.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid.py
@@ -20,6 +20,7 @@ from fbpcs.pid.entity.pid_instance import (
 )
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.pid.service.pid_service.pid_dispatcher import PIDDispatcher
+from fbpcs.pid.entity.pid_stages import UnionPIDStage
 
 
 TEST_INSTANCE_ID = "123"
@@ -83,8 +84,8 @@ class TestPIDService(unittest.TestCase):
         self.assertEqual(TEST_HMAC_KEY, create_call_params.hmac_key)
 
     def test_update_instance(self):
-        stage1 = "stage 1"
-        stage2 = "stage 2"
+        stage1 = UnionPIDStage.PUBLISHER_SHARD
+        stage2 = UnionPIDStage.PUBLISHER_PREPARE
 
         pid_instance = PIDInstance(
             instance_id=TEST_INSTANCE_ID,

--- a/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
@@ -426,11 +426,11 @@ class TestPIDDispatcher(unittest.TestCase):
         )
         # make the instance think it has completed the shard stage previously
         sample_pid_instance.stages_status[
-            str(mock_pid_shard_stage().stage_type)
+            mock_pid_shard_stage().stage_type
         ] = PIDStageStatus.COMPLETED
         # make the instance think it has attempted and failed the prepare stage previously
         sample_pid_instance.stages_status[
-            str(mock_pid_prepare_stage().stage_type)
+            mock_pid_prepare_stage().stage_type
         ] = PIDStageStatus.FAILED
         dispatcher.instance_repository.read = MagicMock(
             return_value=sample_pid_instance


### PR DESCRIPTION
Summary:
## Context
- We need to expose the status of current stage in PID instance
- However, the map storing the stages containers and status are using `str` as key type.

## This diff
- Change the key type of stages_containers and stage_status from `str` to `UnionPIDStage`.
- Fix all corresponding occurrences and unit tests

Reviewed By: jrodal98

Differential Revision: D31739296

