### PR TITLE
Added method get_flow_cls_name to pc_instance.

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -131,6 +131,10 @@ class PrivateComputationInstance(InstanceBase):
         return self.instance_id
 
     @property
+    def get_flow_cls_name(self) -> str:
+        return self._stage_flow_cls_name
+
+    @property
     def pid_stage_output_base_path(self) -> str:
         return self._get_stage_output_path("pid_stage", "csv")
 

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -89,12 +89,15 @@ class AggregateShardsStageService(PrivateComputationStageService):
         binary_name = OneDockerBinaryNames.SHARD_AGGREGATOR.value
         binary_config = self._onedocker_binary_config_map[binary_name]
 
-        # TODO T104195768 : remove the check on _stage_flow_cls_name and replace with a more stable check find the right flow.
-        # Check on _stage_flow_cls_name is an intermediate state, ETA for final state - 2nd November.
+        # Check if the flow is Decoupled flow, meaning that this a PA decoupled flow.
+        # We now have DecoupledFlow as the default flow for PA when computation is performed using run_next.
+        # i.e. if PA computation is called using run_next method, we will always run Decoupled Flow
+        # and if the methods are called directly, we will always run the legacy flow.
+        # Using "PrivateComputationDecoupledStageFlow" instead of PrivateComputationDecoupledStageFlow.get_cls_name() to avoid
+        # circular import error.
         input_stage_path = (
             pc_instance.decoupled_aggregation_stage_output_base_path
-            if pc_instance._stage_flow_cls_name
-            == "PrivateComputationDecoupledStageFlow"
+            if pc_instance.get_flow_cls_name == "PrivateComputationDecoupledStageFlow"
             else pc_instance.compute_stage_output_base_path
         )
 


### PR DESCRIPTION
Summary:
**Changes:**
Changes in this diff are
1. Added a method get_flow_cls_name is private_computation_instance.
2. Added a call to the method in shard aggregation service.

**Why:**
In PA we have two flows now - Decoupled Stage flow and Legacy flow. In the decoupled flow, instead of compute stage, we are calling decoupled attribution and decoupled aggregation stage.
Thus when we get to shard aggregator stage, we need to verify whether we arrived from decoupled_aggregation stage or compute stage so that we could pass the proper input path (compute output or decoupled_aggregation output).
In order to check that, we will check which flow we are using to determine the path.

Reviewed By: jrodal98

Differential Revision: D32020458

