### PR TITLE
Add LiftInputData utility class

### DIFF
--- a/fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.cpp
@@ -7,24 +7,100 @@
 
 #include "fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h"
 
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <vector>
+
 #include "fbpcs/emp_games/lift/common/Column.h"
 #include "fbpcs/emp_games/lift/common/DataFrame.h"
 
 using namespace private_lift;
 
 void LiftDataFrameBuilder::addTestControlPopulationColumns(
-    df::DataFrame &df) const {
-  // Will implement in next diff
+    df::DataFrame& df) const {
+  auto keys = df.keys();
+  if (keys.find("test_flag") != keys.end()) {
+    auto& testFlag = df.get<int64_t>("test_flag");
+    df::Column<int64_t> oneColumn(testFlag.size(), 1);
+    if (keys.find("opportunity") != keys.end()) {
+      auto& opp = df.get<int64_t>("opportunity");
+      df.get<int64_t>("test_population") = opp * testFlag;
+      df.get<int64_t>("control_population") = opp * (oneColumn - testFlag);
+    } else {
+      df.get<int64_t>("test_population") = testFlag;
+      df.get<int64_t>("control_population") = oneColumn - testFlag;
+    }
+  }
 }
 
-void LiftDataFrameBuilder::applyConversionCap(df::DataFrame &df) const {
-  // Will implement in next diff
+void LiftDataFrameBuilder::applyConversionCap(df::DataFrame& df) const {
+  std::vector<std::string> cappedColumnKeys{"event_timestamps", "values"};
+  auto keys = df.keys();
+  for (const auto& key : cappedColumnKeys) {
+    if (keys.find(key) != keys.end()) {
+      // We take the *first N* conversions for this user
+      // NOTE: This should later be switched to *last N*
+      df.get<std::vector<int64_t>>(key).apply(
+          [this](auto& innerVec) { innerVec.resize(conversionCap_); });
+    }
+  }
 }
 
-void LiftDataFrameBuilder::precomputeValuesSquared(df::DataFrame &df) const {
-  // Will implement in next diff
+void LiftDataFrameBuilder::precomputeValuesSquared(df::DataFrame& df) const {
+  auto keys = df.keys();
+  if (keys.find("values") != keys.end()) {
+    df.get<std::vector<int64_t>>("values_squared") =
+        df.get<std::vector<int64_t>>("values").map([](auto& innerVec) {
+          std::vector<int64_t> res(innerVec.size());
+          int64_t acc = 0;
+          // Reverse iterate to accumulate total value in range [i, end)
+          // This may look dumb, but size_t is an unsigned type, so we can't
+          // iterate down to zero (it underflows and never terminates)
+          std::size_t i = innerVec.size();
+          while (i--) {
+            acc += innerVec.at(i);
+            res.at(i) = acc * acc;
+          }
+          return res;
+        });
+  }
 }
 
-void LiftDataFrameBuilder::dropUnnecessaryColumns(df::DataFrame &df) const {
-  // Will implement in next diff
+void LiftDataFrameBuilder::dropUnnecessaryColumns(df::DataFrame& df) const {
+  auto keys = df.keys();
+
+  // First find keys not present in the list of necessary columns
+  for (const auto& key : getNecessaryColumnsForLift()) {
+    keys.erase(key);
+  }
+
+  // Then drop them from the DataFrame
+  for (const auto& extraColumn : keys) {
+    // This code is tricky: since we originally supplied the TypeMap to
+    // df::DataFrame::readCsv, we know *for sure* which column types could be
+    // present here. If you haphazardly try to drop additional columns, it may
+    // cause a SEGV in the downstream application.
+    if (std::find(
+            getLiftTypeMap().boolColumns.begin(),
+            getLiftTypeMap().boolColumns.end(),
+            extraColumn) != getLiftTypeMap().boolColumns.end()) {
+      df.drop<bool>(extraColumn);
+    } else if (
+        std::find(
+            getLiftTypeMap().intColumns.begin(),
+            getLiftTypeMap().intColumns.end(),
+            extraColumn) != getLiftTypeMap().intColumns.end()) {
+      df.drop<int64_t>(extraColumn);
+    } else if (
+        std::find(
+            getLiftTypeMap().intVecColumns.begin(),
+            getLiftTypeMap().intVecColumns.end(),
+            extraColumn) != getLiftTypeMap().intVecColumns.end()) {
+      df.drop<std::vector<int64_t>>(extraColumn);
+    } else {
+      // Everything else is std::string
+      df.drop<std::string>(extraColumn);
+    }
+  }
 }

--- a/fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h
+++ b/fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h
@@ -53,7 +53,8 @@ public:
    * Precompute the total valid value squared at index [i] for each user by
    * applying the math trick of summing all value from `[i, size())` given the
    * property that if conversion[i] is valid, all subsequent conversions must
-   * also be valid.
+   * also be valid. For example: if values are [10, 20, 30] then precomputing
+   * values squared would yield [(10+20+30)^2, (20+30)^2, 30^2].
    *
    * @param df the df::DataFrame to be modified in place
    */

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
+
+#include <string>
+#include <vector>
+
+#include <emp-tool/emp-tool.h>
+
+#include <fbpcf/mpc/EmpGame.h>
+
+#include "fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h"
+#include "fbpcs/emp_games/lift/common/Column.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+static constexpr int64_t kConversionCap = 25;
+
+using namespace private_lift;
+
+LiftInputData::LiftInputData(fbpcf::Party party, const std::string& filePath)
+    : LiftInputData{LiftDataFrameBuilder{filePath, kConversionCap}, party} {}
+
+LiftInputData::LiftInputData(
+    const LiftDataFrameBuilder& builder,
+    fbpcf::Party party)
+    : party_{party}, groupKey_{getGroupKeyForParty(party)} {
+  // Will implement in next diff
+}
+
+int64_t LiftInputData::calculateGroupCount() const {
+  int64_t maxId = 0;
+  // Will implement in next diff
+  return maxId;
+}
+
+std::vector<df::Column<emp::Bit>> LiftInputData::calculateBitmasks() const {
+  std::vector<df::Column<emp::Bit>> res;
+  // Will implement in next diff
+  return res;
+}

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.h
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <emp-tool/emp-tool.h>
+
+#include <fbpcf/mpc/EmpGame.h>
+
+#include "fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h"
+#include "fbpcs/emp_games/lift/common/Column.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace private_lift {
+/**
+ * Class that prepares data for Private Lift from a CSV. Primary interface is
+ * via getDf, though getBitmaskFor is also useful as a precomputed vector of
+ * bitmasks for calculating subgroup lift.
+ */
+class LiftInputData {
+ public:
+  /**
+   * Construct a LiftInputData object for a party with a path to a CSV file.
+   *
+   * @param party the party for which to prepare data
+   * @param filePath the path to the CSV with this party's data
+   */
+  LiftInputData(fbpcf::Party party, const std::string& filePath);
+
+  /**
+   * Construct a LiftInputData object for a party with a custom builder. This
+   * should only be used if you really know what you're doing. It's useful for
+   * extending a builder, but in most cases, the builder-less LiftInputData
+   * constructor will be what a developer wants to use directly.
+   *
+   * @param builder an object which can prepare a Lift DataFrame
+   * @param party the party for which to prepare data
+   */
+  LiftInputData(const LiftDataFrameBuilder& builder, fbpcf::Party party);
+
+  /**
+   * Get the prepared `df::DataFrame`.
+   *
+   * @returns this LiftInputData's `df::DataFrame`
+   */
+  const df::DataFrame& getDf() const {
+    return df_;
+  }
+
+  /**
+   * Non-const version of `LiftInputData::getDf`. Get the prepared
+   * `df::DataFrame`.
+   *
+   * @returns this LiftInputData's `df::DataFrame`
+   */
+  df::DataFrame& getDf() {
+    return const_cast<df::DataFrame&>(
+        const_cast<const LiftInputData&>(*this).getDf());
+  }
+
+  /**
+   * Retrieve the supported groupKey string for an `fbpcf::Party`.
+   *
+   * @returns the supported groupKey string for an `fbpcf::Party`
+   */
+  static std::string getGroupKeyForParty(fbpcf::Party party) {
+    // Assumption: Alice == Publisher
+    return party == fbpcf::Party::Alice ? std::string{"breakdown_id"}
+                                        : std::string{"cohort_id"};
+  }
+
+  /**
+   * Get this LiftInputData's group count (how many subgroups this party wishes
+   * to compute sub-audience lift for). This was previously calculated by
+   * finding the maximum id under this input's groupKey. Since subgroups *must*
+   * begin from index zero, finding index k means there are at least k groups.
+   *
+   * @returns the number of known groups in this LiftInputData
+   */
+  int64_t getGroupCount() const {
+    return groupCount_;
+  }
+
+  /**
+   * Get a column of bits representing a bitmask over a given groupId. These
+   * were precomputed upon creation of this LiftInputData since construction
+   * of new `emp::Bit` columns can be expensive.
+   *
+   * @param groupId the groupId for which to retrieve a bitmask column
+   * @returns a `df::Column` of `emp::Bit` describing whether row[i] is valid
+   *     for this group
+   * @throws std::out_of_range if groupId > groupCount
+   */
+  const df::Column<emp::Bit> &getBitmaskFor(int64_t groupId) const {
+    return bitmasks_.at(groupId);
+  }
+
+  /**
+   * Calculate the number of groups in this LiftInputData by finding the max
+   * id in the groupKey. For more details, see `LiftInputData::getGroupCount`.
+   *
+   * @returns the calculated number of groups in the `df::DataFrame`
+   */
+  int64_t calculateGroupCount() const;
+
+  /**
+   * Calculate all of the bitmasks for groups defined in this LiftInputData.
+   * This is a relatively expensive function, but the intention is that it is
+   * run in the LiftInputData constructor to cache the result for later. For
+   * more details, see `LiftInputData::getBitmaskFor`.
+   *
+   * @returns a vector of Columns of `emp::Bit` representing whether row[i] is
+   *     valid for the group stored in vector index[j]
+   */
+  std::vector<df::Column<emp::Bit>> calculateBitmasks() const;
+
+ private:
+  fbpcf::Party party_;
+  std::string groupKey_;
+  df::DataFrame df_;
+  int64_t groupCount_;
+  std::vector<df::Column<emp::Bit>> bitmasks_;
+};
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/test/LiftDataFrameBuilderTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftDataFrameBuilderTest.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h"
+#include "fbpcs/emp_games/lift/common/Column.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+constexpr int64_t kConversionCap = 2;
+
+using namespace private_lift;
+
+class LiftDataFrameBuilderTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    // clang-format off
+
+    // Try to align these in a nice human-readable way to look like an actual dataframe
+    dfPublisher.get<std::string>("id_") =         {"abc", "def", "ghi"};
+    dfPublisher.get<int64_t>("opportunity") =     {    1,     1,     0};
+    dfPublisher.get<int64_t>("test_flag") =       {    1,     0,     0};
+    dfPublisher.get<int64_t>("breakdown_id") =    {    0,     1,     0};
+    dfPublisher.get<int64_t>("num_impressions") = {    5,     0,     0};
+    dfPublisher.get<int64_t>("num_clicks") =      {    2,     0,     0};
+    dfPublisher.get<int64_t>("total_spend") =     {  100,     0,     0};
+
+    // It gets a bit messy with nested vectors, but hopefully it's halfway readable
+    dfPartner.get<std::string>("id_") =                       {          "abc",       "def",        "ghi"};
+    dfPartner.get<std::vector<int64_t>>("event_timestamps") = {{100, 200, 300}, {0, 0, 125}, {0, 150, 250}};
+    dfPartner.get<std::vector<int64_t>>("values") =           {{ 10,  20,  30}, {0, 0,  12}, {0,  15,  25}};
+    dfPartner.get<int64_t>("cohort_id") =                     {              0,           1,             2};
+
+    // clang-format on
+
+    expectedTestPopulation = {1, 0, 0};
+    expectedControlPopulation = {0, 1, 0};
+    expectedEventTimestampsCapped = {{100, 200}, {0, 0}, {0, 150}};
+    expectedValuesCapped = {{10, 20}, {0, 0}, {0, 15}};
+    expectedValuesSquaredPrecomputed = {{900, 400}, {0, 0}, {225, 225}};
+  }
+
+  df::DataFrame dfPublisher;
+  df::DataFrame dfPartner;
+  df::Column<int64_t> expectedTestPopulation;
+  df::Column<int64_t> expectedControlPopulation;
+  df::Column<std::vector<int64_t>> expectedEventTimestampsCapped;
+  df::Column<std::vector<int64_t>> expectedValuesCapped;
+  df::Column<std::vector<int64_t>> expectedValuesSquaredPrecomputed;
+};
+
+TEST_F(LiftDataFrameBuilderTest, ApplyLiftRules) {
+  LiftDataFrameBuilder builder{"", kConversionCap};
+
+  builder.applyLiftRules(dfPublisher);
+  EXPECT_EQ(dfPublisher.at<int64_t>("test_population"), expectedTestPopulation);
+  EXPECT_EQ(dfPublisher.at<int64_t>("control_population"),
+            expectedControlPopulation);
+
+  auto keysPublisher = dfPublisher.keys();
+  for (const auto &key : LiftDataFrameBuilder::getNecessaryColumnsForLift()) {
+    keysPublisher.erase(key);
+  }
+  // We expect |keys - necessaryKeys| = empty set
+  EXPECT_TRUE(keysPublisher.empty());
+
+  builder.applyLiftRules(dfPartner);
+  EXPECT_EQ(dfPartner.at<std::vector<int64_t>>("event_timestamps"),
+            expectedEventTimestampsCapped);
+  EXPECT_EQ(dfPartner.at<std::vector<int64_t>>("values"), expectedValuesCapped);
+  EXPECT_EQ(dfPartner.at<std::vector<int64_t>>("values_squared"),
+            expectedValuesSquaredPrecomputed);
+
+  auto keysPartner = dfPartner.keys();
+  for (const auto &key : LiftDataFrameBuilder::getNecessaryColumnsForLift()) {
+    keysPartner.erase(key);
+  }
+  // We expect |keys - necessaryKeys| = empty set
+  EXPECT_TRUE(keysPartner.empty());
+
+  // Lastly, check that we didn't add columns to irrelevant DataFrames
+  // This is slightly different from the above check, because all of these
+  // columns are *necessary*, just for the other party's df (not ours).
+  EXPECT_EQ(keysPublisher.find("event_timestamps"), keysPublisher.end());
+  EXPECT_EQ(keysPublisher.find("values"), keysPublisher.end());
+  EXPECT_EQ(keysPublisher.find("values_squared"), keysPublisher.end());
+  EXPECT_EQ(keysPartner.find("test_population"), keysPartner.end());
+  EXPECT_EQ(keysPartner.find("control_population"), keysPartner.end());
+}
+
+TEST_F(LiftDataFrameBuilderTest, AddTestControlPopulationColumns) {
+  LiftDataFrameBuilder builder{"", kConversionCap};
+
+  builder.addTestControlPopulationColumns(dfPublisher);
+  EXPECT_EQ(dfPublisher.at<int64_t>("test_population"), expectedTestPopulation);
+  EXPECT_EQ(dfPublisher.at<int64_t>("control_population"),
+            expectedControlPopulation);
+
+  // For the partner, we wouldn't expect anything to happen at all since the
+  // opportunity and test flag columns are not present
+  builder.addTestControlPopulationColumns(dfPartner);
+  auto keys = dfPartner.keys();
+  EXPECT_EQ(keys.find("test_population"), keys.end());
+  EXPECT_EQ(keys.find("control_population"), keys.end());
+}
+
+TEST_F(LiftDataFrameBuilderTest, ApplyConversionCap) {
+  LiftDataFrameBuilder builder{"", kConversionCap};
+
+  // For the publisher, we wouldn't expect anything to happen at all since the
+  // event_timestamps and values flag columns are not present
+  builder.applyConversionCap(dfPublisher);
+  auto keys = dfPublisher.keys();
+  EXPECT_EQ(keys.find("event_timestamps"), keys.end());
+  EXPECT_EQ(keys.find("values"), keys.end());
+
+  builder.applyConversionCap(dfPartner);
+  EXPECT_EQ(dfPartner.at<std::vector<int64_t>>("event_timestamps"),
+            expectedEventTimestampsCapped);
+  EXPECT_EQ(dfPartner.at<std::vector<int64_t>>("values"), expectedValuesCapped);
+}
+
+TEST_F(LiftDataFrameBuilderTest, PrecomputeValuesSquared) {
+  LiftDataFrameBuilder builder{"", kConversionCap};
+
+  // NOTE: For coherence with the test fixture's expected capping, we must first
+  // call the applyConversionCap function here again.
+  builder.applyConversionCap(dfPublisher);
+  builder.applyConversionCap(dfPartner);
+
+  // For the publisher, we wouldn't expect anything to happen at all since the
+  // event_timestamps and values flag columns are not present
+  builder.precomputeValuesSquared(dfPublisher);
+  auto keys = dfPublisher.keys();
+  EXPECT_EQ(keys.find("values_squared"), keys.end());
+
+  builder.precomputeValuesSquared(dfPartner);
+  EXPECT_EQ(dfPartner.at<std::vector<int64_t>>("values_squared"),
+            expectedValuesSquaredPrecomputed);
+}
+
+TEST_F(LiftDataFrameBuilderTest, DropUnnecessaryColumns) {
+  LiftDataFrameBuilder builder{"", kConversionCap};
+
+  builder.dropUnnecessaryColumns(dfPublisher);
+  auto keysPublisher = dfPublisher.keys();
+
+  std::vector<std::string> diffPublisher;
+  for (const auto &key : LiftDataFrameBuilder::getNecessaryColumnsForLift()) {
+    keysPublisher.erase(key);
+  }
+  // We expect |keys - necessaryKeys| = empty set
+  EXPECT_TRUE(keysPublisher.empty());
+
+  builder.dropUnnecessaryColumns(dfPartner);
+  auto keysPartner = dfPartner.keys();
+  for (const auto &key : LiftDataFrameBuilder::getNecessaryColumnsForLift()) {
+    keysPartner.erase(key);
+  }
+  // We expect |keys - necessaryKeys| = empty set
+  EXPECT_TRUE(keysPartner.empty());
+}


### PR DESCRIPTION
Summary:
# What
* The entry class for supplying a party and a CSV path and getting back data in a format usable for Lift MPC
# Why
* We've now abstracted much of the logic behind Column and DataFrame - let's provide an easy-to-use interface for actually making good use of it.

Differential Revision: D32055044

