### PR TITLE
add container timeout to PIDService

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -10,5 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
   - Centralize default stage flow selection (D32774676)
+  - Finish PIDService container timeout implementation (D32600348)
 
 ### Removed

--- a/fbpcs/data_processing/sharding/sharding_cpp.py
+++ b/fbpcs/data_processing/sharding/sharding_cpp.py
@@ -200,13 +200,17 @@ class CppShardingService(ShardingService):
         # applies to a list of cmds, so we have to immediately dereference
         # to take the first element
         pending_containers = onedocker_svc.start_containers(
-                package_name=exe,
-                version=binary_version,
-                cmd_args_list=[cmd_args],
-                timeout=timeout,
-            )
+            package_name=exe,
+            version=binary_version,
+            cmd_args_list=[cmd_args],
+            timeout=timeout,
+        )
 
-        container = (await onedocker_svc.wait_for_pending_containers([container.instance_id for container in pending_containers]))[0]
+        container = (
+            await onedocker_svc.wait_for_pending_containers(
+                [container.instance_id for container in pending_containers]
+            )
+        )[0]
 
         logger.info("Task started")
         if wait_for_containers:

--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -87,6 +87,7 @@ class PIDService:
         server_ips: Optional[List[str]] = None,
         pid_union_stage: Optional[UnionPIDStage] = None,
         wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDInstance:
         """This function is similar to run_instance but instead of calling dispatcher.run_all,
         it will try to call dispatcher.run_next(), or if the pid_union_stage is given, it will
@@ -128,7 +129,9 @@ class PIDService:
 
             # Finally, call run_stage if the PID stage can be found
             # and all above checks are passed
-            await dispatcher.run_stage(pid_stage, wait_for_containers)
+            await dispatcher.run_stage(
+                pid_stage, wait_for_containers, container_timeout
+            )
 
         return self.update_instance(instance_id)
 

--- a/fbpcs/pid/service/pid_service/pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/pid_dispatcher.py
@@ -137,7 +137,10 @@ class PIDDispatcher(Dispatcher):
         self._cleanup_complete_stages()
 
     async def run_stage(
-        self, stage: PIDStage, wait_for_containers: bool = True
+        self,
+        stage: PIDStage,
+        wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDStageStatus:
         if stage not in self._find_eligible_stages():
             raise PIDStageFailureError(f"{stage} is not yet eligible to be run.")
@@ -148,7 +151,9 @@ class PIDDispatcher(Dispatcher):
         self._update_instance_status(PIDInstanceStatus.STARTED, stage)
 
         res = await stage.run(
-            self.stage_inputs[stage], wait_for_containers=wait_for_containers
+            self.stage_inputs[stage],
+            wait_for_containers=wait_for_containers,
+            container_timeout=container_timeout,
         )
         self.logger.info(f"{stage}: {res}")
         if res is PIDStageStatus.FAILED:

--- a/fbpcs/pid/service/pid_service/pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_prepare_stage.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import asyncio
+from typing import Optional
 
 from fbpcs.data_processing.pid_preparer.union_pid_preparer_cpp import (
     CppUnionPIDDataPreparerService,
@@ -19,7 +20,10 @@ MAX_RETRY = 0
 
 class PIDPrepareStage(PIDStage):
     async def run(
-        self, stage_input: PIDStageInput, wait_for_containers: bool = True
+        self,
+        stage_input: PIDStageInput,
+        wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDStageStatus:
         self.logger.info(f"[{self}] Called run")
         instance_id = stage_input.instance_id
@@ -53,6 +57,7 @@ class PIDPrepareStage(PIDStage):
             num_shards,
             stage_input.fail_fast or False,
             wait_for_containers,
+            container_timeout,
         )
         await self.update_instance_status(instance_id=instance_id, status=status)
         return status
@@ -65,6 +70,7 @@ class PIDPrepareStage(PIDStage):
         num_shards: int,
         fail_fast: bool,
         wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDStageStatus:
         self.logger.info(f"[{self}] Starting CppUnionPIDDataPreparerService")
         preparer = CppUnionPIDDataPreparerService()
@@ -82,6 +88,7 @@ class PIDPrepareStage(PIDStage):
                 tmp_directory=self.onedocker_binary_config.tmp_directory,
                 max_retry=0 if fail_fast else MAX_RETRY,
                 wait_for_container=wait_for_containers,
+                container_timeout=container_timeout,
             )
             coroutines.append(coro)
 

--- a/fbpcs/pid/service/pid_service/pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_shard_stage.py
@@ -15,7 +15,10 @@ from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
 
 class PIDShardStage(PIDStage):
     async def run(
-        self, stage_input: PIDStageInput, wait_for_containers: bool = True
+        self,
+        stage_input: PIDStageInput,
+        wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDStageStatus:
         self.logger.info(f"[{self}] Called run")
         instance_id = stage_input.instance_id
@@ -46,6 +49,7 @@ class PIDShardStage(PIDStage):
             num_shards,
             stage_input.hmac_key,
             wait_for_containers,
+            container_timeout,
         )
 
         # if validating, copy synthetic shard and update instance.num_shards
@@ -76,6 +80,7 @@ class PIDShardStage(PIDStage):
         num_shards: int,
         hmac_key: Optional[str] = None,
         wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDStageStatus:
         self.logger.info(f"[{self}] Starting CppShardingService")
         sharder = CppShardingService()
@@ -92,6 +97,7 @@ class PIDShardStage(PIDStage):
                 tmp_directory=self.onedocker_binary_config.tmp_directory,
                 hmac_key=hmac_key,
                 wait_for_containers=wait_for_containers,
+                container_timeout=container_timeout,
             )
         except Exception as e:
             self.logger.exception(f"CppShardingService failed: {e}")

--- a/fbpcs/pid/service/pid_service/pid_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_stage.py
@@ -8,6 +8,7 @@ import abc
 import logging
 import os
 from typing import Any, Dict, List
+from typing import Optional
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcp.service.onedocker import OneDockerService
@@ -29,7 +30,7 @@ class PIDStage(abc.ABC):
         storage_svc: StorageService,
         onedocker_svc: OneDockerService,
         onedocker_binary_config: OneDockerBinaryConfig,
-        is_joint_stage: bool = False
+        is_joint_stage: bool = False,
     ) -> None:
         self.stage_type = stage
         self.storage_svc = storage_svc
@@ -41,7 +42,10 @@ class PIDStage(abc.ABC):
 
     @abc.abstractmethod
     async def run(
-        self, stage_input: PIDStageInput, wait_for_containers: bool = True
+        self,
+        stage_input: PIDStageInput,
+        wait_for_containers: bool = True,
+        container_timeout: Optional[int] = None,
     ) -> PIDStageStatus:
         """
         Invoke the stage to actually execute. Derived classes must implement

--- a/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
@@ -110,7 +110,9 @@ class TestPIDPrepareStage(unittest.TestCase):
         )
 
         mock_onedocker_svc.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_svc.wait_for_pending_containers = AsyncMock(return_value=[container])
+        mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
+            return_value=[container]
+        )
 
         container.status = (
             ContainerInstanceStatus.COMPLETED
@@ -183,7 +185,7 @@ class TestPIDPrepareStage(unittest.TestCase):
                 stage_input, wait_for_containers=wait_for_containers
             )
             mock_prepare.assert_called_with(
-                instance_id, "in", "out", 2, fail_fast, wait_for_containers
+                instance_id, "in", "out", 2, fail_fast, wait_for_containers, None
             )
 
         # Input not ready

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -68,7 +68,9 @@ class TestPIDShardStage(unittest.TestCase):
         container = ContainerInstance(instance_id="123", ip_address=ip)
 
         mock_onedocker_svc.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_svc.wait_for_pending_containers = AsyncMock(return_value=[container])
+        mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
+            return_value=[container]
+        )
 
         container.status = (
             ContainerInstanceStatus.COMPLETED
@@ -240,4 +242,5 @@ class TestPIDShardStage(unittest.TestCase):
                 tmp_directory=test_onedocker_binary_config.tmp_directory,
                 hmac_key=test_hmac_key,
                 wait_for_containers=wait_for_containers,
+                container_timeout=None,
             )

--- a/fbpcs/private_computation/service/pid_stage_service.py
+++ b/fbpcs/private_computation/service/pid_stage_service.py
@@ -44,6 +44,7 @@ class PIDStageService(PrivateComputationStageService):
         _protocol: An enum consumed by PIDService to determine which protocol to use, e.g. UNION_PID.
         _is_validating: if a test shard is injected to do run time correctness validation
         _synthetic_shard_path: path to the test shard to be injected if _is_validating
+        _container_timeout: optional duration in seconds before cloud containers timeout
     """
 
     def __init__(
@@ -55,6 +56,7 @@ class PIDStageService(PrivateComputationStageService):
         protocol: PIDProtocol = DEFAULT_PID_PROTOCOL,
         is_validating: bool = False,
         synthetic_shard_path: Optional[str] = None,
+        container_timeout: Optional[int] = None,
     ) -> None:
         self._pid_svc = pid_svc
         self._pid_config = pid_config
@@ -63,6 +65,7 @@ class PIDStageService(PrivateComputationStageService):
         self._protocol = protocol
         self._is_validating = is_validating
         self._synthetic_shard_path = synthetic_shard_path
+        self._container_timeout = container_timeout
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of run_async() so that it can be called by Thrift
@@ -130,6 +133,7 @@ class PIDStageService(PrivateComputationStageService):
             if pc_instance.role is PrivateComputationRole.PUBLISHER
             else self._partner_stage,
             wait_for_containers=False,
+            container_timeout=self._container_timeout,
         )
 
         if not pc_instance.instances or not isinstance(


### PR DESCRIPTION
Summary:
## What

* Finish the PIDservice container timeout implementation

## Why

* It looks like it was half implemented at some point?
* tl;dr is the lowest level functions in the PIDService stack (that actually handle the stage execution logic) accept container_timeout as a parameter but nothing higher in the stack actually passes the parameter
* This diff makes it such that we can add custom container timeouts to PIDService

## Next

* Pass the timeouts specified in StageFlows to all of the StageServices

Differential Revision: D32600348

