### PR TITLE
Properly handle Column<bool>::at

### DIFF
--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -11,28 +11,26 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include("common.cmake")
 
+# common
+file(GLOB common_src
+  "fbpcs/emp_games/common/**.c"
+  "fbpcs/emp_games/common/**.cpp"
+  "fbpcs/emp_games/common/**.h"
+  "fbpcs/emp_games/common/**.hpp"
+)
+list(FILTER common_src EXCLUDE REGEX ".*Test.*")
+
 # lift
+file(GLOB lift_src
+  "fbpcs/emp_games/lift/**.c"
+  "fbpcs/emp_games/lift/**.cpp"
+  "fbpcs/emp_games/lift/**.h"
+  "fbpcs/emp_games/lift/**.hpp")
+list(FILTER lift_src EXCLUDE REGEX ".*Test.*")
 add_executable(
   lift_calculator
-  "fbpcs/emp_games/lift/calculator/main.cpp"
-  "fbpcs/emp_games/lift/calculator/OutputMetrics.hpp"
-  "fbpcs/emp_games/lift/common/GroupedLiftMetrics.h"
-  "fbpcs/emp_games/lift/common/GroupedLiftMetrics.cpp"
-  "fbpcs/emp_games/lift/common/LiftMetrics.h"
-  "fbpcs/emp_games/lift/common/LiftMetrics.cpp"
-  "fbpcs/emp_games/lift/calculator/CalculatorApp.h"
-  "fbpcs/emp_games/lift/calculator/CalculatorApp.cpp"
-  "fbpcs/emp_games/lift/calculator/CalculatorGame.h"
-  "fbpcs/emp_games/lift/calculator/OutputMetrics.h"
-  "fbpcs/emp_games/lift/calculator/InputData.cpp"
-  "fbpcs/emp_games/lift/calculator/InputData.h"
-  "fbpcs/emp_games/lift/calculator/CalculatorGameConfig.h"
-  "fbpcs/emp_games/lift/calculator/OutputMetricsData.h"
-  "fbpcs/emp_games/common/PrivateData.h"
-  "fbpcs/emp_games/common/SecretSharing.h"
-  "fbpcs/emp_games/common/EmpOperationUtil.h"
-  "fbpcs/emp_games/common/Csv.h"
-  "fbpcs/emp_games/common/Csv.cpp")
+  ${common_src}
+  ${lift_src})
 target_link_libraries(
   lift_calculator
   empgamecommon)
@@ -55,23 +53,14 @@ install(TARGETS attribution_calculator DESTINATION bin)
 
 # generic shard_aggregator
 file(GLOB shard_aggregator_src
-  "fbpcs/emp_games/attribution/shard_aggregator/AggMetrics.cpp",
-  "fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp",
-  "fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp",
-  "fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidation.cpp",
-  "fbpcs/emp_games/attribution/shard_aggregator/main.cpp"
-  "fbpcs/emp_games/attribution/Aggregator.h"
-  "fbpcs/emp_games/attribution/AttributionMetrics.h"
-  "fbpcs/emp_games/attribution/AttributionRule.h"
-  "fbpcs/emp_games/attribution/Constants.h"
-  "fbpcs/emp_games/attribution/Conversion.h"
-  "fbpcs/emp_games/attribution/Debug.h"
-  "fbpcs/emp_games/attribution/Timestamp.h",
-  "fbpcs/emp_games/attribution/Touchpoint.h",
-  "fbpcs/emp_games/attribution/shard_aggregator/MainUtil.h",
-  "fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorGame.h")
+  "fbpcs/emp_games/attribution/shard_aggregator/**.c"
+  "fbpcs/emp_games/attribution/shard_aggregator/**.cpp"
+  "fbpcs/emp_games/attribution/shard_aggregator/**.h"
+  "fbpcs/emp_games/attribution/shard_aggregator/**.hpp")
+list(FILTER shard_aggregator_src EXCLUDE REGEX ".*Test.*")
 add_executable(
   shard_aggregator
+  ${attribution_src}
   ${shard_aggregator_src})
 target_link_libraries(
   shard_aggregator

--- a/fbpcs/emp_games/common/SecretSharing.cpp
+++ b/fbpcs/emp_games/common/SecretSharing.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/common/SecretSharing.h"
+
+#include <emp-sh2pc/emp-sh2pc.h>
+
+#include <fbpcf/mpc/EmpGame.h>
+
+namespace private_measurement::secret_sharing {
+emp::Bit privatelyShare(fbpcf::Party dataSrc, bool data) {
+  // Unfortunately this ugly static_cast is necessary for the EMP library
+  emp::Bit res{data, static_cast<int>(dataSrc)};
+  return res;
+}
+
+emp::Integer privatelyShare(fbpcf::Party dataSrc, int64_t data) {
+  // Unfortunately this ugly static_cast is necessary for the EMP library
+  emp::Integer res{INT_SIZE, data, static_cast<int>(dataSrc)};
+  return res;
+}
+} // namespace private_measurement::secret_sharing

--- a/fbpcs/emp_games/common/SecretSharing.h
+++ b/fbpcs/emp_games/common/SecretSharing.h
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifndef SECRET_SHARING_H
-#define SECRET_SHARING_H
+#pragma once
 
 #include <functional>
 #include <optional>
@@ -15,9 +14,61 @@
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "PrivateData.h"
+#include <fbpcf/mpc/EmpGame.h>
+
+#include "fbpcs/emp_games/common/PrivateData.h"
 
 namespace private_measurement::secret_sharing {
+/**
+ * Privately share a single bool of data between two parties.
+ *
+ * @param dataSrc the party supplying the bool
+ * @param data the value of the bool (this argument is ignored if the party
+ *     calling this function is not acting as `dataSrc`)
+ * @returns a secure emp::Bit representing `data`
+ */
+emp::Bit privatelyShare(fbpcf::Party dataSrc, bool data);
+
+/**
+ * Privately share a single int of data between two parties.
+ *
+ * @param dataSrc the party supplying the int
+ * @param data the value of the int (this argument is ignored if the party
+ *     calling this function is not acting as `dataSrc`)
+ * @returns a secure emp::Integer representing `data`
+ */
+emp::Integer privatelyShare(fbpcf::Party dataSrc, int64_t data);
+
+/**
+ * Privately share an iterable container of bools of data between two parties.
+ *
+ * @tparam Container an iterable container type (like std::vector)
+ * @param dataSrc the party supplying the Container<bool>
+ * @param data the Container of bool data to send (this argument is ignored if
+ *     the party calling this function is not acting as `dataSrc` but an empty
+ *     container must still be provided for this function to work)
+ * @param n the number of bools to share
+ * @returns a Container of secure emp::Bit representing `data`
+ */
+template <template <typename...> typename Container>
+Container<emp::Bit> privatelyShare(fbpcf::Party dataSrc,
+                                   const Container<bool> &data, std::size_t n);
+
+/**
+ * Privately share an iterable container of ints of data between two parties.
+ *
+ * @tparam Container an iterable container type (like std::vector)
+ * @param dataSrc the party supplying the Container<int64_t>
+ * @param data the Container of int data to send (this argument is ignored if
+ *     the party calling this function is not acting as `dataSrc` but an empty
+ *     column must still be provided for this function to work)
+ * @param n the number of int64_t values to share
+ * @returns a Container of secure emp::Integer representing `data`
+ */
+template <template <typename...> typename Container>
+Container<emp::Integer> privatelyShare(fbpcf::Party dataSrc,
+                                       const Container<int64_t> &data,
+                                       std::size_t n);
 
 /*
  * Share one emp::Integer bidirectionally between both parties
@@ -329,8 +380,4 @@ const std::vector<T> multiplyBitmask(
 
 } // namespace private_measurement::secret_sharing
 
-#ifndef SECRET_SHARING_HPP
-#include "SecretSharing.hpp"
-#endif // SECRET_SHARING_HPP
-
-#endif // SECRET_SHARING_H
+#include "fbpcs/emp_games/common/SecretSharing-impl.h"

--- a/fbpcs/emp_games/common/test/SecretSharingTest.cpp
+++ b/fbpcs/emp_games/common/test/SecretSharingTest.cpp
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include <fbpcf/mpc/EmpTestUtil.h>
 
-#include "../SecretSharing.h"
+#include "fbpcs/emp_games/common/SecretSharing.h"
 
 namespace private_measurement {
 
@@ -26,6 +28,46 @@ std::vector<std::vector<TOut>> revealVectorOfVectors(
     std::vector<std::vector<TIn>>& in) {
   return map<std::vector<TIn>, std::vector<TOut>>(
       in, [](auto empVec) { return revealVector<TIn, TOut>(empVec); });
+}
+
+TEST(SecretSharingTest, TestPrivatelyShareBool) {
+  fbpcf::mpc::wrapTestWithParty<std::function<void(fbpcf::Party party)>>(
+      [](fbpcf::Party party) {
+        bool expected = true;
+        emp::Bit b = privatelyShare(fbpcf::Party::Alice, expected);
+        auto actual = b.reveal<bool>();
+        EXPECT_EQ(expected, actual);
+      });
+}
+
+TEST(SecretSharingTest, TestPrivatelyShareInt) {
+  fbpcf::mpc::wrapTestWithParty<std::function<void(fbpcf::Party party)>>(
+      [](fbpcf::Party party) {
+        int64_t expected = 12345;
+        emp::Integer i = privatelyShare(fbpcf::Party::Alice, expected);
+        auto actual = i.reveal<int64_t>();
+        EXPECT_EQ(expected, actual);
+      });
+}
+
+TEST(SecretSharingTest, TestPrivatelyShareBoolVector) {
+  fbpcf::mpc::wrapTestWithParty<std::function<void(fbpcf::Party party)>>(
+      [](fbpcf::Party party) {
+        std::vector<bool> expected{true, false, false, true};
+        std::vector<emp::Bit> bVec = privatelyShare(fbpcf::Party::Alice, expected, expected.size());
+        auto actual = revealVector<emp::Bit, bool>(bVec);
+        EXPECT_EQ(expected, actual);
+      });
+}
+
+TEST(SecretSharingTest, TestPrivatelyShareIntVector) {
+  fbpcf::mpc::wrapTestWithParty<std::function<void(fbpcf::Party party)>>(
+      [](fbpcf::Party party) {
+        std::vector<int64_t> expected{12, 34, 56, 78};
+        std::vector<emp::Integer> iVec  = privatelyShare(fbpcf::Party::Alice, expected, expected.size());
+        auto actual = revealVector<emp::Integer, int64_t>(iVec);
+        EXPECT_EQ(expected, actual);
+      });
 }
 
 TEST(SecretSharingTest, TestPrivatelyShareIntsFromAlice) {

--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
@@ -5,25 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "fbpcs/emp_games/lift/calculator/CalculatorApp.h"
+
 #include <vector>
 
 #include <gflags/gflags.h>
-#include "folly/logging/xlog.h"
 
 #include <fbpcf/io/FileManagerUtil.h>
 #include <fbpcf/mpc/EmpApp.h>
 #include <fbpcf/mpc/EmpGame.h>
+#include <folly/logging/xlog.h>
 
-#include "CalculatorApp.h"
-#include "CalculatorGame.h"
-#include "CalculatorGameConfig.h"
-#include "InputData.h"
+#include "fbpcs/emp_games/lift/calculator/CalculatorGame.h"
+#include "fbpcs/emp_games/lift/calculator/CalculatorGameConfig.h"
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
 
 namespace private_lift {
 void CalculatorApp::run() {
   try {
     CalculatorGameConfig config = getInputData();
-    int32_t numValues = static_cast<int32_t>(config.inputData.getNumRows());
+    int32_t numValues = static_cast<int32_t>(config.inputData.size());
     XLOG(INFO) << "Have " << numValues << " values in inputData.";
 
     XLOG(INFO) << "connecting...";
@@ -50,19 +51,10 @@ CalculatorGameConfig CalculatorApp::getInputData() {
   int32_t numConversionsPerUser =
       FLAGS_is_conversion_lift ? FLAGS_num_conversions_per_user : 1;
 
-  auto liftGranularityType = FLAGS_is_conversion_lift
-      ? InputData::LiftGranularityType::Conversion
-      : InputData::LiftGranularityType::Converter;
-
   XLOG(INFO) << "Parsing input";
-  InputData inputData{
-      inputPath_,
-      InputData::LiftMPCType::Standard,
-      liftGranularityType,
-      FLAGS_epoch,
-      numConversionsPerUser};
+  LiftInputData inputData{party_, inputPath_};
   CalculatorGameConfig config = {
-      inputData, FLAGS_is_conversion_lift, numConversionsPerUser};
+    std::move(inputData), FLAGS_is_conversion_lift, numConversionsPerUser};
   return config;
 }
 

--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.h
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.h
@@ -15,9 +15,10 @@
 
 #include <fbpcf/mpc/EmpApp.h>
 #include <fbpcf/mpc/EmpGame.h>
-#include "CalculatorGame.h"
-#include "InputData.h"
-#include "OutputMetrics.h"
+
+#include "fbpcs/emp_games/lift/calculator/CalculatorGame.h"
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
+#include "fbpcs/emp_games/lift/calculator/OutputMetrics.h"
 
 // so that these FLAGS set in main.cpp are visible here
 DECLARE_bool(is_conversion_lift);

--- a/fbpcs/emp_games/lift/calculator/CalculatorGame.h
+++ b/fbpcs/emp_games/lift/calculator/CalculatorGame.h
@@ -13,9 +13,8 @@
 #include <gflags/gflags.h>
 
 #include <fbpcf/mpc/EmpGame.h>
-#include "CalculatorGameConfig.h"
-#include "InputData.h"
-#include "OutputMetrics.h"
+#include "fbpcs/emp_games/lift/calculator/CalculatorGameConfig.h"
+#include "fbpcs/emp_games/lift/calculator/OutputMetrics.h"
 
 namespace private_lift {
 template <class IOChannel>

--- a/fbpcs/emp_games/lift/calculator/CalculatorGameConfig.h
+++ b/fbpcs/emp_games/lift/calculator/CalculatorGameConfig.h
@@ -9,14 +9,14 @@
 
 #include <filesystem>
 
-#include "InputData.h"
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
 
 namespace private_lift {
 /*
  * Simple struct representing the all the input arguments for a CalculatorGame
  */
 struct CalculatorGameConfig {
-  InputData inputData;
+  LiftInputData inputData;
   bool isConversionLift;
   int32_t numConversionsPerUser;
 };

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
@@ -8,6 +8,7 @@
 #include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <emp-tool/emp-tool.h>
@@ -18,28 +19,56 @@
 #include "fbpcs/emp_games/lift/common/Column.h"
 #include "fbpcs/emp_games/lift/common/DataFrame.h"
 
-static constexpr int64_t kConversionCap = 25;
+namespace {
+inline constexpr int64_t kConversionCap = 25;
+}
 
-using namespace private_lift;
-
-LiftInputData::LiftInputData(fbpcf::Party party, const std::string& filePath)
-    : LiftInputData{LiftDataFrameBuilder{filePath, kConversionCap}, party} {}
+namespace private_lift {
+LiftInputData::LiftInputData(
+    fbpcf::Party party,
+    const std::string& filePath)
+    : LiftInputData{
+          LiftDataFrameBuilder{filePath, kConversionCap},
+          party} {}
 
 LiftInputData::LiftInputData(
     const LiftDataFrameBuilder& builder,
     fbpcf::Party party)
     : party_{party}, groupKey_{getGroupKeyForParty(party)} {
-  // Will implement in next diff
+  df_ = builder.buildNew();
+  groupCount_ = calculateGroupCount();
+  bitmasks_ = calculateBitmasks();
 }
 
 int64_t LiftInputData::calculateGroupCount() const {
-  int64_t maxId = 0;
-  // Will implement in next diff
-  return maxId;
+  int64_t maxId = -1;
+  auto keys = df_.keys();
+
+  // It's possible that neither group key appears in the dataset - these
+  // are optional fields in the input spec
+  if (keys.find(groupKey_) != keys.end()) {
+    for (const auto& value : df_.at<int64_t>(groupKey_)) {
+      maxId = std::max(maxId, value);
+    }
+  }
+
+  // If neither group key was in this df, this will appropriately set
+  // groupCount_ to zero (no groups in dataset)
+  // NOTE: Since it's expected that groups start from index 0, if we find a max
+  //       id == N, we have N + 1 groups!
+  return maxId + 1;
 }
 
-std::vector<df::Column<emp::Bit>> LiftInputData::calculateBitmasks() const {
-  std::vector<df::Column<emp::Bit>> res;
-  // Will implement in next diff
+std::vector<df::Column<bool>> LiftInputData::calculateBitmasks()
+    const {
+  std::vector<df::Column<bool>> res;
+  for (std::size_t group = 0; group < getGroupCount(); ++group) {
+    df::Column<bool> groupColumn;
+    for (const auto& value : df_.at<int64_t>(groupKey_)) {
+      groupColumn.push_back(value == group);
+    }
+    res.push_back(std::move(groupColumn));
+  }
   return res;
 }
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
@@ -38,6 +38,7 @@ LiftInputData::LiftInputData(
   df_ = builder.buildNew();
   groupCount_ = calculateGroupCount();
   bitmasks_ = calculateBitmasks();
+  size_ = calculateSize();
 }
 
 int64_t LiftInputData::calculateGroupCount() const {
@@ -70,5 +71,15 @@ std::vector<df::Column<bool>> LiftInputData::calculateBitmasks()
     res.push_back(std::move(groupColumn));
   }
   return res;
+}
+
+template <typename BitType>
+std::size_t LiftInputData<BitType>::calculateSize() const {
+  if (df_.containsKey("opportunity_timestamp")) {
+    return df_.at<int64_t>("opportunity_timestamp").size();
+  } else {
+    // This must be the partner
+    return df_.at<std::vector<int64_t>>("event_timestamps").size();
+  }
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.cpp
@@ -20,6 +20,7 @@
 #include "fbpcs/emp_games/lift/common/DataFrame.h"
 
 namespace {
+// TODO: Move this back to being a configurable variable
 inline constexpr int64_t kConversionCap = 25;
 }
 
@@ -73,8 +74,7 @@ std::vector<df::Column<bool>> LiftInputData::calculateBitmasks()
   return res;
 }
 
-template <typename BitType>
-std::size_t LiftInputData<BitType>::calculateSize() const {
+std::size_t LiftInputData::calculateSize() const {
   if (df_.containsKey("opportunity_timestamp")) {
     return df_.at<int64_t>("opportunity_timestamp").size();
   } else {

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.h
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.h
@@ -89,16 +89,13 @@ class LiftInputData {
   }
 
   /**
-   * Get a column of bits representing a bitmask over a given groupId. These
-   * were precomputed upon creation of this LiftInputData since construction
-   * of new `emp::Bit` columns can be expensive.
+   * Get a column of bits representing a bitmask over a given groupId.
    *
    * @param groupId the groupId for which to retrieve a bitmask column
-   * @returns a `df::Column` of `emp::Bit` describing whether row[i] is valid
-   *     for this group
+   * @returns a `df::Column` describing whether row[i] is valid for this group
    * @throws std::out_of_range if groupId > groupCount
    */
-  const df::Column<emp::Bit> &getBitmaskFor(int64_t groupId) const {
+  const df::Column<bool>& getBitmaskFor(int64_t groupId) const {
     return bitmasks_.at(groupId);
   }
 
@@ -116,16 +113,16 @@ class LiftInputData {
    * run in the LiftInputData constructor to cache the result for later. For
    * more details, see `LiftInputData::getBitmaskFor`.
    *
-   * @returns a vector of Columns of `emp::Bit` representing whether row[i] is
-   *     valid for the group stored in vector index[j]
+   * @returns a vector of `Column<bool>` representing whether row[i] is valid
+   *     for the group stored in vector index[j]
    */
-  std::vector<df::Column<emp::Bit>> calculateBitmasks() const;
+  std::vector<df::Column<bool>> calculateBitmasks() const;
 
  private:
   fbpcf::Party party_;
   std::string groupKey_;
   df::DataFrame df_;
   int64_t groupCount_;
-  std::vector<df::Column<emp::Bit>> bitmasks_;
+  std::vector<df::Column<bool>> bitmasks_;
 };
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftInputData.h
+++ b/fbpcs/emp_games/lift/calculator/LiftInputData.h
@@ -89,6 +89,15 @@ class LiftInputData {
   }
 
   /**
+   * Get this LiftInputData's number of rows in the dataset.
+   *
+   * @returns the number of rows in this LiftInputData
+   */
+  int64_t size() const {
+    return size_;
+  }
+
+  /**
    * Get a column of bits representing a bitmask over a given groupId.
    *
    * @param groupId the groupId for which to retrieve a bitmask column
@@ -118,11 +127,23 @@ class LiftInputData {
    */
   std::vector<df::Column<bool>> calculateBitmasks() const;
 
+  /**
+   * Calculate the number of rows in this LiftInputData by taking the size of
+   * the opportunity_timestamp or event_timestamps column (since one must be
+   * defined to represent a valid party to the computation).
+   *
+   * @returns the size of the dataset from the `df::DataFrame`
+   * @throws std::out_of_range if neither of the party-defining columns
+   *     (opportunity_timestamp or event_timestamps) are defined in the dataset
+   */
+  std::size_t calculateSize() const;
+
  private:
   fbpcf::Party party_;
   std::string groupKey_;
   df::DataFrame df_;
   int64_t groupCount_;
   std::vector<df::Column<bool>> bitmasks_;
+  std::size_t size_;
 };
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/LiftRow.h
+++ b/fbpcs/emp_games/lift/calculator/LiftRow.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/common/ColumnNameConstants.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+namespace private_lift {
+/**
+ * This struct represents a single row of Lift data. It is meant to be used in
+ * conjunction with DataFrame objects along with an iterator pattern in order
+ * to enable row-wise traversal of a DataFrame with columns required for lift.
+ *
+ * @tparam BitType the type used internally to represent bits/boolean values
+ * @tparam IntType the type used internally to represent integer values
+ */
+template <typename BitType, typename IntType>
+struct LiftRow {
+  // Required publisher columns
+  const IntType* opportunityTimestamp;
+  const BitType* testPopulation;
+  const BitType* controlPopulation;
+  const BitType* reachedPopulation;
+  // Optional publisher columns
+  const IntType* breakdownId;
+
+  // Required partner columns
+  const BitType* partnerRow;
+  const std::vector<IntType>* eventTimestamps;
+  const std::vector<IntType>* values;
+  const std::vector<IntType>* valuesSquared;
+  // Optional partner columns
+  const IntType* cohortId;
+
+  /**
+   * Construct a LiftRow from a DataFrame at the given index. This functionality
+   * allows us to later actualize a row-wise DataFrame iterator.
+   *
+   * @param dframe the DataFrame from which to pull row data
+   * @param idx the exact index into the DataFrame from which to pull row data
+   * @returns a LiftRow representing a view into `dframe.at(idx)`
+   */
+  static LiftRow fromDataFrame(const df::DataFrame& dframe, std::size_t idx) {
+    LiftRow row;
+    row.opportunityTimestamp =
+        &dframe.get<IntType>(lift_columns::kOpportunityTimestamp).at(idx);
+    row.testPopulation =
+        &dframe.get<BitType>(lift_columns::kTestPopulation).at(idx);
+    row.controlPopulation =
+        &dframe.get<BitType>(lift_columns::kControlPopulation).at(idx);
+    row.reachedPopulation =
+        &dframe.get<BitType>(lift_columns::kReached).at(idx);
+
+    row.partnerRow = &dframe.get<BitType>(lift_columns::kPartnerRow).at(idx);
+    row.eventTimestamps =
+        &dframe.get<std::vector<IntType>>(lift_columns::kEventTimestamps)
+             .at(idx);
+    row.values =
+        &dframe.get<std::vector<IntType>>(lift_columns::kValues).at(idx);
+    row.valuesSquared =
+        &dframe.get<std::vector<IntType>>(lift_columns::kValuesSquared).at(idx);
+
+    // breakdownId and cohortId are both optional
+    row.breakdownId = dframe.containsKey(lift_columns::kBreakdownId)
+        ? &dframe.get<IntType>(lift_columns::kBreakdownId).at(idx)
+        : nullptr;
+
+    row.cohortId = dframe.containsKey(lift_columns::kCohortId)
+        ? &dframe.get<IntType>(lift_columns::kCohortId).at(idx)
+        : nullptr;
+
+    return row;
+  }
+};
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/OutputMetrics.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetrics.h
@@ -13,11 +13,12 @@
 
 #include <emp-sh2pc/emp-sh2pc.h>
 
-#include "../../common/EmpOperationUtil.h"
-#include "../../common/PrivateData.h"
-#include "../../common/SecretSharing.h"
-#include "InputData.h"
-#include "OutputMetricsData.h"
+#include "fbpcs/emp_games/common/EmpOperationUtil.h"
+#include "fbpcs/emp_games/common/PrivateData.h"
+#include "fbpcs/emp_games/common/SecretSharing.h"
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
+#include "fbpcs/emp_games/lift/calculator/OutputMetricsData.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
 
 namespace private_lift {
 /*
@@ -32,12 +33,13 @@ class OutputMetrics {
 
   // Constructor. From an InputData object, calculate all output metrics
   OutputMetrics(
-      const InputData& inputData,
+      const LiftInputData& inputData,
       bool isConversionLift,
       bool useXorEncryption,
       int32_t numConversionsPerUser)
       : inputData_{inputData},
-        n_{static_cast<int64_t>(inputData.getNumRows())},
+        df_{inputData.getDf()},
+        n_{inputData.size()},
         isConversionLift_{isConversionLift},
         useXorEncryption_{useXorEncryption},
         numConversionsPerUser_{numConversionsPerUser} {}
@@ -181,7 +183,8 @@ class OutputMetrics {
    */
   int64_t sum(const std::vector<std::vector<emp::Integer>>& in) const;
 
-  const InputData& inputData_;
+  const LiftInputData& inputData_;
+  const df::DataFrame &df_;
   int64_t n_;
   bool isConversionLift_;
   bool useXorEncryption_;

--- a/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
+++ b/fbpcs/emp_games/lift/calculator/OutputMetricsData.h
@@ -12,7 +12,7 @@
 
 #include <folly/String.h>
 
-#include "../common/GroupedLiftMetrics.h"
+#include "fbpcs/emp_games/lift/common/GroupedLiftMetrics.h"
 
 namespace private_lift {
 

--- a/fbpcs/emp_games/lift/calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/CalculatorAppTest.cpp
@@ -24,7 +24,7 @@
 constexpr int32_t tsOffset = 10;
 
 DEFINE_bool(is_conversion_lift, true, "is conversion lift");
-DEFINE_int32(num_conversions_per_user, 4, "num of converstions per user");
+DEFINE_int32(num_conversions_per_user, 25, "num of conversions per user");
 DEFINE_int64(epoch, 1546300800, "epoch");
 
 namespace private_lift {
@@ -52,7 +52,7 @@ class CalculatorAppTest : public ::testing::Test {
         .setIncrementalityRate(0.0)
         .setEpoch(1546300800);
     testDataGenerator.genFakePublisherInputFile(inputPathAlice_, params);
-    params.setNumConversions(4).setOmitValuesColumn(false);
+    params.setNumConversions(25).setOmitValuesColumn(false);
     testDataGenerator.genFakePartnerInputFile(inputPathBob_, params);
   }
 

--- a/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
@@ -113,12 +113,12 @@ TEST(LiftInputDataTest, CalculateBitmasks) {
 
 TEST(LiftInputData, CalculateSize) {
   MockLiftDataFrameBuilderForAlice mockAlice;
-  LiftInputData<bool> alice{mockAlice, fbpcf::Party::Alice};
+  LiftInputData alice{mockAlice, fbpcf::Party::Alice};
 
   EXPECT_EQ(mockAlice.expectedSize, alice.size());
 
   MockLiftDataFrameBuilderForBob mockBob;
-  LiftInputData<bool> bob{mockBob, fbpcf::Party::Bob};
+  LiftInputData bob{mockBob, fbpcf::Party::Bob};
 
   EXPECT_EQ(mockBob.expectedSize, bob.size());
 }

--- a/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <fbpcf/mpc/EmpGame.h>
+
+#include "fbpcs/emp_games/lift/calculator/LiftDataFrameBuilder.h"
+#include "fbpcs/emp_games/lift/calculator/LiftInputData.h"
+#include "fbpcs/emp_games/lift/common/Column.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+using namespace private_lift;
+
+class MockLiftDataFrameBuilderForAlice : public LiftDataFrameBuilder {
+ public:
+  MockLiftDataFrameBuilderForAlice() : LiftDataFrameBuilder{"", 3} {}
+
+  df::DataFrame buildNew() const final {
+    df::DataFrame res;
+
+    // clang-format off
+
+    // Try to align these in a nice human-readable way to look like an
+    // actual dataframe
+    res.get<int64_t>("test_population") =     {    1,     0,     0};
+    res.get<int64_t>("control_population") =  {    0,     0,     1};
+    res.get<int64_t>("breakdown_id") =        {    1,     0,     0};
+    res.get<int64_t>("num_impressions") =     {    5,     0,     0};
+    res.get<int64_t>("num_clicks") =          {    2,     0,     0};
+    res.get<int64_t>("total_spend") =         {  100,     0,     0};
+
+    // clang-format on
+
+    return res;
+  }
+  int64_t expectedGroupCount = 2;
+  std::vector<df::Column<bool>> expectedBitmasks = {
+      {false, true, true},
+      {true, false, false}};
+};
+
+class MockLiftDataFrameBuilderForBob : public LiftDataFrameBuilder {
+ public:
+  MockLiftDataFrameBuilderForBob() : LiftDataFrameBuilder{"", 3} {}
+
+  df::DataFrame buildNew() const final {
+    df::DataFrame res;
+
+    // clang-format off
+
+    // Try to align these in a nice human-readable way to look like an
+    // actual dataframe
+    res.get<std::string>("id_") =                       {            "abc",       "def",         "ghi"};
+    res.get<std::vector<int64_t>>("event_timestamps") = {{ 100,  200, 300}, {0, 0, 125}, {0,  150, 250}};
+    res.get<std::vector<int64_t>>("values") =           {{  10,   20,  30}, {0, 0,  12}, {0,   15,  25}};
+    res.get<std::vector<int64_t>>("values_squared") =   {{3600, 2500, 900}, {0, 0, 144}, {0, 1600, 625}};
+    res.get<int64_t>("cohort_id") =                     {                0,           1,             2};
+
+    // clang-format on
+
+    return res;
+  }
+
+  int64_t expectedGroupCount = 3;
+  std::vector<df::Column<bool>> expectedBitmasks = {
+      {true, false, false},
+      {false, true, false},
+      {false, false, true}};
+};
+
+TEST(LiftInputDataTest, CalculateGroupCount) {
+  MockLiftDataFrameBuilderForAlice mockAlice;
+  LiftInputData alice{mockAlice, fbpcf::Party::Alice};
+
+  EXPECT_EQ(mockAlice.expectedGroupCount, alice.getGroupCount());
+
+  MockLiftDataFrameBuilderForBob mockBob;
+  LiftInputData bob{mockBob, fbpcf::Party::Bob};
+
+  EXPECT_EQ(mockBob.expectedGroupCount, bob.getGroupCount());
+}
+
+TEST(LiftInputDataTest, CalculateBitmasks) {
+  MockLiftDataFrameBuilderForAlice mockAlice;
+  LiftInputData alice{mockAlice, fbpcf::Party::Alice};
+
+  for (std::size_t i = 0; i < mockAlice.expectedBitmasks.size(); ++i) {
+    auto& expected = mockAlice.expectedBitmasks.at(i);
+    auto& actual = alice.getBitmaskFor(i);
+    EXPECT_EQ(expected, actual);
+  }
+
+  MockLiftDataFrameBuilderForBob mockBob;
+  LiftInputData bob{mockBob, fbpcf::Party::Bob};
+
+  for (std::size_t i = 0; i < mockBob.expectedBitmasks.size(); ++i) {
+    auto& expected = mockBob.expectedBitmasks.at(i);
+    auto& actual = bob.getBitmaskFor(i);
+    EXPECT_EQ(expected, actual);
+  }
+}

--- a/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftInputDataTest.cpp
@@ -30,21 +30,23 @@ class MockLiftDataFrameBuilderForAlice : public LiftDataFrameBuilder {
 
     // Try to align these in a nice human-readable way to look like an
     // actual dataframe
-    res.get<int64_t>("test_population") =     {    1,     0,     0};
-    res.get<int64_t>("control_population") =  {    0,     0,     1};
-    res.get<int64_t>("breakdown_id") =        {    1,     0,     0};
-    res.get<int64_t>("num_impressions") =     {    5,     0,     0};
-    res.get<int64_t>("num_clicks") =          {    2,     0,     0};
-    res.get<int64_t>("total_spend") =         {  100,     0,     0};
+    res.get<int64_t>("opportunity_timestamp") = {  111,     0,   222,   333};
+    res.get<int64_t>("test_population") =       {    1,     0,     0,     1};
+    res.get<int64_t>("control_population") =    {    0,     0,     1,     0};
+    res.get<int64_t>("breakdown_id") =          {    1,     0,     0,     1};
+    res.get<int64_t>("num_impressions") =       {    5,     0,     0,     1};
+    res.get<int64_t>("num_clicks") =            {    2,     0,     0,     0};
+    res.get<int64_t>("total_spend") =           {  100,     0,     0,   200};
 
     // clang-format on
 
     return res;
   }
   int64_t expectedGroupCount = 2;
+  std::size_t expectedSize = 4;
   std::vector<df::Column<bool>> expectedBitmasks = {
-      {false, true, true},
-      {true, false, false}};
+      {false, true, true, false},
+      {true, false, false, true}};
 };
 
 class MockLiftDataFrameBuilderForBob : public LiftDataFrameBuilder {
@@ -70,6 +72,7 @@ class MockLiftDataFrameBuilderForBob : public LiftDataFrameBuilder {
   }
 
   int64_t expectedGroupCount = 3;
+  std::size_t expectedSize = 3;
   std::vector<df::Column<bool>> expectedBitmasks = {
       {true, false, false},
       {false, true, false},
@@ -106,4 +109,16 @@ TEST(LiftInputDataTest, CalculateBitmasks) {
     auto& actual = bob.getBitmaskFor(i);
     EXPECT_EQ(expected, actual);
   }
+}
+
+TEST(LiftInputData, CalculateSize) {
+  MockLiftDataFrameBuilderForAlice mockAlice;
+  LiftInputData<bool> alice{mockAlice, fbpcf::Party::Alice};
+
+  EXPECT_EQ(mockAlice.expectedSize, alice.size());
+
+  MockLiftDataFrameBuilderForBob mockBob;
+  LiftInputData<bool> bob{mockBob, fbpcf::Party::Bob};
+
+  EXPECT_EQ(mockBob.expectedSize, bob.size());
 }

--- a/fbpcs/emp_games/lift/calculator/test/LiftRowTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/LiftRowTest.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/calculator/LiftRow.h"
+#include "fbpcs/emp_games/lift/common/ColumnNameConstants.h"
+#include "fbpcs/emp_games/lift/common/DataFrame.h"
+
+using namespace private_lift;
+
+df::DataFrame buildBasicDataFrame() {
+  df::DataFrame dframe;
+  // NOTE: For testing, we are setting *all* columns as int64_t
+  // This allows us to test against specific constants instead of `true`
+  // which could be harder to debug in case of an error. This is another benefit
+  // of making BitType and IntType template parameters. Testing is easy!
+  dframe.get<int64_t>(lift_columns::kOpportunityTimestamp) = {1, 2, 3};
+  dframe.get<int64_t>(lift_columns::kTestPopulation) = {4, 5, 6};
+  dframe.get<int64_t>(lift_columns::kControlPopulation) = {7, 8, 9};
+  dframe.get<int64_t>(lift_columns::kReached) = {10, 11, 12};
+  dframe.get<int64_t>(lift_columns::kPartnerRow) = {16, 17, 18};
+  dframe.get<std::vector<int64_t>>(lift_columns::kEventTimestamps) = {
+      {19}, {20}, {21}};
+  dframe.get<std::vector<int64_t>>(lift_columns::kValues) = {{22}, {23}, {24}};
+  dframe.get<std::vector<int64_t>>(lift_columns::kValuesSquared) = {
+      {25}, {26}, {27}};
+  return dframe;
+}
+
+TEST(LiftRowTest, FromDataFrameAllPresent) {
+  auto dframe = buildBasicDataFrame();
+  dframe.get<int64_t>(lift_columns::kBreakdownId) = {13, 14, 15};
+  dframe.get<int64_t>(lift_columns::kCohortId) = {28, 29, 30};
+
+  // First test will verify all the rows just to show it works
+  auto row = LiftRow<int64_t, int64_t>::fromDataFrame(dframe, 0);
+  EXPECT_EQ(*row.opportunityTimestamp, 1);
+  EXPECT_EQ(*row.testPopulation, 4);
+  EXPECT_EQ(*row.controlPopulation, 7);
+  EXPECT_EQ(*row.reachedPopulation, 10);
+  EXPECT_EQ(*row.breakdownId, 13);
+  EXPECT_EQ(*row.partnerRow, 16);
+  EXPECT_EQ((*row.eventTimestamps).at(0), 19);
+  EXPECT_EQ((*row.values).at(0), 22);
+  EXPECT_EQ((*row.valuesSquared).at(0), 25);
+  EXPECT_EQ(*row.cohortId, 28);
+
+  auto row2 = LiftRow<int64_t, int64_t>::fromDataFrame(dframe, 1);
+  EXPECT_EQ(*row2.opportunityTimestamp, 2);
+  EXPECT_EQ(*row2.testPopulation, 5);
+  EXPECT_EQ(*row2.controlPopulation, 8);
+  EXPECT_EQ(*row2.reachedPopulation, 11);
+  EXPECT_EQ(*row2.breakdownId, 14);
+  EXPECT_EQ(*row2.partnerRow, 17);
+  EXPECT_EQ((*row2.eventTimestamps).at(0), 20);
+  EXPECT_EQ((*row2.values).at(0), 23);
+  EXPECT_EQ((*row2.valuesSquared).at(0), 26);
+  EXPECT_EQ(*row2.cohortId, 29);
+
+  auto row3 = LiftRow<int64_t, int64_t>::fromDataFrame(dframe, 2);
+  EXPECT_EQ(*row3.opportunityTimestamp, 3);
+  EXPECT_EQ(*row3.testPopulation, 6);
+  EXPECT_EQ(*row3.controlPopulation, 9);
+  EXPECT_EQ(*row3.reachedPopulation, 12);
+  EXPECT_EQ(*row3.breakdownId, 15);
+  EXPECT_EQ(*row3.partnerRow, 18);
+  EXPECT_EQ((*row3.eventTimestamps).at(0), 21);
+  EXPECT_EQ((*row3.values).at(0), 24);
+  EXPECT_EQ((*row3.valuesSquared).at(0), 27);
+  EXPECT_EQ(*row3.cohortId, 30);
+}
+
+TEST(LiftRowTest, FromDataFrameNoBreakdown) {
+  auto dframe = buildBasicDataFrame();
+  dframe.get<int64_t>(lift_columns::kCohortId) = {28, 29, 30};
+
+  // Validate a couple columns
+  auto row = LiftRow<int64_t, int64_t>::fromDataFrame(dframe, 0);
+  EXPECT_EQ(*row.opportunityTimestamp, 1);
+  EXPECT_EQ(row.breakdownId, nullptr);
+  EXPECT_EQ(*row.partnerRow, 16);
+  EXPECT_EQ(*row.cohortId, 28);
+}
+
+TEST(LiftRowTest, FromDataFrameNoCohort) {
+  auto dframe = buildBasicDataFrame();
+  dframe.get<int64_t>(lift_columns::kBreakdownId) = {13, 14, 15};
+
+  // Validate a couple columns
+  auto row = LiftRow<int64_t, int64_t>::fromDataFrame(dframe, 1);
+  EXPECT_EQ(*row.opportunityTimestamp, 2);
+  EXPECT_EQ(*row.breakdownId, 14);
+  EXPECT_EQ(*row.partnerRow, 17);
+  EXPECT_EQ(row.cohortId, nullptr);
+}
+
+TEST(LiftRowTest, FromDataFrameNoOptionalColumns) {
+  auto dframe = buildBasicDataFrame();
+
+  // Validate a couple columns
+  auto row = LiftRow<int64_t, int64_t>::fromDataFrame(dframe, 1);
+  EXPECT_EQ(*row.opportunityTimestamp, 2);
+  EXPECT_EQ(row.breakdownId, nullptr);
+  EXPECT_EQ(*row.partnerRow, 17);
+  EXPECT_EQ(row.cohortId, nullptr);
+}

--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -171,6 +171,20 @@ public:
    *    element from this Column
    * @param f the function to call on each element of this Column
    */
+  template <typename F> void apply(F f) const {
+    for (std::size_t i = 0; i < size(); ++i) {
+      f(at(i));
+    }
+  }
+
+  /**
+   * Non-const version of `Column::apply`. Apply a function on each element of
+   * this Column.
+   *
+   * @tparam F an unspecified function type which can be called with each
+   *    element from this Column
+   * @param f the function to call on each element of this Column
+   */
   template <typename F> void apply(F f) {
     for (std::size_t i = 0; i < size(); ++i) {
       f(at(i));
@@ -347,6 +361,25 @@ public:
       res.push_back(T2(at(i)));
     }
     return res;
+  }
+
+  /**
+   * Get a reference to the underlying vector of this Column.
+   *
+   * @returns the vector backing this Column data structure
+   */
+  const std::vector<T> &data() const {
+    return v_;
+  }
+
+  /**
+   * Non-const version of `Column::data`. Get a reference to the underlying
+   * vector of this Column.
+   *
+   * @returns the vector backing this Column data structure
+   */
+  std::vector<T> &data() {
+    return const_cast<std::vector<T> &>(const_cast<const Column<T> &>(*this).data());
   }
 
   /* Comparison operators */

--- a/fbpcs/emp_games/lift/common/ColumnNameConstants.cpp
+++ b/fbpcs/emp_games/lift/common/ColumnNameConstants.cpp
@@ -12,7 +12,8 @@
 namespace private_lift::lift_columns {
 // Publisher columns
 const std::string kOpportunityTimestamp{"opportunity_timestamp"};
-const std::string kPopulation{"population"};
+const std::string kTestPopulation{"test_population"};
+const std::string kControlPopulation{"control_population"};
 const std::string kNumImpressions{"num_impressions"};
 const std::string kReached{"reached"};
 const std::string kNumClicks{"num_clicks"};

--- a/fbpcs/emp_games/lift/common/ColumnNameConstants.cpp
+++ b/fbpcs/emp_games/lift/common/ColumnNameConstants.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/lift/common/ColumnNameConstants.h"
+
+#include <string>
+
+namespace private_lift::lift_columns {
+// Publisher columns
+const std::string kOpportunityTimestamp{"opportunity_timestamp"};
+const std::string kPopulation{"population"};
+const std::string kNumImpressions{"num_impressions"};
+const std::string kReached{"reached"};
+const std::string kNumClicks{"num_clicks"};
+const std::string kTotalSpend{"total_spend"};
+const std::string kBreakdownId{"breakdown_id"};
+
+// Partner columns
+const std::string kPartnerRow{"partner_row"};
+const std::string kEventTimestamps{"event_timestamps"};
+const std::string kValues{"values"};
+const std::string kValuesSquared{"values_squared"};
+const std::string kCohortId{"cohort_id"};
+
+// Derived columns
+const std::string kValidConversions{"valid_conversions"};
+const std::string kConverters{"converters"};
+const std::string kUserValue{"user_value"};
+const std::string kUserValueSquared{"user_value_squared"};
+const std::string kUserNumConvSquared{"user_num_conv_squared"};
+const std::string kMatchCount{"match_count"};
+const std::string kReachedConversions{"reached_conversions"};
+const std::string kReachedValue{"reached_value"};
+const std::string kConvHistogram{"conv_histogram"};
+} // namespace private_lift::lift_columns

--- a/fbpcs/emp_games/lift/common/ColumnNameConstants.h
+++ b/fbpcs/emp_games/lift/common/ColumnNameConstants.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace private_lift::lift_columns {
+// Publisher columns
+extern const std::string kOpportunityTimestamp;
+extern const std::string kPopulation;
+extern const std::string kNumImpressions;
+extern const std::string kReached;
+extern const std::string kNumClicks;
+extern const std::string kTotalSpend;
+extern const std::string kBreakdownId;
+
+// Partner columns
+extern const std::string kPartnerRow;
+extern const std::string kEventTimestamps;
+extern const std::string kValues;
+extern const std::string kValuesSquared;
+extern const std::string kCohortId;
+
+// Derived columns
+extern const std::string kValidConversions;
+extern const std::string kConverters;
+extern const std::string kUserValue;
+extern const std::string kUserValueSquared;
+extern const std::string kUserNumConvSquared;
+extern const std::string kMatchCount;
+extern const std::string kReachedConversions;
+extern const std::string kReachedValue;
+extern const std::string kConvHistogram;
+} // namespace private_lift::lift_columns

--- a/fbpcs/emp_games/lift/common/ColumnNameConstants.h
+++ b/fbpcs/emp_games/lift/common/ColumnNameConstants.h
@@ -12,7 +12,8 @@
 namespace private_lift::lift_columns {
 // Publisher columns
 extern const std::string kOpportunityTimestamp;
-extern const std::string kPopulation;
+extern const std::string kTestPopulation;
+extern const std::string kControlPopulation;
 extern const std::string kNumImpressions;
 extern const std::string kReached;
 extern const std::string kNumClicks;

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -326,6 +326,20 @@ public:
     types_.erase(typeIt);
   }
 
+  /**
+   * Get a row view into this DataFrame at the given index.
+   *
+   * @tparam RowType a type implementing `fromDataFrame(DataFrame, std::size_t)`
+   *     which represents a view into a specific row of a DataFrame
+   *
+   * @param idx the index of the row the new RowType should point to
+   * @returns a RowType view of this DataFrame at the given index
+   */
+  template <typename RowType>
+  RowType rowAt(std::size_t idx) {
+    return RowType::fromDataFrame(*this, idx);
+  }
+
 private:
   std::unordered_map<std::string, TypeInfo> types_;
   std::unordered_map<std::type_index, std::unique_ptr<BaseMap>> maps_;

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -206,6 +206,15 @@ public:
   }
 
   /**
+   * Check if a given key is defined in this DataFrame already
+   *
+   * @returns true if `key` is stored in this DataFrame
+   */
+  bool containsKey(const std::string &key) const {
+    return types_.find(key) != types_.end();
+  }
+
+  /**
    * Get a `Column<T>` at the given key within this DataFrame. A `dynamic_cast`
    * is necessary since we're dynamically altering types at runtime depending
    * on the values being read or set. While there is a small computational cost

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -414,3 +414,14 @@ TEST(IteratorTest, IteratorFunctionality) {
   ++iter;
   EXPECT_EQ(iter, c.end());
 }
+
+TEST(ColumnTest, Data) {
+  Column<int64_t> iCol{300, 200, 100};
+  Column<bool> bCol{true, true, false};
+
+  std::vector<int64_t> iExpected{300, 200, 100};
+  std::vector<bool> bExpected{true, true, false};
+
+  EXPECT_EQ(iCol.data(), iExpected);
+  EXPECT_EQ(bCol.data(), bExpected);
+}

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -191,10 +191,7 @@ TEST(DataFrameTest, RowAt) {
 
     static RowView fromDataFrame(const DataFrame &df, std::size_t idx) {
       RowView row;
-      // Bools are ugly -- std::vector<bool> is not an actual STL container, so
-      // we have to use a special workaround to make it copyable. The real fix
-      // here is to use `std::deque` as the backing container for bool Columns.
-      row.b = df.get<bool>("boolCol").data().at(idx);
+      row.b = df.get<bool>("boolCol").at(idx);
       row.i = &df.get<int64_t>("intCol").at(idx);
       row.iVec = &df.get<std::vector<int64_t>>("intVecCol").at(idx);
       return row;

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -181,3 +181,42 @@ TEST(DataFrameTest, LoadFromRowsAdvanced) {
   EXPECT_EQ(expected.at<std::vector<int64_t>>("intVec"),
             actual.at<std::vector<int64_t>>("intVec"));
 }
+
+#include <iostream>
+TEST(DataFrameTest, RowAt) {
+  struct RowView {
+    bool b;
+    const int64_t* i;
+    const std::vector<int64_t>* iVec;
+
+    static RowView fromDataFrame(const DataFrame &df, std::size_t idx) {
+      RowView row;
+      // Bools are ugly -- std::vector<bool> is not an actual STL container, so
+      // we have to use a special workaround to make it copyable. The real fix
+      // here is to use `std::deque` as the backing container for bool Columns.
+      row.b = df.get<bool>("boolCol").data().at(idx);
+      row.i = &df.get<int64_t>("intCol").at(idx);
+      row.iVec = &df.get<std::vector<int64_t>>("intVecCol").at(idx);
+      return row;
+    }
+  };
+
+  DataFrame df;
+  df.get<bool>("boolCol") = {true, false};
+  df.get<int64_t>("intCol") = {123, 456};
+  df.get<std::vector<int64_t>>("intVecCol") = {{7, 8, 9}, {333}};
+
+  //auto view = df.rowAt<RowView>(0);
+  auto view = RowView::fromDataFrame(df, 0);
+  EXPECT_EQ(view.b, true);
+  EXPECT_EQ(*view.i, 123);
+  std::vector<int64_t> expectedIVec{7, 8, 9};
+  EXPECT_EQ(*view.iVec, expectedIVec);
+
+  //auto view2 = df.rowAt<RowView>(1);
+  auto view2 = RowView::fromDataFrame(df, 1);
+  EXPECT_EQ(view2.b, false);
+  EXPECT_EQ(*view2.i, 456);
+  std::vector<int64_t> expectedIVec2{333};
+  EXPECT_EQ(*view2.iVec, expectedIVec2);
+}

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -108,6 +108,20 @@ TEST(DataFrameTest, Keys) {
   EXPECT_EQ(boolKeys, df2.keysOf<bool>());
 }
 
+TEST(DataFrameTest, ContainsKey) {
+  DataFrame df;
+  df.get<bool>("bool1") = {true, false};
+  df.get<bool>("bool2") = {true, false};
+  df.get<int64_t>("int1") = {123, 111};
+  df.get<int64_t>("int2") = {456, 222};
+  df.get<std::vector<int64_t>>("intVec") = {{7, 8, 9}, {333}};
+
+  EXPECT_TRUE(df.containsKey("bool1"));
+  EXPECT_TRUE(df.containsKey("int1"));
+  EXPECT_TRUE(df.containsKey("intVec"));
+  EXPECT_FALSE(df.containsKey("int9"));
+}
+
 TEST(DataFrameTest, LoadFromRowsBasic) {
   TypeMap t{
       .boolColumns = {},


### PR DESCRIPTION
Summary:
# What
* Okay, I didn't realize how bad it was to use `std::vector<bool>` behind the scenes... I knew about the bit packing, but I didn't realize how much this was really going to screw things up.
* std::vector<bool> is not an actual STL container, so values in a Column<bool> were not copyable by default. We had to use a hacky workaround because we declared that `Column<T>::at` returned a `T&` (or `const T&`). This is not the case for `bool`!
* This diff fixes the bad type signature by
# Why
* Why does `std::vector<bool>` suck? [See here](https://stackoverflow.com/questions/17794569/why-isnt-vectorbool-a-stl-container).
* This diff

NOTE: Clang-format got mad and decided that all of the code it previously formatted should now be formatted differently... I don't understand this formatter. In other news, I'm going to be looking into [enabling Clang formatter by default on all diffs](https://fb.workplace.com/groups/fbcode.fyi/permalink/4411735958862171/) in fbpcs/ which should make this easier moving forward.

Also a comment from a friend of mine who is a C++ expert:

{F677615717}

Differential Revision: D32240222

