### PR TITLE
post processing handler don't override stageflow

### DIFF
--- a/fbpcs/private_computation/entity/__init__.py
+++ b/fbpcs/private_computation/entity/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+PrivateComputationBaseStageFlow has a mapping from subclass name -> subclass.
+This only works if the subclass is imported somewhere in the global namespace.
+This logic will import all of the modules in the directory, which will guarantee
+that each subclass is imported whenever PrivateComputationBaseStageFlow is imported.
+
+Reference: https://stackoverflow.com/a/60861023/
+"""
+
+from importlib import import_module
+from pathlib import Path
+
+# grabs each python file
+for f in Path(__file__).parent.glob("*.py"):
+    module_name = f.stem
+    # prevents circular imports
+    if (not module_name.startswith("_")) and (module_name not in globals()):
+        import_module(f".{module_name}", __package__)
+    del f, module_name
+# unload these modules
+del import_module, Path

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -9,7 +9,7 @@
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Type
 
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcs.common.entity.instance_base import InstanceBase
@@ -186,6 +186,12 @@ class PrivateComputationInstance(InstanceBase):
         )
 
     @property
+    def stage_flow(self) -> Type[PrivateComputationBaseStageFlow]:
+        return PrivateComputationBaseStageFlow.cls_name_to_cls(
+            self._stage_flow_cls_name
+        )
+
+    @property
     def current_stage(self) -> PrivateComputationBaseStageFlow:
         return PrivateComputationBaseStageFlow.cls_name_to_cls(
             self._stage_flow_cls_name
@@ -198,6 +204,4 @@ class PrivateComputationInstance(InstanceBase):
         * If the instance has a failed status, return the current stage in the flow
         * If the instance has a completed status, return the next stage in the flow (which could be None)
         """
-        return PrivateComputationBaseStageFlow.cls_name_to_cls(
-            self._stage_flow_cls_name
-        ).get_next_runnable_stage_from_status(self.status)
+        return self.stage_flow.get_next_runnable_stage_from_status(self.status)

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -114,6 +114,7 @@ class PostProcessingStageService(PrivateComputationStageService):
         # we can set the status to completed.
         if post_processing_instance.status != PostProcessingInstanceStatus.FAILED:
             post_processing_instance.status = PostProcessingInstanceStatus.COMPLETED
+            pc_instance.status = pc_instance.current_stage.completed_status
         return pc_instance
 
 

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -587,12 +587,16 @@ class PrivateComputationService:
         aggregated_result_path: Optional[str] = None,
         dry_run: Optional[bool] = False,
     ) -> PrivateComputationInstance:
-        # if calling PC the legacy way, make sure that the legacy stage
-        # flow is being used
-        self._override_stage_flow(instance_id, PrivateComputationLegacyStageFlow)
+        instance = self.get_instance(instance_id)
+        # this gets the stage object associated with the post processing handler stage.
+        # It will be validated later in the run to make sure that the stage is actually ready
+        # to be run.
+        pph_stage = instance.stage_flow.get_stage_from_status(
+            PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED
+        )
         return await self.run_stage_async(
             instance_id,
-            PrivateComputationLegacyStageFlow.POST_PROCESSING_HANDLERS,
+            pph_stage,
             PostProcessingStageService(
                 self.storage_svc, self.post_processing_handlers, aggregated_result_path
             ),


### PR DESCRIPTION
Summary:
## What

* Don't override post processing handler stage flow
* Implement custom `__init__.py` that imports all stage flows

## Why

* I originally added stage flow overrides in id match, compute, aggregate, and post processing handler because my thought was that those will only be called when going through the legacy flow, so we should make sure that the flow being used during the run is correct
* In production, run_post_processing_handlers_async is triggered by an EntObserver, so it will continued being called in both the legacy and non legacy stage flows. Thus, we don't want to override the stage flow.

Differential Revision: D32002089

