### PR TITLE
remove references to s3_coordination_file

### DIFF
--- a/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
@@ -20,7 +20,7 @@ from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
 from libfb.py.asyncio.mock import AsyncMock
 from libfb.py.testutil import data_provider
 
-CONFIG = {"s3_coordination_file": "ip_config"}
+CONFIG = {}
 
 
 class TestPIDPrepareStage(unittest.TestCase):

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -21,7 +21,7 @@ from libfb.py.asyncio.unittest import AsyncMock
 from libfb.py.testutil import data_provider
 
 
-CONFIG = {"s3_coordination_file": "ip_config"}
+CONFIG = {}
 
 
 class TestPIDShardStage(unittest.TestCase):


### PR DESCRIPTION
Summary:
## What

* delete the s3_coordination_file from the config dict. We still need to keep the config dict though (it's a required argument to all of the pid stages). Didn't check if it's actually being used but pid service nonsense is outside the scope of this diff

## Why

* because it is dead code and could confuse people
* task reaper told me to: T98640195
* impacc

Differential Revision: D32745726

