### PR TITLE
Update container service API and the API consumers

### DIFF
--- a/fbpcs/common/util/wait_for_containers.py
+++ b/fbpcs/common/util/wait_for_containers.py
@@ -30,6 +30,8 @@ async def wait_for_containers_async(
         while status not in end_states:
             await asyncio.sleep(poll)
             container = onedocker_svc.get_containers([instance_id])[0]
+            if not container:
+                break
             status = container.status
             updated_containers[i] = container
         if status is not ContainerInstanceStatus.COMPLETED:

--- a/fbpcs/data_processing/attribution_id_combiner/attribution_id_spine_combiner_cpp.py
+++ b/fbpcs/data_processing/attribution_id_combiner/attribution_id_spine_combiner_cpp.py
@@ -120,6 +120,7 @@ class CppAttributionIdSpineCombinerService:
         # Busy wait until all containers are finished
         any_failed = False
         for shard, container in enumerate(containers):
+            container_id = container.instance_id
             # Busy wait until the container is finished
             status = ContainerInstanceStatus.UNKNOWN
             logger.info(f"Task[{shard}] started, waiting for completion")
@@ -127,11 +128,16 @@ class CppAttributionIdSpineCombinerService:
                 ContainerInstanceStatus.FAILED,
                 ContainerInstanceStatus.COMPLETED,
             ]:
-                container = onedocker_svc.get_containers([container.instance_id])[0]
+                container = onedocker_svc.get_containers([container_id])[0]
+                if not container:
+                    break
                 status = container.status
                 # Sleep 5 seconds between calls to avoid an unintentional DDoS
                 logger.debug(f"Latest status: {status}")
                 await asyncio.sleep(5)
+
+            if not container:
+                continue
             logger.info(
                 f"container_id({container.instance_id}) finished with status: {status}"
             )

--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -138,7 +138,9 @@ class PIDService:
             containers = instance.stages_containers.get(stage, None)
             if containers:
                 container_ids = [container.instance_id for container in containers]
-                containers = self.onedocker_svc.get_containers(container_ids)
+                containers = list(
+                    filter(None, self.onedocker_svc.get_containers(container_ids))
+                )
                 new_stage_status = PIDStage.get_stage_status_from_containers(containers)
                 if new_stage_status is PIDStageStatus.FAILED:
                     instance.status = PIDInstanceStatus.FAILED


### PR DESCRIPTION
Summary:
Update the abstract base method `get_instances(ids)` to return `List[Optional[ContainerInstances]]`
and all downstream consumer code to update to the new API,
while keeping all previous functionalities as of now (e.g. filter out possible `None`s to match old type)

Differential Revision: D31910817

