### PR TITLE
Remove deleted func declaration from OutputMetrics.h

### DIFF
--- a/fbpcs/emp_games/lift/calculator/OutputMetrics.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetrics.h
@@ -136,16 +136,6 @@ class OutputMetrics {
       const std::vector<std::vector<emp::Bit>>& validPurchaseArrays,
       const std::vector<emp::Bit>& reachedArray);
 
-  // Test/Control clicks: testClicks/controlClicks
-  void calculateClicks(
-      const OutputMetrics::GroupType& groupType,
-      const std::vector<emp::Bit>& populationBits);
-
-  // Test/Control spend: testSpend/controlSpend
-  void calculateSpend(
-      const OutputMetrics::GroupType& groupType,
-      const std::vector<emp::Bit>& populationBits);
-
   // Test/control match count: testPopulation/Control population &
   void calculateMatchCount(
       const OutputMetrics::GroupType& groupType,


### PR DESCRIPTION
Summary: This is the follow up from D31978261 (https://github.com/facebookresearch/fbpcs/commit/53e3fb193671c79019192124bcf3b517d87688b5). Though we deleted `calculateClicks` and `calculateSpend` from OutputMetrics.hpp, the deletion of declaration was missing from OutputMetrics.h. OutputMetrics.hpp is used for header template implementation.

Differential Revision: D32144680

