### PR TITLE
Adding the get_attribution_dataset endpoint to the pci-cli (#418)

### DIFF
--- a/fbpcs/pl_coordinator/pl_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pl_graphapi_utils.py
@@ -65,6 +65,7 @@ class PLGraphAPIClient:
         self._check_err(r, "getting fb instance")
         return r
 
+    # TODO rename to create_pl_instance since we now have a create_pa_instance function
     def create_instance(
         self, study_id: str, breakdown_key: Dict[str, str]
     ) -> requests.Response:
@@ -73,6 +74,20 @@ class PLGraphAPIClient:
         r = requests.post(f"{URL}/{study_id}/instances", params=params)
         self._check_err(r, "creating fb instance")
         return r
+
+    def create_pa_instance(
+        self, dataset_id: str, attribution_rule: str, start_date: str, end_date: str, num_containers: str, result_type: str
+    ) -> requests.Response:
+        params = self.params.copy()
+        params["attribution_rule"] = attribution_rule
+        params["start_date"] = start_date
+        params["end_date"] = end_date
+        params["num_containers"] = num_containers
+        params["result_type"] = result_type
+        r = requests.post(f"{URL}/{dataset_id}/instance", params=params)
+        self._check_err(r, "creating fb pa instance")
+        return r
+
 
     def invoke_operation(self, instance_id: str, operation: str) -> None:
         params = self.params.copy()
@@ -88,6 +103,13 @@ class PLGraphAPIClient:
         params["fields"] = ",".join(fields)
         r = requests.get(f"{URL}/{study_id}", params=params)
         self._check_err(r, "getting study data")
+        return r
+
+    def get_attribution_dataset_info(self, dataset_id: str, fields: List[str]) -> requests.Response:
+        params = self.params.copy()
+        params["fields"] = ",".join(fields)
+        r = requests.get(f"{URL}/{dataset_id}", params=params)
+        self._check_err(r, "getting dataset information")
         return r
 
     def _check_err(self, r: requests.Response, msg: str) -> None:

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import json
+import logging
+from typing import Dict, Any
+
+from fbpcs.pl_coordinator.pl_graphapi_utils import (
+    PLGraphAPIClient,
+)
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    def __init__(self, logger: logging.Logger, prefix: str):
+        super(LoggerAdapter, self).__init__(logger, {})
+        self.prefix = prefix
+
+    def process(self, msg, kwargs):
+        return "[%s] %s" % (self.prefix, msg), kwargs
+
+
+# dataset information fields
+AD_OBJECT_ID = "ad_object_id"
+TARGET_OBJECT_TYPE = "target_object_type"
+DATASETS_INFORMATION = "datasets_information"
+
+
+POLL_INTERVAL = 60
+WAIT_VALID_STATUS_TIMEOUT = 600
+WAIT_VALID_STAGE_TIMEOUT = 300
+OPERATION_REQUEST_TIMEOUT = 1200
+CANCEL_STAGE_TIMEOUT = POLL_INTERVAL * 5
+
+MIN_TRIES = 1
+MAX_TRIES = 2
+RETRY_INTERVAL = 60
+
+MIN_NUM_INSTANCES = 1
+MAX_NUM_INSTANCES = 5
+PROCESS_WAIT = 1  # interval between starting processes.
+INSTANCE_SLA = 14400  # 2 hr instance sla, 2 tries per stage, total 4 hrs.
+
+
+def get_attribution_dataset_info(
+    config: Dict[str, Any], dataset_id: str, logger: logging.Logger
+) -> str:
+    client = PLGraphAPIClient(config["graphapi"]["access_token"], logger)
+
+    return json.loads(
+        client.get_attribution_dataset_info(
+            dataset_id,
+            [AD_OBJECT_ID, TARGET_OBJECT_TYPE, DATASETS_INFORMATION],
+        ).text
+    )

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -24,6 +24,8 @@ Usage:
     pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
+    pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
+
 
 Options:
     -h --help                Show this help
@@ -61,6 +63,7 @@ from fbpcs.private_computation.entity.private_computation_local_test_stage_flow 
 from fbpcs.private_computation.entity.private_computation_stage_flow import (
     PrivateComputationStageFlow,
 )
+from fbpcs.private_computation.pc_attribution_runner import get_attribution_dataset_info
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     cancel_current_stage,
     create_instance,
@@ -94,6 +97,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             "run_study": bool,
             "cancel_current_stage": bool,
             "print_instance": bool,
+            "get_attribution_dataset_info": bool,
             "<instance_id>": schema.Or(None, str),
             "<instance_ids>": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
             "<study_id>": schema.Or(None, str),
@@ -115,6 +119,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 ),
             ),
             "--objective_ids": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
+            "--dataset_id": schema.Or(None, str),
             "--input_path": schema.Or(None, str),
             "--input_paths": schema.Or(None, schema.Use(lambda arg: arg.split(","))),
             "--output_dir": schema.Or(None, str),
@@ -282,6 +287,12 @@ def main(argv: Optional[List[str]] = None) -> None:
             config=config,
             instance_id=instance_id,
             logger=logger,
+        )
+    elif arguments["get_attribution_dataset_info"]:
+        print(
+            get_attribution_dataset_info(
+                config=config, dataset_id=arguments["--dataset_id"], logger=logger
+            )
         )
 
 

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -262,3 +262,12 @@ class TestPrivateComputationCli(TestCase):
         ]
         pc_cli.main(argv)
         print_instance_mock.assert_called_once()
+    @patch("fbpcs.private_computation_cli.private_computation_cli.get_attribution_dataset_info")
+    def test_get_attribution_dataset_info(self, get_attribution_dataset_info_mock):
+        argv=[
+            "get_attribution_dataset_info",
+            "--dataset_id=dataset123",
+            f"--config={self.temp_filename}",
+        ]
+        pc_cli.main(argv)
+        get_attribution_dataset_info_mock.assert_called_once()


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/418

Adding the 'get_attribution_dataset_info' to the pc-cli which calls into the new file that does the GraphAPI call to get the info

Design doc: https://docs.google.com/document/d/1QsTIuZyoDfBekWFlqZHyMWResAb0rB1bwtiRYgEpYaY/edit#

Reviewed By: jrodal98

Differential Revision: D32711135

