### PR TITLE
correct grammar by using past participle version of the verb "to run"

### DIFF
--- a/fbpcs/pid/service/pid_service/pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/pid_dispatcher.py
@@ -194,7 +194,7 @@ class PIDDispatcher(Dispatcher):
         run_ready_stages = []
         for node in self.dag.nodes:
             # nodes with no dependencies left and who have not already been
-            # started are eligible to be ran
+            # started are eligible to run
             if (
                 self.dag.in_degree(node) == 0
                 and instance.stages_status.get(node.stage_type, None)

--- a/fbpcs/private_computation/entity/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_decoupled_local_test_stage_flow.py
@@ -40,7 +40,7 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
     NOTE:
     1. This is enum contains the flow - ID MATCH -> PREPARE -> ATTRIBUTION -> AGGREGATION -> SHARD AGGREGATION.
     2. The order in which the enum members appear is the order in which the stages are intended
-    to be ran. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
     An exception is raised at runtime if _order_ is inconsistent with the actual member order.
     3. This flow currently should only be used for PA.
     """

--- a/fbpcs/private_computation/entity/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_decoupled_stage_flow.py
@@ -44,7 +44,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
     NOTE:
     1. This is enum contains the flow - ID MATCH -> PREPARE -> ATTRIBUTION -> AGGREGATION -> SHARD AGGREGATION.
     2. The order in which the enum members appear is the order in which the stages are intended
-    to be ran. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
     An exception is raised at runtime if _order_ is inconsistent with the actual member order.
     3. This flow currently should only be used for PA.
     """

--- a/fbpcs/private_computation/entity/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_local_test_stage_flow.py
@@ -38,7 +38,7 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
     It also provides methods to get information about the next or previous stage.
 
     NOTE: The order in which the enum members appear is the order in which the stages are intended
-    to be ran. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
     An exception is raised at runtime if _order_ is inconsistent with the actual member order.
     """
 

--- a/fbpcs/private_computation/entity/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_stage_flow.py
@@ -40,7 +40,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
     It also provides methods to get information about the next or previous stage.
 
     NOTE: The order in which the enum members appear is the order in which the stages are intended
-    to be ran. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
     An exception is raised at runtime if _order_ is inconsistent with the actual member order.
     """
 


### PR DESCRIPTION
Summary:
## What

* `ruplacer 'to be ran' 'to run' --go`

## Why

impacc

Differential Revision: D32777531

