### PR TITLE
automatically create directories that don't exist on writes for private computation stages

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -67,6 +67,7 @@ int main(int argc, char** argv) {
     if (outputType == fbpcf::io::FileType::S3) {
       private_lift::s3_utils::uploadToS3(tmpFilepath, outputPath);
     } else if (outputType == fbpcf::io::FileType::Local) {
+      std::filesystem::create_directories(outputPath.parent_path());
       std::filesystem::copy(
           tmpFilepath,
           outputPath,


### PR DESCRIPTION
Summary: the aws write file code automatically creates directories when they don't exist. However, our local filesystem code wasn't doing that. We should have equal behavior when we use the local vs the aws file system.

Reviewed By: gorel

Differential Revision: D32223838

