### PR TITLE
fixe path to call util.sh

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -6,8 +6,8 @@
 
 set -e
 # shellcheck disable=SC1091
-source ./util.sh
-
+# shellcheck disable=SC1090
+source "$(dirname "$(realpath "$0")")/util.sh"
 usage() {
     echo "Usage: deploy.sh <deploy|undeploy>
         [ -r, --region | AWS region, e.g. us-west-2 ]


### PR DESCRIPTION
Summary:
See T103952189 for more details.

If we call deploy for /bin/sh /terraform_script, then we have
```
/ # /bin/sh /terraform_deployment/deploy.sh deploy -r us-west-2 -t "e2e-test-anthony1" -a 592513842793 -p 539290649537 -v vpc-0
36652587a2d1839c -b
/terraform_deployment/deploy.sh: source: line 9: can't open './util.sh': No such file or directory
```

Differential Revision: D31930926

