### PR TITLE
Add route to retrieve logs from Deployment Service

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -119,7 +119,7 @@ public class DeployController {
     try {
       ZipOutputStream zout = new ZipOutputStream(bo);
       compressIfExists("/tmp/server.log", "server.log", zout);
-      compressIfExists("/tmp/deploy.log", "deploy.log", zout);
+      compressIfExists("/tmp/terraform.log", "terraform.log", zout);
       zout.close();
     } catch (IOException e) {
       logger.debug(

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -125,7 +125,7 @@ public class DeploymentRunner extends Thread {
     if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
       if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
       environmentVariables.put("TF_LOG", deployment.logLevel.getLevel());
-      environmentVariables.put("TF_LOG_PATH", "/tmp/deploy.log");
+      environmentVariables.put("TF_LOG_PATH", "/tmp/terraform.log");
     }
   }
 


### PR DESCRIPTION
Summary: This diff simply adds a simple route to relay the deployment logs from the deployment service to the user, as there's no ingress to the service

Reviewed By: marksliva

Differential Revision: D31993370

