### PR TITLE
Add method to query keys in a dataframe

### DIFF
--- a/fbpcs/emp_games/lift/common/CsvReader.cpp
+++ b/fbpcs/emp_games/lift/common/CsvReader.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/lift/common/CsvReader.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "fbpcf/io/FileManagerUtil.h"
+
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace df {
+namespace detail {
+std::vector<std::string> split(const std::string &s) {
+  std::vector<std::string> res;
+  std::size_t i = 0;
+  while (i < s.size()) {
+    std::size_t lastStart = i;
+
+    // Look for the end of this token
+    if (s.at(i) == '[') {
+      // Intentionally no size check
+      // if we don't find ']', the string is malformed
+      // NOTE: Nested brackets are undefined behavior
+      while (s.at(i) != ']') {
+        ++i;
+      }
+      // Since we *do* want to include the ']' character in our parsing,
+      // we advance i one more now
+      ++i;
+    } else {
+      while (i < s.size() && s.at(i) != ',') {
+        ++i;
+      }
+    }
+    res.push_back(s.substr(lastStart, i - lastStart));
+    // Increment i so we're at the next valid character
+    ++i;
+  }
+  return res;
+}
+} // namespace detail
+
+CsvReader::CsvReader(const std::string &filePath) {
+  auto infilePtr = fbpcf::io::getInputStream(filePath);
+  auto &infile = infilePtr->get();
+  if (!infile.good()) {
+    throw CsvFileReadException{filePath};
+  }
+
+  std::string line;
+  std::getline(infile, line);
+  header_ = detail::split(line);
+
+  while (std::getline(infile, line)) {
+    auto nextRow = detail::split(line);
+    if (header_.size() != nextRow.size()) {
+      throw RowLengthMismatch{header_.size(), nextRow.size()};
+    }
+    rows_.push_back(std::move(nextRow));
+  }
+}
+} // namespace df

--- a/fbpcs/emp_games/lift/common/CsvReader.h
+++ b/fbpcs/emp_games/lift/common/CsvReader.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace df {
+namespace detail {
+std::vector<std::string> split(const std::string &s);
+} // namespace detail
+
+/**
+ * Represents an error that a parsed row has a different length than the header.
+ */
+class RowLengthMismatch : public std::exception {
+public:
+  /**
+   * Construct a new RowLengthMismatch error indicating that a parsed row has
+   * a different length than the previously parsed header.
+   *
+   * @param headerSize the number of elements in the header
+   * @param rowSize the number of elements in the newly parsed row
+   */
+  RowLengthMismatch(std::size_t headerSize, std::size_t rowSize) {
+    msg_ = "Header has size " + std::to_string(headerSize) +
+           " while row has size " + std::to_string(rowSize);
+  }
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+private:
+  std::string msg_;
+};
+
+class CsvFileReadException : public std::exception {
+public:
+  explicit CsvFileReadException(const std::string &filePath) {
+    msg_ = "Failed to read file '" + filePath + "'";
+  }
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+private:
+  std::string msg_;
+};
+
+class CsvReader {
+public:
+  explicit CsvReader(const std::string &filePath);
+
+  const std::vector<std::string> &getHeader() const { return header_; }
+
+  std::vector<std::string> &getHeader() {
+    return const_cast<std::vector<std::string> &>(
+        const_cast<const CsvReader &>(*this).getHeader());
+  }
+
+  const std::vector<std::vector<std::string>> &getRows() const { return rows_; }
+
+  std::vector<std::vector<std::string>> &getRows() {
+    return const_cast<std::vector<std::vector<std::string>> &>(
+        const_cast<const CsvReader &>(*this).getRows());
+  }
+
+private:
+  std::vector<std::string> header_;
+  std::vector<std::vector<std::string>> rows_;
+};
+} // namespace df

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -13,6 +13,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "fbpcs/emp_games/lift/common/Column.h"
@@ -52,6 +53,25 @@ public:
     if (expected.first != actual.first) {
       throw BadTypeException{expected.second, actual.second};
     }
+  }
+
+  std::unordered_set<std::string> keys() const {
+    std::unordered_set<std::string> res;
+    for (const auto &[typ, _] : types_) {
+      res.insert(typ);
+    }
+    return res;
+  }
+
+  template <typename T> std::unordered_set<std::string> keysOf() const {
+    std::unordered_set<std::string> res;
+    auto target = std::type_index(typeid(T));
+    for (const auto &[typ, info] : types_) {
+      if (info.first == target) {
+        res.insert(typ);
+      }
+    }
+    return res;
   }
 
   template <typename T> const Column<T> &get(const std::string &key) const {

--- a/fbpcs/emp_games/lift/common/test/CsvReaderTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/CsvReaderTest.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/common/CsvReader.h"
+
+using namespace df;
+
+TEST(CsvReaderDetail, Split) {
+  std::vector<std::string> expected{"123", "456", "789"};
+  EXPECT_EQ(expected, detail::split("123,456,789"));
+
+  std::vector<std::string> expected2{"[1,2,3]", "456", "789"};
+  EXPECT_EQ(expected2, detail::split("[1,2,3],456,789"));
+
+  std::vector<std::string> expected3{"[1,2,3]", "[4,5,6]", "789"};
+  EXPECT_EQ(expected3, detail::split("[1,2,3],[4,5,6],789"));
+
+  std::vector<std::string> expected4{"[1,2,3,4,5,6,7,8,9]"};
+  EXPECT_EQ(expected4, detail::split("[1,2,3,4,5,6,7,8,9]"));
+
+  // Missing trailing ']'
+  EXPECT_THROW(detail::split("[1,2,3,4,5,6,7,8,9"), std::out_of_range);
+}

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -62,4 +63,30 @@ TEST(DataFrameTest, DropColumn) {
 
   df.drop<int64_t>("intCol");
   EXPECT_THROW(df.at<int64_t>("intCol"), std::out_of_range);
+}
+
+TEST(DataFrameTest, Keys) {
+  DataFrame df;
+  df.get<std::string>("bool1") = {"true", "false"};
+  df.get<std::string>("bool2") = {"1", "0"};
+  df.get<std::string>("int1") = {"123", "111"};
+  df.get<std::string>("int2") = {"456", "222"};
+  df.get<std::string>("intVec") = {"[7,8,9]", "[333]"};
+
+  std::unordered_set<std::string> allKeys{"bool1", "bool2", "int1", "int2",
+                                          "intVec"};
+  EXPECT_EQ(allKeys, df.keys());
+  EXPECT_EQ(allKeys, df.keysOf<std::string>());
+
+  DataFrame df2;
+  df2.get<bool>("bool1") = {true, false};
+  df2.get<bool>("bool2") = {true, false};
+  df2.get<int64_t>("int1") = {123, 111};
+  df2.get<int64_t>("int2") = {456, 222};
+  df2.get<std::vector<int64_t>>("intVec") = {{7, 8, 9}, {333}};
+
+  EXPECT_EQ(allKeys, df2.keys());
+
+  std::unordered_set<std::string> boolKeys{"bool1", "bool2"};
+  EXPECT_EQ(boolKeys, df2.keysOf<bool>());
 }


### PR DESCRIPTION
Summary:
# What
* `keys()` and `keysOf<T>()` for `DataFrame`
# Why
* I found this to be really useful when debugging

Differential Revision: D31910468

