### PR TITLE
Load --from config only if not None

### DIFF
--- a/fbpcs/scripts/gen_config.py
+++ b/fbpcs/scripts/gen_config.py
@@ -98,7 +98,7 @@ def update_dict(
 def gen_config(args: Dict[str, Any]) -> None:
     config = yaml.load(args["<input_path>"])
     replacements = {}
-    if "--from" in args:
+    if "--from" in args and args["--from"] is not None:
         other_config = yaml.load(args["--from"])
         replacements = build_replacements_from_config(other_config)
     update_dict(config, args["--replace"], replacements, args["--accept_all"])


### PR DESCRIPTION
Summary:
Currently, `gen_config` set `None` as a default value for `--from` argument which causes an error because we cannot open a None config file.

```
[supasate@devvm1633]~/fbsource/fbcode/fbpcs% buck run :gen_config ./config.yml
Downloaded 1/1 artifacts, 5.24 Kbytes, 0.0% cache miss (for updated rules)
Building: finished in 0.4 sec (100%) 32/32 jobs, 1/32 updated
  Total time: 0.5 sec
BUILD SUCCEEDED
Traceback (most recent call last):
  File "<string>", line 49, in <module>
  File "<string>", line 47, in __run
  File "/usr/local/fbcode/platform009/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/fbcode/platform009/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/data/users/supasate/fbsource/fbcode/buck-out/dev/gen/aab7ed39/fbpcs/gen_config#link-tree/fbpcs/scripts/gen_config.py", line 129, in <module>
    main()
  File "/data/users/supasate/fbsource/fbcode/buck-out/dev/gen/aab7ed39/fbpcs/gen_config#link-tree/fbpcs/scripts/gen_config.py", line 125, in main
    gen_config(args)
  File "/data/users/supasate/fbsource/fbcode/buck-out/dev/gen/aab7ed39/fbpcs/gen_config#link-tree/fbpcs/scripts/gen_config.py", line 102, in gen_config
    other_config = yaml.load(args["--from"])
  File "/data/users/supasate/fbsource/fbcode/buck-out/dev/gen/aab7ed39/fbpcs/gen_config#link-tree/fbpcp/util/yaml.py", line 16, in load
    with open(file_path) as stream:
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This diff fixes this error by validating that `--from` is not None.

Reviewed By: gorel

Differential Revision: D31918303

