### PR TITLE
one command runner support run next

### DIFF
--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -52,6 +52,9 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_legacy_stage_flow import (
     PrivateComputationLegacyStageFlow,
 )
+from fbpcs.private_computation.entity.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
+)
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     aggregate_shards,
     cancel_current_stage,
@@ -253,8 +256,7 @@ def main():
         if arguments["--legacy"]:
             stage_flow = PrivateComputationLegacyStageFlow
         else:
-            # I will replace this in later diffs in stack
-            stage_flow = PrivateComputationLegacyStageFlow
+            stage_flow = PrivateComputationStageFlow
 
         logger.info(f"Running instance: {instance_id}")
         run_instance(
@@ -271,8 +273,7 @@ def main():
         if arguments["--legacy"]:
             stage_flow = PrivateComputationLegacyStageFlow
         else:
-            # I will replace this in later diffs in stack
-            stage_flow = PrivateComputationLegacyStageFlow
+            stage_flow = PrivateComputationStageFlow
         run_instances(
             config=config,
             instance_ids=arguments["<instance_ids>"],
@@ -287,8 +288,7 @@ def main():
         if arguments["--legacy"]:
             stage_flow = PrivateComputationLegacyStageFlow
         else:
-            # I will replace this in later diffs in stack
-            stage_flow = PrivateComputationLegacyStageFlow
+            stage_flow = PrivateComputationStageFlow
         run_study(
             config=config,
             study_id=arguments["<study_id>"],

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -73,7 +73,9 @@ class TestPlInstanceRunner(TestCase):
                 mock_get_instance.return_value = self._get_pc_instance(partner_status)
 
                 runner = self._get_runner(type(stage))
-                ready_for_stage = runner.ready_for_stage(stage)
+                # this test is updated in the next diff to check publisher and partner
+                # with possibly differing "ready for" results
+                ready_for_stage = runner.publisher.ready_for_stage(stage)
                 self.assertEqual(ready_for_stage, result)
 
     @patch(


### PR DESCRIPTION
Summary:
## What

* Add run next support to one command runner
* Most of the added logic is to support non joint stages (stages that don't require server ips and can run in parallel)
    * e.g. you can have PREPARE_DATA_FAILED in publisher and PREPARE_DATA_COMPLETED in partner. The valid stage here would be PREPARE and only the publisher would rerun.
* Handle TIMEOUT status, which is a generic status exclusive to the NEXT graph api operation. If this status is seen, we must send a NEXT graph api request and wait for it to give a valid status

## Why

* You can now run some stages in parallel, e.g. prepare data (before compute metrics) is now run in parallel.
* This will let us add and remove stages and create entirely new stage flows without making changes to the one command instance runner.

Differential Revision: D32051864

