### PR TITLE
Add 'deploy' parameter to command passed to deployment script

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -84,6 +84,7 @@ public class DeploymentRunner extends Thread {
     deployCommand = new ArrayList<String>();
     deployCommand.add("/bin/sh");
     deployCommand.add("/terraform_deployment/deploy.sh");
+    deployCommand.add("deploy");
     deployCommand.add("-r");
     deployCommand.add(deployment.region);
     deployCommand.add("-a");


### PR DESCRIPTION
Summary: Deployment script expects a new "deploy" parameters which is not passed by the server today. This change adds it, and enables the "undeploy" command to be added.

Reviewed By: anthonyzhang25

Differential Revision: D31793821

