### PR TITLE
Make config and data storage and semi-automatic pipeline arguments optional

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -93,11 +93,11 @@ public class DeploymentParams {
   }
 
   public boolean validConfigStorage() {
-    return validBucketID(configStorage);
+    return configStorage == null || validBucketID(configStorage);
   }
 
   public boolean validDataStorage() {
-    return validBucketID(dataStorage);
+    return dataStorage == null || validBucketID(dataStorage);
   }
 
   // Amazon S3 Buck identifier format can be found in

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -93,12 +93,16 @@ public class DeploymentRunner extends Thread {
     deployCommand.add(deployment.pubAccountId);
     deployCommand.add("-v");
     deployCommand.add(deployment.vpcId);
-    deployCommand.add("-s");
-    deployCommand.add(deployment.configStorage);
-    deployCommand.add("-d");
-    deployCommand.add(deployment.dataStorage);
     deployCommand.add("-t");
     deployCommand.add(deployment.tag);
+    if (deployment.configStorage != null) {
+      deployCommand.add("-s");
+      deployCommand.add(deployment.configStorage);
+    }
+    if (deployment.dataStorage != null) {
+      deployCommand.add("-d");
+      deployCommand.add(deployment.dataStorage);
+    }
     if (deployment.enableSemiAutomatedDataIngestion) {
       deployCommand.add("-b");
     }
@@ -174,7 +178,9 @@ public class DeploymentRunner extends Thread {
       throw new DeploymentException("Deployment could not be started");
     } finally {
       deploymentState = DeploymentState.STATE_FINISHED;
-      if (provisioningProcess.isAlive()) provisioningProcess.destroy();
+      if (provisioningProcess != null && provisioningProcess.isAlive()) {
+        provisioningProcess.destroy();
+      }
       provisioningProcess = null;
       logger.info("  Deployment finished");
 


### PR DESCRIPTION
Summary:
There are sane defaults for config storage and data storage, and also for enabling the
semi-automatic data pipeline. So it is safe to disable those flags and make them optional

Differential Revision: D31856135

