### PR TITLE
Expose current_stage in PID instance

### DIFF
--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -66,6 +66,7 @@ class PIDInstance(InstanceBase):
     stages_containers: Dict[UnionPIDStage, List[ContainerInstance]] = field(default_factory=dict)
     stages_status: Dict[UnionPIDStage, PIDStageStatus] = field(default_factory=dict)
     status: PIDInstanceStatus = PIDInstanceStatus.UNKNOWN
+    current_stage: Optional[UnionPIDStage] = None
     server_ips: List[str] = field(default_factory=list)
 
     def get_instance_id(self) -> str:

--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -144,6 +144,7 @@ class PIDService:
                     instance.status = PIDInstanceStatus.FAILED
                 instance.stages_status[stage] = new_stage_status
                 instance.stages_containers[stage] = containers
+                instance.current_stage = stage
         # if all of the stages are complete, then PID for instance is complete
         if all(
             status is PIDStageStatus.COMPLETED

--- a/fbpcs/pid/service/pid_service/tests/test_pid.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid.py
@@ -105,6 +105,7 @@ class TestPIDService(unittest.TestCase):
         self.pid_service.instance_repository.read = MagicMock(return_value=pid_instance)
         pid_instance = self.pid_service.update_instance(TEST_INSTANCE_ID)
         self.assertEqual(pid_instance.status, PIDInstanceStatus.STARTED)
+        self.assertIsNone(pid_instance.current_stage)
         self.assertEqual(
             pid_instance.stages_status[stage1],
             PIDStageStatus.UNKNOWN,
@@ -121,6 +122,7 @@ class TestPIDService(unittest.TestCase):
         self.pid_service.instance_repository.read = MagicMock(return_value=pid_instance)
         pid_instance = self.pid_service.update_instance(TEST_INSTANCE_ID)
         self.assertEqual(pid_instance.status, PIDInstanceStatus.STARTED)
+        self.assertEqual(pid_instance.current_stage, stage1)
         self.assertEqual(
             pid_instance.stages_status[stage1],
             PIDStageStatus.STARTED,
@@ -136,6 +138,7 @@ class TestPIDService(unittest.TestCase):
         self.pid_service.instance_repository.read = MagicMock(return_value=pid_instance)
         pid_instance = self.pid_service.update_instance(TEST_INSTANCE_ID)
         self.assertEqual(pid_instance.status, PIDInstanceStatus.STARTED)
+        self.assertEqual(pid_instance.current_stage, stage1)
         self.assertEqual(
             pid_instance.stages_status[stage1],
             PIDStageStatus.COMPLETED,
@@ -157,6 +160,7 @@ class TestPIDService(unittest.TestCase):
         self.pid_service.instance_repository.read = MagicMock(return_value=pid_instance)
         pid_instance = self.pid_service.update_instance(TEST_INSTANCE_ID)
         self.assertEqual(pid_instance.status, PIDInstanceStatus.FAILED)
+        self.assertEqual(pid_instance.current_stage, stage2)
         self.assertEqual(
             pid_instance.stages_status[stage2],
             PIDStageStatus.FAILED,
@@ -178,6 +182,7 @@ class TestPIDService(unittest.TestCase):
         self.pid_service.instance_repository.read = MagicMock(return_value=pid_instance)
         pid_instance = self.pid_service.update_instance(TEST_INSTANCE_ID)
         self.assertEqual(pid_instance.status, PIDInstanceStatus.COMPLETED)
+        self.assertEqual(pid_instance.current_stage, stage2)
         self.assertEqual(
             pid_instance.stages_status[stage2],
             PIDStageStatus.COMPLETED,


### PR DESCRIPTION
Summary:
## Context
- The high level idea is that PID service need to have the ability to run a single stage.
- This would provide PCS the ability to make several thrift calls
- Initial design is to modify the PIDInstanceStatus to include the indicate of stages
- However this is not scalable and not elegant
- After some discussion with Jacob, especially in D31739740, we can expose a `current_stage` field to keep track of the current stage and the make it visible for PCS to see the status of PID instance.

## This diff
- Create a new field call 'current_stage'
- Update the current stage when updating the instance status or the stage is run
- Update the unit test along the way.

Reviewed By: jrodal98

Differential Revision: D31806660

