### PR TITLE
Decoupling - adding decoupled games to on-call scripts.

### DIFF
--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -77,3 +77,34 @@ target_link_libraries(
   shard_aggregator
   empgamecommon)
 install(TARGETS shard_aggregator DESTINATION bin)
+
+# decoupled_attribution
+file(GLOB decoupled_attribution_src
+  "fbpcs/emp_games/attribution/decoupled_attribution/**.c"
+  "fbpcs/emp_games/attribution/decoupled_attribution/**.cpp"
+  "fbpcs/emp_games/attribution/decoupled_attribution/**.h"
+  "fbpcs/emp_games/attribution/decoupled_attribution/**.hpp")
+list(FILTER decoupled_attribution_src EXCLUDE REGEX ".*Test.*")
+add_executable(
+  decoupled_attribution_calculator
+  ${decoupled_attribution_src})
+target_link_libraries(
+  decoupled_attribution_calculator
+  empgamecommon)
+install(TARGETS decoupled_attribution_calculator DESTINATION bin)
+
+# decoupled_aggregation
+file(GLOB decoupled_aggregation_src
+  "fbpcs/emp_games/attribution/decoupled_aggregation/**.c"
+  "fbpcs/emp_games/attribution/decoupled_aggregation/**.cpp"
+  "fbpcs/emp_games/attribution/decoupled_aggregation/**.h"
+  "fbpcs/emp_games/attribution/decoupled_aggregation/metadata/**.h"
+  "fbpcs/emp_games/attribution/decoupled_aggregation/**.hpp")
+list(FILTER decoupled_aggregation_src EXCLUDE REGEX ".*Test.*")
+add_executable(
+  decoupled_aggregation_calculator
+  ${decoupled_aggregation_src})
+target_link_libraries(
+  decoupled_aggregation_calculator
+  empgamecommon)
+install(TARGETS decoupled_aggregation_calculator DESTINATION bin)

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -54,10 +54,12 @@ COPY --from=private_id /opt/private-id/bin/private-id-server /usr/local/bin/priv
 
 # Link all the binaries into /root/onedocker/package
 WORKDIR /usr/local/bin
-RUN for b in $(ls attribution* lift* pid* shard* private-id*); do ln -s $(pwd)/$b /root/onedocker/package/$b; done
+RUN for b in $(ls attribution* lift* pid* shard* private-id* decoupled*); do ln -s $(pwd)/$b /root/onedocker/package/$b; done
 
 # Link binaries name to match with onedocker binaries name
 RUN ln -s attribution_calculator /root/onedocker/package/compute
+RUN ln -s decoupled_attribution_calculator /root/onedocker/package/decoupled_attribution
+RUN ln -s decoupled_aggregation_calculator /root/onedocker/package/decoupled_aggregation
 RUN ln -s lift_calculator /root/onedocker/package/lift
 RUN ln -s shard_aggregator /root/onedocker/package/shard-aggregator
 

--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -45,6 +45,8 @@ if [ "$PACKAGE" = "emp_games" ]; then
 docker create -ti --name temp_container "fbpcs/emp-games:${TAG}"
 docker cp temp_container:/usr/local/bin/lift_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/attribution_calculator "$SCRIPT_DIR/binaries_out/."
+docker cp temp_container:/usr/local/bin/decoupled_attribution_calculator "$SCRIPT_DIR/binaries_out/."
+docker cp temp_container:/usr/local/bin/decoupled_aggregation_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/shard_aggregator "$SCRIPT_DIR/binaries_out/."
 docker rm -f temp_container
 fi


### PR DESCRIPTION
Summary:
**Changes:**
Modified on-call scripts and related files (CMakeLists.txt, Dockerfile.ubuntu) for new decoupled games.

**Why:**
We use on-call scripts to promote binaries in master to prod on a weekly basis.
The process is as follows
1. build the binaries and export them to AWS S3 (with rc tag).
2. Run E2E tests on the rc tagged binaries.
3. If tests passed, promote the binaries to prod.

Thus, once this diff is landed, decoupled_attribution and decoupled_aggregation binaries will be promoted to prod along with other binaries.

Reviewed By: gorel

Differential Revision: D31961557

