### PR TITLE
Deprecate PL/PA-Coordinators

### DIFF
--- a/fbpcs/scripts/run_fbpcs.sh
+++ b/fbpcs/scripts/run_fbpcs.sh
@@ -51,7 +51,7 @@ function parse_args() {
 
     case $1 in
         lift )
-            docker_cmd+=('fbpcs.pl_coordinator.pl_coordinator')
+            docker_cmd+=('fbpcs.private_computation_cli.private_computation_cli')
             ;;
         attribution )
             docker_cmd+=('fbpcs.pa_coordinator.pa_coordinator')

--- a/fbpcs/tests/github/config.sh
+++ b/fbpcs/tests/github/config.sh
@@ -18,7 +18,7 @@ export DOCKER_INSTANCE_REPO="/instances"
 # Lift study configs
 export LIFT_PUBLIHSER_NAME="pl_publisher_github"
 export LIFT_PARTNER_NAME="pl_partner_github"
-export LIFT_COORDINATOR="python3.8 -m fbpcs.pl_coordinator.pl_coordinator"
+export LIFT_COORDINATOR="python3.8 -m fbpcs.private_computation_cli.private_computation_cli"
 export LIFT_NUM_MPC_CONTAIENRS=2
 export LIFT_NUM_PID_CONTAINERS=2
 export LIFT_CONCURRENCY=4


### PR DESCRIPTION
Summary:
Delete pl/pa_coordinator.py and use private_computation_cli.py instead (already created by copying pl_coordinator.py and renaming).

This diff is huge, but I think in summary it doesn't only a few things:

1. Delete pl_coordinator.py and pa_coordinator.py;
2. Remove "pl_coordinator_intern" and "pa_coordinator_intern" Python binary buck rules in TARGETS;
3. Use the new "private_computation_cli_intern" in .sh (script for running individual stages for dev server testing), TARGETS and fbpcs_e2e_runner;
3. Pyhon 3.8 commands changed to `fbpcs.private_computation_cli.private_computation_cli` in run_fbpcs.sh change, e2e-test.sh, and github/config.sh (highlighted below with inline comments).

**Next steps**:
1. After this diff gets release to prod, update PL user facing document because no need to specify "lift" anymore: https://fburl.com/gdoc/xug9fruh [`./run_fbpcs.sh lift run_study`  -> `./run_fbpcs.sh run_study`]
2. After this diff gets release to prod, update PA user facing document: https://fburl.com/gdoc/feacfl4h (I know it says "Within FB" in the title...this is what Ben Lampert gave me at this beginning of Oct so I'll double check with him) [`fbpcs:pa_coordinator_intern` -> `fbpcs:private_computation_cli_intern`]
3. ANYTHING ELSE I MISSED?

Differential Revision: D31642801

