### PR TITLE
use UTC instead of localtime

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerUtil.h
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerUtil.h
@@ -16,7 +16,7 @@ inline std::string getDateString(){
   time_t timeNow = time(nullptr);
   char dateStr[12];
   struct tm newTime;
-  strftime(dateStr, sizeof(dateStr), "%Y-%m-%d", localtime_r(&timeNow, &newTime));
+  strftime(dateStr, sizeof(dateStr), "%Y-%m-%d", gmtime_r(&timeNow, &newTime));
   return dateStr;
 }
 


### PR DESCRIPTION
Summary:
**What?**
- As pointed out by gorel, it's better to use UTC which will prevent getting inconsistent dates for two runs that might have happened at the same time.

Differential Revision: D31855025

