### PR TITLE
fix os version regex parsing

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -157,7 +157,9 @@ def _parse_client_user_agent(client_user_agent):
     for regex in OS_VERSION_REGEXES:
         matches = regex.match(client_user_agent)
         if matches:
-            parsed_fields[DEVICE_OS_VERSION] = '.'.join(matches.groups()[1:])
-            break
+            groups = list(filter(lambda item: type(item) == str, matches.groups()))
+            if (len(groups) > 1):
+                parsed_fields[DEVICE_OS_VERSION] = '.'.join(groups[1:])
+                break
 
     return parsed_fields

--- a/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
@@ -186,6 +186,18 @@ class TestDataIngestion(TestCase):
         self.assertEqual(parsed2['device_os'], 'Android')
         self.assertEqual(parsed2['device_os_version'], '7.1.1')
 
+    def test_parse_user_agent_no_minor_version(self):
+        client_user_agent = ''.join([
+            'Mozilla/5.0 (Linux; Android 11.0; CPH1725) ',
+            'AppleWebKit/537.36 (KHTML, like Gecko) ',
+            'Chrome/93.0.4577.82 Mobile Safari/537.36',
+        ])
+        parsed = _parse_client_user_agent(client_user_agent)
+
+        self.assertEqual(parsed['browser_name'], 'Chrome Mobile')
+        self.assertEqual(parsed['device_os'], 'Android')
+        self.assertEqual(parsed['device_os_version'], '11.0')
+
     def sample_event(self, event):
         sample_encoded_data = base64.b64encode(json.dumps(event).encode('utf-8'))
         return {


### PR DESCRIPTION
Summary:
The regex matching was returning None for the 'patch' part of the OS version
number. We filter out these None values before joining them with a '.' to fix
the issue.

Differential Revision: D32292718

