### PR TITLE
split pl_instance_runner.py into multiple files

### DIFF
--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from typing import List
+
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+
+INVALID_STATUS_LIST: List[PrivateComputationInstanceStatus] = [
+    PrivateComputationInstanceStatus.UNKNOWN,
+    PrivateComputationInstanceStatus.PROCESSING_REQUEST,
+    PrivateComputationInstanceStatus.TIMEOUT,
+]
+
+POLL_INTERVAL = 60
+WAIT_VALID_STATUS_TIMEOUT = 600
+WAIT_VALID_STAGE_TIMEOUT = 300
+OPERATION_REQUEST_TIMEOUT = 1200
+CANCEL_STAGE_TIMEOUT: int = POLL_INTERVAL * 5
+
+MIN_TRIES = 1
+MAX_TRIES = 2
+RETRY_INTERVAL = 60
+
+MIN_NUM_INSTANCES = 1
+MAX_NUM_INSTANCES = 5
+PROCESS_WAIT = 1  # interval between starting processes.
+INSTANCE_SLA = 14400  # 2 hr instance sla, 2 tries per stage, total 4 hrs.

--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class PLInstanceCalculationException(RuntimeError):
+    pass

--- a/fbpcs/pl_coordinator/pc_calc_instance.py
+++ b/fbpcs/pl_coordinator/pc_calc_instance.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import logging
+from time import sleep, time
+from typing import Optional, Type
+
+from fbpcs.pl_coordinator.constants import (
+    INVALID_STATUS_LIST,
+    POLL_INTERVAL,
+    OPERATION_REQUEST_TIMEOUT,
+)
+from fbpcs.pl_coordinator.exceptions import PLInstanceCalculationException
+from fbpcs.pl_coordinator.pl_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
+from fbpcs.private_computation.entity.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+
+
+# TODO(T107103692): [BE] rename PrivateLiftCalcInstance
+class PrivateLiftCalcInstance:
+    """
+    Representation of a publisher or partner instance being calculated.
+    """
+
+    def __init__(
+        self, instance_id: str, logger: logging.Logger, role: PrivateComputationRole
+    ) -> None:
+        self.instance_id: str = instance_id
+        self.logger: logging.Logger = logger
+        self.role: PrivateComputationRole = role
+        self.status: PrivateComputationInstanceStatus = (
+            PrivateComputationInstanceStatus.UNKNOWN
+        )
+
+    def update_instance(self) -> None:
+        raise NotImplementedError(
+            "This is a parent method to be overrided and should not be called."
+        )
+
+    def status_ready(self, status: PrivateComputationInstanceStatus) -> bool:
+        self.logger.info(f"{self.role} instance status: {self.status}.")
+        return self.status is status
+
+    def wait_valid_status(
+        self,
+        timeout: int,
+    ) -> None:
+        self.update_instance()
+        if self.status in INVALID_STATUS_LIST:
+            self.logger.info(
+                f"{self.role} instance status {self.status} invalid for calculation."
+            )
+            self.logger.info(f"Poll {self.role} instance expecting valid status.")
+            if timeout <= 0:
+                raise ValueError(f"Timeout must be > 0, not {timeout}")
+            start_time = time()
+            while time() < start_time + timeout:
+                self.update_instance()
+                self.logger.info(f"{self.role} instance status: {self.status}.")
+                if self.status not in INVALID_STATUS_LIST:
+                    self.logger.info(
+                        f"{self.role} instance has valid status: {self.status}."
+                    )
+                    return
+                sleep(POLL_INTERVAL)
+            raise PLInstanceCalculationException(
+                f"Poll {self.role} status timed out after {timeout}s expecting valid status."
+            )
+
+    def wait_instance_status(
+        self,
+        status: PrivateComputationInstanceStatus,
+        fail_status: PrivateComputationInstanceStatus,
+        timeout: int,
+    ) -> None:
+        self.logger.info(f"Poll {self.role} instance expecting status: {status}.")
+        if timeout <= 0:
+            raise ValueError(f"Timeout must be > 0, not {timeout}")
+        start_time = time()
+        while time() < start_time + timeout:
+            self.update_instance()
+            if self.status_ready(status):
+                self.logger.info(f"{self.role} instance has expected status: {status}.")
+                return
+            if status not in [
+                fail_status,
+                PrivateComputationInstanceStatus.TIMEOUT,
+            ] and self.status in [
+                fail_status,
+                PrivateComputationInstanceStatus.TIMEOUT,
+            ]:
+                raise PLInstanceCalculationException(
+                    f"{self.role} failed with status {self.status}. Expecting status {status}."
+                )
+            sleep(POLL_INTERVAL)
+        raise PLInstanceCalculationException(
+            f"Poll {self.role} status timed out after {timeout}s expecting status: {status}."
+        )
+
+    def ready_for_stage(self, stage: PrivateComputationBaseStageFlow) -> bool:
+        # This function checks whether the instance is ready for the publisher-partner
+        # <stage> (PLInstanceCalculation.run_stage(<stage>)). Suppose user first
+        # invokes publisher <stage> through GraphAPI, now publisher status is
+        # '<STAGE>_STARTED`. Then, user runs pl-coordinator 'run_instance' command,
+        # we would want to still allow <stage> to run.
+        self.update_instance()
+        previous_stage = stage.previous_stage
+        return self.status in [
+            previous_stage.completed_status if previous_stage else None,
+            stage.started_status,
+            stage.failed_status,
+        ]
+
+    def get_valid_stage(
+        self, stage_flow: Type[PrivateComputationBaseStageFlow]
+    ) -> Optional[PrivateComputationBaseStageFlow]:
+        if not self.is_finished():
+            for stage in list(stage_flow):
+                if self.ready_for_stage(stage):
+                    return stage
+        return None
+
+    def should_invoke_operation(self, stage: PrivateComputationBaseStageFlow) -> bool:
+        # Once the the publisher-partner <stage> is called, this function
+        # determines if <stage> operation should be invoked at publisher/partner end. If
+        # the status is already <STAGE>_STARTED, then there's no need to invoke it
+        # a second time.
+        return self.ready_for_stage(stage) and self.status is not stage.started_status
+
+    def wait_stage_start(self, stage: PrivateComputationBaseStageFlow) -> None:
+        self.wait_instance_status(
+            stage.started_status,
+            stage.failed_status,
+            OPERATION_REQUEST_TIMEOUT,
+        )
+
+    def is_finished(self) -> bool:
+        finished_status = GRAPHAPI_INSTANCE_STATUSES["RESULT_READY"]
+        return self.status is finished_status

--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fbpcs.pl_coordinator.constants import WAIT_VALID_STATUS_TIMEOUT
+from fbpcs.pl_coordinator.pc_calc_instance import PrivateLiftCalcInstance
+from fbpcs.private_computation.entity.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation_cli.private_computation_service_wrapper import (
+    cancel_current_stage,
+    create_instance,
+    get_instance,
+    run_stage,
+)
+
+
+# TODO(T107103724): [BE] rename PrivateLiftPartnerInstance
+class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
+    """
+    Representation of a partner instance.
+    """
+
+    def __init__(
+        self,
+        instance_id: str,
+        config: Dict[str, Any],
+        input_path: str,
+        num_shards: int,
+        logger: logging.Logger,
+    ) -> None:
+        super().__init__(instance_id, logger, PrivateComputationRole.PARTNER)
+        self.config: Dict[str, Any] = config
+        self.input_path: str = input_path
+        self.output_dir: str = self.get_output_dir_from_input_path(input_path)
+        try:
+            self.status: PrivateComputationInstanceStatus = get_instance(
+                self.config, self.instance_id, self.logger
+            ).status
+        except RuntimeError:
+            self.logger.info(f"Creating new partner instance {self.instance_id}")
+            self.status = create_instance(
+                config=self.config,
+                instance_id=self.instance_id,
+                role=PrivateComputationRole.PARTNER,
+                game_type=PrivateComputationGameType.LIFT,
+                logger=self.logger,
+                input_path=self.input_path,
+                output_dir=self.output_dir,
+                num_pid_containers=num_shards,
+                num_mpc_containers=num_shards,
+            ).status
+        self.wait_valid_status(WAIT_VALID_STATUS_TIMEOUT)
+
+    def update_instance(self) -> None:
+        self.status = get_instance(self.config, self.instance_id, self.logger).status
+
+    def cancel_current_stage(self) -> None:
+        cancel_current_stage(self.config, self.instance_id, self.logger)
+
+    def get_output_dir_from_input_path(self, input_path: str) -> str:
+        return input_path[: input_path.rfind("/")]
+
+    def run_stage(
+        self,
+        stage: PrivateComputationBaseStageFlow,
+        server_ips: Optional[List[str]] = None,
+    ) -> None:
+        if self.should_invoke_operation(stage):
+            try:
+                run_stage(
+                    config=self.config,
+                    instance_id=self.instance_id,
+                    stage=stage,
+                    logger=self.logger,
+                    server_ips=server_ips,
+                )
+            except Exception as error:
+                self.logger.exception(f"Error running partner {stage.name} {error}")

--- a/fbpcs/pl_coordinator/pc_publisher_instance.py
+++ b/fbpcs/pl_coordinator/pc_publisher_instance.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import logging
+from typing import List, Optional
+
+from fbpcs.pl_coordinator.constants import WAIT_VALID_STATUS_TIMEOUT
+from fbpcs.pl_coordinator.pc_calc_instance import PrivateLiftCalcInstance
+from fbpcs.pl_coordinator.pl_graphapi_utils import (
+    GRAPHAPI_INSTANCE_STATUSES,
+    GraphAPIGenericException,
+    PLGraphAPIClient,
+)
+from fbpcs.private_computation.entity.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+
+
+# TODO(T107103749): [BE] rename PrivateLiftPublisherInstance
+class PrivateLiftPublisherInstance(PrivateLiftCalcInstance):
+    """
+    Representation of a publisher instance.
+    """
+
+    def __init__(
+        self, instance_id: str, logger: logging.Logger, client: PLGraphAPIClient
+    ) -> None:
+        super().__init__(instance_id, logger, PrivateComputationRole.PUBLISHER)
+        self.client: PLGraphAPIClient = client
+        self.server_ips: Optional[List[str]] = None
+        self.wait_valid_status(WAIT_VALID_STATUS_TIMEOUT)
+
+    def update_instance(self) -> None:
+        response = json.loads(self.client.get_instance(self.instance_id).text)
+        status = response.get("status")
+        try:
+            self.status = GRAPHAPI_INSTANCE_STATUSES[status]
+        except KeyError:
+            raise GraphAPIGenericException(
+                f"Error getting Publisher instance status: Unexpected value {status}."
+            )
+        self.server_ips = response.get("server_ips")
+
+    def wait_valid_status(
+        self,
+        timeout: int,
+    ) -> None:
+        self.update_instance()
+        if self.status is PrivateComputationInstanceStatus.TIMEOUT:
+            self.client.invoke_operation(self.instance_id, "NEXT")
+        super().wait_valid_status(timeout)
+
+    def status_ready(self, status: PrivateComputationInstanceStatus) -> bool:
+        self.logger.info(
+            f"{self.role} instance status: {self.status}, server ips: {self.server_ips}."
+        )
+        return self.status is status and self.server_ips is not None
+
+    def run_stage(self, stage: PrivateComputationBaseStageFlow) -> None:
+        if self.should_invoke_operation(stage):
+            self.client.invoke_operation(self.instance_id, "NEXT")

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -12,6 +12,9 @@ import time
 from typing import Any, Dict, List, Optional
 from typing import Type
 
+from fbpcs.pl_coordinator.constants import (
+    MAX_NUM_INSTANCES,
+)
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     PLGraphAPIClient,
     GraphAPIGenericException,
@@ -19,7 +22,6 @@ from fbpcs.pl_coordinator.pl_graphapi_utils import (
 )
 from fbpcs.pl_coordinator.pl_instance_runner import (
     run_instances,
-    MAX_NUM_INSTANCES,
 )
 from fbpcs.private_computation.entity.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -51,9 +51,9 @@ class TestPlInstanceRunner(TestCase):
         self.instance_id = "123"
 
     @patch(
-        "fbpcs.pl_coordinator.pl_instance_runner.PrivateLiftCalcInstance.wait_valid_status"
+        "fbpcs.pl_coordinator.pc_calc_instance.PrivateLiftCalcInstance.wait_valid_status"
     )
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_ready_for_stage(self, mock_get_instance, mock_wait_valid_status) -> None:
         for (
             publisher_status,
@@ -87,9 +87,9 @@ class TestPlInstanceRunner(TestCase):
                 )
 
     @patch(
-        "fbpcs.pl_coordinator.pl_instance_runner.PrivateLiftCalcInstance.wait_valid_status"
+        "fbpcs.pl_coordinator.pc_calc_instance.PrivateLiftCalcInstance.wait_valid_status"
     )
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_get_valid_stage(self, mock_get_instance, mock_wait_valid_status) -> None:
         for (
             publisher_status,
@@ -117,9 +117,9 @@ class TestPlInstanceRunner(TestCase):
                 self.assertEqual(valid_stage, stage)
 
     @patch(
-        "fbpcs.pl_coordinator.pl_instance_runner.PrivateLiftCalcInstance.wait_valid_status"
+        "fbpcs.pl_coordinator.pc_calc_instance.PrivateLiftCalcInstance.wait_valid_status"
     )
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_should_invoke(self, mock_get_instance, mock_wait_valid_status) -> None:
         for (
             publisher_status,
@@ -158,14 +158,14 @@ class TestPlInstanceRunner(TestCase):
                     partner_should_invoke_expected, partner_should_invoke_actual
                 )
 
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.run_stage")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.run_stage")
     @patch(
-        "fbpcs.pl_coordinator.pl_instance_runner.PrivateLiftCalcInstance.wait_stage_start"
+        "fbpcs.pl_coordinator.pc_calc_instance.PrivateLiftCalcInstance.wait_stage_start"
     )
     @patch(
         "fbpcs.pl_coordinator.pl_instance_runner.PLInstanceRunner.wait_stage_complete"
     )
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_run_stage(
         self,
         mock_get_instance,
@@ -220,8 +220,8 @@ class TestPlInstanceRunner(TestCase):
                     else:
                         mock_run_stage.assert_not_called()
 
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.sleep")
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_calc_instance.sleep")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_wait_stage_start(self, mock_get_instance, mock_sleep) -> None:
         for (
             stage,
@@ -247,9 +247,9 @@ class TestPlInstanceRunner(TestCase):
                 else:
                     runner.publisher.wait_stage_start(stage)
 
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.cancel_current_stage")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.cancel_current_stage")
     @patch("fbpcs.pl_coordinator.pl_instance_runner.sleep")
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_wait_stage_completed(
         self, mock_get_instance, mock_sleep, mock_cancel_current_stage
     ) -> None:
@@ -279,8 +279,8 @@ class TestPlInstanceRunner(TestCase):
                 else:
                     runner.wait_stage_complete(stage)
 
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.sleep")
-    @patch("fbpcs.pl_coordinator.pl_instance_runner.get_instance")
+    @patch("fbpcs.pl_coordinator.pc_calc_instance.sleep")
+    @patch("fbpcs.pl_coordinator.pc_partner_instance.get_instance")
     def test_wait_until_not_timeout(self, mock_get_instance, mock_sleep) -> None:
         stage = PrivateComputationStageFlow.PREPARE
         self.mock_graph_api_client.invoke_operation.call_count = 0


### PR DESCRIPTION
Summary:
## Note

* Diff size misleading. Everything was just moved into new files, which Phabricator did a good job of highlighting using the orange vertical lines.

## What

* Split pl_instance_runner.py into 6 files

## Why

* Everything being stored in a single file makes it difficult to share components / make things generic

## Next

* Rename classes (e.g. from PrivateLiftX to PrivateComputationX)
* Move files (everything is in pl_coordinator directory which is dead)

Will do all of this after Rohan lands his diffs for "one command runner attribution" to minimize merge pains

Differential Revision: D32730163

