### PR TITLE
Add server side encryption to the config bucket created by deploy.sh

### DIFF
--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -39,6 +39,7 @@ validate_or_create_s3_bucket() {
         echo "The bucket $bucket_name doesn't exist. Creating..."
         aws s3api create-bucket --bucket "$bucket_name" --region "$region" --create-bucket-configuration LocationConstraint="$region" || exit 1
         aws s3api put-bucket-versioning --bucket "$bucket_name" --versioning-configuration Status=Enabled
+        aws s3api put-bucket-encryption --bucket "$bucket_name" --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "aws:kms"},"BucketKeyEnabled": true}]}'
         echo "The bucket $bucket_name is created."
 
     elif [ "$error" -eq "400" ]


### PR DESCRIPTION
Summary: Got this security task T105173937 to ask us to add server side encryption. The `s3_bucket_data_pipeline` is already have server side encryption. This diff is to add SSE to the `s3_bucket_for_storage` bucket.

Reviewed By: peking2

Differential Revision: D32684147

