### PR TITLE
Adding cost estimation to fbpcs

### DIFF
--- a/docker/data_processing/Dockerfile.ubuntu
+++ b/docker/data_processing/Dockerfile.ubuntu
@@ -13,7 +13,7 @@ WORKDIR /root/build/data_processing
 # cmake files
 COPY docker/data_processing/CMakeLists.txt .
 # data processing build and install
-COPY fbpcs/emp_games/attribution/CostEstimation.h ./fbpcs/emp_games/attribution/CostEstimation.h
+COPY fbpcs/performance_tools/ ./fbpcs/performance_tools
 COPY fbpcs/data_processing/attribution_id_combiner/ ./fbpcs/data_processing/attribution_id_combiner
 COPY fbpcs/data_processing/common/ ./fbpcs/data_processing/common
 COPY fbpcs/data_processing/hash_slinging_salter/ ./fbpcs/data_processing/hash_slinging_salter

--- a/docker/emp_games/Dockerfile.ubuntu
+++ b/docker/emp_games/Dockerfile.ubuntu
@@ -14,6 +14,7 @@ WORKDIR /root/build/emp_game
 COPY docker/emp_games/CMakeLists.txt .
 COPY docker/emp_games/common.cmake .
 # attribution, lift and shard aggregator build and install
+COPY fbpcs/performance_tools/ ./fbpcs/performance_tools
 COPY fbpcs/emp_games/attribution/ ./fbpcs/emp_games/attribution
 COPY fbpcs/emp_games/lift/ ./fbpcs/emp_games/lift
 COPY fbpcs/emp_games/common/ ./fbpcs/emp_games/common

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -24,10 +24,10 @@
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h"
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerUtil.h"
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineFileCombiner.h"
-#include "fbpcs/emp_games/attribution/CostEstimation.h"
+#include <fbpcs/performance_tools/CostEstimation.h>
 
 int main(int argc, char** argv) {
-  measurement::private_attribution::CostEstimation cost{"data_processing"};
+  fbpcs::performance_tools::CostEstimation cost{"data_processing"};
   cost.start();
 
   folly::init(&argc, &argv);

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/main.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/main.cpp
@@ -15,14 +15,14 @@
 
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/mpc/MpcAppExecutor.h>
-#include "fbpcs/emp_games/attribution/CostEstimation.h"
+#include <fbpcs/performance_tools/CostEstimation.h>
 
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.h"
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/MainUtil.h"
 
 int main(int argc, char* argv[]) {
-  measurement::private_attribution::CostEstimation cost =
-      measurement::private_attribution::CostEstimation(
+  fbpcs::performance_tools::CostEstimation cost =
+      fbpcs::performance_tools::CostEstimation(
           "computation_experimental");
   cost.start();
 

--- a/fbpcs/emp_games/attribution/decoupled_attribution/main.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/main.cpp
@@ -13,7 +13,7 @@
 #include "folly/Format.h"
 #include <fbpcf/mpc/EmpGame.h>
 
-#include "fbpcs/emp_games/attribution/CostEstimation.h"
+#include <fbpcs/performance_tools/CostEstimation.h>
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/mpc/MpcAppExecutor.h>
 #include "fbpcs/emp_games/attribution/decoupled_attribution/MainUtil.h"
@@ -23,8 +23,8 @@
 
 int main(int argc, char* argv[]) {
 
-  measurement::private_attribution::CostEstimation cost =
-            measurement::private_attribution::CostEstimation("computation_experimental");
+  fbpcs::performance_tools::CostEstimation cost =
+            fbpcs::performance_tools::CostEstimation("computation_experimental");
   cost.start();
 
   folly::init(&argc, &argv);

--- a/fbpcs/emp_games/attribution/main.cpp
+++ b/fbpcs/emp_games/attribution/main.cpp
@@ -14,15 +14,15 @@
 
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/mpc/MpcAppExecutor.h>
+#include <fbpcs/performance_tools/CostEstimation.h>
 #include "AttributionApp.h"
 #include "fbpcs/emp_games/attribution/AttributionOptions.h"
 #include "MainUtil.h"
-#include "CostEstimation.h"
 
 int main(int argc, char* argv[]) {
 
-  measurement::private_attribution::CostEstimation cost =
-            measurement::private_attribution::CostEstimation("attribution");
+  fbpcs::performance_tools::CostEstimation cost =
+            fbpcs::performance_tools::CostEstimation("attribution");
   cost.start();
 
   XLOG(INFO) << "Start of main, printing network stats: "

--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -15,7 +15,7 @@
 
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/exception/ExceptionBase.h>
-#include "../CostEstimation.h"
+#include <fbpcs/performance_tools/CostEstimation.h>
 #include "MainUtil.h"
 #include "ShardAggregatorApp.h"
 
@@ -41,7 +41,7 @@ DEFINE_string(
 DEFINE_string(run_name, "", "User given name used to write cost info in S3");
 
 int main(int argc, char* argv[]) {
-  measurement::private_attribution::CostEstimation cost{"shard_aggregator"};
+  fbpcs::performance_tools::CostEstimation cost{"shard_aggregator"};
   cost.start();
 
   folly::init(&argc, &argv);

--- a/fbpcs/performance_tools/CostEstimation.h
+++ b/fbpcs/performance_tools/CostEstimation.h
@@ -23,7 +23,7 @@
 #include "folly/logging/xlog.h"
 
 
-namespace measurement::private_attribution {
+namespace fbpcs::performance_tools {
 
 // Constants used for fargate container cost computation
 const int64_t MEMORY_SIZE = 30;
@@ -195,4 +195,4 @@ class CostEstimation {
   std::chrono::time_point<std::chrono::system_clock> end_time_;
 };
 
-} // namespace measurement::private_attribution
+} // namespace fbpcs::performance_tools


### PR DESCRIPTION
Summary:
**What**
- Currently, the cost estimation script CostEstimation.h is locally copied over to each project directory. Previously, we could not make it a single version that all can use. Now, after the fbpcs directory is stable, adding cost estimation to fbpcs.
- Next: will have all projects use the same script instead of their local ones.

Differential Revision: D32741338

