### PR TITLE
Update coordinator image workflow trigger events

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'fbpcs/pl_coordinator/**'
-      - 'fbpcs/pa_coordinator/**'
+      - 'fbpcs/private_computation_cli/**'
+      - 'fbpcs/pip_requirements.txt'
+      - 'fbpcs/Dockerfile'
   workflow_dispatch:
     inputs:
       name:


### PR DESCRIPTION
Summary:
PL/PA coordinator is migrated to private_computation_cli, in this diff, I change the trigger event to be any change under private_computation_cli.

Also when there is a change to pip_requirements.txt and Dockerfile(these two files are used to build coordinator image) , workflow will get triggered too.

Differential Revision: D31986793

