### PR TITLE
add run stage to private computation service wrapper

### DIFF
--- a/fbpcs/private_computation/entity/__init__.py
+++ b/fbpcs/private_computation/entity/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+PrivateComputationBaseStageFlow has a mapping from subclass name -> subclass.
+This only works if the subclass is imported somewhere in the global namespace.
+This logic will import all of the modules in the directory, which will guarantee
+that each subclass is imported whenever PrivateComputationBaseStageFlow is imported.
+
+Reference: https://stackoverflow.com/a/60861023/
+"""
+
+from importlib import import_module
+from pathlib import Path
+
+# grabs each python file
+for f in Path(__file__).parent.glob("*.py"):
+    module_name = f.stem
+    # prevents circular imports
+    if (not module_name.startswith("_")) and (module_name not in globals()):
+        import_module(f".{module_name}", __package__)
+    del f, module_name
+# unload these modules
+del import_module, Path

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -9,7 +9,7 @@
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Type
 
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcs.common.entity.instance_base import InstanceBase
@@ -186,6 +186,12 @@ class PrivateComputationInstance(InstanceBase):
         )
 
     @property
+    def stage_flow(self) -> Type[PrivateComputationBaseStageFlow]:
+        return PrivateComputationBaseStageFlow.cls_name_to_cls(
+            self._stage_flow_cls_name
+        )
+
+    @property
     def current_stage(self) -> PrivateComputationBaseStageFlow:
         return PrivateComputationBaseStageFlow.cls_name_to_cls(
             self._stage_flow_cls_name
@@ -198,6 +204,4 @@ class PrivateComputationInstance(InstanceBase):
         * If the instance has a failed status, return the current stage in the flow
         * If the instance has a completed status, return the next stage in the flow (which could be None)
         """
-        return PrivateComputationBaseStageFlow.cls_name_to_cls(
-            self._stage_flow_cls_name
-        ).get_next_runnable_stage_from_status(self.status)
+        return self.stage_flow.get_next_runnable_stage_from_status(self.status)

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -114,6 +114,7 @@ class PostProcessingStageService(PrivateComputationStageService):
         # we can set the status to completed.
         if post_processing_instance.status != PostProcessingInstanceStatus.FAILED:
             post_processing_instance.status = PostProcessingInstanceStatus.COMPLETED
+            pc_instance.status = pc_instance.current_stage.completed_status
         return pc_instance
 
 

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -224,16 +224,15 @@ class PrivateComputationService:
         if not next_stage:
             self.logger.warning("There are no eligble stages to be ran at this time.")
             return pc_instance
-        stage_svc = next_stage.get_stage_service(self.stage_service_args)
         return await self.run_stage_async(
-            instance_id, next_stage, stage_svc, server_ips=server_ips
+            instance_id, next_stage, server_ips=server_ips
         )
 
     def run_stage(
         self,
         instance_id: str,
         stage: PrivateComputationBaseStageFlow,
-        stage_svc: PrivateComputationStageService,
+        stage_svc: Optional[PrivateComputationStageService] = None,
         server_ips: Optional[List[str]] = None,
         dry_run: bool = False,
     ) -> PrivateComputationInstance:
@@ -287,7 +286,7 @@ class PrivateComputationService:
         self,
         instance_id: str,
         stage: PrivateComputationBaseStageFlow,
-        stage_svc: PrivateComputationStageService,
+        stage_svc: Optional[PrivateComputationStageService] = None,
         server_ips: Optional[List[str]] = None,
         dry_run: bool = False,
     ) -> PrivateComputationInstance:
@@ -306,6 +305,7 @@ class PrivateComputationService:
         )
         self.logger.info(repr(stage))
         try:
+            stage_svc = stage_svc or stage.get_stage_service(self.stage_service_args)
             pc_instance = await stage_svc.run_async(pc_instance, server_ips)
         except Exception as e:
             self.logger.error(f"Caught exception when running {stage}\n{e}")

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -587,12 +587,16 @@ class PrivateComputationService:
         aggregated_result_path: Optional[str] = None,
         dry_run: Optional[bool] = False,
     ) -> PrivateComputationInstance:
-        # if calling PC the legacy way, make sure that the legacy stage
-        # flow is being used
-        self._override_stage_flow(instance_id, PrivateComputationLegacyStageFlow)
+        instance = self.get_instance(instance_id)
+        # this gets the stage object associated with the post processing handler stage.
+        # It will be validated later in the run to make sure that the stage is actually ready
+        # to be run.
+        pph_stage = instance.stage_flow.get_stage_from_status(
+            PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED
+        )
         return await self.run_stage_async(
             instance_id,
-            PrivateComputationLegacyStageFlow.POST_PROCESSING_HANDLERS,
+            pph_stage,
             PostProcessingStageService(
                 self.storage_svc, self.post_processing_handlers, aggregated_result_path
             ),

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -316,6 +316,30 @@ def run_next(
 
     logger.info(instance)
 
+def run_stage(
+    config: Dict[str, Any],
+    instance_id: str,
+    stage: PrivateComputationBaseStageFlow,
+    logger: logging.Logger,
+    server_ips: Optional[List[str]] = None,
+) -> None:
+
+    pc_service = _build_private_computation_service(
+        config["private_computation"],
+        config["mpc"],
+        config["pid"],
+        config.get("post_processing_handlers", {}),
+    )
+
+    # Because it's possible that the "get" command never gets called to update the instance since the last step started,
+    # so it could appear that the current status is still XXX_STARTED when it should be XXX_FAILED or XXX_COMPLETED,
+    # so we need to explicitly call update_instance() here to get the current status.
+    pc_service.update_instance(instance_id)
+
+    instance = pc_service.run_stage(instance_id=instance_id, stage=stage, server_ips=server_ips)
+
+    logger.info(instance)
+
 
 def get_instance(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger


### PR DESCRIPTION
Summary:
## What

* Add run stage to PCS wrapper
* Stage service is now an optional argument to run_stage

## Why

* It will let us call run_stage directly on a stage flow instance from one command runner
* Later on, we can add --dry-run to this so that we can skip stages (e.g. create a stage and then run only aggregate for testing purposes).

Differential Revision: D32031582

