### PR TITLE
Add helper mapWithInPlace in preparation of operatorBinOp=

### DIFF
--- a/fbpcs/emp_games/lift/common/Column-impl.h
+++ b/fbpcs/emp_games/lift/common/Column-impl.h
@@ -24,4 +24,43 @@ auto operator+(const Column<T> &a, T2 &b) -> Column<decltype(a.at(0) + b)> {
       b, [](const T &aValue, const T2 &bValue) { return aValue + bValue; });
 }
 
+template <typename T, typename T2>
+auto operator-(const Column<T> &a, const Column<T2> &b)
+    -> Column<decltype(a.at(0) - b.at(0))> {
+  return a.mapWith(
+      b, [](const T &aValue, const T2 &bValue) { return aValue - bValue; });
+}
+
+template <typename T, typename T2>
+auto operator-(const Column<T> &a, T2 &b) -> Column<decltype(a.at(0) - b)> {
+  return a.mapWithScalar(
+      b, [](const T &aValue, const T2 &bValue) { return aValue - bValue; });
+}
+
+template <typename T, typename T2>
+auto operator*(const Column<T> &a, const Column<T2> &b)
+    -> Column<decltype(a.at(0) * b.at(0))> {
+  return a.mapWith(
+      b, [](const T &aValue, const T2 &bValue) { return aValue * bValue; });
+}
+
+template <typename T, typename T2>
+auto operator*(const Column<T> &a, T2 &b) -> Column<decltype(a.at(0) * b)> {
+  return a.mapWithScalar(
+      b, [](const T &aValue, const T2 &bValue) { return aValue * bValue; });
+}
+
+template <typename T, typename T2>
+auto operator/(const Column<T> &a, const Column<T2> &b)
+    -> Column<decltype(a.at(0) / b.at(0))> {
+  return a.mapWith(
+      b, [](const T &aValue, const T2 &bValue) { return aValue / bValue; });
+}
+
+template <typename T, typename T2>
+auto operator/(const Column<T> &a, T2 &b) -> Column<decltype(a.at(0) / b)> {
+  return a.mapWithScalar(
+      b, [](const T &aValue, const T2 &bValue) { return aValue / bValue; });
+}
+
 } // namespace df

--- a/fbpcs/emp_games/lift/common/Column-impl.h
+++ b/fbpcs/emp_games/lift/common/Column-impl.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/common/Column.h"
+
+namespace df {
+
+template <typename T, typename T2>
+auto operator+(const Column<T> &a, const Column<T2> &b)
+    -> Column<decltype(a.at(0) + b.at(0))> {
+  return a.mapWith(
+      b, [](const T &aValue, const T2 &bValue) { return aValue + bValue; });
+}
+
+template <typename T, typename T2>
+auto operator+(const Column<T> &a, T2 &b) -> Column<decltype(a.at(0) + b)> {
+  return a.mapWithScalar(
+      b, [](const T &aValue, const T2 &bValue) { return aValue + bValue; });
+}
+
+} // namespace df

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <initializer_list>
+#include <vector>
+
+namespace df {
+
+template <typename T> class Column {
+public:
+  /* Basic constructors */
+  Column() {}
+  Column(const Column<T> &other) = default;
+  Column(Column<T> &&other) = default;
+  Column<T> &operator=(Column<T> &other) = default;
+  Column<T> &operator=(Column<T> &&other) = default;
+
+  explicit Column(std::size_t count, const T &value = T()) : v_(count, value) {}
+
+  template <class InputIt>
+  Column(InputIt first, InputIt last) : v_(first, last) {}
+
+  /* implicit */ Column(std::initializer_list<T> init) : v_(init) {}
+
+  Column<T> &operator=(std::initializer_list<T> init) {
+    v_ = init;
+    return *this;
+  }
+
+  /* Constructors from vector<T> */
+
+  /* implicit */ Column(std::vector<T> &other) : v_(other) {}
+
+  /* implicit */ Column(std::vector<T> &&other) : v_(other) {}
+
+  Column &operator=(std::vector<T> &other) {
+    v_ = other;
+    return *this;
+  }
+
+  Column<T> &operator=(std::vector<T> &&other) {
+    v_ = other;
+    return *this;
+  }
+
+  /* Member functions */
+
+  const T &at(std::size_t pos) const { return v_.at(pos); }
+
+  T &at(std::size_t pos) {
+    return const_cast<T &>(const_cast<const Column &>(*this).at(pos));
+  }
+
+  bool empty() const { return v_.empty(); }
+
+  std::size_t size() const { return v_.size(); }
+
+  void push_back(const T &value) { v_.push_back(value); }
+
+  void push_back(T &&value) { v_.push_back(value); }
+
+  template <class... Args> T &emplace_back(Args &&...args) {
+    return v_.emplace_back(args...);
+  }
+
+  /* Comparison operators */
+  friend bool operator==(const Column<T> &a, const Column<T> &b) {
+    return a.v_ == b.v_;
+  }
+
+  friend bool operator!=(const Column<T> &a, const Column<T> &b) {
+    return a.v_ != b.v_;
+  }
+
+private:
+  std::vector<T> v_;
+};
+
+} // namespace df

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -79,8 +79,8 @@ public:
     }
   }
 
-  template <typename F> Column<T> map(F f) const {
-    Column<T> res;
+  template <typename F> auto map(F f) const -> Column<decltype(f(at(0)))> {
+    Column<decltype(f(at(0)))> res;
     res.reserve(size());
     for (std::size_t i = 0; i < size(); ++i) {
       res.push_back(f(at(i)));

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <initializer_list>
+#include <optional>
 #include <vector>
 
 namespace df {
@@ -58,6 +59,8 @@ public:
     return const_cast<T &>(const_cast<const Column &>(*this).at(pos));
   }
 
+  void reserve(std::size_t capacity) { v_.reserve(capacity); }
+
   bool empty() const { return v_.empty(); }
 
   std::size_t size() const { return v_.size(); }
@@ -68,6 +71,45 @@ public:
 
   template <class... Args> T &emplace_back(Args &&...args) {
     return v_.emplace_back(args...);
+  }
+
+  template <typename F> void apply(F f) {
+    for (std::size_t i = 0; i < size(); ++i) {
+      f(at(i));
+    }
+  }
+
+  template <typename F> Column<T> map(F f) const {
+    Column<T> res;
+    res.reserve(size());
+    for (std::size_t i = 0; i < size(); ++i) {
+      res.push_back(f(at(i)));
+    }
+    return res;
+  }
+
+  template <typename F> void mapInPlace(F f) {
+    for (std::size_t i = 0; i < size(); ++i) {
+      at(i) = f(at(i));
+    }
+  }
+
+  template <typename F>
+  T reduce(F f, std::optional<T> acc = std::nullopt) const {
+    std::size_t idx = 0;
+    T res;
+    if (acc == std::nullopt) {
+      // Calling reduce on an empty Column with no acc is undefined
+      ++idx;
+      res = at(0);
+    } else {
+      res = acc.value();
+    }
+
+    for (/* empty */; idx < size(); ++idx) {
+      res = f(res, at(idx));
+    }
+    return res;
   }
 
   /* Comparison operators */

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <optional>
+#include <sstream>
 #include <vector>
 
 namespace df {
@@ -84,6 +85,36 @@ public:
     res.reserve(size());
     for (std::size_t i = 0; i < size(); ++i) {
       res.push_back(f(at(i)));
+    }
+    return res;
+  }
+
+  template <typename T2, typename F>
+  auto mapWith(const Column<T2> &other, F f) const
+      -> Column<decltype(f(at(0), other.at(0)))> {
+    Column<decltype(f(at(0), other.at(0)))> res;
+    if (size() != other.size()) {
+      std::stringstream ss;
+      ss << "This Column has size() = " << size()
+         << ", but other Column has size() = " << other.size();
+      throw std::invalid_argument{ss.str()};
+    }
+
+    res.reserve(size());
+    for (std::size_t i = 0; i < size(); ++i) {
+      res.push_back(f(at(i), other.at(i)));
+    }
+    return res;
+  }
+
+  template <typename T2, typename F>
+  auto mapWithScalar(const T2 &other, F f) const
+      -> Column<decltype(f(at(0), other))> {
+    Column<decltype(f(at(0), other))> res;
+
+    res.reserve(size());
+    for (std::size_t i = 0; i < size(); ++i) {
+      res.push_back(f(at(i), other));
     }
     return res;
   }

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -112,6 +112,15 @@ public:
     return res;
   }
 
+  template <typename T2> Column<T2> toColumn() const {
+    Column<T2> res;
+    res.reserve(size());
+    for (std::size_t i = 0; i < size(); ++i) {
+      res.push_back(T2(at(i)));
+    }
+    return res;
+  }
+
   /* Comparison operators */
   friend bool operator==(const Column<T> &a, const Column<T> &b) {
     return a.v_ == b.v_;

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -125,6 +125,27 @@ public:
     }
   }
 
+  template <typename T2, typename F>
+  void mapWithInPlace(const Column<T2> &other, F f) {
+    if (size() != other.size()) {
+      std::stringstream ss;
+      ss << "This Column has size() = " << size()
+         << ", but other Column has size() = " << other.size();
+      throw std::invalid_argument{ss.str()};
+    }
+
+    for (std::size_t i = 0; i < size(); ++i) {
+      at(i) = f(at(i), other.at(i));
+    }
+  }
+
+  template <typename T2, typename F>
+  void mapWithScalarInPlace(const T2 &other, F f) {
+    for (std::size_t i = 0; i < size(); ++i) {
+      at(i) = f(at(i), other);
+    }
+  }
+
   template <typename F>
   T reduce(F f, std::optional<T> acc = std::nullopt) const {
     std::size_t idx = 0;

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -166,3 +166,5 @@ private:
 };
 
 } // namespace df
+
+#include "fbpcs/emp_games/lift/common/Column-impl.h"

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -98,6 +98,18 @@ public:
         const_cast<const DataFrame &>(*this).at<T>(key));
   }
 
+  template <typename T> void drop(const std::string &key) {
+    auto idx = std::type_index(typeid(T));
+    auto &ptr = maps_.at(idx);
+
+    // First erase from column map
+    dynamic_cast<MapT<T> &>(*ptr).erase(key);
+
+    // Then erase from types_
+    auto typeIt = types_.find(key);
+    types_.erase(typeIt);
+  }
+
 private:
   std::unordered_map<std::string, TypeInfo> types_;
   std::unordered_map<std::type_index, std::unique_ptr<BaseMap>> maps_;

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <utility>
+
+#include "fbpcs/emp_games/lift/common/Column.h"
+
+/*
+ * This DataFrame implementation is loosely based on an answer from
+ * https://stackoverflow.com/a/32651111/15625637
+ */
+namespace df {
+class BaseMap {
+public:
+  virtual ~BaseMap() {}
+};
+
+// actual map of Columns
+template <typename T>
+class MapT : public BaseMap,
+             public std::unordered_map<std::string, Column<T>> {};
+
+class BadTypeException : public std::exception {
+public:
+  explicit BadTypeException(std::string expected, std::string actual) {
+    msg_ = "Expected type '" + expected + "', but got type '" + actual + "'";
+  }
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+private:
+  std::string msg_;
+};
+
+class DataFrame {
+public:
+  using TypeInfo = std::pair<std::type_index, std::string>;
+
+  static void checkType(const TypeInfo &expected, const TypeInfo &actual) {
+    if (expected.first != actual.first) {
+      throw BadTypeException{expected.second, actual.second};
+    }
+  }
+
+  template <typename T> const Column<T> &get(const std::string &key) const {
+    auto idx = std::type_index(typeid(T));
+    // If this column is defined, ensure the type is correct
+    if (types_.find(key) != types_.end()) {
+      auto typeName = typeid(T).name();
+      checkType(types_.at(key), std::make_pair(idx, typeName));
+    }
+
+    auto &ptr = maps_.at(idx);
+    return dynamic_cast<MapT<T> &>(*ptr)[key];
+  }
+
+  template <typename T> Column<T> &get(const std::string &key) {
+    auto idx = std::type_index(typeid(T));
+    auto typeName = typeid(T).name();
+
+    // First check if we've added any columns of this type
+    if (maps_.find(idx) == maps_.end()) {
+      maps_.emplace(idx, std::make_unique<MapT<T>>());
+    }
+
+    // Then check if we've seen this key before
+    if (types_.find(key) == types_.end()) {
+      types_.emplace(key, std::make_pair(idx, typeName));
+    }
+
+    return const_cast<Column<T> &>(
+        const_cast<const DataFrame &>(*this).get<T>(key));
+  }
+
+  template <typename T> const Column<T> &at(const std::string &key) const {
+    auto idx = std::type_index(typeid(T));
+    auto typeName = typeid(T).name();
+    // Ensure the type is correct
+    // NOTE: This will throw std::out_of_range if `key` is not present
+    checkType(types_.at(key), std::make_pair(idx, typeName));
+    return (*this).get<T>(key);
+  }
+
+  template <typename T> Column<T> &at(const std::string &key) {
+    return const_cast<Column<T> &>(
+        const_cast<const DataFrame &>(*this).at<T>(key));
+  }
+
+private:
+  std::unordered_map<std::string, TypeInfo> types_;
+  std::unordered_map<std::type_index, std::unique_ptr<BaseMap>> maps_;
+};
+
+} // namespace df

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -15,6 +15,7 @@ using namespace df;
 
 class Foo {
 public:
+  explicit Foo(int64_t a) : a_{a}, b_{0} {}
   Foo(int64_t a, int64_t b) : a_{a}, b_{b} {}
 
   friend bool operator==(const Foo &f1, const Foo &f2) {
@@ -26,7 +27,7 @@ private:
   int64_t b_;
 };
 
-TEST(Constructor, Default) {
+TEST(ColumnTest, Default) {
   Column<int64_t> c;
   c.push_back(1);
   c.push_back(2);
@@ -38,7 +39,7 @@ TEST(Constructor, Default) {
   EXPECT_EQ(c.at(2), 3);
 }
 
-TEST(Constructor, DefaultFilled) {
+TEST(ColumnTest, DefaultFilled) {
   Column<int64_t> c(4, 5);
 
   ASSERT_EQ(c.size(), 4);
@@ -48,7 +49,7 @@ TEST(Constructor, DefaultFilled) {
   EXPECT_EQ(c.at(3), 5);
 }
 
-TEST(Constructor, FromIterator) {
+TEST(ColumnTest, FromIterator) {
   std::vector<int64_t> vec{4, 5, 6};
   Column<int64_t> c(vec.begin(), vec.end());
 
@@ -58,7 +59,7 @@ TEST(Constructor, FromIterator) {
   EXPECT_EQ(c.at(2), 6);
 }
 
-TEST(Constructor, CopyVector) {
+TEST(ColumnTest, CopyVector) {
   std::vector<int64_t> vec{7, 8, 9};
   Column<int64_t> c(vec);
 
@@ -68,7 +69,7 @@ TEST(Constructor, CopyVector) {
   EXPECT_EQ(c.at(2), 9);
 }
 
-TEST(Constructor, FromVectorRValueReference) {
+TEST(ColumnTest, FromVectorRValueReference) {
   std::vector<int64_t> vec{1, 3, 5};
   Column<int64_t> c(std::move(vec));
 
@@ -78,7 +79,7 @@ TEST(Constructor, FromVectorRValueReference) {
   EXPECT_EQ(c.at(2), 5);
 }
 
-TEST(Constructor, FromInitializerList) {
+TEST(ColumnTest, FromInitializerList) {
   Column<int64_t> c{2, 4, 6};
   ASSERT_EQ(c.size(), 3);
   EXPECT_EQ(c.at(0), 2);
@@ -86,7 +87,7 @@ TEST(Constructor, FromInitializerList) {
   EXPECT_EQ(c.at(2), 6);
 }
 
-TEST(Constructor, FromColumnReference) {
+TEST(ColumnTest, FromColumnReference) {
   Column<int64_t> from{9, 8, 7};
   Column<int64_t> c(from);
 
@@ -96,7 +97,7 @@ TEST(Constructor, FromColumnReference) {
   EXPECT_EQ(c.at(2), 7);
 }
 
-TEST(Constructor, FromColumnRValueReference) {
+TEST(ColumnTest, FromColumnRValueReference) {
   Column<int64_t> from{6, 5, 4};
   Column<int64_t> c(std::move(from));
 
@@ -107,7 +108,7 @@ TEST(Constructor, FromColumnRValueReference) {
 }
 
 // Copy assignment constructor given std::vector
-TEST(CopyAssignmentConstructor, FromVectorReference) {
+TEST(ColumnTest, CopyFromVectorReference) {
   std::vector<int64_t> from{3, 2, 1};
   Column<int64_t> c = from;
 
@@ -117,7 +118,7 @@ TEST(CopyAssignmentConstructor, FromVectorReference) {
   EXPECT_EQ(c.at(2), 1);
 }
 // Copy constructor given std::vector&&
-TEST(CopyAssignmentConstructor, FromVectorRValueReference) {
+TEST(ColumnTest, CopyFromVectorRValueReference) {
   std::vector<int64_t> from{3, 5, 7};
   Column<int64_t> c = std::move(from);
 
@@ -127,7 +128,7 @@ TEST(CopyAssignmentConstructor, FromVectorRValueReference) {
   EXPECT_EQ(c.at(2), 7);
 }
 // Copy constructor given Column
-TEST(CopyAssignmentConstructor, FromColumnReference) {
+TEST(ColumnTest, CopyFromColumnReference) {
   Column<int64_t> from{4, 6, 8};
   Column<int64_t> c = from;
 
@@ -137,7 +138,7 @@ TEST(CopyAssignmentConstructor, FromColumnReference) {
   EXPECT_EQ(c.at(2), 8);
 }
 // Copy constructor given Column&&
-TEST(CopyAssignmentConstructor, FromColumnRValueReference) {
+TEST(ColumnTest, CopyFromColumnRValueReference) {
   std::vector<int64_t> from{5, 7, 9};
   Column<int64_t> c = std::move(from);
   Column<int64_t> c2 = std::move(c);
@@ -148,7 +149,7 @@ TEST(CopyAssignmentConstructor, FromColumnRValueReference) {
   EXPECT_EQ(c2.at(2), 9);
 }
 // Copy constructor given std::initializer_list
-TEST(CopyAssignmentConstructor, FromInitializerList) {
+TEST(ColumnTest, CopyFromInitializerList) {
   Column<int64_t> c = {2, 4, 6, 8, 10};
 
   ASSERT_EQ(c.size(), 5);
@@ -159,7 +160,7 @@ TEST(CopyAssignmentConstructor, FromInitializerList) {
   EXPECT_EQ(c.at(4), 10);
 }
 
-TEST(ColumnFunctionality, At) {
+TEST(ColumnTest, At) {
   Column<int64_t> c{1, 2, 3, 4, 5};
   EXPECT_EQ(c.at(0), 1);
   EXPECT_EQ(c.at(1), 2);
@@ -169,7 +170,7 @@ TEST(ColumnFunctionality, At) {
   EXPECT_THROW(c.at(5), std::out_of_range);
 }
 
-TEST(ColumnFunctionality, Empty) {
+TEST(ColumnTest, Empty) {
   Column<int64_t> c;
   EXPECT_TRUE(c.empty());
 
@@ -179,7 +180,7 @@ TEST(ColumnFunctionality, Empty) {
   EXPECT_FALSE(c.empty());
 }
 
-TEST(ColumnFunctionality, Size) {
+TEST(ColumnTest, Size) {
   Column<int64_t> c;
   EXPECT_EQ(c.size(), 0);
 
@@ -189,7 +190,7 @@ TEST(ColumnFunctionality, Size) {
   EXPECT_EQ(c.size(), 3);
 }
 
-TEST(ColumnFunctionality, EmplaceBack) {
+TEST(ColumnTest, EmplaceBack) {
   Column<Foo> c;
   Foo f(123, 456);
   c.emplace_back(123, 456);
@@ -198,7 +199,7 @@ TEST(ColumnFunctionality, EmplaceBack) {
   EXPECT_EQ(c.at(0), f);
 }
 
-TEST(ColumnFunctionality, ComparisonOperators) {
+TEST(ColumnTest, ComparisonOperators) {
   Column<int64_t> c1{1, 2, 3};
   Column<int64_t> c2{1, 2, 3};
   Column<int64_t> c3{4, 5, 6};
@@ -208,7 +209,7 @@ TEST(ColumnFunctionality, ComparisonOperators) {
   EXPECT_NE(c1, c3);
 }
 
-TEST(FunctionalTest, Apply) {
+TEST(ColumnTest, Apply) {
   Column<int64_t> c1{1, 2, 3};
   Column<int64_t> c2{1, 4, 9};
 
@@ -221,7 +222,7 @@ TEST(FunctionalTest, Apply) {
   EXPECT_EQ(vec, vecExpected);
 }
 
-TEST(FunctionalTest, Map) {
+TEST(ColumnTest, Map) {
   Column<int64_t> c1{1, 2, 3};
   auto c2 = c1.map([](int64_t v) { return v + 1; });
   Column<int64_t> expected{2, 3, 4};
@@ -235,7 +236,7 @@ TEST(FunctionalTest, Map) {
   EXPECT_EQ(c1, expected2);
 }
 
-TEST(FunctionalTest, Reduce) {
+TEST(ColumnTest, Reduce) {
   Column<int64_t> c{10, 20, 30};
   // Basic test
   auto sum = c.reduce([](int64_t acc, int64_t v) { return acc + v; });
@@ -253,4 +254,12 @@ TEST(FunctionalTest, Reduce) {
   // Empty column, no accumulator
   EXPECT_THROW(c2.reduce([](int64_t acc, int64_t v) { return acc + v; }),
                std::out_of_range);
+}
+
+TEST(ColumnTest, ToColumn) {
+  Column<int64_t> c{10, 20, 30};
+  Column<Foo> expected{Foo{10, 0}, Foo{20, 0}, Foo{30, 0}};
+
+  auto actual = c.toColumn<Foo>();
+  EXPECT_EQ(expected, actual);
 }

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -234,6 +234,11 @@ TEST(ColumnTest, Map) {
   Column<int64_t> expected2{2, 4, 6};
 
   EXPECT_EQ(c1, expected2);
+
+  Column<int64_t> c3{111, 222, 333};
+  Column<Foo> foosExpected{Foo{111, 111}, Foo{222, 222}, Foo{333, 333}};
+  auto foosActual = c3.map([](int64_t v) { return Foo{v, v}; });
+  EXPECT_EQ(foosExpected, foosActual);
 }
 
 TEST(ColumnTest, Reduce) {

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/common/Column.h"
+
+using namespace df;
+
+class Foo {
+public:
+  Foo(int64_t a, int64_t b) : a_{a}, b_{b} {}
+
+  friend bool operator==(const Foo &f1, const Foo &f2) {
+    return f1.a_ == f2.a_ && f1.b_ == f2.b_;
+  }
+
+private:
+  int64_t a_;
+  int64_t b_;
+};
+
+TEST(Constructor, Default) {
+  Column<int64_t> c;
+  c.push_back(1);
+  c.push_back(2);
+  c.push_back(3);
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 1);
+  EXPECT_EQ(c.at(1), 2);
+  EXPECT_EQ(c.at(2), 3);
+}
+
+TEST(Constructor, DefaultFilled) {
+  Column<int64_t> c(4, 5);
+
+  ASSERT_EQ(c.size(), 4);
+  EXPECT_EQ(c.at(0), 5);
+  EXPECT_EQ(c.at(1), 5);
+  EXPECT_EQ(c.at(2), 5);
+  EXPECT_EQ(c.at(3), 5);
+}
+
+TEST(Constructor, FromIterator) {
+  std::vector<int64_t> vec{4, 5, 6};
+  Column<int64_t> c(vec.begin(), vec.end());
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 4);
+  EXPECT_EQ(c.at(1), 5);
+  EXPECT_EQ(c.at(2), 6);
+}
+
+TEST(Constructor, CopyVector) {
+  std::vector<int64_t> vec{7, 8, 9};
+  Column<int64_t> c(vec);
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 7);
+  EXPECT_EQ(c.at(1), 8);
+  EXPECT_EQ(c.at(2), 9);
+}
+
+TEST(Constructor, FromVectorRValueReference) {
+  std::vector<int64_t> vec{1, 3, 5};
+  Column<int64_t> c(std::move(vec));
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 1);
+  EXPECT_EQ(c.at(1), 3);
+  EXPECT_EQ(c.at(2), 5);
+}
+
+TEST(Constructor, FromInitializerList) {
+  Column<int64_t> c{2, 4, 6};
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 2);
+  EXPECT_EQ(c.at(1), 4);
+  EXPECT_EQ(c.at(2), 6);
+}
+
+TEST(Constructor, FromColumnReference) {
+  Column<int64_t> from{9, 8, 7};
+  Column<int64_t> c(from);
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 9);
+  EXPECT_EQ(c.at(1), 8);
+  EXPECT_EQ(c.at(2), 7);
+}
+
+TEST(Constructor, FromColumnRValueReference) {
+  Column<int64_t> from{6, 5, 4};
+  Column<int64_t> c(std::move(from));
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 6);
+  EXPECT_EQ(c.at(1), 5);
+  EXPECT_EQ(c.at(2), 4);
+}
+
+// Copy assignment constructor given std::vector
+TEST(CopyAssignmentConstructor, FromVectorReference) {
+  std::vector<int64_t> from{3, 2, 1};
+  Column<int64_t> c = from;
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 3);
+  EXPECT_EQ(c.at(1), 2);
+  EXPECT_EQ(c.at(2), 1);
+}
+// Copy constructor given std::vector&&
+TEST(CopyAssignmentConstructor, FromVectorRValueReference) {
+  std::vector<int64_t> from{3, 5, 7};
+  Column<int64_t> c = std::move(from);
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 3);
+  EXPECT_EQ(c.at(1), 5);
+  EXPECT_EQ(c.at(2), 7);
+}
+// Copy constructor given Column
+TEST(CopyAssignmentConstructor, FromColumnReference) {
+  Column<int64_t> from{4, 6, 8};
+  Column<int64_t> c = from;
+
+  ASSERT_EQ(c.size(), 3);
+  EXPECT_EQ(c.at(0), 4);
+  EXPECT_EQ(c.at(1), 6);
+  EXPECT_EQ(c.at(2), 8);
+}
+// Copy constructor given Column&&
+TEST(CopyAssignmentConstructor, FromColumnRValueReference) {
+  std::vector<int64_t> from{5, 7, 9};
+  Column<int64_t> c = std::move(from);
+  Column<int64_t> c2 = std::move(c);
+
+  ASSERT_EQ(c2.size(), 3);
+  EXPECT_EQ(c2.at(0), 5);
+  EXPECT_EQ(c2.at(1), 7);
+  EXPECT_EQ(c2.at(2), 9);
+}
+// Copy constructor given std::initializer_list
+TEST(CopyAssignmentConstructor, FromInitializerList) {
+  Column<int64_t> c = {2, 4, 6, 8, 10};
+
+  ASSERT_EQ(c.size(), 5);
+  EXPECT_EQ(c.at(0), 2);
+  EXPECT_EQ(c.at(1), 4);
+  EXPECT_EQ(c.at(2), 6);
+  EXPECT_EQ(c.at(3), 8);
+  EXPECT_EQ(c.at(4), 10);
+}
+
+TEST(ColumnFunctionality, At) {
+  Column<int64_t> c{1, 2, 3, 4, 5};
+  EXPECT_EQ(c.at(0), 1);
+  EXPECT_EQ(c.at(1), 2);
+  EXPECT_EQ(c.at(2), 3);
+  EXPECT_EQ(c.at(3), 4);
+  EXPECT_EQ(c.at(4), 5);
+  EXPECT_THROW(c.at(5), std::out_of_range);
+}
+
+TEST(ColumnFunctionality, Empty) {
+  Column<int64_t> c;
+  EXPECT_TRUE(c.empty());
+
+  c.push_back(1);
+  c.push_back(2);
+  c.push_back(3);
+  EXPECT_FALSE(c.empty());
+}
+
+TEST(ColumnFunctionality, Size) {
+  Column<int64_t> c;
+  EXPECT_EQ(c.size(), 0);
+
+  c.push_back(1);
+  c.push_back(2);
+  c.push_back(3);
+  EXPECT_EQ(c.size(), 3);
+}
+
+TEST(ColumnFunctionality, EmplaceBack) {
+  Column<Foo> c;
+  Foo f(123, 456);
+  c.emplace_back(123, 456);
+
+  ASSERT_EQ(c.size(), 1);
+  EXPECT_EQ(c.at(0), f);
+}
+
+TEST(ColumnFunctionality, ComparisonOperators) {
+  Column<int64_t> c1{1, 2, 3};
+  Column<int64_t> c2{1, 2, 3};
+  Column<int64_t> c3{4, 5, 6};
+
+  EXPECT_EQ(c1, c2);
+  EXPECT_EQ(c2, c1);
+  EXPECT_NE(c1, c3);
+}

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -286,3 +286,17 @@ TEST(ColumnTest, ToColumn) {
   auto actual = c.toColumn<Foo>();
   EXPECT_EQ(expected, actual);
 }
+
+TEST(BinaryOpTest, Plus) {
+  Column<int64_t> c{1, 2, 3};
+  Column<int64_t> c2{4, 5, 6};
+  int64_t s = 10;
+
+  Column<int64_t> expectedC{5, 7, 9};
+  Column<int64_t> expectedS{11, 12, 13};
+  auto actualC = c + c2;
+  auto actualS = c + s;
+
+  EXPECT_EQ(expectedC, actualC);
+  EXPECT_EQ(expectedS, actualS);
+}

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -300,3 +300,45 @@ TEST(BinaryOpTest, Plus) {
   EXPECT_EQ(expectedC, actualC);
   EXPECT_EQ(expectedS, actualS);
 }
+
+TEST(BinaryOpTest, Minus) {
+  Column<int64_t> c{1, 2, 3};
+  Column<int64_t> c2{4, 5, 6};
+  int64_t s = 10;
+
+  Column<int64_t> expectedC{-3, -3, -3};
+  Column<int64_t> expectedS{-9, -8, -7};
+  auto actualC = c - c2;
+  auto actualS = c - s;
+
+  EXPECT_EQ(expectedC, actualC);
+  EXPECT_EQ(expectedS, actualS);
+}
+
+TEST(BinaryOpTest, Multiply) {
+  Column<int64_t> c{1, 2, 3};
+  Column<int64_t> c2{4, 5, 6};
+  int64_t s = 10;
+
+  Column<int64_t> expectedC{4, 10, 18};
+  Column<int64_t> expectedS{10, 20, 30};
+  auto actualC = c * c2;
+  auto actualS = c * s;
+
+  EXPECT_EQ(expectedC, actualC);
+  EXPECT_EQ(expectedS, actualS);
+}
+
+TEST(BinaryOpTest, Divide) {
+  Column<int64_t> c{100, 200, 300};
+  Column<int64_t> c2{10, 20, 30};
+  int64_t s = 100;
+
+  Column<int64_t> expectedC{10, 10, 10};
+  Column<int64_t> expectedS{1, 2, 3};
+  auto actualC = c / c2;
+  auto actualS = c / s;
+
+  EXPECT_EQ(expectedC, actualC);
+  EXPECT_EQ(expectedS, actualS);
+}

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -248,6 +248,14 @@ TEST(FunctionalTest, MapWith) {
   Column<int64_t> expected{4, 10, 18};
   auto actual = c1.mapWith(c2, [](int64_t a, int64_t b) { return a * b; });
   EXPECT_EQ(expected, actual);
+
+  c1.mapWithInPlace(c2, [](int64_t a, int64_t b) { return a + b + 1; });
+  Column<int64_t> expected2{6, 8, 10};
+  EXPECT_EQ(c1, expected2);
+
+  c2.mapWithScalarInPlace(100, [](int64_t a, int64_t b) { return b - a; });
+  Column<int64_t> expected3{96, 95, 94};
+  EXPECT_EQ(c2, expected3);
 }
 
 TEST(FunctionalTest, MapWithScalar) {

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -241,6 +241,24 @@ TEST(ColumnTest, Map) {
   EXPECT_EQ(foosExpected, foosActual);
 }
 
+TEST(FunctionalTest, MapWith) {
+  Column<int64_t> c1{1, 2, 3};
+  Column<int64_t> c2{4, 5, 6};
+
+  Column<int64_t> expected{4, 10, 18};
+  auto actual = c1.mapWith(c2, [](int64_t a, int64_t b) { return a * b; });
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(FunctionalTest, MapWithScalar) {
+  Column<int64_t> c1{1, 2, 3};
+  int64_t s = 10;
+
+  Column<int64_t> expected{10, 20, 30};
+  auto actual = c1.mapWithScalar(s, [](int64_t a, int64_t b) { return a * b; });
+  EXPECT_EQ(expected, actual);
+}
+
 TEST(ColumnTest, Reduce) {
   Column<int64_t> c{10, 20, 30};
   // Basic test

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -46,3 +46,20 @@ TEST(DataFrameTest, CheckType) {
   EXPECT_NO_THROW(DataFrame::checkType(string, string2));
   EXPECT_THROW(DataFrame::checkType(string, int64), BadTypeException);
 }
+
+TEST(DataFrameTest, DropColumn) {
+  DataFrame df;
+  std::vector<int64_t> vI{1, 2, 3};
+  std::vector<std::string> vS{"a", "b", "c"};
+
+  df.get<int64_t>("intCol") = vI;
+  Column cI(vI);
+  df.get<std::string>("stringCol") = vS;
+  Column cS(vS);
+
+  EXPECT_EQ(df.at<int64_t>("intCol"), cI);
+  EXPECT_EQ(df.at<std::string>("stringCol"), cS);
+
+  df.drop<int64_t>("intCol");
+  EXPECT_THROW(df.at<int64_t>("intCol"), std::out_of_range);
+}

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdexcept>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/common/Column.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+using namespace df;
+
+TEST(DataFrameTest, CreateBasicDataFrame) {
+  DataFrame df;
+  Column<int64_t> c1{1, 2, 3};
+  df.get<int64_t>("intCol1") = c1;
+
+  Column<int64_t> c2{4, 5, 6};
+  df.get<int64_t>("intCol2") = std::move(c2);
+
+  df.get<int64_t>("intCol3") = {7, 8, 9};
+
+  df.get<std::string>("stringCol") = {"a", "b", "c"};
+  df.get<std::vector<int64_t>>("intVecCol") = {{1, 2}, {3, 4}, {5, 6}};
+}
+
+TEST(DataFrameTest, MissingColumn) {
+  DataFrame df;
+  df.get<int64_t>("abc") = {1, 2, 3};
+  // Throw because we're accessing a missing column
+  EXPECT_THROW(df.at<int64_t>("def"), std::out_of_range);
+  // Throw because we're accessing the wrong type
+  EXPECT_THROW(df.at<std::string>("abc"), BadTypeException);
+}
+
+TEST(DataFrameTest, CheckType) {
+  DataFrame::TypeInfo string{std::type_index(typeid(std::string)), "string"};
+  DataFrame::TypeInfo int64{std::type_index(typeid(int64_t)), "int64_t"};
+  DataFrame::TypeInfo string2{std::type_index(typeid(std::string)), "string"};
+
+  EXPECT_NO_THROW(DataFrame::checkType(string, string2));
+  EXPECT_THROW(DataFrame::checkType(string, int64), BadTypeException);
+}


### PR DESCRIPTION
Summary:
# What
* `mapWithInPlace` and `mapWithScalarInPlace` to complement `mapWith` and `mapWithScalar`
# Why
* These will be useful for implementing methods like `operator+=` similar to how we did `operator+` using `mapWith`

Differential Revision: D31889981

