### PR TITLE
Add logging to the entire output of the deployment script

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -119,6 +119,7 @@ public class DeployController {
     try {
       ZipOutputStream zout = new ZipOutputStream(bo);
       compressIfExists("/tmp/server.log", "server.log", zout);
+      compressIfExists("/tmp/deploy.log", "deploy.log", zout);
       compressIfExists("/tmp/terraform.log", "terraform.log", zout);
       zout.close();
     } catch (IOException e) {


### PR DESCRIPTION
Summary: This diff adds not only logging to terraform and the deployment server status, but to every single command issued to AWS, bash and terraform during execution

Reviewed By: anthonyzhang25, marksliva

Differential Revision: D31997526

