### PR TITLE
remove the preprocessed user_agent fields

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -56,10 +56,6 @@ def lambda_handler(event, context):
         client_user_agent = row_data.get("user_data", dummy_dict).get("client_user_agent")
         click_id = row_data.get("user_data", dummy_dict).get("fbc")
         login_id = row_data.get("user_data", dummy_dict).get("fbp")
-        custom_properties = row_data.get("custom_data", dummy_dict).get("custom_properties", dummy_dict)
-        browser_name = custom_properties.get("_cloudbridge_browser_name")
-        device_os = custom_properties.get("_cloudbridge_device_os")
-        device_os_version = custom_properties.get("_cloudbridge_device_os_version")
 
         # make sure not all values are None
         if all(
@@ -102,12 +98,6 @@ def lambda_handler(event, context):
             user_data["click_id"] = click_id
         if login_id:
             user_data["login_id"] = login_id
-        if browser_name:
-            user_data["browser_name"] = browser_name
-        if device_os:
-            user_data["device_os"] = device_os
-        if device_os_version:
-            user_data["device_os_version"] = device_os_version
 
         data['user_data'] = user_data
         # firehose need data to be b64-encoded

--- a/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
@@ -69,34 +69,6 @@ class TestDataIngestion(TestCase):
 
         self.assertEqual(len(result['records']), 0)
 
-    def test_user_agent_parsed_fields(self):
-        record = self.sample_record_data
-        server_side_event = record['serverSideEvent']
-        server_side_event['custom_data']['custom_properties'] = {
-            'ignored': '1',
-            '_cloudbridge_browser_name': 'Chrome Desktop',
-            '_cloudbridge_device_os': 'Mac OS X',
-            '_cloudbridge_device_os_version': '10.13.6',
-        }
-        event = self.sample_event(record)
-        result = lambda_handler(event, self.sample_context)
-        encoded_data = result['records'][0]['data']
-        decoded_data = base64.b64decode(encoded_data)
-        decoded_dict = json.loads(decoded_data)
-
-        self.assertEqual(
-            server_side_event['custom_data']['custom_properties']['_cloudbridge_browser_name'],
-            decoded_dict['user_data']['browser_name']
-        )
-        self.assertEqual(
-            server_side_event['custom_data']['custom_properties']['_cloudbridge_device_os'],
-            decoded_dict['user_data']['device_os']
-        )
-        self.assertEqual(
-            server_side_event['custom_data']['custom_properties']['_cloudbridge_device_os_version'],
-            decoded_dict['user_data']['device_os_version']
-        )
-
     def test_user_data_fields(self):
         record = self.sample_record_data
         server_side_event = record['serverSideEvent']


### PR DESCRIPTION
Summary:
After backing out the user_agent processing changes from upstream Cloudbridge
processing in D32042836 we also remove this dependency on those fields.

Differential Revision: D32045398

