### PR TITLE
stage flow convert name to stage

### DIFF
--- a/fbpcs/stage_flow/exceptions.py
+++ b/fbpcs/stage_flow/exceptions.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class StageFlowException(Exception):
+    pass
+
+
+class StageFlowStageNotFoundError(KeyError, StageFlowException):
+    pass

--- a/fbpcs/stage_flow/test/test_stage_flow.py
+++ b/fbpcs/stage_flow/test/test_stage_flow.py
@@ -6,6 +6,7 @@
 
 from unittest import TestCase
 
+from fbpcs.stage_flow.exceptions import StageFlowStageNotFoundError
 from fbpcs.stage_flow.test.dummy_stage_flow import (
     DummyStageFlow,
     DummyStageFlowStatus,
@@ -112,3 +113,21 @@ class TestStageFlow(TestCase):
                 self.assertIs(
                     stage, DummyStageFlow.get_next_runnable_stage_from_status(status)
                 )
+
+    def test_get_stage_from_name(self):
+        # setup
+        expected_stage = DummyStageFlow.get_first_stage()
+
+        # test that lower case works
+        actual_stage = DummyStageFlow.get_stage_from_str(expected_stage.name.lower())
+        self.assertEqual(expected_stage, actual_stage)
+
+        # test that uppercase works
+        actual_stage = DummyStageFlow.get_stage_from_str(expected_stage.name.upper())
+        self.assertEqual(expected_stage, actual_stage)
+
+        # test that non existent stages raise error
+        with self.assertRaises(StageFlowStageNotFoundError):
+            DummyStageFlow.get_stage_from_str(
+                "do not name your stage this or you will be fired"
+            )


### PR DESCRIPTION
Summary:
## What

* add a class method to stage flow that converts a name string to stage object

## Why

* In the next diff, I add a run_stage endpoint to PC-CLI for dry running arbitrary stages.

Differential Revision: D32370912

