### PR TITLE
Fix issue with status command not properly returning end states

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -98,6 +98,7 @@ public class DeployController {
       return new APIReturn(APIReturn.Status.STATUS_SUCCESS, NO_UPDATES_MESSAGE);
     }
 
+    String output = runner.getOutput();
     DeploymentRunner.DeploymentState state = runner.getDeploymentState();
 
     ObjectMapper mapper = new ObjectMapper();
@@ -106,7 +107,7 @@ public class DeployController {
     if (state == DeploymentRunner.DeploymentState.STATE_FINISHED)
       rootNode.put("exitValue", runner.getExitValue());
 
-    return new APIReturn(APIReturn.Status.STATUS_SUCCESS, runner.getOutput(), rootNode);
+    return new APIReturn(APIReturn.Status.STATUS_SUCCESS, output, rootNode);
   }
 
   @GetMapping(path = "/v1/deployment/logs")


### PR DESCRIPTION
Summary:
There was an issue where once a process stopped running its final logs could be discarded by the cleanup work.
It was caused if there were no calls to get the logs just before the process finished.

Differential Revision: D31957781

