### PR TITLE
fix typo in fbpcs github release pipeline

### DIFF
--- a/fbpcs/tests/github/attribution_run_stages.sh
+++ b/fbpcs/tests/github/attribution_run_stages.sh
@@ -19,7 +19,7 @@ docker_command="docker exec $container_name $COORDINATOR"
 case "$stage" in
     create_instance )
         echo "Create Attribution Publisher instance"
-        $docker_command create_instance "$ATTRIBUTION_PUBLIHSER_NAME" \
+        $docker_command create_instance "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE" \
             --input_path="$ATTRIBUTION_PUBLISHER_INPUT_FILE" \
             --output_dir="$ATTRIBUTION_OUTPUT_DIR" \
@@ -48,7 +48,7 @@ case "$stage" in
     # Stages without passing IP addresses
     prepare_compute_input )
         echo "Attribution Publisher $stage starts"
-        $docker_command run_next "$ATTRIBUTION_PUBLIHSER_NAME" \
+        $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
         echo "Attribution Partner $stage starts"
         $docker_command run_next "$ATTRIBUTION_PARTNER_NAME" \
@@ -57,10 +57,10 @@ case "$stage" in
      # Stages need to pass IP address
     run_next )
         echo "Attribution Publisher $stage starts"
-        $docker_command run_next "$ATTRIBUTION_PUBLIHSER_NAME" \
+        $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
         echo "Get Publisher Ips"
-        publisher_server_ips=$($docker_command get_server_ips "$ATTRIBUTION_PUBLIHSER_NAME" \
+        publisher_server_ips=$($docker_command get_server_ips "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE" | sed 's/\r//g')
         echo "Server IPs are ${publisher_server_ips}"
         echo "Attribution Partner $stage starts"

--- a/fbpcs/tests/github/check_status.sh
+++ b/fbpcs/tests/github/check_status.sh
@@ -13,7 +13,7 @@ game=$2
 if [ "$game" == 'lift' ]||[ "$game" == 'attribution' ]
 then
     upper_game=${game^^}
-    publisher_name=${upper_game}_PUBLIHSER_NAME
+    publisher_name=${upper_game}_PUBLISHER_NAME
     partner_name=${upper_game}_PARTNER_NAME
 else
     echo "Invalid Game"

--- a/fbpcs/tests/github/config.sh
+++ b/fbpcs/tests/github/config.sh
@@ -19,7 +19,7 @@ export DOCKER_INSTANCE_REPO="/instances"
 
 ## Lift
 # Lift study configs
-export LIFT_PUBLIHSER_NAME="pl_publisher_github"
+export LIFT_PUBLISHER_NAME="pl_publisher_github"
 export LIFT_PARTNER_NAME="pl_partner_github"
 export LIFT_NUM_MPC_CONTAIENRS=2
 export LIFT_NUM_PID_CONTAINERS=2
@@ -30,7 +30,7 @@ export LIFT_OUTPUT_DIR=$E2E_GITHUB_S3_URL/lift/outputs
 
 # Lift result comparision
 export LIFT_OUTPUT_PATH=s3://$E2E_S3_BUCKET/lift/outputs
-export LIFT_PUBLISHER_AGGREGATION_OUTPUT=$LIFT_OUTPUT_PATH/"$LIFT_PUBLIHSER_NAME"_out_dir/shard_aggregation_stage/out.json
+export LIFT_PUBLISHER_AGGREGATION_OUTPUT=$LIFT_OUTPUT_PATH/"$LIFT_PUBLISHER_NAME"_out_dir/shard_aggregation_stage/out.json
 export LIFT_PARTNER_AGGREGATION_OUTPUT=$LIFT_OUTPUT_PATH/"$LIFT_PARTNER_NAME"_out_dir/shard_aggregation_stage/out.json
 
 export LIFT_RESULT_PATH=s3://$E2E_S3_BUCKET/lift/results
@@ -39,7 +39,7 @@ export LIFT_PARTNER_EXPECTED_RESULT=$LIFT_RESULT_PATH/partner_expected_result.js
 
 ## Attribution
 # Attribution study configs
-export ATTRIBUTION_PUBLIHSER_NAME="pa_publisher_github"
+export ATTRIBUTION_PUBLISHER_NAME="pa_publisher_github"
 export ATTRIBUTION_PARTNER_NAME="pa_partner_github"
 
 export ATTRIBUTION_NUM_FILES_PER_MPC_CONTAINER=1
@@ -56,7 +56,7 @@ export ATTRIBUTION_OUTPUT_DIR=$E2E_GITHUB_S3_URL/attribution/outputs
 
 # Attribution result comparision
 export ATTRIBUTION_OUTPUT_PATH=s3://$E2E_S3_BUCKET/attribution/outputs
-export ATTRIBUTION_PUBLISHER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PUBLIHSER_NAME"_out_dir/shard_aggregation_stage/out.json
+export ATTRIBUTION_PUBLISHER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PUBLISHER_NAME"_out_dir/shard_aggregation_stage/out.json
 export ATTRIBUTION_PARTNER_AGGREGATION_OUTPUT=$ATTRIBUTION_OUTPUT_PATH/"$ATTRIBUTION_PARTNER_NAME"_out_dir/shard_aggregation_stage/out.json
 
 export ATTRIBUTION_RESULT_PATH=s3://$E2E_S3_BUCKET/attribution/results

--- a/fbpcs/tests/github/lift_run_stages.sh
+++ b/fbpcs/tests/github/lift_run_stages.sh
@@ -19,7 +19,7 @@ docker_command="docker exec $container_name $COORDINATOR"
 case "$stage" in
     create_instance )
         echo "Create Lift Publisher instance"
-        $docker_command create_instance "$LIFT_PUBLIHSER_NAME" \
+        $docker_command create_instance "$LIFT_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE" \
             --role=publisher \
             --game_type=lift \
@@ -42,7 +42,7 @@ case "$stage" in
     # stages donot need IP exchange
     prepare_compute_input | pid_shard | pid_prepare )
         echo "Lift Publisher $stage starts"
-        $docker_command run_next "$LIFT_PUBLIHSER_NAME" \
+        $docker_command run_next "$LIFT_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
         echo "Lift Partner $stage starts"
         $docker_command run_next "$LIFT_PARTNER_NAME" \
@@ -51,11 +51,11 @@ case "$stage" in
     # stages require IP exchange
     run_next )
         echo "Lift Publisher $stage starts"
-        $docker_command run_next "$LIFT_PUBLIHSER_NAME" \
+        $docker_command run_next "$LIFT_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"
         echo "Get Publisher Ips"
         # get_server_ips returns an extra carriage return character
-        publisher_server_ips=$($docker_command get_server_ips "$LIFT_PUBLIHSER_NAME" \
+        publisher_server_ips=$($docker_command get_server_ips "$LIFT_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE" | sed 's/\r//g')
         echo "Server IPs are ${publisher_server_ips}"
         echo "Lift Partner $stage starts"


### PR DESCRIPTION
Summary: There are some typos in the scripts for running the github release pipeline for fbpcs.  This diff just corrects them.

Differential Revision: D32511852

