### PR TITLE
Make a dummy pl_coordinator.py just to print an instruction to download new run_fbpcs.sh

### DIFF
--- a/fbpcs/pl_coordinator/pl_coordinator.py
+++ b/fbpcs/pl_coordinator/pl_coordinator.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Legacy CLI for running a Private Lift study. This exists only because the run_fbpcs.sh script some advertisers have
+still calls this CLI and we would like to request them to update run_fbpcs.sh through this warning message.
+"""
+
+
+if __name__ == "__main__":
+    print(
+        "Hello! It looks like you're running an outdated version of run_fbpcs.sh. Please follow these steps:\n"
+        + '1. Run this command on your terminal to get the new run_fbpcs.sh: "curl -O https://raw.githubusercontent.com/facebookresearch/fbpcs/main/fbpcs/scripts/run_fbpcs.sh && chmod +x run_fbpcs.sh"\n'
+        + '2. Modify the run_fbpcs command you ran by removing "lift" right after "run_fbpcs"\n'
+        + "3. Run the modified run_fbpcs command. You should be good!"
+    )


### PR DESCRIPTION
Summary: The copy of run_fbpcs.sh that advertisers have doesn't get updated with pa/pl weekly release. I recently removed fbpcs/pl_coordinator/pl_coordinator.py from fbcode. If we do not land this diff, then in the next release next week, when advertisers use their existing copy of run_fbpcs.sh, it would fail because it calls fbpcs.pl_coordinator.pl_coordinator. If we include this very diff in the next release, then run_fbpcs.sh wouldn't fail. Advertisers would see an 3-step-instruction printed on the console and know to download new run_fbpcs.sh.

Differential Revision: D32036864

