### PR TITLE
default to logging cost to s3

### DIFF
--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -22,6 +22,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -49,7 +50,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
         is_validating: bool = False,
-        log_cost_to_s3: bool = False,
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
     ) -> None:
         self._onedocker_binary_config_map = onedocker_binary_config_map

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -25,6 +25,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )
@@ -57,7 +58,7 @@ class ComputeMetricsStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
         is_validating: bool = False,
-        log_cost_to_s3: bool = False,
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
         skip_partial_container_retry: bool = False,
     ) -> None:

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -23,6 +23,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )
@@ -55,7 +56,7 @@ class AggregationStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
         is_validating: bool = False,
-        log_cost_to_s3: bool = False,
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
         skip_partial_container_retry: bool = False,
     ) -> None:

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -22,6 +22,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )
@@ -54,7 +55,7 @@ class AttributionStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
         is_validating: bool = False,
-        log_cost_to_s3: bool = False,
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
         skip_partial_container_retry: bool = False,
     ) -> None:

--- a/fbpcs/private_computation/service/prepare_data_stage_service.py
+++ b/fbpcs/private_computation/service/prepare_data_stage_service.py
@@ -35,6 +35,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )
@@ -59,8 +60,8 @@ class PrepareDataStageService(PrivateComputationStageService):
         onedocker_svc: OneDockerService,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         is_validating: bool = False,
-        log_cost_to_s3: bool = False,
-        update_status_to_complete: bool = False
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
+        update_status_to_complete: bool = False,
     ) -> None:
         self._onedocker_svc = onedocker_svc
         self._onedocker_binary_config_map = onedocker_binary_config_map
@@ -86,7 +87,6 @@ class PrepareDataStageService(PrivateComputationStageService):
             An updated version of pc_instance
         """
 
-
         output_path = pc_instance.data_processing_output_path
         combine_output_path = output_path + "_combine"
 
@@ -104,9 +104,7 @@ class PrepareDataStageService(PrivateComputationStageService):
         #     note we need each file to be sharded into the same # of files
         #     because we want to keep the data of each existing file to run
         #     on the same container
-        await self._run_sharder_service(
-            pc_instance, combine_output_path
-        )
+        await self._run_sharder_service(pc_instance, combine_output_path)
         # currently, prepare data blocks and runs until completion or failure (exception is thrown)
         # this if statement will let the legacy way of calling prepare data NOT update the status,
         # whereas the new way of calling prepare data can update the status.

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -46,7 +46,8 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
     async def test_aggregate_shards(self):
         private_computation_instance = self._create_pc_instance()
         mpc_instance = PCSMPCInstance.create_instance(
-            instance_id=private_computation_instance.instance_id + "_aggregate_metrics0",
+            instance_id=private_computation_instance.instance_id
+            + "_aggregate_metrics0",
             game_name=GameNames.LIFT.value,
             mpc_party=MPCParty.CLIENT,
             num_workers=private_computation_instance.num_mpc_containers,
@@ -63,10 +64,13 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             {
                 "input_base_path": private_computation_instance.compute_stage_output_base_path,
                 "metrics_format_type": "lift",
-                "num_shards": private_computation_instance.num_mpc_containers * NUM_NEW_SHARDS_PER_FILE,
+                "num_shards": private_computation_instance.num_mpc_containers
+                * NUM_NEW_SHARDS_PER_FILE,
                 "output_path": private_computation_instance.shard_aggregate_stage_output_path,
                 "threshold": private_computation_instance.k_anonymity_threshold,
-                "run_name": "",
+                "run_name": private_computation_instance.instance_id
+                if self.stage_svc._log_cost_to_s3
+                else "",
             }
         ]
 

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -11,15 +11,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.private_computation_decoupled_stage_flow import (
+    PrivateComputationInstanceStatus,
+)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AttributionRule,
     PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationRole,
     AggregationType,
-)
-from fbpcs.private_computation.entity.private_computation_decoupled_stage_flow import (
-    PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import (
@@ -74,7 +74,9 @@ class TestAggregationStageService(IsolatedAsyncioTestCase):
             "output_base_path": private_computation_instance.decoupled_aggregation_stage_output_base_path,
             "num_files": private_computation_instance.num_files_per_mpc_container,
             "concurrency": private_computation_instance.concurrency,
-            "run_name": "",
+            "run_name": private_computation_instance.instance_id
+            if self.stage_svc._log_cost_to_s3
+            else "",
             "max_num_touchpoints": private_computation_instance.padding_size,
             "max_num_conversions": private_computation_instance.padding_size,
             "attribution_rules": private_computation_instance.attribution_rule.value,
@@ -93,7 +95,9 @@ class TestAggregationStageService(IsolatedAsyncioTestCase):
             },
         ]
 
-        actual_value = self.stage_svc._get_compute_metrics_game_args(private_computation_instance)
+        actual_value = self.stage_svc._get_compute_metrics_game_args(
+            private_computation_instance
+        )
         self.assertEqual(
             test_game_args,
             actual_value,

--- a/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
@@ -12,7 +12,8 @@ from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
-    AttributionRule, PrivateComputationGameType,
+    AttributionRule,
+    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationRole,
 )
@@ -71,7 +72,10 @@ class TestAttributionStageService(IsolatedAsyncioTestCase):
             "output_base_path": private_computation_instance.decoupled_attribution_stage_output_base_path,
             "num_files": private_computation_instance.num_files_per_mpc_container,
             "concurrency": private_computation_instance.concurrency,
-            "run_name": "",
+            "run_name": private_computation_instance.instance_id
+            + "_decoupled_attribution"
+            if self.stage_svc._log_cost_to_s3
+            else "",
             "max_num_touchpoints": private_computation_instance.padding_size,
             "max_num_conversions": private_computation_instance.padding_size,
             "attribution_rules": AttributionRule.LAST_CLICK_1D.value,


### PR DESCRIPTION
Summary:
## What

* Use the default log cost to s3 variable stored in const.py
* Modify unit tests to work with the variable being set to true and false.

## Why

I wasn't aware that the intended default behavior for this variable was True until I moved the location of the DEFAULT_LOG_COST_TO_S3 constants file. This uses the new default value.

Differential Revision: D32406661

