### PR TITLE
fix config.yml

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -321,10 +321,6 @@ deploy_aws_resources() {
     sed -i "s/task_definition: TODO_ONEDOCKER_TASK_DEFINITION/task_definition: $onedocker_task_definition/g" config.yml
     echo "Populated Onedocker - task_definition with value $onedocker_task_definition"
 
-    sed -i "/access_key_id/d" config.yml
-    sed -i "/access_key_data/d" config.yml
-    echo "Removed the credential lines"
-
     echo "########################Upload config.ymls to S3########################"
     cd /terraform_deployment
     aws s3api put-object --bucket "$s3_bucket_for_storage" --key "config.yml" --body ./config.yml


### PR DESCRIPTION
Summary:
`config.yml` was broken: (gorel's comment in https://fb.workplace.com/groups/331044242148818/permalink/351261806793728/)

We should not remove the credential lines. Although this short-term fix could unblock advertisers, but it's not automated (advertisers need to manually key in/updates the credential)

**Next**

update PL/PA playbook for advertisers, and advertiser onboarding docs with ashishkharbanda

Differential Revision: D31915663

