### PR TITLE
flag functions as deprecated

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -74,6 +74,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 from fbpcs.private_computation.service.utils import (
     ready_for_partial_container_retry,
+    deprecated,
 )
 from fbpcs.utils.optional import unwrap_or_default
 
@@ -322,6 +323,7 @@ class PrivateComputationService:
         return pc_instance
 
     # PID stage
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     def id_match(
         self,
         instance_id: str,
@@ -356,6 +358,7 @@ class PrivateComputationService:
             self.instance_repository.update(instance)
 
     # TODD T101783992: delete this function and call run_stage directly
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     async def id_match_async(
         self,
         instance_id: str,
@@ -382,6 +385,7 @@ class PrivateComputationService:
             dry_run or False,
         )
 
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     def prepare_data(
         self,
         instance_id: str,
@@ -399,6 +403,7 @@ class PrivateComputationService:
         )
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     async def prepare_data_async(
         self,
         instance_id: str,
@@ -445,6 +450,7 @@ class PrivateComputationService:
             await stage_svc.run_async(private_computation_instance)
 
     # MPC step 1
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     def compute_metrics(
         self,
         instance_id: str,
@@ -467,6 +473,7 @@ class PrivateComputationService:
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of compute_metrics() so that it can be called by Thrift
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     async def compute_metrics_async(
         self,
         instance_id: str,
@@ -495,6 +502,7 @@ class PrivateComputationService:
         )
 
     # MPC step 2
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     def aggregate_shards(
         self,
         instance_id: str,
@@ -517,6 +525,7 @@ class PrivateComputationService:
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of aggregate_shards() so that it can be called by Thrift
+    @deprecated("DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted.")
     async def aggregate_shards_async(
         self,
         instance_id: str,

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -7,6 +7,8 @@
 # pyre-strict
 
 
+import functools
+import warnings
 from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus
@@ -197,3 +199,33 @@ def get_updated_pc_status_mpc_game(
             status = current_stage.failed_status
 
     return status
+
+
+# decorators are a serious pain to add typing for, so I'm not going to bother...
+# pyre-ignore return typing
+def deprecated(reason: str):
+    """
+    Logs a warning that a function is deprecated
+    """
+
+    # pyre-ignore return typing
+    def wrap(func):
+        warning_color = '\033[93m' # orange/yellow ascii escape sequence
+        end = '\033[0m' # end ascii escape sequence
+        explanation: str = f"{warning_color}{func.__name__} is deprecated! explanation: {reason}{end}"
+
+        @functools.wraps(func)
+        # pyre-ignore typing on args, kwargs, and return
+        def wrapped(*args, **kwargs):
+            warnings.simplefilter("always", DeprecationWarning)
+            warnings.warn(
+                explanation,
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            warnings.simplefilter("default", DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return wrap

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -46,6 +46,9 @@ from fbpcs.private_computation.repository.private_computation_instance import (
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )
+from fbpcs.private_computation.service.utils import (
+    deprecated,
+)
 from fbpcs.utils.config_yaml import reflect
 
 # Added an is_decoupled argument to create_instance. This argument will act as a switch
@@ -68,7 +71,7 @@ def create_instance(
     padding_size: Optional[int] = None,
     k_anonymity_threshold: Optional[int] = None,
     fail_fast: bool = False,
-    stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None
+    stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
 ) -> PrivateComputationInstance:
     pc_service = _build_private_computation_service(
         config["private_computation"],
@@ -109,6 +112,9 @@ def create_instance(
     return instance
 
 
+@deprecated(
+    "DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted."
+)
 def id_match(
     config: Dict[str, Any],
     instance_id: str,
@@ -140,6 +146,9 @@ def id_match(
     logger.info(instance)
 
 
+@deprecated(
+    "DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted."
+)
 def prepare_compute_input(
     config: Dict[str, Any],
     instance_id: str,
@@ -173,6 +182,9 @@ def prepare_compute_input(
     logging.info("Finished preparing data")
 
 
+@deprecated(
+    "DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted."
+)
 def compute_metrics(
     config: Dict[str, Any],
     instance_id: str,
@@ -204,6 +216,9 @@ def compute_metrics(
     logger.info(instance)
 
 
+@deprecated(
+    "DO NOT USE! This is replaced by the generic run_next + run_stage functions and will soon be deleted."
+)
 def aggregate_shards(
     config: Dict[str, Any],
     instance_id: str,
@@ -316,6 +331,7 @@ def run_next(
 
     logger.info(instance)
 
+
 def run_stage(
     config: Dict[str, Any],
     instance_id: str,
@@ -336,7 +352,9 @@ def run_stage(
     # so we need to explicitly call update_instance() here to get the current status.
     pc_service.update_instance(instance_id)
 
-    instance = pc_service.run_stage(instance_id=instance_id, stage=stage, server_ips=server_ips)
+    instance = pc_service.run_stage(
+        instance_id=instance_id, stage=stage, server_ips=server_ips
+    )
 
     logger.info(instance)
 


### PR DESCRIPTION
Summary:
## What

* Use the decorator created in last diff in stack to flag functions as deprecated

## Why

* I'm going to to delete a lot of functions soon. Since the deletion is unlikely to be released for a few weeks due to code freeze, I'd like to at least put an annoying log that says to stop using it. The decorator should also pop out to anyone reading the code before it's deleted.

Differential Revision: D32339824

