### PR TITLE
centralize default stage flow selection

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Created official changelog
 
 ### Changed
+  - Centralize default stage flow selection (D32774676)
 
 ### Removed

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -24,6 +24,9 @@ from fbpcs.private_computation.entity.pce_config import PCEConfig
 from fbpcs.private_computation.entity.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
+from fbpcs.private_computation.entity.private_computation_decoupled_stage_flow import (
+    PrivateComputationDecoupledStageFlow,
+)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -137,11 +140,10 @@ class PrivateComputationService:
         padding_size: Optional[int] = None,
         k_anonymity_threshold: Optional[int] = None,
         fail_fast: bool = False,
-        stage_flow_cls: Type[
-            PrivateComputationBaseStageFlow
-        ] = PrivateComputationStageFlow,
+        stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
+
         instance = PrivateComputationInstance(
             instance_id=instance_id,
             role=role,
@@ -175,7 +177,12 @@ class PrivateComputationService:
                 optional=k_anonymity_threshold, default=DEFAULT_K_ANONYMITY_THRESHOLD
             ),
             fail_fast=fail_fast,
-            _stage_flow_cls_name=stage_flow_cls.get_cls_name(),
+            _stage_flow_cls_name=unwrap_or_default(
+                optional=stage_flow_cls,
+                default=PrivateComputationDecoupledStageFlow
+                if game_type is PrivateComputationGameType.ATTRIBUTION
+                else PrivateComputationStageFlow,
+            ).get_cls_name(),
         )
 
         self.instance_repository.create(instance)

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -48,8 +48,7 @@ from fbpcs.private_computation.service.private_computation import (
 )
 from fbpcs.utils.config_yaml import reflect
 
-# Added an is_decoupled argument to create_instance. This argument will act as a switch
-# to let us know to run the new decoupled flow when true else legacy flow.
+
 def create_instance(
     config: Dict[str, Any],
     instance_id: str,
@@ -76,12 +75,6 @@ def create_instance(
         config["pid"],
         config.get("post_processing_handlers", {}),
     )
-
-    if not stage_flow_cls:
-        if game_type is PrivateComputationGameType.ATTRIBUTION:
-            stage_flow_cls = PrivateComputationDecoupledStageFlow
-        else:
-            stage_flow_cls = PrivateComputationStageFlow
 
     instance = pc_service.create_instance(
         instance_id=instance_id,


### PR DESCRIPTION
Summary:
## What

* see title

## Why

* The thrift server createInstance and PC Service wrapper create_instance both implement the same logic to get a default stage flow. It's better to centralize it in one place to make sure that they can't ever get out of sync

Differential Revision: D32774676

