### PR TITLE
Add const apply and 'data' functions for Column

### DIFF
--- a/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
@@ -8,6 +8,7 @@
 #include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <emp-tool/emp-tool.h>
@@ -18,28 +19,56 @@
 #include "fbpcs/emp_games/lift/common/Column.h"
 #include "fbpcs/emp_games/lift/common/DataFrame.h"
 
-static constexpr int64_t kConversionCap = 25;
+namespace {
+inline constexpr int64_t kConversionCap = 25;
+}
 
-using namespace private_lift;
-
-LiftInputData::LiftInputData(fbpcf::Party party, const std::string& filePath)
-    : LiftInputData{LiftDataFrameBuilder{filePath, kConversionCap}, party} {}
+namespace private_lift {
+LiftInputData::LiftInputData(
+    fbpcf::Party party,
+    const std::string& filePath)
+    : LiftInputData{
+          LiftDataFrameBuilder{filePath, kConversionCap},
+          party} {}
 
 LiftInputData::LiftInputData(
     const LiftDataFrameBuilder& builder,
     fbpcf::Party party)
     : party_{party}, groupKey_{getGroupKeyForParty(party)} {
-  // Will implement in next diff
+  df_ = builder.buildNew();
+  groupCount_ = calculateGroupCount();
+  bitmasks_ = calculateBitmasks();
 }
 
 int64_t LiftInputData::calculateGroupCount() const {
-  int64_t maxId = 0;
-  // Will implement in next diff
-  return maxId;
+  int64_t maxId = -1;
+  auto keys = df_.keys();
+
+  // It's possible that neither group key appears in the dataset - these
+  // are optional fields in the input spec
+  if (keys.find(groupKey_) != keys.end()) {
+    for (const auto& value : df_.at<int64_t>(groupKey_)) {
+      maxId = std::max(maxId, value);
+    }
+  }
+
+  // If neither group key was in this df, this will appropriately set
+  // groupCount_ to zero (no groups in dataset)
+  // NOTE: Since it's expected that groups start from index 0, if we find a max
+  //       id == N, we have N + 1 groups!
+  return maxId + 1;
 }
 
-std::vector<df::Column<emp::Bit>> LiftInputData::calculateBitmasks() const {
-  std::vector<df::Column<emp::Bit>> res;
-  // Will implement in next diff
+std::vector<df::Column<bool>> LiftInputData::calculateBitmasks()
+    const {
+  std::vector<df::Column<bool>> res;
+  for (std::size_t group = 0; group < getGroupCount(); ++group) {
+    df::Column<bool> groupColumn;
+    for (const auto& value : df_.at<int64_t>(groupKey_)) {
+      groupColumn.push_back(value == group);
+    }
+    res.push_back(std::move(groupColumn));
+  }
   return res;
 }
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
@@ -38,6 +38,7 @@ LiftInputData::LiftInputData(
   df_ = builder.buildNew();
   groupCount_ = calculateGroupCount();
   bitmasks_ = calculateBitmasks();
+  size_ = calculateSize();
 }
 
 int64_t LiftInputData::calculateGroupCount() const {
@@ -70,5 +71,14 @@ std::vector<df::Column<bool>> LiftInputData::calculateBitmasks()
     res.push_back(std::move(groupColumn));
   }
   return res;
+}
+
+std::size_t LiftInputData::calculateSize() const {
+  if (df_.containsKey("opportunity_timestamp")) {
+    return df_.at<int64_t>("opportunity_timestamp").size();
+  } else {
+    // This must be the partner
+    return df_.at<std::vector<int64_t>>("event_timestamps").size();
+  }
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.h
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.h
@@ -89,16 +89,13 @@ class LiftInputData {
   }
 
   /**
-   * Get a column of bits representing a bitmask over a given groupId. These
-   * were precomputed upon creation of this LiftInputData since construction
-   * of new `emp::Bit` columns can be expensive.
+   * Get a column of bits representing a bitmask over a given groupId.
    *
    * @param groupId the groupId for which to retrieve a bitmask column
-   * @returns a `df::Column` of `emp::Bit` describing whether row[i] is valid
-   *     for this group
+   * @returns a `df::Column` describing whether row[i] is valid for this group
    * @throws std::out_of_range if groupId > groupCount
    */
-  const df::Column<emp::Bit> &getBitmaskFor(int64_t groupId) const {
+  const df::Column<bool>& getBitmaskFor(int64_t groupId) const {
     return bitmasks_.at(groupId);
   }
 
@@ -116,16 +113,16 @@ class LiftInputData {
    * run in the LiftInputData constructor to cache the result for later. For
    * more details, see `LiftInputData::getBitmaskFor`.
    *
-   * @returns a vector of Columns of `emp::Bit` representing whether row[i] is
-   *     valid for the group stored in vector index[j]
+   * @returns a vector of `Column<bool>` representing whether row[i] is valid
+   *     for the group stored in vector index[j]
    */
-  std::vector<df::Column<emp::Bit>> calculateBitmasks() const;
+  std::vector<df::Column<bool>> calculateBitmasks() const;
 
  private:
   fbpcf::Party party_;
   std::string groupKey_;
   df::DataFrame df_;
   int64_t groupCount_;
-  std::vector<df::Column<emp::Bit>> bitmasks_;
+  std::vector<df::Column<bool>> bitmasks_;
 };
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.h
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.h
@@ -89,6 +89,15 @@ class LiftInputData {
   }
 
   /**
+   * Get this LiftInputData's number of rows in the dataset.
+   *
+   * @returns the number of rows in this LiftInputData
+   */
+  int64_t size() const {
+    return size_;
+  }
+
+  /**
    * Get a column of bits representing a bitmask over a given groupId.
    *
    * @param groupId the groupId for which to retrieve a bitmask column
@@ -118,11 +127,23 @@ class LiftInputData {
    */
   std::vector<df::Column<bool>> calculateBitmasks() const;
 
+  /**
+   * Calculate the number of rows in this LiftInputData by taking the size of
+   * the opportunity_timestamp or event_timestamps column (since one must be
+   * defined to represent a valid party to the computation).
+   *
+   * @returns the size of the dataset from the `df::DataFrame`
+   * @throws std::out_of_range if neither of the party-defining columns
+   *     (opportunity_timestamp or event_timestamps) are defined in the dataset
+   */
+  std::size_t calculateSize() const;
+
  private:
   fbpcf::Party party_;
   std::string groupKey_;
   df::DataFrame df_;
   int64_t groupCount_;
   std::vector<df::Column<bool>> bitmasks_;
+  std::size_t size_;
 };
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
@@ -30,21 +30,23 @@ class MockLiftDataFrameBuilderForAlice : public LiftDataFrameBuilder {
 
     // Try to align these in a nice human-readable way to look like an
     // actual dataframe
-    res.get<int64_t>("test_population") =     {    1,     0,     0};
-    res.get<int64_t>("control_population") =  {    0,     0,     1};
-    res.get<int64_t>("breakdown_id") =        {    1,     0,     0};
-    res.get<int64_t>("num_impressions") =     {    5,     0,     0};
-    res.get<int64_t>("num_clicks") =          {    2,     0,     0};
-    res.get<int64_t>("total_spend") =         {  100,     0,     0};
+    res.get<int64_t>("opportunity_timestamp") = {  111,     0,   222,   333};
+    res.get<int64_t>("test_population") =       {    1,     0,     0,     1};
+    res.get<int64_t>("control_population") =    {    0,     0,     1,     0};
+    res.get<int64_t>("breakdown_id") =          {    1,     0,     0,     1};
+    res.get<int64_t>("num_impressions") =       {    5,     0,     0,     1};
+    res.get<int64_t>("num_clicks") =            {    2,     0,     0,     0};
+    res.get<int64_t>("total_spend") =           {  100,     0,     0,   200};
 
     // clang-format on
 
     return res;
   }
   int64_t expectedGroupCount = 2;
+  std::size_t expectedSize = 4;
   std::vector<df::Column<bool>> expectedBitmasks = {
-      {false, true, true},
-      {true, false, false}};
+      {false, true, true, false},
+      {true, false, false, true}};
 };
 
 class MockLiftDataFrameBuilderForBob : public LiftDataFrameBuilder {
@@ -70,6 +72,7 @@ class MockLiftDataFrameBuilderForBob : public LiftDataFrameBuilder {
   }
 
   int64_t expectedGroupCount = 3;
+  std::size_t expectedSize = 3;
   std::vector<df::Column<bool>> expectedBitmasks = {
       {true, false, false},
       {false, true, false},
@@ -106,4 +109,16 @@ TEST(LiftInputDataTest, CalculateBitmasks) {
     auto& actual = bob.getBitmaskFor(i);
     EXPECT_EQ(expected, actual);
   }
+}
+
+TEST(LiftInputData, CalculateSize) {
+  MockLiftDataFrameBuilderForAlice mockAlice;
+  LiftInputData alice{mockAlice, fbpcf::Party::Alice};
+
+  EXPECT_EQ(mockAlice.expectedSize, alice.size());
+
+  MockLiftDataFrameBuilderForBob mockBob;
+  LiftInputData bob{mockBob, fbpcf::Party::Bob};
+
+  EXPECT_EQ(mockBob.expectedSize, bob.size());
 }

--- a/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <fbpcf/mpc/EmpGame.h>
+
+#include "fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h"
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
+#include "fbpcs/emp_games/lift/common/Column.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+using namespace private_lift;
+
+class MockLiftDataFrameBuilderForAlice : public LiftDataFrameBuilder {
+ public:
+  MockLiftDataFrameBuilderForAlice() : LiftDataFrameBuilder{"", 3} {}
+
+  df::DataFrame buildNew() const final {
+    df::DataFrame res;
+
+    // clang-format off
+
+    // Try to align these in a nice human-readable way to look like an
+    // actual dataframe
+    res.get<int64_t>("test_population") =     {    1,     0,     0};
+    res.get<int64_t>("control_population") =  {    0,     0,     1};
+    res.get<int64_t>("breakdown_id") =        {    1,     0,     0};
+    res.get<int64_t>("num_impressions") =     {    5,     0,     0};
+    res.get<int64_t>("num_clicks") =          {    2,     0,     0};
+    res.get<int64_t>("total_spend") =         {  100,     0,     0};
+
+    // clang-format on
+
+    return res;
+  }
+  int64_t expectedGroupCount = 2;
+  std::vector<df::Column<bool>> expectedBitmasks = {
+      {false, true, true},
+      {true, false, false}};
+};
+
+class MockLiftDataFrameBuilderForBob : public LiftDataFrameBuilder {
+ public:
+  MockLiftDataFrameBuilderForBob() : LiftDataFrameBuilder{"", 3} {}
+
+  df::DataFrame buildNew() const final {
+    df::DataFrame res;
+
+    // clang-format off
+
+    // Try to align these in a nice human-readable way to look like an
+    // actual dataframe
+    res.get<std::string>("id_") =                       {            "abc",       "def",         "ghi"};
+    res.get<std::vector<int64_t>>("event_timestamps") = {{ 100,  200, 300}, {0, 0, 125}, {0,  150, 250}};
+    res.get<std::vector<int64_t>>("values") =           {{  10,   20,  30}, {0, 0,  12}, {0,   15,  25}};
+    res.get<std::vector<int64_t>>("values_squared") =   {{3600, 2500, 900}, {0, 0, 144}, {0, 1600, 625}};
+    res.get<int64_t>("cohort_id") =                     {                0,           1,             2};
+
+    // clang-format on
+
+    return res;
+  }
+
+  int64_t expectedGroupCount = 3;
+  std::vector<df::Column<bool>> expectedBitmasks = {
+      {true, false, false},
+      {false, true, false},
+      {false, false, true}};
+};
+
+TEST(LiftInputDataTest, CalculateGroupCount) {
+  MockLiftDataFrameBuilderForAlice mockAlice;
+  LiftInputData alice{mockAlice, fbpcf::Party::Alice};
+
+  EXPECT_EQ(mockAlice.expectedGroupCount, alice.getGroupCount());
+
+  MockLiftDataFrameBuilderForBob mockBob;
+  LiftInputData bob{mockBob, fbpcf::Party::Bob};
+
+  EXPECT_EQ(mockBob.expectedGroupCount, bob.getGroupCount());
+}
+
+TEST(LiftInputDataTest, CalculateBitmasks) {
+  MockLiftDataFrameBuilderForAlice mockAlice;
+  LiftInputData alice{mockAlice, fbpcf::Party::Alice};
+
+  for (std::size_t i = 0; i < mockAlice.expectedBitmasks.size(); ++i) {
+    auto& expected = mockAlice.expectedBitmasks.at(i);
+    auto& actual = alice.getBitmaskFor(i);
+    EXPECT_EQ(expected, actual);
+  }
+
+  MockLiftDataFrameBuilderForBob mockBob;
+  LiftInputData bob{mockBob, fbpcf::Party::Bob};
+
+  for (std::size_t i = 0; i < mockBob.expectedBitmasks.size(); ++i) {
+    auto& expected = mockBob.expectedBitmasks.at(i);
+    auto& actual = bob.getBitmaskFor(i);
+    EXPECT_EQ(expected, actual);
+  }
+}

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -171,6 +171,20 @@ public:
    *    element from this Column
    * @param f the function to call on each element of this Column
    */
+  template <typename F> void apply(F f) const {
+    for (std::size_t i = 0; i < size(); ++i) {
+      f(at(i));
+    }
+  }
+
+  /**
+   * Non-const version of `Column::apply`. Apply a function on each element of
+   * this Column.
+   *
+   * @tparam F an unspecified function type which can be called with each
+   *    element from this Column
+   * @param f the function to call on each element of this Column
+   */
   template <typename F> void apply(F f) {
     for (std::size_t i = 0; i < size(); ++i) {
       f(at(i));
@@ -347,6 +361,25 @@ public:
       res.push_back(T2(at(i)));
     }
     return res;
+  }
+
+  /**
+   * Get a reference to the underlying vector of this Column.
+   *
+   * @returns the vector backing this Column data structure
+   */
+  const std::vector<T> &data() const {
+    return v_;
+  }
+
+  /**
+   * Non-const version of `Column::data`. Get a reference to the underlying
+   * vector of this Column.
+   *
+   * @returns the vector backing this Column data structure
+   */
+  std::vector<T> &data() {
+    return const_cast<std::vector<T> &>(const_cast<const Column<T> &>(*this).data());
   }
 
   /* Comparison operators */

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -206,6 +206,15 @@ public:
   }
 
   /**
+   * Check if a given key is defined in this DataFrame already
+   *
+   * @returns true if `key` is stored in this DataFrame
+   */
+  bool containsKey(const std::string &key) const {
+    return types_.find(key) != types_.end();
+  }
+
+  /**
    * Get a `Column<T>` at the given key within this DataFrame. A `dynamic_cast`
    * is necessary since we're dynamically altering types at runtime depending
    * on the values being read or set. While there is a small computational cost

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -414,3 +414,14 @@ TEST(IteratorTest, IteratorFunctionality) {
   ++iter;
   EXPECT_EQ(iter, c.end());
 }
+
+TEST(ColumnTest, Data) {
+  Column<int64_t> iCol{300, 200, 100};
+  Column<bool> bCol{true, true, false};
+
+  std::vector<int64_t> iExpected{300, 200, 100};
+  std::vector<bool> bExpected{true, true, false};
+
+  EXPECT_EQ(iCol.data(), iExpected);
+  EXPECT_EQ(bCol.data(), bExpected);
+}

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -108,6 +108,20 @@ TEST(DataFrameTest, Keys) {
   EXPECT_EQ(boolKeys, df2.keysOf<bool>());
 }
 
+TEST(DataFrameTest, ContainsKey) {
+  DataFrame df;
+  df.get<bool>("bool1") = {true, false};
+  df.get<bool>("bool2") = {true, false};
+  df.get<int64_t>("int1") = {123, 111};
+  df.get<int64_t>("int2") = {456, 222};
+  df.get<std::vector<int64_t>>("intVec") = {{7, 8, 9}, {333}};
+
+  EXPECT_TRUE(df.containsKey("bool1"));
+  EXPECT_TRUE(df.containsKey("int1"));
+  EXPECT_TRUE(df.containsKey("intVec"));
+  EXPECT_FALSE(df.containsKey("int9"));
+}
+
 TEST(DataFrameTest, LoadFromRowsBasic) {
   TypeMap t{
       .boolColumns = {},


### PR DESCRIPTION
Summary:
# What
* `apply` function that works on `const Column&`
* `data` function to get at the underlying vector structure (useful during migration for methods which take a std::vector instead of a more generic Container type)
# Why
* Needed this for the OutputMetrics.hpp migration

Differential Revision: D32128759

