### PR TITLE
remove sign-compare warnings in attribution and aggregation games

### DIFF
--- a/fbpcs/data_processing/id_combiner/AddPaddingToCols.cpp
+++ b/fbpcs/data_processing/id_combiner/AddPaddingToCols.cpp
@@ -47,7 +47,7 @@ void addPaddingToCols(
   outFile << vectorToString(header) << "\n";
 
   std::vector<int> colsIndexesToPad;
-  for (auto i = 0; i < cols.size(); i++) {
+  for (std::vector<std::string>::size_type i = 0; i < cols.size(); i++) {
     colsIndexesToPad.push_back(headerIndex(header, cols.at(i)));
   }
 

--- a/fbpcs/emp_games/attribution/Aggregator.cpp
+++ b/fbpcs/emp_games/attribution/Aggregator.cpp
@@ -136,7 +136,7 @@ class DeliveryAggregator : public Aggregator {
     CHECK_EQ(uids.size(), touchpoints.size())
         << "uid array and touchpoint array must be equal size";
 
-    for (auto i = 0; i < uids.size(); i++) {
+    for (std::vector<int64_t>::size_type i = 0; i < uids.size(); i++) {
       auto uid = uids[i];
       auto& tps = touchpoints[i];
 
@@ -249,7 +249,7 @@ class AttributionAggregator : public Aggregator {
     CHECK_EQ(uids.size(), touchpoints.size())
         << "uid array and touchpoint array must be equal size";
 
-    for (auto i = 0; i < uids.size(); i++) {
+    for (std::vector<int64_t>::size_type i = 0; i < uids.size(); i++) {
       auto uid = uids[i];
       auto& tps = touchpoints[i];
 
@@ -352,7 +352,7 @@ class PcmAggregator : public Aggregator {
     CHECK_EQ(uids.size(), touchpoints.size())
         << "uid array and touchpoint array must be equal size";
 
-    for (auto i = 0; i < uids.size(); i++) {
+    for (std::vector<int64_t>::size_type i = 0; i < uids.size(); i++) {
       auto uid = uids[i];
       auto& tps = touchpoints[i];
 

--- a/fbpcs/emp_games/attribution/Attribution.hpp
+++ b/fbpcs/emp_games/attribution/Attribution.hpp
@@ -67,7 +67,7 @@ const std::vector<AttributionRule> shareAttributionRules(
 
   std::vector<int64_t> attributionIds;
   if constexpr (MY_ROLE == PUBLISHER) {
-    for (auto i = 0; i < rules.size(); i++) {
+    for (std::vector<AttributionRule>::size_type i = 0; i < rules.size(); i++) {
       attributionIds.push_back(rules[i].id);
     }
     XLOGF(
@@ -103,7 +103,7 @@ const std::vector<AggregationFormat> shareAggregationFormats(
 
   std::vector<int64_t> aggregationIds;
   if constexpr (MY_ROLE == PUBLISHER) {
-    for (auto i = 0; i < aggregationFormats.size(); i++) {
+    for (std::vector<AggregationFormat>::size_type i = 0; i < aggregationFormats.size(); i++) {
       aggregationIds.push_back(aggregationFormats[i].id);
     }
     XLOGF(
@@ -262,7 +262,7 @@ AttributionOutputMetrics computeAttributions(
         aggregationFormats,
         AggregationContext{adIds, inputData.getIds(), tpArrays},
         outputVisibility};
-    for (auto i = 0; i < numIds; i++) {
+    for (std::vector<int64_t>::size_type i = 0; i < numIds; i++) {
       auto id = ids[i];
       auto tps = tpArrays[i];
       auto convs = convArrays[i];

--- a/fbpcs/emp_games/attribution/AttributionMetrics.cpp
+++ b/fbpcs/emp_games/attribution/AttributionMetrics.cpp
@@ -58,7 +58,7 @@ static const std::vector<Touchpoint> parseTouchpoints(
   std::vector<int64_t> timestamps;
   std::vector<int64_t> isClicks;
   std::vector<int64_t> campaignMetadata;
-  for (auto i = 0; i < header.size(); ++i) {
+  for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
     auto column = header[i];
     auto value = parts[i];
     if (column == "ad_ids") {
@@ -86,8 +86,8 @@ static const std::vector<Touchpoint> parseTouchpoints(
   // (ad_id, ts) tuple, or some kind of id that is synchronized
   // with the caller. Id is unique per row only.
   std::vector<int64_t> unique_ids;
-  for (int64_t i=0; i<timestamps.size(); i++){
-      unique_ids.push_back(i);
+  for (std::vector<int64_t>::size_type i=0; i<timestamps.size(); i++){
+      unique_ids.push_back(static_cast<int64_t>(i));
   }
 
   const std::unordered_set<int64_t> idSet{unique_ids.begin(), unique_ids.end()};
@@ -96,7 +96,7 @@ static const std::vector<Touchpoint> parseTouchpoints(
       << "This implementation currently only supports unique touchpoint ids per user.";
 
   std::vector<Touchpoint> tps;
-  for (auto i = 0; i < adIds.size(); i++) {
+  for (std::vector<int64_t>::size_type i = 0; i < adIds.size(); i++) {
     tps.push_back(Touchpoint{
         /* id */ unique_ids.at(i),
         /* isClick */ isClicks.at(i) == 1,
@@ -115,7 +115,7 @@ static const std::vector<Conversion> parseConversions(
   std::vector<int64_t> convValues;
   std::vector<int64_t> convMetadata;
 
-  for (auto i = 0; i < header.size(); ++i) {
+  for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
     auto column = header[i];
     auto value = parts[i];
 
@@ -136,7 +136,7 @@ static const std::vector<Conversion> parseConversions(
       << "Number of conversions exceeds the maximum allowed value.";
 
   std::vector<Conversion> convs;
-  for (auto i = 0; i < convTimestamps.size(); i++) {
+  for (std::vector<int64_t>::size_type i = 0; i < convTimestamps.size(); i++) {
     convs.push_back(Conversion{
         /* ts */ convTimestamps.at(i),
         /* value */ convValues.at(i),
@@ -187,7 +187,7 @@ AttributionInputMetrics::AttributionInputMetrics(
         }
         XLOGF(DBG, "{}: {}", lineNo, private_measurement::vecToString(parts));
 
-        for (auto i = 0; i < header.size(); ++i) {
+        for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
           auto column = header[i];
           auto value = parts[i];
 

--- a/fbpcs/emp_games/attribution/MainUtil.h
+++ b/fbpcs/emp_games/attribution/MainUtil.h
@@ -34,7 +34,7 @@ inline void startAttributionAppsForShardedFiles(
   std::vector<std::unique_ptr<measurement::private_attribution::
                                   AttributionApp<PARTY, OUTPUT_VISIBILITY>>>
       attributionApps;
-  for (auto i = 0; i < inputFilenames.size(); i++) {
+  for (std::vector<std::string>::size_type i = 0; i < inputFilenames.size(); i++) {
     attributionApps.push_back(
         std::make_unique<measurement::private_attribution::
                             AttributionApp<PARTY, OUTPUT_VISIBILITY>>(
@@ -64,7 +64,7 @@ getIOFilenames(
   std::vector<std::string> outputFilenames;
 
   try{
-    for (auto i = 0; i < numFiles; i++) {
+    for (int32_t i = 0; i < numFiles; i++) {
       std::string inputPathName = folly::sformat(
           "{}_{}", inputBasePath, (fileStartIndex + i));
       std::string outputPathName = folly::sformat(

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregation.hpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregation.hpp
@@ -134,7 +134,7 @@ const std::vector<AggregationFormat> shareAggregationFormats(
 
   std::vector<int64_t> aggregationIds;
   if constexpr (MY_ROLE == PUBLISHER) {
-    for (auto i = 0; i < aggregationFormats.size(); i++) {
+    for (std::vector<AggregationFormat>::size_type i = 0; i < aggregationFormats.size(); i++) {
       aggregationIds.push_back(aggregationFormats[i].id);
     }
     XLOGF(
@@ -269,7 +269,7 @@ AggregationOutputMetrics computeAggregations(
   const auto& touchpointSecretShares = inputData.getTouchpointSecretShares();
   const auto& conversionSecretShares = inputData.getConversionSecretShares();
 
-  for (int i = 0; i < attributionRules.size(); i++) {
+  for (std::vector<std::string>::size_type i = 0; i < attributionRules.size(); i++) {
     // share secret shares computed for each attribution Rule
     XLOG(INFO, "Sharing touchpoint attribution results...");
     std::vector<std::vector<AttributionResult>> tpAttributionResultsPerRule;

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.cpp
@@ -40,7 +40,7 @@ static const std::vector<TouchpointMetadata> parseTouchpointMetadata(
   std::vector<int64_t> timestamps;
   std::vector<int64_t> isClicks;
   std::vector<int64_t> campaignMetadata;
-  for (auto i = 0; i < header.size(); ++i) {
+  for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
     auto column = header[i];
     auto value = parts[i];
     if (column == "ad_ids") {
@@ -62,8 +62,8 @@ static const std::vector<TouchpointMetadata> parseTouchpointMetadata(
       << "Ad ids and campaign_metadata arrays are not the same length.";
 
   std::vector<int64_t> unique_ids;
-  for (int64_t i = 0; i < timestamps.size(); i++) {
-    unique_ids.push_back(i);
+  for (std::vector<int64_t>::size_type i = 0; i < timestamps.size(); i++) {
+    unique_ids.push_back(static_cast<int64_t>(i));
   }
 
   const std::unordered_set<int64_t> idSet{unique_ids.begin(), unique_ids.end()};
@@ -72,7 +72,7 @@ static const std::vector<TouchpointMetadata> parseTouchpointMetadata(
       << "This implementation currently only supports unique touchpoint ids per user.";
 
   std::vector<TouchpointMetadata> tpms;
-  for (auto i = 0; i < adIds.size(); i++) {
+  for (std::vector<int64_t>::size_type i = 0; i < adIds.size(); i++) {
     tpms.push_back(TouchpointMetadata{
         /* adId */ adIds.at(i),
         /* ts */ timestamps.at(i),
@@ -97,7 +97,7 @@ static const std::vector<ConversionMetadata> parseConversions(
   std::vector<int32_t> convValues;
   std::vector<int32_t> convMetadata;
 
-  for (auto i = 0; i < header.size(); ++i) {
+  for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
     auto column = header[i];
     auto value = parts[i];
 
@@ -116,7 +116,7 @@ static const std::vector<ConversionMetadata> parseConversions(
       << "Conversion timetamps and  arrays are not the same length.";
 
   std::vector<ConversionMetadata> convs;
-  for (auto i = 0; i < convTimestamps.size(); i++) {
+  for (std::vector<int64_t>::size_type i = 0; i < convTimestamps.size(); i++) {
     convs.push_back(ConversionMetadata{
         /* ts */ convTimestamps.at(i),
         /* value */ convValues.at(i),

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
@@ -88,11 +88,7 @@ class MeasurementAggregator : public Aggregator {
     std::vector<std::vector<
         MeasurementAggregation::PrivateMeasurementAggregationResult>>
         touchpointConversionResults;
-    for (int i = 0; i < privateCvmArrays.size(); i++) {
-      const auto& privateTpAttributionArray = privateTpAttributionArrays.at(i);
-      const auto& privateCvmAttributionArray =
-          privateCvmAttributionsArrays.at(i);
-
+    for (std::size_t i = 0; i < privateCvmArrays.size(); i++) {
       // Retrieve the touchpoint-conversion metadata pairs based on attribution
       // results. One assumption here is that one conversion will only be
       // attributed to one touchpoint.

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/MainUtil.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/MainUtil.h
@@ -33,7 +33,7 @@ inline std::vector<std::string> getIOInputFilenames(
   try {
     // if multiple of attribution output files is greater than 1.
     if (use_postfix) {
-      for (auto i = 0; i < numFiles; i++) {
+      for (int32_t i = 0; i < numFiles; i++) {
         std::string inputFilePath =
             folly::sformat("{}_{}", inputBasePath, (fileStartIndex + i));
         inputFilePaths.push_back(inputFilePath);
@@ -65,7 +65,7 @@ inline void startPrivateAggregationApp(
       aggregationApps;
   CHECK_EQ(inputSecretShareFilePaths.size(), inputClearTextFilePaths.size())
       << "number of attribution results and metadata files not matching.";
-  for (auto i = 0; i < inputSecretShareFilePaths.size(); i++) {
+  for (std::vector<std::string>::size_type i = 0; i < inputSecretShareFilePaths.size(); i++) {
     aggregationApps.push_back(
         std::make_unique<aggregation::private_aggregation::
                              AggregationApp<PARTY, OUTPUT_VISIBILITY>>(

--- a/fbpcs/emp_games/attribution/decoupled_attribution/Attribution.hpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/Attribution.hpp
@@ -60,7 +60,7 @@ const std::vector<AttributionRule> shareAttributionRules(
 
   std::vector<int64_t> attributionIds;
   if constexpr (MY_ROLE == PUBLISHER) {
-    for (auto i = 0; i < rules.size(); i++) {
+    for (std::vector<AttributionRule>::size_type i = 0; i < rules.size(); i++) {
       attributionIds.push_back(rules[i].id);
     }
     XLOGF(
@@ -181,7 +181,7 @@ AttributionOutputMetrics computeAttributions(
         attributionFormats,
         AttributionContext{inputData.getIds(), tpArrays},
         outputVisibility};
-    for (auto i = 0; i < numIds; i++) {
+    for (std::vector<int64_t>::size_type i = 0; i < numIds; i++) {
       auto id = ids[i];
       auto tps = tpArrays[i];
       auto convs = convArrays[i];

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionMetrics.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionMetrics.cpp
@@ -55,7 +55,7 @@ static const std::vector<Touchpoint> parseTouchpoints(
     const std::vector<std::string>& parts) {
   std::vector<int64_t> timestamps;
   std::vector<int64_t> isClicks;
-  for (auto i = 0; i < header.size(); ++i) {
+  for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
     auto column = header[i];
     auto value = parts[i];
     if (column == "timestamps") {
@@ -75,8 +75,8 @@ static const std::vector<Touchpoint> parseTouchpoints(
   // (ad_id, ts) tuple, or some kind of id that is synchronized
   // with the caller. Id is unique per row only.
   std::vector<int64_t> unique_ids;
-  for (int64_t i = 0; i < timestamps.size(); i++) {
-    unique_ids.push_back(i);
+  for (std::vector<int64_t>::size_type i = 0; i < timestamps.size(); i++) {
+    unique_ids.push_back(static_cast<int64_t>(i));
   }
 
   const std::unordered_set<int64_t> idSet{unique_ids.begin(), unique_ids.end()};
@@ -85,7 +85,7 @@ static const std::vector<Touchpoint> parseTouchpoints(
       << "This implementation currently only supports unique touchpoint ids per user.";
 
   std::vector<Touchpoint> tps;
-  for (auto i = 0; i < timestamps.size(); i++) {
+  for (std::vector<int64_t>::size_type i = 0; i < timestamps.size(); i++) {
     tps.push_back(Touchpoint{
         /* id */ unique_ids.at(i),
         /* isClick */ isClicks.at(i) == 1,
@@ -104,7 +104,7 @@ static const std::vector<Conversion> parseConversions(
     const std::vector<std::string>& parts) {
   std::vector<int64_t> convTimestamps;
 
-  for (auto i = 0; i < header.size(); ++i) {
+  for (std::vector<std::string>::size_type i = 0; i < header.size(); ++i) {
     auto column = header[i];
     auto value = parts[i];
 
@@ -117,7 +117,7 @@ static const std::vector<Conversion> parseConversions(
       << "Number of conversions exceeds the maximum allowed value.";
 
   std::vector<Conversion> convs;
-  for (auto i = 0; i < convTimestamps.size(); i++) {
+  for (std::vector<int64_t>::size_type i = 0; i < convTimestamps.size(); i++) {
     convs.push_back(Conversion{/* ts */ convTimestamps.at(i)});
   }
   // Sorting conversions based on timestamp.

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.cpp
@@ -48,7 +48,7 @@ class AttributionDefault : public AttributionOutput {
     CHECK_EQ(uids.size(), touchpoints.size())
         << "uid array and touchpoint array must be equal size";
 
-    for (auto i = 0; i < uids.size(); i++) {
+    for (std::vector<int64_t>::size_type i = 0; i < uids.size(); i++) {
       idToMetrics_.emplace(uids[i], PrivateAttDefaultMap{});
     }
   }

--- a/fbpcs/emp_games/attribution/decoupled_attribution/MainUtil.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/MainUtil.h
@@ -37,7 +37,7 @@ getIOFilenames(
   try{
     // if multiple files used (sharding)
     if (use_postfix){
-      for (auto i = 0; i < numFiles; i++) {
+      for (int32_t i = 0; i < numFiles; i++) {
         std::string inputPathName = folly::sformat(
             "{}_{}", inputBasePath, (fileStartIndex + i));
         std::string outputPathName = folly::sformat(
@@ -69,7 +69,7 @@ inline void startAttributionAppsForShardedFiles(
     std::vector<std::unique_ptr<aggregation::private_attribution::
                                   AttributionApp<PARTY, OUTPUT_VISIBILITY>>>
       attributionApps;
-    for (auto i = 0; i < inputFilenames.size(); i++) {
+    for (std::vector<std::string>::size_type i = 0; i < inputFilenames.size(); i++) {
       attributionApps.push_back(
           std::make_unique<aggregation::private_attribution::
                               AttributionApp<PARTY, OUTPUT_VISIBILITY>>(

--- a/fbpcs/emp_games/common/EmpOperationUtil.hpp
+++ b/fbpcs/emp_games/common/EmpOperationUtil.hpp
@@ -13,7 +13,7 @@ inline const std::vector<emp::Bit> intsToBits(
     const std::vector<emp::Integer>& in) {
   std::vector<emp::Bit> bits;
   bits.reserve(in.size());
-  for (auto i = 0; i < in.size(); ++i) {
+  for (std::vector<emp::Integer>::size_type i = 0; i < in.size(); ++i) {
     // We only take the first (zero-th) bit. It's up to the caller to ensure
     // that the input vector of Integers actually represents Bits.
     bits.push_back(in[i][0]);
@@ -30,7 +30,7 @@ inline const std::vector<emp::Integer> bitsToInts(
 
   std::vector<emp::Integer> ints;
   ints.reserve(in.size());
-  for (auto i = 0; i < in.size(); ++i) {
+  for (std::vector<emp::Bit>::size_type i = 0; i < in.size(); ++i) {
     ints.emplace_back(emp::If(in[i], one, zero));
   }
   return ints;
@@ -43,7 +43,7 @@ inline const emp::Integer getMin(emp::Integer value1, emp::Integer value2) {
 
 inline const emp::Integer getMin(const std::vector<emp::Integer>& values) {
   emp::Integer minValue(INT_SIZE, __INT_MAX__, emp::PUBLIC);
-  for (auto i = 0; i < values.size(); i++) {
+  for (std::vector<emp::Integer>::size_type i = 0; i < values.size(); i++) {
     minValue = getMin(minValue, values.at(i));
   }
   return minValue;

--- a/fbpcs/emp_games/common/PrivateData.h
+++ b/fbpcs/emp_games/common/PrivateData.h
@@ -44,7 +44,7 @@ std::string vecToString(
   std::stringstream out;
 
   out << "[";
-  for (auto j = 0; j < in.size(); j++) {
+  for (std::size_t j = 0; j < in.size(); j++) {
     const auto& val = in[j];
     if (nullValue.has_value() && val == nullValue.value()) {
       out << "✗";

--- a/fbpcs/emp_games/common/SecretSharing.hpp
+++ b/fbpcs/emp_games/common/SecretSharing.hpp
@@ -348,7 +348,7 @@ const std::vector<O> map(
   // Apply the map function
   std::vector<O> out;
   out.reserve(vec.size());
-  for (int i = 0; i < vec.size(); ++i) {
+  for (std::size_t i = 0; i < vec.size(); ++i) {
     out.push_back(map_fn(vec[i]));
   }
   return out;
@@ -363,7 +363,7 @@ const std::vector<O> zip_and_map(
 
   // Apply the map function
   std::vector<O> out;
-  for (int i = 0; i < vec1.size(); ++i) {
+  for (std::size_t i = 0; i < vec1.size(); ++i) {
     out.push_back(map_fn(vec1[i], vec2[i]));
   }
 
@@ -437,7 +437,7 @@ inline const std::vector<emp::Integer> multiplyBitmask(
 
   const emp::Integer zero{INT_SIZE, 0, emp::PUBLIC};
 
-  for (auto i = 0; i < vec.size(); ++i) {
+  for (std::vector<emp::Integer>::size_type i = 0; i < vec.size(); ++i) {
     // emp::If(condition, true_case, false_case)
     out.push_back(emp::If(bitmask.at(i), vec.at(i), zero));
   }
@@ -453,7 +453,7 @@ inline const std::vector<emp::Bit> multiplyBitmask(
 
   std::vector<emp::Bit> out;
   out.reserve(vec.size());
-  for (auto i = 0; i < vec.size(); ++i) {
+  for (std::vector<emp::Bit>::size_type i = 0; i < vec.size(); ++i) {
     out.push_back(vec.at(i) & bitmask.at(i));
   }
   return out;
@@ -468,10 +468,10 @@ inline const std::vector<std::vector<emp::Integer>> multiplyBitmask(
 
   std::vector<std::vector<emp::Integer>> out;
   out.reserve(vec.size());
-  for (auto i = 0; i < vec.size(); ++i) {
+  for (std::vector<std::vector<emp::Integer>>::size_type i = 0; i < vec.size(); ++i) {
     out.emplace_back();
     const emp::Integer zero{INT_SIZE, 0, emp::PUBLIC};
-    for (auto j = 0; j < vec.at(i).size(); ++j) {
+    for (std::vector<emp::Integer>::size_type j = 0; j < vec.at(i).size(); ++j) {
       out.back().push_back(zero.select(bitmask.at(i), vec.at(i).at(j)));
     }
   }
@@ -487,9 +487,9 @@ inline const std::vector<std::vector<emp::Bit>> multiplyBitmask(
 
   std::vector<std::vector<emp::Bit>> out;
   out.reserve(vec.size());
-  for (auto i = 0; i < vec.size(); ++i) {
+  for (std::vector<std::vector<emp::Bit>>::size_type i = 0; i < vec.size(); ++i) {
     out.emplace_back();
-    for (auto j = 0; j < vec.at(i).size(); ++j) {
+    for (std::vector<emp::Bit>::size_type j = 0; j < vec.at(i).size(); ++j) {
       out.back().push_back(vec.at(i).at(j) & bitmask.at(i));
     }
   }


### PR DESCRIPTION
Summary: In private attribution and private aggregation games, we currently have a bunch of sign-compare compilation warnings.  These are mostly comparisons between a signed integer and an unsigned integer.  This diff attempts to resolve most of them.

Differential Revision: D32538314

