### PR TITLE
Refactor GenericSharder to expose getShardFor abstract method

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.cpp
+++ b/fbpcs/data_processing/sharding/GenericSharder.cpp
@@ -8,23 +8,127 @@
 #include "fbpcs/data_processing/sharding/GenericSharder.h"
 
 #include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include <fbpcf/io/FileManagerUtil.h>
+#include <folly/Random.h>
+#include <folly/logging/xlog.h>
+
+#include "fbpcs/data_processing/common/FilepathHelpers.h"
+#include "fbpcs/data_processing/common/Logging.h"
+#include "fbpcs/data_processing/common/S3CopyFromLocalUtil.h"
+
 namespace data_processing::sharder {
 namespace detail {
-void stripQuotes(std::string &s) {
+void stripQuotes(std::string& s) {
   s.erase(std::remove(s.begin(), s.end(), '"'), s.end());
 }
 } // namespace detail
 
-std::vector<std::string>
-GenericSharder::genOutputPaths(const std::string &outputBasePath,
-                               std::size_t startIndex, std::size_t endIndex) {
+std::vector<std::string> GenericSharder::genOutputPaths(
+    const std::string& outputBasePath,
+    std::size_t startIndex,
+    std::size_t endIndex) {
   std::vector<std::string> res;
   for (std::size_t i = startIndex; i < endIndex; ++i) {
     res.push_back(outputBasePath + '_' + std::to_string(i));
   }
   return res;
+}
+
+void GenericSharder::shard() {
+  std::size_t numShards = getOutputPaths().size();
+  auto inStreamPtr = fbpcf::io::getInputStream(getInputPath());
+  auto& inStream = inStreamPtr->get();
+
+  std::filesystem::path tmpDirectory{"/tmp"};
+  std::vector<std::string> tmpFilenames;
+  std::vector<std::unique_ptr<std::ofstream>> tmpFiles;
+
+  auto filename = std::filesystem::path{
+      private_lift::filepath_helpers::getBaseFilename(getInputPath())};
+  auto stem = filename.stem().string();
+  auto extension = filename.extension().string();
+  // Get a random ID to avoid potential name collisions if multiple
+  // runs at the same time point to the same input file
+  auto randomId = std::to_string(folly::Random::secureRand64());
+
+  for (auto i = 0; i < numShards; ++i) {
+    std::stringstream tmpName;
+    tmpName << randomId << "_" << stem << "_" << i << extension;
+
+    auto tmpFilepath = tmpDirectory / tmpName.str();
+
+    tmpFilenames.push_back(tmpFilepath.string());
+    tmpFiles.push_back(std::make_unique<std::ofstream>(tmpFilepath));
+  }
+
+  // First get the header and put it in all the output files
+  std::string line;
+  getline(inStream, line);
+  detail::stripQuotes(line);
+  for (const auto& tmpFile : tmpFiles) {
+    *tmpFile << line << "\n";
+  }
+  XLOG(INFO) << "Got header line: '" << line;
+
+  // Read lines and send to appropriate outFile repeatedly
+  uint64_t lineIdx = 0;
+  while (getline(inStream, line)) {
+    detail::stripQuotes(line);
+    shardLine(std::move(line), tmpFiles);
+    ++lineIdx;
+    if (lineIdx % getLogRate() == 0) {
+      XLOG(INFO) << "Processed line "
+                 << private_lift::logging::formatNumber(lineIdx);
+    }
+  }
+
+  XLOG(INFO) << "Finished after processing "
+             << private_lift::logging::formatNumber(lineIdx) << " lines.";
+
+  XLOG(INFO) << "Now copying files to final output path...";
+  for (auto i = 0; i < numShards; ++i) {
+    auto outputDst = getOutputPaths().at(i);
+    auto tmpFileSrc = tmpFilenames.at(i);
+
+    if (outputDst == tmpFileSrc) {
+      continue;
+    }
+
+    // Reset underlying unique_ptr to ensure buffer gets flushed
+    tmpFiles.at(i).reset();
+
+    XLOG(INFO) << "Writing " << tmpFileSrc << " -> " << outputDst;
+    auto outputType = fbpcf::io::getFileType(outputDst);
+    if (outputType == fbpcf::io::FileType::S3) {
+      private_lift::s3_utils::uploadToS3(tmpFileSrc, outputDst);
+    } else if (outputType == fbpcf::io::FileType::Local) {
+      std::filesystem::copy(
+          tmpFileSrc,
+          outputDst,
+          std::filesystem::copy_options::overwrite_existing);
+    } else {
+      throw std::runtime_error{"Unsupported output destination"};
+    }
+    // We need to make sure we clean up the tmpfiles now
+    std::remove(tmpFileSrc.c_str());
+  }
+  XLOG(INFO) << "All file writes successful";
+}
+
+void GenericSharder::shardLine(
+    std::string line,
+    const std::vector<std::unique_ptr<std::ofstream>>& outFiles) {
+  auto commaPos = line.find_first_of(",");
+  auto id = line.substr(0, commaPos);
+  auto shard = getShardFor(id, outFiles.size());
+  *outFiles.at(shard) << line << "\n";
 }
 } // namespace data_processing::sharder

--- a/fbpcs/data_processing/sharding/HashBasedSharder.cpp
+++ b/fbpcs/data_processing/sharding/HashBasedSharder.cpp
@@ -29,12 +29,12 @@
 
 namespace data_processing::sharder {
 namespace detail {
-std::vector<uint8_t> toBytes(const std::string& key) {
+std::vector<uint8_t> toBytes(const std::string &key) {
   std::vector<uint8_t> res(key.begin(), key.end());
   return res;
 }
 
-int32_t bytesToInt(const std::vector<uint8_t>& bytes) {
+int32_t bytesToInt(const std::vector<uint8_t> &bytes) {
   int32_t res = 0;
 
   auto bytesInSizeT = sizeof(res) / sizeof(uint8_t);
@@ -47,115 +47,32 @@ int32_t bytesToInt(const std::vector<uint8_t>& bytes) {
   // copied bytes are in "network byte order" and convert them to a host long.
   return ntohl(res);
 }
-
-std::size_t getShardFor(const std::string& id, std::size_t numShards) {
-  auto toInt = bytesToInt(toBytes(id));
-  return toInt % numShards;
-}
 } // namespace detail
 
-void HashBasedSharder::shard() const {
-  std::size_t numShards = getOutputPaths().size();
-  auto inStreamPtr = fbpcf::io::getInputStream(getInputPath());
-  auto& inStream = inStreamPtr->get();
+std::size_t HashBasedSharder::getShardFor(const std::string& id,
+                                          std::size_t numShards) {
+  auto toInt = detail::bytesToInt(detail::toBytes(id));
+  return toInt % numShards;
+}
 
-  std::filesystem::path tmpDirectory{"/tmp"};
-  std::vector<std::string> tmpFilenames;
-  std::vector<std::unique_ptr<std::ofstream>> tmpFiles;
-
-  auto filename = std::filesystem::path{
-      private_lift::filepath_helpers::getBaseFilename(getInputPath())};
-  auto stem = filename.stem().string();
-  auto extension = filename.extension().string();
-  // Get a random ID to avoid potential name collisions if multiple
-  // runs at the same time point to the same input file
-  auto randomId = std::to_string(folly::Random::secureRand64());
-
-  for (std::size_t i = 0; i < numShards; ++i) {
-    std::stringstream tmpName;
-    tmpName << randomId << "_" << stem << "_" << i << extension;
-
-    auto tmpFilepath = tmpDirectory / tmpName.str();
-
-    tmpFilenames.push_back(tmpFilepath.string());
-    tmpFiles.push_back(std::make_unique<std::ofstream>(tmpFilepath));
-  }
-
-  // First get the header and put it in all the output files
-  std::string line;
-  getline(inStream, line);
-  detail::stripQuotes(line);
-  for (const auto& tmpFile : tmpFiles) {
-    *tmpFile << line << "\n";
-  }
-  XLOG(INFO) << "Got header line: '" << line;
-
-  // Read lines and send to appropriate outFile repeatedly
-  uint64_t lineIdx = 0;
+void HashBasedSharder::shardLine(
+    std::string line,
+    const std::vector<std::unique_ptr<std::ofstream>> &outFiles) {
+  auto commaPos = line.find_first_of(",");
+  auto id = line.substr(0, commaPos);
+  auto numShards = outFiles.size();
   if (hmacKey_.empty()) {
-    while (getline(inStream, line)) {
-      detail::stripQuotes(line);
-      auto commaPos = line.find_first_of(",");
-      auto id = line.substr(0, commaPos);
-      // Assumption: the string is *already* an HMAC hashed value
-      // If hmacBase64Key is empty, the hashing already happened upstream.
-      // This means we can reinterpret the id as a base64-encoded string.
-      auto shard = detail::getShardFor(id, numShards);
-      *tmpFiles.at(shard) << line << "\n";
-      ++lineIdx;
-      if (lineIdx % getLogRate() == 0) {
-        XLOG(INFO) << "Processed line "
-                   << private_lift::logging::formatNumber(lineIdx);
-      }
-    }
+    // Assumption: the string is *already* an HMAC hashed value
+    // If hmacBase64Key is empty, the hashing already happened upstream.
+    // This means we can reinterpret the id as a base64-encoded string.
+    auto shard = getShardFor(id, numShards);
+    *outFiles.at(shard) << line << "\n";
   } else {
-    while (getline(inStream, line)) {
-      detail::stripQuotes(line);
-      auto commaPos = line.find_first_of(",");
-      auto id = line.substr(0, commaPos);
-      auto base64SaltedId =
-          private_lift::hash_slinging_salter::base64SaltedHashFromBase64Key(
-              id, hmacKey_);
-      auto shard = detail::getShardFor(base64SaltedId, numShards);
-      *tmpFiles.at(shard) << base64SaltedId << line.substr(commaPos) << "\n";
-      ++lineIdx;
-      if (lineIdx % getLogRate() == 0) {
-        XLOG(INFO) << "Processed line "
-                   << private_lift::logging::formatNumber(lineIdx);
-      }
-    }
+    auto base64SaltedId =
+        private_lift::hash_slinging_salter::base64SaltedHashFromBase64Key(
+            id, hmacKey_);
+    auto shard = getShardFor(base64SaltedId, numShards);
+    *outFiles.at(shard) << base64SaltedId << line.substr(commaPos) << "\n";
   }
-
-  XLOG(INFO) << "Finished after processing "
-             << private_lift::logging::formatNumber(lineIdx) << " lines.";
-
-  XLOG(INFO) << "Now copying files to final output path...";
-  for (std::size_t i = 0; i < numShards; ++i) {
-    auto outputDst = getOutputPaths().at(i);
-    auto tmpFileSrc = tmpFilenames.at(i);
-
-    if (outputDst == tmpFileSrc) {
-      continue;
-    }
-
-    // Reset underlying unique_ptr to ensure buffer gets flushed
-    tmpFiles.at(i).reset();
-
-    XLOG(INFO) << "Writing " << tmpFileSrc << " -> " << outputDst;
-    auto outputType = fbpcf::io::getFileType(outputDst);
-    if (outputType == fbpcf::io::FileType::S3) {
-      private_lift::s3_utils::uploadToS3(tmpFileSrc, outputDst);
-    } else if (outputType == fbpcf::io::FileType::Local) {
-      std::filesystem::copy(
-          tmpFileSrc,
-          outputDst,
-          std::filesystem::copy_options::overwrite_existing);
-    } else {
-      throw std::runtime_error{"Unsupported output destination"};
-    }
-    // We need to make sure we clean up the tmpfiles now
-    std::remove(tmpFileSrc.c_str());
-  }
-  XLOG(INFO) << "All file writes successful";
 }
 } // namespace data_processing::sharder

--- a/fbpcs/data_processing/sharding/HashBasedSharder.h
+++ b/fbpcs/data_processing/sharding/HashBasedSharder.h
@@ -7,6 +7,11 @@
 
 #pragma once
 
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "fbpcs/data_processing/sharding/GenericSharder.h"
 
 namespace data_processing::sharder {
@@ -31,15 +36,6 @@ std::vector<uint8_t> toBytes(const std::string& key);
  *     many will fit into an `int32_t` in practice.
  */
 int32_t bytesToInt(const std::vector<uint8_t>& bytes);
-
-/**
- * Get the correct shard associated with a string.
- *
- * @param id the id to be sharded
- * @param numShards the total number of shards being created
- * @returns the shard index this identifier belongs to
- */
-std::size_t getShardFor(const std::string& id, std::size_t numShards);
 } // namespace detail
 
 class HashBasedSharder final : public GenericSharder {
@@ -89,10 +85,22 @@ class HashBasedSharder final : public GenericSharder {
         hmacKey_{std::move(hmacKey)} {}
 
   /**
-   * Shard an input file by hashing each identifier into an int32_t first using
-   * a hashing method that works on both big- and little-endian machines.
+   * Get the correct shard associated with a string.
+   *
+   * @param id the id to be sharded
+   * @param numShards the total number of shards being created
+   * @returns the shard index this identifier belongs to
    */
-  void shard() const final;
+  std::size_t getShardFor(const std::string& id, std::size_t numShards) final;
+
+  /**
+   * Shard an input line by hashing each identifier into an int32_t first using
+   * a hashing method that works on both big- and little-endian machines.
+   *
+   * @param line the line to be sharded
+   * @param outFiles the list of output files to be sharded into
+   */
+  void shardLine(std::string line, const std::vector<std::unique_ptr<std::ofstream>>& outFiles) final;
 
  private:
   std::string hmacKey_;


### PR DESCRIPTION
Summary:
# What
* Refactor
# Why
* More modular

NOTE: Diff looks big, but it's a lot of copy-paste from HashBasedSharder -> GenericSharder

I thought about splitting it up, but honestly I think it would be more trouble than just sitting down with someone and going through together.

Reviewed By: jrodal98

Differential Revision: D32549773

