### PR TITLE
Create DataFrameBuilder interface

### DIFF
--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <initializer_list>
+#include <iterator>
 #include <optional>
 #include <sstream>
 #include <vector>
@@ -71,7 +72,37 @@ public:
     return *this;
   }
 
-  /* Member functions */
+  /**
+   * Get a const_iterator to the beginning of this Column's data by deferring to
+   * the underlying vector's implementation.
+   *
+   * @returns a const_iterator to the beginning of this Column's data
+   */
+  typename std::vector<T>::const_iterator begin() const { return v_.begin(); }
+
+  /**
+   * Get an iterator to the beginning of this Column's data by deferring to the
+   * underlying vector's implementation.
+   *
+   * @returns an iterator to the beginning of this Column's data
+   */
+  typename std::vector<T>::iterator begin() { return v_.begin(); }
+
+  /**
+   * Get a const_iterator to the end of this Column's data by deffering to the
+   * underlying vector's implementation.
+   *
+   * @returns a const_iterator to the end of this Column's data
+   */
+  typename std::vector<T>::const_iterator end() const { return v_.end(); }
+
+  /**
+   * Get an iterator to the end of this Column's data by deferring to the
+   * underlying vector's implementation.
+   *
+   * @returns an iterator to the end of this Column's data
+   */
+  typename std::vector<T>::iterator end() { return v_.end(); }
 
   /**
    * Retrieve a value at a specific index in the column.
@@ -89,7 +120,8 @@ public:
   /**
    * Reserve capacity in the Column.
    *
-   * @param capacity the amount of capacity to reserve in the underlying std::vector
+   * @param capacity the amount of capacity to reserve in the underlying
+   * std::vector
    */
   void reserve(std::size_t capacity) { v_.reserve(capacity); }
 
@@ -109,10 +141,16 @@ public:
 
   /**
    * Add a new value to this Column.
+   *
    * @param value The value to add to this Column
    */
   void push_back(const T &value) { v_.push_back(value); }
 
+  /**
+   * Add a new (rvalue reference) value to this Column.
+   *
+   * @param value The value to add to this Column
+   */
   void push_back(T &&value) { v_.push_back(value); }
 
   /**

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -15,6 +15,8 @@
 
 namespace {
 // Taken from https://stackoverflow.com/a/28796458/15625637
+// Useful to denote if if a class Test is a specialization of a Reference class
+// Example: is_specialization<std::vector<int64_t>, std::vector>::value -> true
 template <typename Test, template <typename...> class Ref>
 struct is_specialization : std::false_type {};
 
@@ -24,6 +26,14 @@ struct is_specialization<Ref<Args...>, Ref> : std::true_type {};
 
 namespace df {
 
+/**
+ * This is an extension of a std::vector to be used for typical data processing.
+ * It provides methods for a functional paradigm (map, apply, reduce). It's also
+ * made for tight integration with std::vector so that getting the additional
+ * features of df::Column should be an easy switch.
+ *
+ * @tparam T the type of data stored in this Column
+ */
 template <typename T> class Column {
 public:
   /* Basic constructors */
@@ -63,32 +73,81 @@ public:
 
   /* Member functions */
 
+  /**
+   * Retrieve a value at a specific index in the column.
+   *
+   * @param pos the index into this Column
+   * @returns the value at index `pos`
+   * @throws `std::out_of_range` if `pos` is larger than `this->size()`
+   */
   const T &at(std::size_t pos) const { return v_.at(pos); }
 
   T &at(std::size_t pos) {
     return const_cast<T &>(const_cast<const Column &>(*this).at(pos));
   }
 
+  /**
+   * Reserve capacity in the Column.
+   *
+   * @param capacity the amount of capacity to reserve in the underlying std::vector
+   */
   void reserve(std::size_t capacity) { v_.reserve(capacity); }
 
+  /**
+   * Checks whether this Column is empty.
+   *
+   * @returns true if this Column has no values
+   */
   bool empty() const { return v_.empty(); }
 
+  /**
+   * Get the number of items stored in this Column.
+   *
+   * @returns the number of elements in this Column
+   */
   std::size_t size() const { return v_.size(); }
 
+  /**
+   * Add a new value to this Column.
+   * @param value The value to add to this Column
+   */
   void push_back(const T &value) { v_.push_back(value); }
 
   void push_back(T &&value) { v_.push_back(value); }
 
+  /**
+   * Constructs an element in-place at the back of this Column.
+   *
+   * @tparam Args argtypes to pass into the T constructor
+   * @param args arguments to pass to the T constructor
+   * @returns a reference to the newly constructed element
+   */
   template <class... Args> T &emplace_back(Args &&...args) {
     return v_.emplace_back(args...);
   }
 
+  /**
+   * Apply a function on each element of this Column.
+   *
+   * @tparam F an unspecified function type which can be called with each
+   *    element from this Column
+   * @param f the function to call on each element of this Column
+   */
   template <typename F> void apply(F f) {
     for (std::size_t i = 0; i < size(); ++i) {
       f(at(i));
     }
   }
 
+  /**
+   * Map this column into a new Column by applying a function to each element.
+   *
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param f the function to call on each element of this column
+   * @returns a new Column where each element is the result of calling f on the
+   *     the respective element from this Column
+   */
   template <typename F> auto map(F f) const -> Column<decltype(f(at(0)))> {
     Column<decltype(f(at(0)))> res;
     res.reserve(size());
@@ -98,6 +157,18 @@ public:
     return res;
   }
 
+  /**
+   * Map this column into a new Column by applying a function to each element
+   * along with another column at the same time.
+   *
+   * @tparam T2 the value type of the other Column
+   * @param other the Column which will be mapped with this column
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param f the function to call on each element of this column
+   * @returns a new Column where each element is the result of calling f on the
+   *     the respective element from this Column
+   */
   template <typename T2, typename F>
   auto mapWith(const Column<T2> &other, F f) const
       -> Column<decltype(f(at(0), other.at(0)))> {
@@ -116,6 +187,18 @@ public:
     return res;
   }
 
+  /**
+   * Map this column into a new Column by applying a function to each element
+   * along with another scalar value at the same time.
+   *
+   * @tparam T2 the type of the scalar
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param other the scalar value which will be mapped with this column
+   * @param f the function to call on each element of this column
+   * @returns a new Column where each element is the result of calling f on the
+   *     the respective element from this Column
+   */
   template <typename T2, typename F>
   auto mapWithScalar(const T2 &other, F f) const
       -> Column<decltype(f(at(0), other))> {
@@ -128,12 +211,29 @@ public:
     return res;
   }
 
+  /**
+   * Modify this column IN PLACE by applying a function to each element.
+   *
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param f the function to call on each element of this column
+   */
   template <typename F> void mapInPlace(F f) {
     for (std::size_t i = 0; i < size(); ++i) {
       at(i) = f(at(i));
     }
   }
 
+  /**
+   * Map this column IN PLACE by applying a function to each element along
+   * with another column at the same time.
+   *
+   * @tparam T2 the value type of the other Column
+   * @param other the Column which will be mapped with this column
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param f the function to call on each element of this column
+   */
   template <typename T2, typename F>
   void mapWithInPlace(const Column<T2> &other, F f) {
     if (size() != other.size()) {
@@ -148,6 +248,16 @@ public:
     }
   }
 
+  /**
+   * Map this column IN PLACE by applying a function to each element along
+   * with another scalar value at the same time.
+   *
+   * @tparam T2 the type of the scalar
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param other the scalar value which will be mapped with this column
+   * @param f the function to call on each element of this column
+   */
   template <typename T2, typename F>
   void mapWithScalarInPlace(const T2 &other, F f) {
     for (std::size_t i = 0; i < size(); ++i) {
@@ -155,6 +265,16 @@ public:
     }
   }
 
+  /**
+   * Perform a left fold of this Column by applying the binary function `f`
+   * over each element, starting with the accumulator `acc`.
+   *
+   * @tparam F an unspecified function type which can be called with each
+   *     element from this Column
+   * @param f the binary function to apply for reduction
+   * @param acc the initial value for the reduction
+   * @returns the result of a left fold of this Column over `f`
+   */
   template <typename F>
   T reduce(F f, std::optional<T> acc = std::nullopt) const {
     std::size_t idx = 0;
@@ -173,6 +293,15 @@ public:
     return res;
   }
 
+  /**
+   * Constructs a new Column from this Column by calling the constructor of `T2`
+   * which takes an element of `T`. This is a shorthand method for `map` when
+   * the caller just wishes to convert from one type to another and the target
+   * type defines a constructor of the form `T2(T)`.
+   *
+   * @tparam T2 the value type of the other Column
+   * @returns a new column mapped to the type T2
+   */
   template <typename T2> Column<T2> toColumn() const {
     Column<T2> res;
     res.reserve(size());

--- a/fbpcs/emp_games/lift/common/CsvReader.cpp
+++ b/fbpcs/emp_games/lift/common/CsvReader.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/lift/common/CsvReader.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "fbpcf/io/FileManagerUtil.h"
+
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace df {
+namespace detail {
+std::vector<std::string> split(const std::string &s) {
+  std::vector<std::string> res;
+  std::size_t i = 0;
+  while (i < s.size()) {
+    std::size_t lastStart = i;
+
+    // Look for the end of this token
+    if (s.at(i) == '[') {
+      // Intentionally no size check
+      // if we don't find ']', the string is malformed
+      // NOTE: Nested brackets are undefined behavior
+      while (s.at(i) != ']') {
+        ++i;
+      }
+      // Since we *do* want to include the ']' character in our parsing,
+      // we advance i one more now
+      ++i;
+    } else {
+      while (i < s.size() && s.at(i) != ',') {
+        ++i;
+      }
+    }
+    res.push_back(s.substr(lastStart, i - lastStart));
+    // Increment i so we're at the next valid character
+    ++i;
+  }
+  return res;
+}
+} // namespace detail
+
+CsvReader::CsvReader(const std::string &filePath) {
+  auto infilePtr = fbpcf::io::getInputStream(filePath);
+  auto &infile = infilePtr->get();
+  if (!infile.good()) {
+    throw CsvFileReadException{filePath};
+  }
+
+  std::string line;
+  std::getline(infile, line);
+  header_ = detail::split(line);
+
+  while (std::getline(infile, line)) {
+    auto nextRow = detail::split(line);
+    if (header_.size() != nextRow.size()) {
+      throw RowLengthMismatch{header_.size(), nextRow.size()};
+    }
+    rows_.push_back(std::move(nextRow));
+  }
+}
+} // namespace df

--- a/fbpcs/emp_games/lift/common/CsvReader.h
+++ b/fbpcs/emp_games/lift/common/CsvReader.h
@@ -15,6 +15,14 @@
 
 namespace df {
 namespace detail {
+/**
+ * Splits a string up into a vector of strings on comma characters. There is
+ * support for "list" fields denoted by brackets `[]`. For example, the string
+ * `abc,[1,2,3],4,5` would be split as `{"abc", "[1,2,3]", "4", "5"}`.
+ *
+ * @param s the string to split
+ * @returns a vector of strings split on commas
+ */
 std::vector<std::string> split(const std::string &s);
 } // namespace detail
 
@@ -41,8 +49,16 @@ private:
   std::string msg_;
 };
 
+/**
+ * An exception that is thrown if there is an error parsing a CSV file.
+ */
 class CsvFileReadException : public std::exception {
 public:
+  /**
+   * Constructs an exception referring to the given filePath.
+   *
+   * @param filePath the file that the CsvReader failed to parse
+   */
   explicit CsvFileReadException(const std::string &filePath) {
     msg_ = "Failed to read file '" + filePath + "'";
   }
@@ -53,19 +69,52 @@ private:
   std::string msg_;
 };
 
+/**
+ * A class which parses a CSV file into a header and a vector of rows.
+ */
 class CsvReader {
 public:
+  /**
+   * Constructs a new CsvReader to read the given filePath.
+   *
+   * @param filePath the filePath of the CSV to be read
+   */
   explicit CsvReader(const std::string &filePath);
 
+  /**
+   * Get the header parsed from the file passed in the constructor.
+   *
+   * @returns the header of the file as a vector of strings
+   */
   const std::vector<std::string> &getHeader() const { return header_; }
 
+  /**
+   * Non-const version of `CsvReader::getHeader`. Get the header parsed from the
+   * file passed in the constructor.
+   *
+   *
+   * @returns the header of the file as a vector of strings
+   */
   std::vector<std::string> &getHeader() {
     return const_cast<std::vector<std::string> &>(
         const_cast<const CsvReader &>(*this).getHeader());
   }
 
+  /**
+   * Get the rows parsed from the file passed in the constructor. This will not
+   * include the header row (to get the header, use `CsvReader::getHeader`).
+   *
+   * @returns the rows of the file as a vector of vector strings
+   */
   const std::vector<std::vector<std::string>> &getRows() const { return rows_; }
 
+  /**
+   * Non-const version of `CsvReader::getRows`. Get the rows parsed from the
+   * file passed in the constructor. This will not include the header row (to
+   * get the header, use `CsvReader::getHeader`).
+   *
+   * @returns the rows of the file as a vector of vector strings
+   */
   std::vector<std::vector<std::string>> &getRows() {
     return const_cast<std::vector<std::vector<std::string>> &>(
         const_cast<const CsvReader &>(*this).getRows());

--- a/fbpcs/emp_games/lift/common/CsvReader.h
+++ b/fbpcs/emp_games/lift/common/CsvReader.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace df {
+namespace detail {
+std::vector<std::string> split(const std::string &s);
+} // namespace detail
+
+/**
+ * Represents an error that a parsed row has a different length than the header.
+ */
+class RowLengthMismatch : public std::exception {
+public:
+  /**
+   * Construct a new RowLengthMismatch error indicating that a parsed row has
+   * a different length than the previously parsed header.
+   *
+   * @param headerSize the number of elements in the header
+   * @param rowSize the number of elements in the newly parsed row
+   */
+  RowLengthMismatch(std::size_t headerSize, std::size_t rowSize) {
+    msg_ = "Header has size " + std::to_string(headerSize) +
+           " while row has size " + std::to_string(rowSize);
+  }
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+private:
+  std::string msg_;
+};
+
+class CsvFileReadException : public std::exception {
+public:
+  explicit CsvFileReadException(const std::string &filePath) {
+    msg_ = "Failed to read file '" + filePath + "'";
+  }
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+private:
+  std::string msg_;
+};
+
+class CsvReader {
+public:
+  explicit CsvReader(const std::string &filePath);
+
+  const std::vector<std::string> &getHeader() const { return header_; }
+
+  std::vector<std::string> &getHeader() {
+    return const_cast<std::vector<std::string> &>(
+        const_cast<const CsvReader &>(*this).getHeader());
+  }
+
+  const std::vector<std::vector<std::string>> &getRows() const { return rows_; }
+
+  std::vector<std::vector<std::string>> &getRows() {
+    return const_cast<std::vector<std::vector<std::string>> &>(
+        const_cast<const CsvReader &>(*this).getRows());
+  }
+
+private:
+  std::vector<std::string> header_;
+  std::vector<std::vector<std::string>> rows_;
+};
+} // namespace df

--- a/fbpcs/emp_games/lift/common/DataFrame.cpp
+++ b/fbpcs/emp_games/lift/common/DataFrame.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "fbpcs/emp_games/lift/common/CsvReader.h"
+
+namespace df {
+DataFrame DataFrame::readCsv(const TypeMap &typeMap,
+                             const std::string &filePath) {
+  CsvReader rdr{filePath};
+  return loadFromRows(typeMap, rdr.getHeader(), rdr.getRows());
+}
+
+DataFrame
+DataFrame::loadFromRows(const TypeMap &typeMap,
+                        const std::vector<std::string> &header,
+                        const std::vector<std::vector<std::string>> &rows) {
+  DataFrame df;
+
+  for (const auto &row : rows) {
+    for (std::size_t i = 0; i < row.size(); ++i) {
+      auto colName = header.at(i);
+      if (std::find(typeMap.boolColumns.begin(), typeMap.boolColumns.end(),
+                    colName) != typeMap.boolColumns.end()) {
+        df.get<bool>(colName).push_back(detail::parse<bool>(row.at(i)));
+      } else if (std::find(typeMap.intColumns.begin(), typeMap.intColumns.end(),
+                           colName) != typeMap.intColumns.end()) {
+        df.get<int64_t>(colName).push_back(detail::parse<int64_t>(row.at(i)));
+      } else if (std::find(typeMap.intVecColumns.begin(),
+                           typeMap.intVecColumns.end(),
+                           colName) != typeMap.intVecColumns.end()) {
+        df.get<std::vector<int64_t>>(colName).push_back(
+            detail::parseVector<int64_t>(row.at(i)));
+      } else {
+        // Either we don't know what this column is, or it's supposed to be a
+        // string anyway. Safest approach is to not do *any* parsing in this
+        // case.
+        df.get<std::string>(colName).push_back(row.at(i));
+      }
+    }
+  }
+
+  return df;
+}
+} // namespace df

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -25,8 +25,21 @@
  * https://stackoverflow.com/a/32651111/15625637
  */
 namespace df {
+/**
+ * This class is a convenience wrapper for an error in parsing a string to a
+ * specific subType. It allows the caller to gracefully catch an exception
+ * from parsing user-supplied data instead of getting an opaque issue related to
+ * a stream failure.
+ */
 class ParseException : public std::exception {
 public:
+  /**
+   * Construct a new ParseException that represents a failure to parse `s` as
+   * the specified type.
+   *
+   * @param s the string being parsed
+   * @param typeName a human-readable name for the type s was being parsed as
+   */
   explicit ParseException(const std::string &s, const std::string &typeName) {
     msg_ = "Failed to parse '" + s + "' as type '" + typeName + "'";
   }
@@ -37,18 +50,40 @@ private:
   std::string msg_;
 };
 
+/**
+ * A class which should not be instantiated directly, but is useful in the
+ * development of our dynamically typed DataFrame.
+ */
 class BaseMap {
 public:
   virtual ~BaseMap() {}
 };
 
 // actual map of Columns
+/**
+ * A class which represents an unordered_map of strings to type T. It extends
+ * our virtual BaseMap above which will let us do the dynamic typing later in
+ * DataFrame, which is why we have this (seemingly) useless definition.
+ *
+ * @tparam T the type of data stored in this MapT
+ */
 template <typename T>
 class MapT : public BaseMap,
              public std::unordered_map<std::string, Column<T>> {};
 
+/**
+ * This class is a convenience wrapper for an error in accessing our DataFrame
+ * with the wrong type specifier. For example, code might throw this exception
+ * when calling `df.get<int>("stringCol")` since int != string.
+ */
 class BadTypeException : public std::exception {
 public:
+  /**
+   * Construct a BadTypeException.
+   *
+   * @param expected a human-readable name for the type that was expected
+   * @param actual a human-readable name for the type that was given
+   */
   explicit BadTypeException(std::string expected, std::string actual) {
     msg_ = "Expected type '" + expected + "', but got type '" + actual + "'";
   }
@@ -59,28 +94,89 @@ private:
   std::string msg_;
 };
 
+/**
+ * A struct for holding lists of expected types when parsing a CSV. Since C++
+ * is a statically typed language, we must know *before* reading a CSV what
+ * type we expect each column to have if we want to make efficent use of our
+ * DataFrame and avoid a bunch of dynamic_casts. By marking ahead of time which
+ * columns will have which types, we have a single dynamic_cast to get into
+ * the Column, but accesses to individual elements will natively be of type T.
+ */
 struct TypeMap {
   std::vector<std::string> boolColumns;
   std::vector<std::string> intColumns;
   std::vector<std::string> intVecColumns;
 };
 
+/**
+ * A generic DataFrame usable much like one would expect in Python's `pandas`!
+ * A DataFrame can be constructed by hand or loaded from a CSV/rows for a more
+ * abstract interface. Columns can be modified or accessed via the `get`/`at`
+ * methods. There is currently no way to apply functions across rows (it is
+ * expected that this library will be used in a columnar fashion), but that
+ * feature may be added later.
+ */
 class DataFrame {
 public:
   using TypeInfo = std::pair<std::type_index, std::string>;
 
+  /**
+   * Read a CSV into a new DataFrame. Takes a typeMap to parse strings to typed
+   * values during reading. Columns encountered in the CSV which are not listed
+   * in the typeMap, will be parsed as `std::string`. The caller may choose
+   * later to convert these to a new type via functions like `Column::map`.
+   *
+   * @param typeMap expected typing for each column that will be read from the
+   *     CSV. If a type is given in this map, all values in the Column *must*
+   *     parse to that type or a `ParseException` will be thrown.
+   * @param filePath a path to the CSV to be loaded
+   * @returns a DataFrame object loaded from the filePath with the given types
+   * @throws `ParseException` if a type is given but a value in the Column
+   *     cannot parse to that type
+   * @note for columns not in `typeMap`, `std::string` will be assumed
+   */
   static DataFrame readCsv(const TypeMap &typeMap, const std::string &filePath);
 
+  /**
+   * Read a CSV into a new DataFrame. Takes a typeMap to parse strings to typed
+   * values during reading. Columns encountered in the CSV which are not listed
+   * in the typeMap, will be parsed as `std::string`. The caller may choose
+   * later to convert these to a new type via functions like `Column::map`.
+   *
+   * @param typeMap expected typing for each column that will be read from the
+   *     CSV. If a type is given in this map, all values in the Column *must*
+   *     parse to that type or a `ParseException` will be thrown.
+   * @param header the list of column names being loaded
+   * @param rows a list of rows where each row is the size of the header; it is
+   *     assumed that `header[i]` corresponds to `rows[_][i]`
+   * @returns a DataFrame object loaded from the filePath with the given types
+   * @throws `ParseException` if a type is given but a value in the Column
+   *     cannot parse to that type
+   * @note for columns not in `typeMap`, `std::string` will be assumed
+   */
   static DataFrame
   loadFromRows(const TypeMap &typeMap, const std::vector<std::string> &header,
                const std::vector<std::vector<std::string>> &rows);
 
+  /**
+   * Check that two types are equivalent. This is used to avoid a potentially
+   * bad `dynamic_cast` in `get`/`at` calls.
+   *
+   * @param expected the type being expected
+   * @param actual the actual type supplied
+   * @throws `BadTypeException` if `expected` is not equal to `actual`
+   */
   static void checkType(const TypeInfo &expected, const TypeInfo &actual) {
     if (expected.first != actual.first) {
       throw BadTypeException{expected.second, actual.second};
     }
   }
 
+  /**
+   * Get the keys contained within this DataFrame.
+   *
+   * @returns the set of keys stored in this DataFrame
+   */
   std::unordered_set<std::string> keys() const {
     std::unordered_set<std::string> res;
     for (const auto &[typ, _] : types_) {
@@ -89,6 +185,15 @@ public:
     return res;
   }
 
+  /**
+   * Get the keys of type `T` contained within this DataFrame. For example, if
+   * this DataFrame contains two int Columns intsCol1 and intsCol2 and two
+   * `std::string` Columns stringsCol1 and stringsCol2, then a call to
+   * `keysOf<int>()` would return the set `{"intsCol1", "intsCol2"}.`
+   *
+   * @tparam T a filter for which keys to ask for
+   * @returns the set of keys stored in this DataFrame that have type T
+   */
   template <typename T> std::unordered_set<std::string> keysOf() const {
     std::unordered_set<std::string> res;
     auto target = std::type_index(typeid(T));
@@ -100,6 +205,20 @@ public:
     return res;
   }
 
+  /**
+   * Get a `Column<T>` at the given key within this DataFrame. A `dynamic_cast`
+   * is necessary since we're dynamically altering types at runtime depending
+   * on the values being read or set. While there is a small computational cost
+   * to this cast, since we can guarantee that all elements of the resulting
+   * Column are of type `T`, it is only incurred upon this initial `get<T>`.
+   *
+   * @tparam T the type of Column<T> stored at the given key
+   * @param key the Column key to look up in this DataFrame
+   * @returns the `Column<T>` stored at the given key
+   * @throws `BadTypeException` if the key is already in the DataFrame but
+   *     stored as a type other than `T`
+   * @throws `std::out_of_range` if `key` does not exist within this DataFrame
+   */
   template <typename T> const Column<T> &get(const std::string &key) const {
     auto idx = std::type_index(typeid(T));
     // If this column is defined, ensure the type is correct
@@ -112,6 +231,18 @@ public:
     return dynamic_cast<MapT<T> &>(*ptr)[key];
   }
 
+  /**
+   * The non-const version of `DataFrame::get<T>` which may insert a new Column
+   * into this DataFrame if the key doesn't already exist. If the key does
+   * exist, we return a reference to its Column in this DataFrame.
+   *
+   * @tparam T the type of Column<T> stored at the given key (or the type of the
+   *     newly created column if `key` doesn't already exist in this DataFrame)
+   * @param key the Column key to look up in this DataFrame
+   * @returns the `Column<T>` stored at the given key (could be newly created)
+   * @throws `BadTypeException` if the key is already in the DataFrame but
+   *     stored as a type other than `T`
+   */
   template <typename T> Column<T> &get(const std::string &key) {
     auto idx = std::type_index(typeid(T));
     auto typeName = typeid(T).name();
@@ -130,6 +261,16 @@ public:
         const_cast<const DataFrame &>(*this).get<T>(key));
   }
 
+  /**
+   * Get a `Column<T>` at the given key within this DataFrame.
+   *
+   * @tparam T the type of Column<T> stored at the given key
+   * @param key the Column key to look up in this DataFrame
+   * @returns the `Column<T>` stored at the given key
+   * @throws `BadTypeException` if the key is already in the DataFrame but
+   *     stored as a type other than `T`
+   * @throws `std::out_of_range` if `key` does not exist within this DataFrame
+   */
   template <typename T> const Column<T> &at(const std::string &key) const {
     auto idx = std::type_index(typeid(T));
     auto typeName = typeid(T).name();
@@ -139,11 +280,31 @@ public:
     return (*this).get<T>(key);
   }
 
+  /**
+   * The non-const version of `DataFrame::at<T>`. This method will *not* insert
+   * a new Column into this DataFrame if an entry does not exist at the key.
+   *
+   * @tparam T the type of Column<T> stored at the given key
+   * @param key the Column key to look up in this DataFrame
+   * @returns the `Column<T>` stored at the given key
+   * @throws `BadTypeException` if the key is already in the DataFrame but
+   *     stored as a type other than `T`
+   * @throws `std::out_of_range` if `key` does not exist within this DataFrame
+   */
   template <typename T> Column<T> &at(const std::string &key) {
     return const_cast<Column<T> &>(
         const_cast<const DataFrame &>(*this).at<T>(key));
   }
 
+  /**
+   * Remove a column from this DataFrame by erasing the reference from it in
+   * the internal map. This is useful if you no longer need access to a given
+   * Column and wish to aggressively free memory related to it.
+   *
+   * @tparam T the type of Column<T> stored at the given key
+   *
+   * @param key the key to remove from this DataFrame
+   */
   template <typename T> void drop(const std::string &key) {
     auto idx = std::type_index(typeid(T));
     auto &ptr = maps_.at(idx);
@@ -162,6 +323,14 @@ private:
 };
 
 namespace detail {
+/**
+ * Parse a `std::string` into the given type using a `std::istringstream`.
+ *
+ * @tparam T the type to parse `value` into
+ * @param value the string to be parsed into a new T
+ * @returns `value` parsed as a `T`
+ * @throws `ParseException` if the value cannot be parsed into a `T`
+ */
 template <typename T> T parse(const std::string &value) {
   std::istringstream iss{value};
   T res;
@@ -183,6 +352,16 @@ template <typename T> T parse(const std::string &value) {
   return res;
 }
 
+/**
+ * Parse a `std::string` into a vector the given type by splitting across commas
+ * and calling `parse<T>` on each relevant substring.
+ *
+ * @tparam T the type to parse `value` into
+ * @param value the string to be parsed into a new T
+ * @returns `value` parsed as a `T`
+ * @throws `ParseException` if the value cannot be parsed into a `T`
+ * @note requires that `value` begin with `[` and end with `]`
+ */
 template <typename T> std::vector<T> parseVector(const std::string &value) {
   if (value.at(0) != '[' || value.at(value.size() - 1) != ']') {
     auto typeName = std::string{"std::vector<"} + typeid(T).name() + ">";

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -13,6 +13,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "fbpcs/emp_games/lift/common/Column.h"
@@ -52,6 +53,25 @@ public:
     if (expected.first != actual.first) {
       throw BadTypeException{expected.second, actual.second};
     }
+  }
+
+  std::unordered_set<std::string> keys() const {
+    std::unordered_set<std::string> res;
+    for (const auto &[typ, _] : types_) {
+      res.insert(typ);
+    }
+    return res;
+  }
+
+  template <typename T> std::unordered_set<std::string> keysOf() const {
+    std::unordered_set<std::string> res;
+    auto target = std::type_index(typeid(T));
+    for (const auto &[typ, info] : types_) {
+      if (info.first == target) {
+        res.insert(typ);
+      }
+    }
+    return res;
   }
 
   template <typename T> const Column<T> &get(const std::string &key) const {

--- a/fbpcs/emp_games/lift/common/IDataFrameBuilder.h
+++ b/fbpcs/emp_games/lift/common/IDataFrameBuilder.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace private_lift {
+/**
+ * Interface for a class which is able to build a new DataFrame in some context.
+ * It's useful to define this as an interface for easier testability in classes
+ * which may wish to use a DataFrameBuilder, but would benefit from mocking the
+ * implementation to return static data in test classes.
+ */
+class IDataFrameBuilder {
+ public:
+  /**
+   * Virtual destructor since this class is an interface.
+   */
+  virtual ~IDataFrameBuilder() {}
+
+  /**
+   * Construct a new `df::DataFrame` (*not* a reference to an existing object).
+   *
+   * @returns a newly constructed `df::DataFrame`
+   */
+  virtual df::DataFrame buildNew() const = 0;
+};
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -402,3 +402,15 @@ TEST(BinaryAssignmentOpTest, Divide) {
   EXPECT_EQ(expected1, c);
   EXPECT_EQ(expected2, c2);
 }
+
+TEST(IteratorTest, IteratorFunctionality) {
+  Column<int64_t> c{300, 200, 100};
+  auto iter = c.begin();
+  EXPECT_EQ(*iter, 300);
+  ++iter;
+  EXPECT_EQ(*iter, 200);
+  ++iter;
+  EXPECT_EQ(*iter, 100);
+  ++iter;
+  EXPECT_EQ(iter, c.end());
+}

--- a/fbpcs/emp_games/lift/common/test/CsvReaderTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/CsvReaderTest.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/common/CsvReader.h"
+
+using namespace df;
+
+TEST(CsvReaderDetail, Split) {
+  std::vector<std::string> expected{"123", "456", "789"};
+  EXPECT_EQ(expected, detail::split("123,456,789"));
+
+  std::vector<std::string> expected2{"[1,2,3]", "456", "789"};
+  EXPECT_EQ(expected2, detail::split("[1,2,3],456,789"));
+
+  std::vector<std::string> expected3{"[1,2,3]", "[4,5,6]", "789"};
+  EXPECT_EQ(expected3, detail::split("[1,2,3],[4,5,6],789"));
+
+  std::vector<std::string> expected4{"[1,2,3,4,5,6,7,8,9]"};
+  EXPECT_EQ(expected4, detail::split("[1,2,3,4,5,6,7,8,9]"));
+
+  // Missing trailing ']'
+  EXPECT_THROW(detail::split("[1,2,3,4,5,6,7,8,9"), std::out_of_range);
+}

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -62,4 +63,30 @@ TEST(DataFrameTest, DropColumn) {
 
   df.drop<int64_t>("intCol");
   EXPECT_THROW(df.at<int64_t>("intCol"), std::out_of_range);
+}
+
+TEST(DataFrameTest, Keys) {
+  DataFrame df;
+  df.get<std::string>("bool1") = {"true", "false"};
+  df.get<std::string>("bool2") = {"1", "0"};
+  df.get<std::string>("int1") = {"123", "111"};
+  df.get<std::string>("int2") = {"456", "222"};
+  df.get<std::string>("intVec") = {"[7,8,9]", "[333]"};
+
+  std::unordered_set<std::string> allKeys{"bool1", "bool2", "int1", "int2",
+                                          "intVec"};
+  EXPECT_EQ(allKeys, df.keys());
+  EXPECT_EQ(allKeys, df.keysOf<std::string>());
+
+  DataFrame df2;
+  df2.get<bool>("bool1") = {true, false};
+  df2.get<bool>("bool2") = {true, false};
+  df2.get<int64_t>("int1") = {123, 111};
+  df2.get<int64_t>("int2") = {456, 222};
+  df2.get<std::vector<int64_t>>("intVec") = {{7, 8, 9}, {333}};
+
+  EXPECT_EQ(allKeys, df2.keys());
+
+  std::unordered_set<std::string> boolKeys{"bool1", "bool2"};
+  EXPECT_EQ(boolKeys, df2.keysOf<bool>());
 }


### PR DESCRIPTION
Summary:
# What
 * Interface for a class which is able to build a new DataFrame in some context.
# Why
* It's useful to define this as an interface for easier testability in classes which may wish to use a DataFrameBuilder, but would benefit from mocking the implementation to return static data in test classes.

## "Why the weird numbering of 19.5?"
I came back and created this later when I was writing diffs in a later part of the stack. Rather than make things confusing by renaming the whole stack, I just inserted it between diffs 19 and 20.

Differential Revision: D32056581

