### PR TITLE
Adding output format to attribution

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_attribution/Attribution.hpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/Attribution.hpp
@@ -22,6 +22,7 @@
 #include "fbpcs/emp_games/attribution/decoupled_attribution/AttributionMetrics.h"
 #include "fbpcs/emp_games/attribution/decoupled_attribution/AttributionOptions.h"
 #include "fbpcs/emp_games/attribution/decoupled_attribution/Timestamp.h"
+#include "fbpcs/emp_games/attribution/decoupled_attribution/Debug.h"
 
 namespace aggregation::private_attribution {
 
@@ -172,8 +173,13 @@ AttributionOutputMetrics computeAttributions(
 
     // Currently we have one attribution output format
     std::vector<AttributionFormat> attributionFormats;
-    attributionFormats.push_back(
+    IF_OMNISCIENT_MODE {
+        attributionFormats.push_back(
+        getAttributionFormatFromNameOrThrow("debug"));
+    } else{
+        attributionFormats.push_back(
         getAttributionFormatFromNameOrThrow("default"));
+    }
 
     // Compute all attributions for all rule/format combinations.
     PrivateAttributionMetrics attributionMetrics{

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.cpp
@@ -7,15 +7,18 @@
 
 #include "fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.h"
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include "folly/dynamic.h"
+#include "fbpcs/emp_games/attribution/decoupled_attribution/Constants.h"
 
 namespace aggregation::private_attribution {
 
 using PrivateAttDefaultMap = std::vector<PrivateOutputMetricDefault>;
+using PrivateAttErrorMap = std::vector<std::unordered_map<int64_t,PrivateOutputMetricWithError>>;
 
 namespace {
 
@@ -91,6 +94,117 @@ class AttributionDefault : public AttributionOutput {
   std::unordered_map<int64_t, PrivateAttDefaultMap> idToMetrics_;
 };
 
+struct AttributionErrorFmt {
+  std::unordered_map<int64_t, std::vector<std::unordered_map<int64_t,OutputMetricWithError>>> idToMetrics;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic res = folly::dynamic::object();
+
+    for (const auto& [k1, v1] : idToMetrics) {
+      auto uid = std::to_string(k1);
+      folly::dynamic metricList = folly::dynamic::array();
+      for (const auto& metric : v1) {
+        for (const auto& item : metric) {
+          folly::dynamic sub_res = folly::dynamic::object();
+          sub_res.insert(std::to_string(item.first), item.second.toDynamic());
+          metricList.push_back(sub_res);
+        }
+      }
+      res.insert(uid, metricList);
+    }
+    return res;
+  }
+};
+
+
+class AttributionWithError : public AttributionOutput {
+ public:
+  explicit AttributionWithError(
+      AttributionRule attributionRule,
+      const std::vector<int64_t>& uids,
+      const std::vector<std::vector<PrivateTouchpoint>>& touchpoints,
+      const fbpcf::Visibility& outputVisibility)
+      : AttributionOutput(attributionRule, outputVisibility) {
+    CHECK_EQ(uids.size(), touchpoints.size())
+        << "uid array and touchpoint array must be equal size";
+
+    for (auto i = 0; i < uids.size(); i++) {
+      idToMetrics_.emplace(uids[i], PrivateAttErrorMap{});
+    }
+  }
+
+  virtual void addAttribution(const PrivateAttribution& attribution) override {
+    const emp::Bit true_bit{true, emp::PUBLIC};
+    const emp::Bit false_bit{false, emp::PUBLIC};
+
+    PrivateAttErrorMap& metrics = idToMetrics_[attribution.uid];
+    auto is_att = emp::If(attribution.hasAttributedTouchpoint, true_bit, false_bit);
+    auto tp_ts = emp::Integer(INT_SIZE, attribution.tp.ts.reveal<int64_t>(emp::PUBLIC));
+    auto conv_ts = emp::Integer(INT_SIZE, attribution.conv.ts.reveal<int64_t>(emp::PUBLIC));
+
+    int64_t code = -1; // if eventually -1, that means undetermined cause
+    if (is_att.reveal<bool>(emp::PUBLIC)){
+      code = 0;  // all okay
+    } else if (!attribution.tp.isClick.reveal<bool>()){
+      code = 1;  // is not click
+    } else if(attribution.tp.ts.reveal<int64_t>() < 1){
+      code = 2;  // invalid touchpoint
+    } else if (attribution.tp.ts.reveal<int64_t>() >= attribution.conv.ts.reveal<int64_t>()) {
+      code = 3;  // touchpoint timestamp > conversion timestamp
+    } else if ((attribution.conv.ts.reveal<int64_t>() - attribution.tp.ts.reveal<int64_t>()) >= attributionRule_.window_in_sec) {
+      code = 4;  // out of attribution window
+    } else if ((attribution.conv.ts.reveal<int64_t>() - attribution.tp.ts.reveal<int64_t>()) < attributionRule_.window_in_sec) {
+      code = 5;  // valid attribution but not last click
+    }
+
+    auto error_code = emp::Integer(INT_SIZE, code);
+
+    XLOGF(
+      DBG,
+      "Revealing is_att={}, tp_ts={}, conv_ts={}, code={}",
+      is_att.reveal<bool>(emp::PUBLIC),
+      tp_ts.reveal<int64_t>(emp::PUBLIC),
+      conv_ts.reveal<int64_t>(emp::PUBLIC),
+      error_code.reveal<int64_t>(emp::PUBLIC)
+    );
+
+    PrivateOutputMetricWithError metric{
+      is_att, tp_ts, conv_ts, error_code
+    };
+
+    int top_index = metrics.size();
+    std::unordered_map<int64_t,PrivateOutputMetricWithError> output_metric;
+    output_metric.emplace(top_index, metric);
+    metrics.push_back(output_metric);
+  }
+
+  virtual AttributionResult reveal() const override {
+    AttributionErrorFmt out;
+
+    for (const auto& [uid, privateIdToMetric] : idToMetrics_) {
+      XLOGF(
+          DBG,
+          "Revealing attribution metrics for rule={} uid={}",
+          attributionRule_.name,
+          uid);
+
+      std::vector<std::unordered_map<int64_t, OutputMetricWithError>> revealedMetric;
+      for (const auto& seq_metric : privateIdToMetric) {
+        for (const auto& item : seq_metric){
+          std::unordered_map<int64_t, OutputMetricWithError> aa;
+          aa.insert(std::make_pair(item.first, item.second.reveal(fbpcf::Visibility::Public)));
+          revealedMetric.push_back(aa);
+        }
+      }
+      out.idToMetrics.emplace(uid, revealedMetric);
+    }
+    return out.toDynamic();
+  }
+
+ private:
+  std::unordered_map<int64_t, PrivateAttErrorMap> idToMetrics_;
+};
+
 } // namespace
 
 static const std::array SUPPORTED_ATTRIBUTION_FORMATS{
@@ -103,6 +217,18 @@ static const std::array SUPPORTED_ATTRIBUTION_FORMATS{
            fbpcf::Visibility outputVisibility)
             -> std::unique_ptr<AttributionOutput> {
           return std::make_unique<AttributionDefault>(
+              rule, ctx.uids, ctx.touchpoints, outputVisibility);
+        },
+    },
+    AttributionFormat{
+        /* id */ 2,
+        /* name */ "debug",
+        /* newAttributor */
+        [](AttributionRule rule,
+           AttributionContext ctx,
+           fbpcf::Visibility outputVisibility)
+            -> std::unique_ptr<AttributionOutput> {
+          return std::make_unique<AttributionWithError>(
               rule, ctx.uids, ctx.touchpoints, outputVisibility);
         },
     },

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.h
@@ -36,6 +36,32 @@ struct PrivateAttribution {
         tp{_tp} {}
 };
 
+
+struct OutputMetricWithError {
+  bool is_attributed;
+  int64_t tp_ts;
+  int64_t conv_ts;
+  int64_t error_code;
+
+  folly::dynamic toDynamic() const {
+    return folly::dynamic::object
+        ("is_attributed", is_attributed)
+        ("tp_ts", tp_ts)
+        ("conv_ts", conv_ts)
+        ("error_code", error_code);
+  }
+
+  static OutputMetricWithError fromDynamic(const folly::dynamic& obj) {
+    OutputMetricWithError out = OutputMetricWithError{};
+    out.is_attributed = obj["is_attributed"].asBool();
+    out.tp_ts = obj["tp_ts"].asInt();
+    out.conv_ts = obj["conv_ts"].asInt();
+    out.error_code = obj["error_code"].asInt();
+    return out;
+  }
+};
+
+
 struct OutputMetricDefault {
   bool is_attributed;
 
@@ -61,6 +87,25 @@ struct PrivateOutputMetricDefault {
 
     return OutputMetricDefault{
           is_attributed.reveal<bool>(party)};
+  }
+};
+
+
+struct PrivateOutputMetricWithError {
+  emp::Bit is_attributed{false, emp::PUBLIC};
+  emp::Integer tp_ts;
+  emp::Integer conv_ts;
+  emp::Integer error_code;
+
+  OutputMetricWithError reveal(fbpcf::Visibility outputVisibility) const {
+    int party =
+        outputVisibility == fbpcf::Visibility::Xor ? emp::XOR : emp::PUBLIC;
+
+    return OutputMetricWithError{
+          is_attributed.reveal<bool>(party),
+          tp_ts.reveal<int64_t>(party),
+          conv_ts.reveal<int64_t>(party),
+          error_code.reveal<int64_t>(party)};
   }
 };
 

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionRule.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionRule.cpp
@@ -12,6 +12,7 @@ namespace aggregation::private_attribution {
 const AttributionRule LAST_CLICK_1D{
     /* id */ 1,
     /* name */ "last_click_1d",
+    /* window_in_sec */ 86400,
     /* isAttributable */
     [](const PrivateTouchpoint& tp,
        const PrivateConversion& conv) -> const emp::Bit {
@@ -29,6 +30,7 @@ const AttributionRule LAST_CLICK_1D{
 const AttributionRule LAST_CLICK_28D{
     /* id */ 2,
     /* name */ "last_click_28d",
+    /* window_in_sec */ 2419200,
     /* isAttributable */
     [](const PrivateTouchpoint& tp,
        const PrivateConversion& conv) -> const emp::Bit {
@@ -48,6 +50,7 @@ const AttributionRule LAST_CLICK_28D{
 const AttributionRule LAST_TOUCH_CT1D_IMP1D{
     /* id */ 3,
     /* name */ "last_touch_1d",
+    /* window_in_sec */ 86400,
     /* isAttributable: if click within 1d, if touch within 1d */
     [](const PrivateTouchpoint& tp,
        const PrivateConversion& conv) -> const emp::Bit {
@@ -74,6 +77,7 @@ const AttributionRule LAST_TOUCH_CT1D_IMP1D{
 const AttributionRule LAST_TOUCH_CT28D_IMP1D{
     /* id */ 4,
     /* name */ "last_touch_28d",
+    /* window_in_sec */ 2419200,
     /* isAttributable: if click within 28d, if touch within 1d */
     [](const PrivateTouchpoint& tp,
        const PrivateConversion& conv) -> const emp::Bit {

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionRule.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionRule.h
@@ -25,6 +25,9 @@ struct AttributionRule {
   // pass in a list of names, and the output json will be keyed by names
   const std::string name;
 
+  // time window for attribution, in seconds
+  const int64_t window_in_sec;
+
   // Should return true if the given touchpoint is eligible to be attributed
   // to the given conversion
   const std::function<


### PR DESCRIPTION
Summary:
**what?**
- As we have started comparing MPC with AdConv attributions, we are finding gaps between the two systems. But the current minimalistic output format is not good for development and debugging issues.
- So, I'm adding another special output format for debug only, which outputs extra information that makes it easier for us to debug and dive deep into.

**How?**
- This mode is only activated when `omniscientModeEnabled = true` in `Debug.h`. So, this will not be accidentally turned on in production run.
- The `error_code` indicated various reasons why a <conversion, touchpoint> was not attributed.

Differential Revision: D32515154

