### PR TITLE
don't swallow exceptions

### DIFF
--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -398,7 +398,7 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
                         dry_run=None,
                     )
             except Exception as error:
-                self.logger.error(f"Error running partner {stage.value} {error}")
+                self.logger.exception(f"Error running partner {stage.value} {error}")
 
 
 class PLInstanceRunner:


### PR DESCRIPTION
Summary:
## What

Log one command runner exception stack traces, not just the error

## Why

logger.error only gives the error message. logger.exception gives the whole stack trace. The latter is much more useful for debugging.

Example:

```
import logging

def func() -> None:
    raise Exception("This is my error message")

def swallow() -> None:
    try:
        func()
    except Exception as e:
        print("swallowing exception")
        logging.error(e)
        print("exception swallowed :(")

def no_swallow() -> None:
    try:
        func()
    except Exception as e:
        print("not swallowing exception")
        logging.exception(e)
        print("exception not swallowed :)")

print("---------SWALLOW-----------")
swallow()
print("---------NO SWALLOW-----------")
no_swallow()
print("Done")

```

```
┌─jrodal@jrodal-mbp ~/Downloads via ⬢ v14.15.5 via {emoji:1f40d} v2.7.16 on {emoji:2601}  (us-west-2)
└─❮ python3 test.py
---------SWALLOW-----------
swallowing exception
ERROR:root:This is my error message
exception swallowed :(
---------NO SWALLOW-----------
not swallowing exception
ERROR:root:This is my error message
Traceback (most recent call last):
  File "test.py", line 16, in no_swallow
    func()
  File "test.py", line 4, in func
    raise Exception("This is my error message")
Exception: This is my error message
exception not swallowed :)
Done
```

Reviewed By: gorel, Olivia-liu

Differential Revision: D31870458

