### PR TITLE
update LiftSpineCombiner to create directory before writing file

### DIFF
--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineFileCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineFileCombiner.cpp
@@ -191,6 +191,9 @@ void LiftIdSpineFileCombiner::combineFile() {
     if (outputType == fbpcf::io::FileType::S3) {
       private_lift::s3_utils::uploadToS3(tmpFilepath, outputPath_);
     } else if (outputType == fbpcf::io::FileType::Local) {
+      if (outputPath_.has_parent_path()) {
+        std::filesystem::create_directories(outputPath_.parent_path());
+      }
       std::filesystem::copy(
           tmpFilepath,
           outputPath_,


### PR DESCRIPTION
Summary:
similar to: D32223838 (https://github.com/facebookresearch/fbpcs/commit/6c85a750c2373c90a5a740ce82037c62233fc3b4)

the aws write file code automatically creates directories when they don't exist. However, our local filesystem code wasn't doing that. We should have equal behavior when we use the local vs the aws file system.

Reviewed By: gorel, jrodal98

Differential Revision: D32289055

