### PR TITLE
Temporarily remove population counts

### DIFF
--- a/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
@@ -20,8 +20,6 @@ namespace private_lift {
  * Simple struct representing the metrics in a Lift computation
  */
 struct OutputMetricsData {
-  int64_t testPopulation = 0;
-  int64_t controlPopulation = 0;
   int64_t testEvents = 0;
   int64_t controlEvents = 0;
   int64_t testConverters = 0;
@@ -34,16 +32,6 @@ struct OutputMetricsData {
   int64_t controlNumConvSquared = 0;
   int64_t testMatchCount = 0;
   int64_t controlMatchCount = 0;
-  int64_t testImpressions = 0;
-  int64_t controlImpressions = 0;
-  int64_t testClicks = 0;
-  int64_t controlClicks = 0;
-  int64_t testSpend = 0;
-  int64_t controlSpend = 0;
-  int64_t testReach = 0;
-  int64_t controlReach = 0;
-  int64_t testClickers = 0;
-  int64_t controlClickers = 0;
   int64_t reachedConversions = 0;
   int64_t reachedValue = 0;
   std::vector<int64_t> testConvHistogram;
@@ -71,20 +59,8 @@ struct OutputMetricsData {
     os << "Control Value Squared: " << out.controlValueSquared << "\n";
     os << "Test NumConv Squared: " << out.testNumConvSquared << "\n";
     os << "Control NumConv Squared: " << out.controlNumConvSquared << "\n";
-    os << "Test Population: " << out.testPopulation << "\n";
-    os << "Control Population: " << out.controlPopulation << "\n";
     os << "Test Match Count: " << out.testMatchCount << "\n";
     os << "Control Match Count: " << out.controlMatchCount << "\n";
-    os << "Test Impressions: " << out.testImpressions << "\n";
-    os << "Control Impressions: " << out.controlImpressions << "\n";
-    os << "Test Clicks: " << out.testClicks << "\n";
-    os << "Control Clicks: " << out.controlClicks << "\n";
-    os << "Test Spend: " << out.testSpend << "\n";
-    os << "Control Spend: " << out.controlSpend << "\n";
-    os << "Test Reach: " << out.testReach << "\n";
-    os << "Control Reach: " << out.controlReach << "\n";
-    os << "Test Clickers: " << out.testClickers << "\n";
-    os << "Control Clickers: " << out.controlClickers << "\n";
     os << "Reached Conversions: " << out.reachedConversions << "\n";
     os << "Reached Value: " << out.reachedValue << "\n";
     os << "Test Conversion histogram: " << folly::join(',', out.testConvHistogram) << "\n";
@@ -99,8 +75,6 @@ struct OutputMetricsData {
   // aggregator
   LiftMetrics toLiftMetrics() const {
     LiftMetrics metrics{};
-    metrics.testPopulation = testPopulation;
-    metrics.controlPopulation = controlPopulation;
     metrics.testConversions = testEvents;
     metrics.controlConversions = controlEvents;
     metrics.testConverters = testConverters;
@@ -113,16 +87,6 @@ struct OutputMetricsData {
     metrics.controlNumConvSquared = controlNumConvSquared;
     metrics.testMatchCount = testMatchCount;
     metrics.controlMatchCount = controlMatchCount;
-    metrics.testImpressions = testImpressions;
-    metrics.controlImpressions = controlImpressions;
-    metrics.testClicks = testClicks;
-    metrics.controlClicks = controlClicks;
-    metrics.testSpend = testSpend;
-    metrics.controlSpend = controlSpend;
-    metrics.testReach = testReach;
-    metrics.controlReach = controlReach;
-    metrics.testClickers = testClickers;
-    metrics.controlClickers = controlClickers;
     metrics.reachedConversions = reachedConversions;
     metrics.reachedValue = reachedValue;
     metrics.testConvHistogram = testConvHistogram;

--- a/fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp
@@ -71,8 +71,6 @@ OutputMetricsData LiftCalculator::compute(
   std::string linePartner;
 
   // Initialize field values from OutputMetricsData
-  out.testPopulation = 0;
-  out.controlPopulation = 0;
   out.testEvents = 0;
   out.controlEvents = 0;
   out.testConverters = 0;
@@ -85,16 +83,6 @@ OutputMetricsData LiftCalculator::compute(
   out.controlNumConvSquared = 0;
   out.testMatchCount = 0;
   out.controlMatchCount = 0;
-  out.testImpressions = 0;
-  out.controlImpressions = 0;
-  out.testClicks = 0;
-  out.controlClicks = 0;
-  out.testSpend = 0;
-  out.controlSpend = 0;
-  out.testReach = 0;
-  out.controlReach = 0;
-  out.testClickers = 0;
-  out.controlClickers = 0;
   out.reachedConversions = 0;
   out.reachedValue = 0;
 
@@ -195,7 +183,6 @@ OutputMetricsData LiftCalculator::compute(
       bool converted = false;
       bool countedMatchAlready = false;
       if (testFlag) {
-        ++out.testPopulation;
 
         for (auto i = 0; i < eventTimestamps.size(); ++i) {
           if (opportunityTimestamp > 0 && eventTimestamps.at(i) > 0 &&
@@ -227,14 +214,8 @@ OutputMetricsData LiftCalculator::compute(
         }
         out.testValueSquared += value_subsum * value_subsum;
         out.testNumConvSquared += convCount * convCount;
-        out.testImpressions += numImpressions;
-        out.testClicks += numClicks;
-        out.testSpend += totalSpend;
-        out.testReach += (numImpressions > 0 ? 1 : 0);
-        out.testClickers += (numClicks > 0 ? 1 : 0);
         ++out.testConvHistogram[convCount];
       } else {
-        ++out.controlPopulation;
         for (auto i = 0; i < eventTimestamps.size(); ++i) {
           if (opportunityTimestamp > 0 && eventTimestamps.at(i) > 0 &&
               !countedMatchAlready) {
@@ -259,11 +240,6 @@ OutputMetricsData LiftCalculator::compute(
         out.controlValue += value_subsum;
         out.controlValueSquared += value_subsum * value_subsum;
         out.controlNumConvSquared += convCount * convCount;
-        out.controlImpressions += numImpressions;
-        out.controlClicks += numClicks;
-        out.controlSpend += totalSpend;
-        out.controlReach += (numImpressions > 0 ? 1 : 0);
-        out.controlClickers += (numClicks > 0 ? 1 : 0);
         ++out.controlConvHistogram[convCount];
       }
     }

--- a/fbpcs/emp_games/lift/calculator/test/tool/ComputeLift.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/tool/ComputeLift.cpp
@@ -65,10 +65,6 @@ int main(int argc, char** argv) {
       inFilePublisher, inFilePartner, colNameToIndex, tsOffset);
 
   // Output results
-  XLOG(INFO) << std::setw(20) << "test_population: " << std::setw(12)
-             << out.testPopulation;
-  XLOG(INFO) << std::setw(20) << "control_population: " << std::setw(12)
-             << out.controlPopulation;
   XLOG(INFO) << std::setw(20) << "test_event: " << std::setw(12)
              << out.testEvents;
   XLOG(INFO) << std::setw(20) << "control_event: " << std::setw(12)

--- a/fbpcs/emp_games/lift/common/LiftMetrics.cpp
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.cpp
@@ -18,9 +18,7 @@
 
 namespace private_lift {
 bool LiftMetrics::operator==(const LiftMetrics& other) const noexcept {
-  return testPopulation == other.testPopulation &&
-      controlPopulation == other.controlPopulation &&
-      testConversions == other.testConversions &&
+  return testConversions == other.testConversions &&
       controlConversions == other.controlConversions &&
       testConverters == other.testConverters &&
       controlConverters == other.controlConverters &&
@@ -31,13 +29,6 @@ bool LiftMetrics::operator==(const LiftMetrics& other) const noexcept {
       controlNumConvSquared == other.controlNumConvSquared &&
       testMatchCount == other.testMatchCount &&
       controlMatchCount == other.controlMatchCount &&
-      testImpressions == other.testImpressions &&
-      controlImpressions == other.controlImpressions &&
-      testClicks == other.testClicks && controlClicks == other.controlClicks &&
-      testSpend == other.testSpend && controlSpend == other.controlSpend &&
-      testReach == other.testReach && controlReach == other.controlReach &&
-      testClickers == other.testClickers &&
-      controlClickers == other.controlClickers &&
       reachedConversions == other.reachedConversions &&
       reachedValue == other.reachedValue &&
       testConvHistogram == other.testConvHistogram &&
@@ -69,8 +60,6 @@ LiftMetrics LiftMetrics::operator+(const LiftMetrics& other) const noexcept {
   }
 
   return LiftMetrics{
-      testPopulation + other.testPopulation,
-      controlPopulation + other.controlPopulation,
       testConversions + other.testConversions,
       controlConversions + other.controlConversions,
       testConverters + other.testConverters,
@@ -83,16 +72,6 @@ LiftMetrics LiftMetrics::operator+(const LiftMetrics& other) const noexcept {
       controlNumConvSquared + other.controlNumConvSquared,
       testMatchCount + other.testMatchCount,
       controlMatchCount + other.controlMatchCount,
-      testImpressions + other.testImpressions,
-      controlImpressions + other.controlImpressions,
-      testClicks + other.testClicks,
-      controlClicks + other.controlClicks,
-      testSpend + other.testSpend,
-      controlSpend + other.controlSpend,
-      testReach + other.testReach,
-      controlReach + other.controlReach,
-      testClickers + other.testClickers,
-      controlClickers + other.controlClickers,
       reachedConversions + other.reachedConversions,
       reachedValue + other.reachedValue,
       addedTestConvHistogram,
@@ -125,8 +104,6 @@ LiftMetrics LiftMetrics::operator^(const LiftMetrics& other) const noexcept {
   }
 
   return LiftMetrics{
-      testPopulation ^ other.testPopulation,
-      controlPopulation ^ other.controlPopulation,
       testConversions ^ other.testConversions,
       controlConversions ^ other.controlConversions,
       testConverters ^ other.testConverters,
@@ -139,16 +116,6 @@ LiftMetrics LiftMetrics::operator^(const LiftMetrics& other) const noexcept {
       controlNumConvSquared ^ other.controlNumConvSquared,
       testMatchCount ^ other.testMatchCount,
       controlMatchCount ^ other.controlMatchCount,
-      testImpressions ^ other.testImpressions,
-      controlImpressions ^ other.controlImpressions,
-      testClicks ^ other.testClicks,
-      controlClicks ^ other.controlClicks,
-      testSpend ^ other.testSpend,
-      controlSpend ^ other.controlSpend,
-      testReach ^ other.testReach,
-      controlReach ^ other.controlReach,
-      testClickers ^ other.testClickers,
-      controlClickers ^ other.controlClickers,
       reachedConversions ^ other.reachedConversions,
       reachedValue ^ other.reachedValue,
       xoredTestConvHistogram,
@@ -176,8 +143,6 @@ folly::dynamic LiftMetrics::toDynamic() const {
       folly::dynamic(controlConvHistogram.begin(), controlConvHistogram.end());
 
   return folly::dynamic::object(
-      "testPopulation", testPopulation)(
-      "controlPopulation", controlPopulation)(
       "testConversions", testConversions)(
       "controlConversions", controlConversions)(
       "testConverters", testConverters)(
@@ -190,16 +155,6 @@ folly::dynamic LiftMetrics::toDynamic() const {
       "controlNumConvSquared", controlNumConvSquared)(
       "testMatchCount", testMatchCount)(
       "controlMatchCount", controlMatchCount)(
-      "testImpressions", testImpressions)(
-      "controlImpressions", controlImpressions)(
-      "testClicks", testClicks)(
-      "controlClicks", controlClicks)(
-      "testSpend", testSpend)(
-      "controlSpend", controlSpend)(
-      "testReach", testReach)(
-      "controlReach", controlReach)(
-      "testClickers", testClickers)(
-      "controlClickers", controlClickers)(
       "reachedConversions", reachedConversions)(
       "reachedValue", reachedValue)(
       "testConvHistogram", testConvHistogramDynamic)(
@@ -211,8 +166,6 @@ LiftMetrics LiftMetrics::fromDynamic(const folly::dynamic& obj) {
   std::vector<int64_t> testConvHistogram;
   std::vector<int64_t> controlConvHistogram;
 
-  metrics.testPopulation = obj["testPopulation"].asInt();
-  metrics.controlPopulation = obj["controlPopulation"].asInt();
   metrics.testConversions = obj["testConversions"].asInt();
   metrics.controlConversions = obj["controlConversions"].asInt();
   metrics.testConverters = obj["testConverters"].asInt();
@@ -225,16 +178,6 @@ LiftMetrics LiftMetrics::fromDynamic(const folly::dynamic& obj) {
   metrics.controlNumConvSquared = obj["controlNumConvSquared"].asInt();
   metrics.testMatchCount = obj["testMatchCount"].asInt();
   metrics.controlMatchCount = obj["controlMatchCount"].asInt();
-  metrics.testImpressions = obj["testImpressions"].asInt();
-  metrics.controlImpressions = obj["controlImpressions"].asInt();
-  metrics.testClicks = obj["testClicks"].asInt();
-  metrics.controlClicks = obj["controlClicks"].asInt();
-  metrics.testSpend = obj["testSpend"].asInt();
-  metrics.controlSpend = obj["controlSpend"].asInt();
-  metrics.testReach = obj["testReach"].asInt();
-  metrics.controlReach = obj["controlReach"].asInt();
-  metrics.testClickers = obj["testClickers"].asInt();
-  metrics.controlClickers = obj["controlClickers"].asInt();
   metrics.reachedConversions = obj["reachedConversions"].asInt();
   metrics.reachedValue = obj["reachedValue"].asInt();
 

--- a/fbpcs/emp_games/lift/common/LiftMetrics.h
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.h
@@ -17,8 +17,6 @@ namespace private_lift {
  * Simple struct representing the metrics in a Lift computation
  */
 struct LiftMetrics {
-  int64_t testPopulation;
-  int64_t controlPopulation;
   int64_t testConversions;
   int64_t controlConversions;
   int64_t testConverters;
@@ -31,16 +29,6 @@ struct LiftMetrics {
   int64_t controlNumConvSquared;
   int64_t testMatchCount;
   int64_t controlMatchCount;
-  int64_t testImpressions;
-  int64_t controlImpressions;
-  int64_t testClicks;
-  int64_t controlClicks;
-  int64_t testSpend;
-  int64_t controlSpend;
-  int64_t testReach;
-  int64_t controlReach;
-  int64_t testClickers;
-  int64_t controlClickers;
   int64_t reachedConversions;
   int64_t reachedValue;
   std::vector<int64_t> testConvHistogram;

--- a/fbpcs/emp_games/lift/common/test/GroupedLiftMetricsTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/GroupedLiftMetricsTest.cpp
@@ -17,7 +17,7 @@ class GroupedLiftMetricsTest : public ::testing::Test {
   LiftMetrics fakeLiftMetrics() {
     auto r = []() { return folly::Random::rand32(); };
     return LiftMetrics{r(), r(), r(), r(), r(), r(), r(), r(), r(), r(), r(),
-                       r(), r(), r(), r(), r(), r(), r(), r(), r(), r(), r()};
+                       r(), r(), r()};
   }
 
  protected:

--- a/fbpcs/emp_games/lift/common/test/LiftMetricsTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/LiftMetricsTest.cpp
@@ -17,7 +17,7 @@ class LiftMetricsTest : public ::testing::Test {
   LiftMetrics fakeLiftMetrics() {
     auto r = []() { return folly::Random::rand32(); };
     return LiftMetrics{r(), r(), r(), r(), r(), r(), r(), r(), r(), r(), r(),
-                       r(), r(), r(), r(), r(), r(), r(), r(), r(), r(), r()};
+                       r(), r(), r()};
   }
 
  protected:


### PR DESCRIPTION
Summary:
# Description
As outlined in [PL population counts for stacked-key Private Matching](https://docs.google.com/document/d/1iM1AAbhkTUW4o_GfDlCWRR9jdoQiXuZEQy5S3qjG0LE/edit?usp=sharing), we are temporarily removing population counts.

# Details
We removed `testPopulation` and `controlPopulation` from `OutputMetricsData`, and deleted all the associated code pointers.

Differential Revision: D31978261

