### PR TITLE
Create function to allow PID service to be called with specific stage or call for run_next

### DIFF
--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -47,6 +47,7 @@ class PIDProtocolRunStage(PIDStage):
             storage_svc=storage_svc,
             onedocker_svc=onedocker_svc,
             onedocker_binary_config=onedocker_binary_config,
+            is_joint_stage=True
         )
 
         self.cloud_credential_service = self._build_cloud_credential_service(

--- a/fbpcs/pid/service/pid_service/pid_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_stage.py
@@ -29,6 +29,7 @@ class PIDStage(abc.ABC):
         storage_svc: StorageService,
         onedocker_svc: OneDockerService,
         onedocker_binary_config: OneDockerBinaryConfig,
+        is_joint_stage: bool = False
     ) -> None:
         self.stage_type = stage
         self.storage_svc = storage_svc
@@ -36,6 +37,7 @@ class PIDStage(abc.ABC):
         self.onedocker_binary_config = onedocker_binary_config
         self.instance_repository = instance_repository
         self.logger: logging.Logger = logging.getLogger(__name__)
+        self.is_joint_stage = is_joint_stage
 
     @abc.abstractmethod
     async def run(

--- a/fbpcs/pid/service/pid_service/tests/test_pid.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid.py
@@ -204,6 +204,10 @@ class TestPIDService(unittest.TestCase):
         ) as mock_build_stages, patch.object(PIDDispatcher, "run_all") as mock_run_all:
             # add the line below to avoid "TypeError: __init__() should return None, not 'MagicMock'""
             mock_init.return_value = None
+            sample_pid_instance = self._get_sample_pid_instance()
+            self.pid_service.instance_repository.read = MagicMock(
+                return_value=sample_pid_instance
+            )
             await self.pid_service.run_instance(
                 instance_id=TEST_INSTANCE_ID,
                 pid_config=TEST_PID_CONFIG,


### PR DESCRIPTION
Summary:
## Context
- Right now in the PI service, we only have `run_instance` to call dispatcher.run_all()
- However, the PCS will make different thrift call for different stage. This require the PID service to support running different stage separately
- So we need to create a new function to call `dispatcher.run_stage` or `dispatcher.run_next` to allow dispatch to run individual stage.

## This diff
- Create a new function called `run_stage_or_next` function which take an optional pid_union_stage as input argument
- If it's not none, it will try to call `dispatcher.run_stage`
- If not, it will call `dispatcher.run_next` by default.

Reviewed By: jrodal98

Differential Revision: D32040997

