### PR TITLE
pid instance update time

### DIFF
--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-from fbpcs.private_computation.entity.private_computation_instance import PrivateComputationInstanceStatus
 from typing import Any, Dict, List, Optional
 
 from fbpcs.pid.entity.pid_instance import PIDInstance
@@ -14,6 +13,9 @@ from fbpcs.pid.entity.pid_instance import PIDInstanceStatus, PIDProtocol, PIDRol
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
@@ -86,17 +88,16 @@ class IdMatchStageService(PrivateComputationStageService):
             hmac_key=pc_instance.hmac_key,
         )
 
-        # Push PID instance to PrivateComputationInstance.instances and update PL Instance status
-        pid_instance.status = PIDInstanceStatus.STARTED
-        pc_instance.instances.append(pid_instance)
-
         # Run pid
-        await self._pid_svc.run_instance(
+        pid_instance = await self._pid_svc.run_instance(
             instance_id=pid_instance_id,
             pid_config=self._pid_config,
             fail_fast=pc_instance.fail_fast,
             server_ips=server_ips,
         )
+
+        # Push PID instance to PrivateComputationInstance.instances
+        pc_instance.instances.append(pid_instance)
 
         return pc_instance
 

--- a/fbpcs/private_computation/test/service/test_id_match_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_match_stage_service.py
@@ -4,19 +4,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.private_computation.service.id_match_stage_service import IdMatchStageService
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from fbpcs.pid.entity.pid_instance import PIDInstance, PIDInstanceStatus
+from fbpcs.pid.entity.pid_instance import PIDProtocol, PIDRole
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationRole,
 )
-from unittest.mock import AsyncMock, MagicMock, patch
-from fbpcs.pid.entity.pid_instance import PIDInstance, PIDInstanceStatus
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.pid.entity.pid_instance import PIDProtocol, PIDRole
+from fbpcs.private_computation.service.id_match_stage_service import IdMatchStageService
 
 
 class TestIdMatchStageService(IsolatedAsyncioTestCase):
@@ -47,8 +48,7 @@ class TestIdMatchStageService(IsolatedAsyncioTestCase):
             status=PIDInstanceStatus.STARTED,
         )
 
-        pid_svc_mock.create_instance = MagicMock(return_value=pid_instance)
-        pid_svc_mock.run_instance = AsyncMock()
+        pid_svc_mock.run_instance = AsyncMock(return_value=pid_instance)
 
         stage_svc = IdMatchStageService(
             pid_svc_mock,


### PR DESCRIPTION
Summary:
I was told that the get_server_ips command didn't work for the id match stage. It returns nothing. I did some investigation and found that if you call the get_instance command before get_server_ips, then get_server_ips works fine. It was only a problem with the id match stage, not the other stages.

I think I found why. `self._pid_svc.run_instance` actually returns a pid instance with server_ips, but we didn't save it.

Differential Revision: D31946920

