### PR TITLE
Fix input parsing and breakdown output for S249300

### DIFF
--- a/fbpcs/emp_games/lift/calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/InputData.cpp
@@ -171,21 +171,21 @@ void InputData::addFromCSV(
     }
 
     if (column == "opportunity") {
+      sawOppFlag = true;
       if (sawTestFlag) {
         testPopulation_.push_back(parsed & storedTestFlag ? 1 : 0);
         controlPopulation_.push_back(
             (parsed & ((!storedTestFlag) ? 1 : 0)) ? 1 : 0);
       } else {
         storedOpportunityFlag = parsed;
-        sawOppFlag = true;
       }
     } else if (column == "test_flag") {
+      sawTestFlag = true;
       if (sawOppFlag) {
         testPopulation_.push_back(parsed & storedOpportunityFlag ? 1 : 0);
         controlPopulation_.push_back((!parsed) & storedOpportunityFlag ? 1 : 0);
       } else {
         storedTestFlag = parsed;
-        sawTestFlag = true;
       }
     } else if (column == "opportunity_timestamp") {
       // secret-share-lift can have negative input timestamps

--- a/fbpcs/emp_games/lift/calculator/OutputMetrics.hpp
+++ b/fbpcs/emp_games/lift/calculator/OutputMetrics.hpp
@@ -152,6 +152,9 @@ template <int32_t MY_ROLE> std::string OutputMetrics<MY_ROLE>::toJson() const {
   std::transform(cohortMetrics_.begin(), cohortMetrics_.end(),
                  std::back_inserter(groupedLiftMetrics.cohortMetrics),
                  [](auto const &p) { return p.second.toLiftMetrics(); });
+  std::transform(publisherBreakdowns_.begin(), publisherBreakdowns_.end(),
+                 std::back_inserter(groupedLiftMetrics.publisherBreakdowns),
+                 [](auto const &p) { return p.second.toLiftMetrics(); });
   return groupedLiftMetrics.toJson();
 }
 


### PR DESCRIPTION
Summary:
## What happened?
Input parsing in Lift MPC was broken due to bad parsing logic around assuming `opportunity` would always be present *after* the `test_flag` column. Note that we didn't *intentionally* write code to assume this ordering, it's just due to logic being piled into InputData.cpp over time and eventually breaking once we started adding columns after `opportunity` (precisely, `breakdown_id` now occurs as the last column).

Additionally, `publisherBreakdowns_` wasn't being output from Lift MPC due to a missing `std::transform` in `OutputMetrics<T>::toJson`; this wasn't contributing to the *wrong* metrics the advertiser was seeing, but it did mean a large section of output was simply missing.

## More details - how did this break MPC?
We parse columns in InputData.cpp and these get converted to `emp::Integer` or `emp::Bit` types in MPC. Due to a bug involving us allowing the `opportunity` column to be optional (a relic from the early days of Private Lift), if the `sawOppFlag` boolean value was not set after parsing the last column, we would append to the population vectors... *unfortunately*, there was a bug: we only set `sawOppFlag` to true if we had *not* yet seen the test_flag. In practice, our S3 uploader always uploaded `test_flag` before `opportunity` (which is actually only populated in the id_spine_combiner stage), which meant `sawOppFlag` would **never** be set.

## Follow-up
This will go into the SEV, but we have a few follow-ups:
1. Write tests that randomize ordering of columns and ensure appropriate output
2. Clean up InputData processing; it's ridiculously complex now and extension is nearly impossible. I'll note that my BE plan for [Improving Lift MPC](https://fb.quip.com/C5IUANtjyANq) would have actually solved this :(
3. More generally, the Lift MPC code is really hard to test. ~5 hours have been spent investigating a simple parsing bug.
4. Add a test that checks for appropriate breakdown_id support downstream

Differential Revision: D31973728

