### PR TITLE
add new stages to github e2e test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -125,6 +125,28 @@ jobs:
         ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} create_instance
        working-directory: ./fbpcs/tests/github/
 
+     - name: Lift - Pid shard
+       run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_shard
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Check Status
+       timeout-minutes: 5
+       run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Lift - Pid prepare
+       run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_prepare
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Check Status
+       timeout-minutes: 5
+       run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+       working-directory: ./fbpcs/tests/github/
+
      - name: Lift - Id Match
        run: |
         ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} run_next

--- a/fbpcs/tests/github/lift_run_stages.sh
+++ b/fbpcs/tests/github/lift_run_stages.sh
@@ -40,7 +40,7 @@ case "$stage" in
             --concurrency="$LIFT_CONCURRENCY"
             ;;
     # stages donot need IP exchange
-    prepare_compute_input )
+    prepare_compute_input | pid_shard | pid_prepare )
         echo "Lift Publisher $stage starts"
         $docker_command run_next "$LIFT_PUBLIHSER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"


### PR DESCRIPTION
Summary:
## What

* Add pid shard and pid prepare as new stages in the lift github e2e test
* Following instructions from this wiki: https://fburl.com/wiki/ma3vg042. Neither stage requires server ips, so I added it to the corresponding section.

## Why

* The new stages were added to PCS here: D32175518 (https://github.com/facebookresearch/fbpcs/commit/39f898229b62641863c548472e7c7e914784ed46) and we need to update the test accordingly.

Differential Revision: D32295577

