### PR TITLE
E2E Tests Add PA 2 decoupled stages and update check_statush.sh [8/n]

### DIFF
--- a/.github/workflows/pa-e2e.yml
+++ b/.github/workflows/pa-e2e.yml
@@ -47,7 +47,7 @@ jobs:
 
      - name: Attribution - Id Match
        run: |
-        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} id_match
+        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
        working-directory: ./fbpcs/tests/github/
 
      - name: Check status
@@ -67,9 +67,20 @@ jobs:
         ./check_status.sh ${{ env.CONTAINER_NAME }} attribution
        working-directory: ./fbpcs/tests/github/
 
-     - name: Attribution - Compute Attribution
+     - name: Attribution - Decoupled Attribution
        run: |
-        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} compute_metrics
+        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Check Status
+       timeout-minutes: 5
+       run: |
+        ./check_status.sh ${{ env.CONTAINER_NAME }} attribution
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Attribution - Decoupled Aggregation
+       run: |
+        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
        working-directory: ./fbpcs/tests/github/
 
      - name: Check Status
@@ -80,7 +91,7 @@ jobs:
 
      - name: Attribution - Aggregate Shards
        run: |
-        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} aggregate_shards
+        ./attribution_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
        working-directory: ./fbpcs/tests/github/
 
      - name: Check Status

--- a/.github/workflows/pl-e2e.yml
+++ b/.github/workflows/pl-e2e.yml
@@ -46,7 +46,7 @@ jobs:
 
      - name: Lift - Id Match
        run: |
-        ./lift_run_stages.sh ${{ env.CONTAINER_NAME }} id_match
+        ./lift_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
        working-directory: ./fbpcs/tests/github/
 
      - name: Check Status
@@ -68,7 +68,7 @@ jobs:
 
      - name: Lift - Compute Metrics
        run: |
-        ./lift_run_stages.sh ${{ env.CONTAINER_NAME }} compute_metrics
+        ./lift_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
        working-directory: ./fbpcs/tests/github/
 
      - name: Check Status
@@ -79,7 +79,7 @@ jobs:
 
      - name: Lift - Aggregate Shards
        run: |
-        ./lift_run_stages.sh ${{ env.CONTAINER_NAME }} aggregate_shards
+        ./lift_run_stages.sh ${{ env.CONTAINER_NAME }} run_next
        working-directory: ./fbpcs/tests/github/
 
      - name: Check Status

--- a/fbpcs/tests/github/attribution_run_stages.sh
+++ b/fbpcs/tests/github/attribution_run_stages.sh
@@ -45,6 +45,7 @@ case "$stage" in
             --attribution_rule="$ATTRIBUTION_RULE" \
             --aggregation_type="$ATTRIBUTION_TYPE"
             ;;
+    # Stages without passing IP addresses
     prepare_compute_input )
         echo "Attribution Publisher $stage starts"
         $docker_command run_next "$ATTRIBUTION_PUBLIHSER_NAME" \
@@ -53,12 +54,11 @@ case "$stage" in
         $docker_command run_next "$ATTRIBUTION_PARTNER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
         ;;
-    id_match|compute_metrics|aggregate_shards )
+     # Stages need to pass IP address
+    run_next )
         echo "Attribution Publisher $stage starts"
         $docker_command run_next "$ATTRIBUTION_PUBLIHSER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
-        #Temporary solution: need to call get_status before get_sever_ips, otherwise get_server_ips returns none
-        $docker_command get_instance "$ATTRIBUTION_PUBLIHSER_NAME" --config="$DOCKER_CLOUD_CONFIG_FILE"
         echo "Get Publisher Ips"
         publisher_server_ips=$($docker_command get_server_ips "$ATTRIBUTION_PUBLIHSER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE" | sed 's/\r//g')

--- a/fbpcs/tests/github/lift_run_stages.sh
+++ b/fbpcs/tests/github/lift_run_stages.sh
@@ -39,7 +39,8 @@ case "$stage" in
             --num_mpc_containers="$LIFT_NUM_MPC_CONTAIENRS" \
             --concurrency="$LIFT_CONCURRENCY"
             ;;
-     prepare_compute_input )
+    # stages donot need IP exchange
+    prepare_compute_input )
         echo "Lift Publisher $stage starts"
         $docker_command run_next "$LIFT_PUBLIHSER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
@@ -47,12 +48,11 @@ case "$stage" in
         $docker_command run_next "$LIFT_PARTNER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
         ;;
-    id_match|compute_metrics|aggregate_shards )
+    # stages require IP exchange
+    run_next )
         echo "Lift Publisher $stage starts"
         $docker_command run_next "$LIFT_PUBLIHSER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
-        #Temporary solution: need to call get_status before get_sever_ips, otherwise get_server_ips returns none
-        $docker_command get_instance "$LIFT_PUBLIHSER_NAME" --config="$DOCKER_CLOUD_CONFIG_FILE"
         echo "Get Publisher Ips"
         # get_server_ips returns an extra carriage return character
         publisher_server_ips=$($docker_command get_server_ips "$LIFT_PUBLIHSER_NAME" \

--- a/fbpcs/tests/github/validate_result.sh
+++ b/fbpcs/tests/github/validate_result.sh
@@ -42,6 +42,7 @@ else
 fi
 # check if there is difference
 function check_results_match() {
+    diff <(jq -S . "$1") <(jq -S . "$2") || exit 1
     diff_output=$(diff <(jq -S . "$1") <(jq -S . "$2"))
     if [ -z "$diff_output" ];
     then
@@ -59,4 +60,5 @@ then
     echo "$game e2e tests succeed"
 else
     echo "$game e2e tests failed, results donot not match"
+    exit 1
 fi


### PR DESCRIPTION
Summary:
PA has two decoupled stages added recently, updating the workflow file to reflect the change. These two stages do not have a matched name step(e.g. decoupled_attibution) in private_computation_cli, so I can only call it through run_next. To save future effort, I update the Workflow file to use run_next.

How to decide how many run_next to use?
I am using PrivateComputationDecoupledStageFlow; for example for PA is has
.DECOUPLED_ATTRIBUTION=CREATED -> ID_MATCH -> PREPARE -> DECOUPLED_ATTRIBUTION -> DECOUPLED_AGGREGATION -> AGGREGATE

This can help me decide the number of times for me to run next_step

Also, when checking status, completed status is not only showing "status": "COMPLETED" but also "status": "XXX_COMPLETED", adding regex checks for that

Differential Revision: D31999146

