### PR TITLE
remove usage of pid_config + secret group

### DIFF
--- a/fbpcs/pid/service/pid_service/dispatcher.py
+++ b/fbpcs/pid/service/pid_service/dispatcher.py
@@ -17,7 +17,6 @@ class Dispatcher(abc.ABC):
         input_path: str,
         output_path: str,
         num_shards: int,
-        pid_config: Union[Dict[str, Any], str],
         protocol: PIDProtocol,
         role: PIDRole,
         data_path: Optional[str] = None,

--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -82,7 +82,6 @@ class PIDService:
     async def run_stage_or_next(
         self,
         instance_id: str,
-        pid_config: Dict[str, Any],
         fail_fast: bool = False,
         server_ips: Optional[List[str]] = None,
         pid_union_stage: Optional[UnionPIDStage] = None,
@@ -102,7 +101,7 @@ class PIDService:
 
         # Create the dispatcher and build stages.
         dispatcher = self.__get_dispatcher_and_build_stages(
-            instance, pid_config, fail_fast, server_ips
+            instance, fail_fast, server_ips
         )
 
         if pid_union_stage is None:
@@ -138,7 +137,6 @@ class PIDService:
     async def run_instance(
         self,
         instance_id: str,
-        pid_config: Dict[str, Any],
         fail_fast: bool = False,
         server_ips: Optional[List[str]] = None,
     ) -> PIDInstance:
@@ -152,7 +150,7 @@ class PIDService:
 
         # Call the dispatcher to run all stages
         dispatcher = self.__get_dispatcher_and_build_stages(
-            instance, pid_config, fail_fast, server_ips
+            instance, fail_fast, server_ips
         )
         await dispatcher.run_all()
 
@@ -197,7 +195,6 @@ class PIDService:
     def __get_dispatcher_and_build_stages(
         self,
         instance: PIDInstance,
-        pid_config: Dict[str, Any],
         fail_fast: bool = False,
         server_ips: Optional[List[str]] = None,
     ) -> PIDDispatcher:
@@ -211,7 +208,6 @@ class PIDService:
             num_shards=instance.num_shards,
             is_validating=instance.is_validating,
             synthetic_shard_path=instance.synthetic_shard_path,
-            pid_config=pid_config,
             protocol=instance.protocol,
             role=instance.pid_role,
             onedocker_svc=self.onedocker_svc,

--- a/fbpcs/pid/service/pid_service/pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/pid_dispatcher.py
@@ -44,7 +44,6 @@ class PIDDispatcher(Dispatcher):
         input_path: str,
         output_path: str,
         num_shards: int,
-        pid_config: Union[Dict[str, Any], str],
         protocol: PIDProtocol,
         role: PIDRole,
         onedocker_svc: OneDockerService,
@@ -59,18 +58,12 @@ class PIDDispatcher(Dispatcher):
         hmac_key: Optional[str] = None,
     ) -> None:
         flow_map = pid_execution_map.get_execution_flow(role, protocol)
-        # read config into a dict if it was given as a path
-        if isinstance(pid_config, str):
-            config_dict = yaml.load(pathlib.Path(pid_config))
-        else:
-            config_dict = pid_config
 
         # maintain a map of enums to actual pid execution stages
         self.enum_to_stage_map = {}
         for node in flow_map.flow:
             stage = PIDStageMapper.get_stage(
                 stage=node,
-                config=config_dict,
                 instance_repository=self.instance_repository,
                 storage_svc=storage_svc,
                 onedocker_svc=onedocker_svc,

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -266,13 +266,7 @@ class PIDProtocolRunStage(PIDStage):
             )
 
     def _gen_env_vars(self) -> Dict[str, str]:
-        # The Rust AWS-SDK currently only supports credentials via ENV variables
-        # so we must set them here (as opposed to the "intrinsic" credentials
-        # you can normally use just by virtue of running on ECS)
-        # This also means that the binary for PID is currently tightly coupled
-        # to running in AWS and would not support other container services.
         env_vars = {
             "RUST_LOG": "info",
-            **self.cloud_credential_service.get_creds(),
         }
         return env_vars

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -33,7 +33,6 @@ class PIDProtocolRunStage(PIDStage):
     def __init__(
         self,
         stage: UnionPIDStage,
-        config: Dict[str, Any],
         instance_repository: PIDInstanceRepository,
         storage_svc: StorageService,
         onedocker_svc: OneDockerService,
@@ -42,32 +41,15 @@ class PIDProtocolRunStage(PIDStage):
     ) -> None:
         super().__init__(
             stage=stage,
-            config=config,
             instance_repository=instance_repository,
             storage_svc=storage_svc,
             onedocker_svc=onedocker_svc,
             onedocker_binary_config=onedocker_binary_config,
-            is_joint_stage=True
+            is_joint_stage=True,
         )
 
-        self.cloud_credential_service = self._build_cloud_credential_service(
-            config["CloudCredentialService"]
-        )
         self.server_ips = server_ips
         self.logger: logging.Logger = logging.getLogger(__name__)
-
-    @staticmethod
-    def _build_cloud_credential_service(
-        config: Dict[str, Any]
-    ) -> CloudCredentialService:
-        cls = reflect.get_class(config["class"])
-        res = cls(**config.get("constructor", {}))
-        if not isinstance(res, CloudCredentialService):
-            typename = str(type(res))
-            raise ValueError(
-                f"Class created via reflection should be of type CloudCredentialService but is of type {typename}"
-            )
-        return res
 
     async def run(
         self,
@@ -116,7 +98,9 @@ class PIDProtocolRunStage(PIDStage):
                     timeout=timeout,
                 )
 
-                containers = await self.onedocker_svc.wait_for_pending_containers([container.instance_id for container in pending_containers])
+                containers = await self.onedocker_svc.wait_for_pending_containers(
+                    [container.instance_id for container in pending_containers]
+                )
             except Exception as e:
                 status = PIDStageStatus.FAILED
                 await self.update_instance_status(
@@ -175,7 +159,9 @@ class PIDProtocolRunStage(PIDStage):
                     timeout=timeout,
                 )
 
-                containers = await self.onedocker_svc.wait_for_pending_containers([container.instance_id for container in pending_containers])
+                containers = await self.onedocker_svc.wait_for_pending_containers(
+                    [container.instance_id for container in pending_containers]
+                )
             except Exception as e:
                 status = PIDStageStatus.FAILED
                 await self.update_instance_status(

--- a/fbpcs/pid/service/pid_service/pid_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_stage.py
@@ -25,7 +25,6 @@ class PIDStage(abc.ABC):
     def __init__(
         self,
         stage: UnionPIDStage,
-        config: Dict[str, Any],
         instance_repository: PIDInstanceRepository,
         storage_svc: StorageService,
         onedocker_svc: OneDockerService,
@@ -95,18 +94,6 @@ class PIDStage(abc.ABC):
         that there's some special function to use to shard a filepath.
         """
         return f"{path}_{shard}"
-
-    @staticmethod
-    def build_service(config: Dict[str, Any], **kwargs) -> Any:
-        """
-        Build a service by getting the class through reflection and calling
-        its constructor. Note the return type of Any. The caller is responsible
-        for checking that the returned object is of the expected type.
-        """
-        cls = reflect.get_class(config["class"])
-        if "constructor" in config:
-            return cls(**config["constructor"], **kwargs)
-        return cls()
 
     def files_exist(self, paths: List[str]) -> bool:
         """

--- a/fbpcs/pid/service/pid_service/pid_stage_mapper.py
+++ b/fbpcs/pid/service/pid_service/pid_stage_mapper.py
@@ -33,7 +33,6 @@ class PIDStageMapper:
     @staticmethod
     def get_stage(
         stage: UnionPIDStage,
-        config: Dict[str, Any],
         instance_repository: PIDInstanceRepository,
         storage_svc: StorageService,
         onedocker_svc: OneDockerService,
@@ -43,7 +42,6 @@ class PIDStageMapper:
         if stage is UnionPIDStage.PUBLISHER_SHARD:
             return PIDShardStage(
                 stage,
-                config,
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
@@ -52,7 +50,6 @@ class PIDStageMapper:
         elif stage is UnionPIDStage.PUBLISHER_PREPARE:
             return PIDPrepareStage(
                 stage,
-                config,
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
@@ -61,7 +58,6 @@ class PIDStageMapper:
         elif stage is UnionPIDStage.PUBLISHER_RUN_PID:
             return PIDProtocolRunStage(
                 stage,
-                config,
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
@@ -71,7 +67,6 @@ class PIDStageMapper:
         elif stage is UnionPIDStage.ADV_SHARD:
             return PIDShardStage(
                 stage,
-                config,
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
@@ -80,7 +75,6 @@ class PIDStageMapper:
         elif stage is UnionPIDStage.ADV_PREPARE:
             return PIDPrepareStage(
                 stage,
-                config,
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
@@ -89,7 +83,6 @@ class PIDStageMapper:
         elif stage is UnionPIDStage.ADV_RUN_PID:
             return PIDProtocolRunStage(
                 stage,
-                config,
                 instance_repository,
                 storage_svc,
                 onedocker_svc,

--- a/fbpcs/pid/service/pid_service/tests/test_pid.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid.py
@@ -26,7 +26,6 @@ from fbpcs.pid.entity.pid_stages import UnionPIDStage
 TEST_INSTANCE_ID = "123"
 TEST_PROTOCOL = PIDProtocol.UNION_PID
 TEST_PID_ROLE = PIDRole.PUBLISHER
-TEST_PID_CONFIG = {"pid": "config"}
 TEST_NUM_SHARDS = 4
 TEST_INPUT_PATH = "in"
 TEST_OUTPUT_PATH = "out"
@@ -210,7 +209,6 @@ class TestPIDService(unittest.TestCase):
             )
             await self.pid_service.run_instance(
                 instance_id=TEST_INSTANCE_ID,
-                pid_config=TEST_PID_CONFIG,
             )
             mock_init.assert_called_once()
             init_call_params = mock_init.call_args[1]

--- a/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
@@ -27,22 +27,6 @@ from fbpcs.pid.service.pid_service.pid_execution_map import PIDFlow
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
 
 
-CONFIG_TEXT = """
-dependency:
-    CoordinationService:
-        class: fbpcs.pid.service.coordination.file_coordination.FileCoordinationService
-        constructor:
-            coordination_objects:
-                pid_ip_addrs:
-                    value: ip_config.txt
-CloudCredentialService:
-    class: fbpcs.pid.service.credential_service.simple_cloud_credential_service.SimpleCloudCredentialService
-    constructor:
-        access_key_id: key_id
-        access_key_data: key_data
-"""
-
-
 class TestPIDDispatcher(unittest.TestCase):
     def setUp(self):
         self.onedocker_binary_config = OneDockerBinaryConfig(
@@ -59,19 +43,17 @@ class TestPIDDispatcher(unittest.TestCase):
             instance_id="456", instance_repository=mock_instance_repo
         )
         with self.assertRaises(PIDFlowUnsupportedError):
-            with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-                dispatcher.build_stages(
-                    input_path="abc.text",
-                    output_path="def.txt",
-                    num_shards=50,
-                    pid_config="config.yml",
-                    protocol=PIDProtocol.PS3I_M_TO_M,
-                    role=PIDRole.PUBLISHER,
-                    storage_svc="STORAGE",
-                    onedocker_svc="ONEDOCKER",
-                    onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                    fail_fast=True,
-                )
+            dispatcher.build_stages(
+                input_path="abc.text",
+                output_path="def.txt",
+                num_shards=50,
+                protocol=PIDProtocol.PS3I_M_TO_M,
+                role=PIDRole.PUBLISHER,
+                storage_svc="STORAGE",
+                onedocker_svc="ONEDOCKER",
+                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+                fail_fast=True,
+            )
 
     @patch(
         "fbpcs.pid.service.coordination.file_coordination.FileCoordinationService",
@@ -92,19 +74,17 @@ class TestPIDDispatcher(unittest.TestCase):
         dispatcher = PIDDispatcher(
             instance_id="456", instance_repository=mock_instance_repo
         )
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path="abc.text",
-                output_path="def.txt",
-                num_shards=50,
-                pid_config="config.yml",
-                protocol=PIDProtocol.UNION_PID,
-                role=PIDRole.PUBLISHER,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=True,
-            )
+        dispatcher.build_stages(
+            input_path="abc.text",
+            output_path="def.txt",
+            num_shards=50,
+            protocol=PIDProtocol.UNION_PID,
+            role=PIDRole.PUBLISHER,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=True,
+        )
         constructed_map = {}
         for stage in dispatcher.dag.nodes:
             constructed_map[stage.stage_type] = [
@@ -145,21 +125,19 @@ class TestPIDDispatcher(unittest.TestCase):
         )
         # provide optional parameters (data_path and spine_path)
         # expect no impact overall
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path="abc.text",
-                output_path="def.txt",
-                num_shards=50,
-                pid_config="config.yml",
-                protocol=PIDProtocol.UNION_PID,
-                role=PIDRole.PUBLISHER,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                data_path="data.txt",
-                spine_path="spine.txt",
-                fail_fast=True,
-            )
+        dispatcher.build_stages(
+            input_path="abc.text",
+            output_path="def.txt",
+            num_shards=50,
+            protocol=PIDProtocol.UNION_PID,
+            role=PIDRole.PUBLISHER,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            data_path="data.txt",
+            spine_path="spine.txt",
+            fail_fast=True,
+        )
         constructed_map = {}
         for stage in dispatcher.dag.nodes:
             constructed_map[stage.stage_type] = [
@@ -198,19 +176,17 @@ class TestPIDDispatcher(unittest.TestCase):
         dispatcher = PIDDispatcher(
             instance_id="456", instance_repository=mock_instance_repo
         )
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path="abc.text",
-                output_path="def.txt",
-                num_shards=50,
-                pid_config="config.yml",
-                protocol=PIDProtocol.UNION_PID,
-                role=PIDRole.PARTNER,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=True,
-            )
+        dispatcher.build_stages(
+            input_path="abc.text",
+            output_path="def.txt",
+            num_shards=50,
+            protocol=PIDProtocol.UNION_PID,
+            role=PIDRole.PARTNER,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=True,
+        )
         constructed_map = {}
         for stage in dispatcher.dag.nodes:
             constructed_map[stage.stage_type] = [
@@ -260,7 +236,6 @@ class TestPIDDispatcher(unittest.TestCase):
         is_validating = False
         input_path = "abc.text"
         output_path = "def.txt"
-        pid_config = "config.yml"
 
         dispatcher = PIDDispatcher(
             instance_id=instance_id, instance_repository=mock_instance_repo
@@ -279,19 +254,17 @@ class TestPIDDispatcher(unittest.TestCase):
             return_value=sample_pid_instance
         )
 
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path=input_path,
-                output_path=output_path,
-                num_shards=num_shards,
-                pid_config=pid_config,
-                protocol=protocol,
-                role=pid_role,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=True,
-            )
+        dispatcher.build_stages(
+            input_path=input_path,
+            output_path=output_path,
+            num_shards=num_shards,
+            protocol=protocol,
+            role=pid_role,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=True,
+        )
 
         # pre-run DAG should have 3 nodes
         self.assertEqual(len(dispatcher.dag.nodes), 3)
@@ -331,25 +304,22 @@ class TestPIDDispatcher(unittest.TestCase):
         num_shards = 50
         input_path = "abc.text"
         output_path = "def.txt"
-        pid_config = "config.yml"
 
         dispatcher = PIDDispatcher(
             instance_id=instance_id, instance_repository=mock_instance_repo
         )
 
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path=input_path,
-                output_path=output_path,
-                num_shards=num_shards,
-                pid_config=pid_config,
-                protocol=protocol,
-                role=pid_role,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=True,
-            )
+        dispatcher.build_stages(
+            input_path=input_path,
+            output_path=output_path,
+            num_shards=num_shards,
+            protocol=protocol,
+            role=pid_role,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=True,
+        )
 
         # pre-run DAG should have 3 nodes
         self.assertEqual(len(dispatcher.dag.nodes), 3)
@@ -409,7 +379,6 @@ class TestPIDDispatcher(unittest.TestCase):
         is_validating = False
         input_path = "abc.text"
         output_path = "def.txt"
-        pid_config = "config.yml"
 
         dispatcher = PIDDispatcher(
             instance_id=instance_id, instance_repository=mock_instance_repo
@@ -436,19 +405,17 @@ class TestPIDDispatcher(unittest.TestCase):
             return_value=sample_pid_instance
         )
 
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path=input_path,
-                output_path=output_path,
-                num_shards=num_shards,
-                pid_config=pid_config,
-                protocol=protocol,
-                role=pid_role,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=True,
-            )
+        dispatcher.build_stages(
+            input_path=input_path,
+            output_path=output_path,
+            num_shards=num_shards,
+            protocol=protocol,
+            role=pid_role,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=True,
+        )
 
         # pre-run DAG should have 2 nodes, since PID Shard is already finished
         self.assertEqual(len(dispatcher.dag.nodes), 2)
@@ -491,19 +458,17 @@ class TestPIDDispatcher(unittest.TestCase):
         dispatcher = PIDDispatcher(
             instance_id="456", instance_repository=mock_instance_repo
         )
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path="abc.text",
-                output_path="def.txt",
-                num_shards=50,
-                pid_config="config.yml",
-                protocol=PIDProtocol.UNION_PID,
-                role=PIDRole.PARTNER,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=False,
-            )
+        dispatcher.build_stages(
+            input_path="abc.text",
+            output_path="def.txt",
+            num_shards=50,
+            protocol=PIDProtocol.UNION_PID,
+            role=PIDRole.PARTNER,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=False,
+        )
 
         self.assertEqual(len(dispatcher.dag.nodes), 3)
 
@@ -574,21 +539,19 @@ class TestPIDDispatcher(unittest.TestCase):
         # The stage contains two additional parameters: data_path and spine_path
         # data_path is the output of the shard stage
         # spine_path is the output of the protocol run stage
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path="abc.text",
-                output_path="def.txt",
-                num_shards=50,
-                pid_config="config.yml",
-                protocol=PIDProtocol.UNION_PID,
-                role=PIDRole.PARTNER,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                data_path="data.txt",
-                spine_path="spine.txt",
-                fail_fast=False,
-            )
+        dispatcher.build_stages(
+            input_path="abc.text",
+            output_path="def.txt",
+            num_shards=50,
+            protocol=PIDProtocol.UNION_PID,
+            role=PIDRole.PARTNER,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            data_path="data.txt",
+            spine_path="spine.txt",
+            fail_fast=False,
+        )
 
         self.assertEqual(len(dispatcher.dag.nodes), 3)
 
@@ -675,19 +638,17 @@ class TestPIDDispatcher(unittest.TestCase):
         dispatcher = PIDDispatcher(
             instance_id="456", instance_repository=mock_instance_repo
         )
-        with patch("builtins.open", mock_open(read_data=CONFIG_TEXT)):
-            dispatcher.build_stages(
-                input_path="abc.text",
-                output_path="def.txt",
-                num_shards=50,
-                pid_config="config.yml",
-                protocol=PIDProtocol.UNION_PID,
-                role=PIDRole.PARTNER,
-                storage_svc=mock_s3_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
-                fail_fast=False,
-            )
+        dispatcher.build_stages(
+            input_path="abc.text",
+            output_path="def.txt",
+            num_shards=50,
+            protocol=PIDProtocol.UNION_PID,
+            role=PIDRole.PARTNER,
+            storage_svc=mock_s3_storage_service,
+            onedocker_svc=mock_onedocker_service,
+            onedocker_binary_config_map=defaultdict(lambda: "OD_CONFIG"),
+            fail_fast=False,
+        )
 
         self.assertEqual(len(dispatcher.dag.nodes), 3)
 

--- a/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
@@ -20,8 +20,6 @@ from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
 from libfb.py.asyncio.mock import AsyncMock
 from libfb.py.testutil import data_provider
 
-CONFIG = {}
-
 
 class TestPIDPrepareStage(unittest.TestCase):
     @data_provider(
@@ -62,7 +60,6 @@ class TestPIDPrepareStage(unittest.TestCase):
             mock_prepare_on_container_async.return_value = container
             stage = PIDPrepareStage(
                 stage=UnionPIDStage.PUBLISHER_PREPARE,
-                config=CONFIG,
                 instance_repository=mock_instance_repo,
                 storage_svc="STORAGE",
                 onedocker_svc="ONEDOCKER",
@@ -123,7 +120,6 @@ class TestPIDPrepareStage(unittest.TestCase):
 
         stage = PIDPrepareStage(
             stage=UnionPIDStage.PUBLISHER_PREPARE,
-            config=CONFIG,
             instance_repository=mock_instance_repo,
             storage_svc=mock_storage_svc,
             onedocker_svc=mock_onedocker_svc,
@@ -146,7 +142,6 @@ class TestPIDPrepareStage(unittest.TestCase):
             mock_fe.return_value = True
             stage = PIDPrepareStage(
                 stage=UnionPIDStage.PUBLISHER_PREPARE,
-                config=CONFIG,
                 instance_repository=mock_instance_repo,
                 storage_svc=mock_storage_svc,
                 onedocker_svc=mock_onedocker_svc,
@@ -203,7 +198,6 @@ class TestPIDPrepareStage(unittest.TestCase):
                 stage_input.input_paths = ["in1", "in2"]
                 stage = PIDPrepareStage(
                     stage=UnionPIDStage.PUBLISHER_PREPARE,
-                    config=CONFIG,
                     instance_repository=mock_instance_repo,
                     storage_svc=mock_storage_svc,
                     onedocker_svc=mock_onedocker_svc,

--- a/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
@@ -19,27 +19,6 @@ from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
 from libfb.py.asyncio.mock import AsyncMock
 from libfb.py.testutil import data_provider
 
-CONFIG = {
-    "dependency": {
-        "CoordinationService": {
-            "class": "fbpcs.pid.service.coordination.file_coordination.FileCoordinationService",
-            "constructor": {
-                "coordination_objects": {
-                    "pid_ip_addrs": {
-                        "value": "ip_config.txt",
-                    },
-                },
-            },
-        },
-    },
-    "CloudCredentialService": {
-        "class": "fbpcs.pid.service.credential_service.simple_cloud_credential_service.SimpleCloudCredentialService",
-        "constructor": {
-            "access_key_id": "key_id",
-            "access_key_data": "key_data",
-        },
-    },
-}
 
 
 class TestPIDProtocolRunStage(unittest.TestCase):
@@ -60,7 +39,6 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         )
         adv_run_stage = PIDProtocolRunStage(
             stage=UnionPIDStage.ADV_RUN_PID,
-            config=CONFIG,
             instance_repository=mock_instance_repo,
             storage_svc="STORAGE",
             onedocker_svc="ONEDOCKER",
@@ -115,7 +93,6 @@ class TestPIDProtocolRunStage(unittest.TestCase):
             # Run publisher
             publisher_run_stage = PIDProtocolRunStage(
                 stage=UnionPIDStage.PUBLISHER_RUN_PID,
-                config=CONFIG,
                 instance_repository=mock_instance_repo,
                 storage_svc=mock_storage_service,
                 onedocker_svc=mock_onedocker_service,
@@ -211,7 +188,6 @@ class TestPIDProtocolRunStage(unittest.TestCase):
             # Run advertiser
             adv_run_stage = PIDProtocolRunStage(
                 stage=UnionPIDStage.ADV_RUN_PID,
-                config=CONFIG,
                 instance_repository=mock_instance_repo,
                 storage_svc=mock_storage_service,
                 onedocker_svc=mock_onedocker_service,

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -21,16 +21,12 @@ from libfb.py.asyncio.unittest import AsyncMock
 from libfb.py.testutil import data_provider
 
 
-CONFIG = {}
-
-
 class TestPIDShardStage(unittest.TestCase):
     @to_sync
     @patch("fbpcs.pid.repository.pid_instance.PIDInstanceRepository")
     async def test_ready(self, mock_instance_repo):
         stage = PIDShardStage(
             stage=UnionPIDStage.PUBLISHER_SHARD,
-            config=CONFIG,
             instance_repository=mock_instance_repo,
             storage_svc="STORAGE",
             onedocker_svc="ONEDOCKER",
@@ -84,7 +80,6 @@ class TestPIDShardStage(unittest.TestCase):
         )
         stage = PIDShardStage(
             stage=UnionPIDStage.PUBLISHER_SHARD,
-            config=CONFIG,
             instance_repository=mock_instance_repo,
             storage_svc=mock_storage_svc,
             onedocker_svc=mock_onedocker_svc,
@@ -103,7 +98,6 @@ class TestPIDShardStage(unittest.TestCase):
             mock_fe.return_value = True
             stage = PIDShardStage(
                 stage=UnionPIDStage.PUBLISHER_SHARD,
-                config=CONFIG,
                 instance_repository=mock_instance_repo,
                 storage_svc=mock_storage_svc,
                 onedocker_svc=mock_onedocker_svc,
@@ -144,7 +138,6 @@ class TestPIDShardStage(unittest.TestCase):
                 stage_input.input_paths = ["in1", "in2"]
                 stage = PIDShardStage(
                     stage=UnionPIDStage.PUBLISHER_SHARD,
-                    config=CONFIG,
                     instance_repository=mock_instance_repo,
                     storage_svc=mock_storage_svc,
                     onedocker_svc=mock_onedocker_svc,
@@ -203,7 +196,6 @@ class TestPIDShardStage(unittest.TestCase):
             mock_sharder.return_value = container
             stage = PIDShardStage(
                 stage=UnionPIDStage.PUBLISHER_SHARD,
-                config=CONFIG,
                 instance_repository=mock_instance_repo,
                 storage_svc=mock_storage_svc,
                 onedocker_svc=mock_onedocker_svc,

--- a/fbpcs/private_computation/entity/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_decoupled_stage_flow.py
@@ -120,7 +120,6 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         elif self is self.ID_MATCH:
             return IdMatchStageService(
                 args.pid_svc,
-                args.pid_config,
             )
         elif self is self.PREPARE:
             return PrepareDataStageService(

--- a/fbpcs/private_computation/entity/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/entity/private_computation_stage_flow.py
@@ -119,21 +119,18 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         elif self is self.PID_SHARD:
             return PIDStageService(
                 args.pid_svc,
-                args.pid_config,
                 UnionPIDStage.PUBLISHER_SHARD,
                 UnionPIDStage.ADV_SHARD,
             )
         elif self is self.PID_PREPARE:
             return PIDStageService(
                 args.pid_svc,
-                args.pid_config,
                 UnionPIDStage.PUBLISHER_PREPARE,
                 UnionPIDStage.ADV_PREPARE,
             )
         elif self is self.ID_MATCH:
             return PIDStageService(
                 args.pid_svc,
-                args.pid_config,
                 UnionPIDStage.PUBLISHER_RUN_PID,
                 UnionPIDStage.ADV_RUN_PID,
             )

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -33,7 +33,6 @@ class IdMatchStageService(PrivateComputationStageService):
 
     Private attributes:
         _pid_svc: Creates PID instances and runs PID SHARD, PID PREPARE, and PID RUN
-        _pid_config: Consumed by PIDService to determine cloud credentials
         _protocol: An enum consumed by PIDService to determine which protocol to use, e.g. UNION_PID.
         _is_validating: if a test shard is injected to do run time correctness validation
         _synthetic_shard_path: path to the test shard to be injected if _is_validating
@@ -42,13 +41,11 @@ class IdMatchStageService(PrivateComputationStageService):
     def __init__(
         self,
         pid_svc: PIDService,
-        pid_config: Dict[str, Any],
         protocol: PIDProtocol = DEFAULT_PID_PROTOCOL,
         is_validating: bool = False,
         synthetic_shard_path: Optional[str] = None,
     ) -> None:
         self._pid_svc = pid_svc
-        self._pid_config = pid_config
         self._protocol = protocol
         self._is_validating = is_validating
         self._synthetic_shard_path = synthetic_shard_path
@@ -91,7 +88,6 @@ class IdMatchStageService(PrivateComputationStageService):
         # Run pid
         pid_instance = await self._pid_svc.run_instance(
             instance_id=pid_instance_id,
-            pid_config=self._pid_config,
             fail_fast=pc_instance.fail_fast,
             server_ips=server_ips,
         )

--- a/fbpcs/private_computation/service/pid_stage_service.py
+++ b/fbpcs/private_computation/service/pid_stage_service.py
@@ -38,7 +38,6 @@ class PIDStageService(PrivateComputationStageService):
 
     Private attributes:
         _pid_svc: Creates PID instances and runs PID SHARD, PID PREPARE, and PID RUN
-        _pid_config: Consumed by PIDService to determine cloud credentials
         _publisher_stage: The pid stage that should be ran by the publisher
         _partner_stage: The pid stage that should be ran by the partner
         _protocol: An enum consumed by PIDService to determine which protocol to use, e.g. UNION_PID.
@@ -50,7 +49,6 @@ class PIDStageService(PrivateComputationStageService):
     def __init__(
         self,
         pid_svc: PIDService,
-        pid_config: Dict[str, Any],
         publisher_stage: UnionPIDStage,
         partner_stage: UnionPIDStage,
         protocol: PIDProtocol = DEFAULT_PID_PROTOCOL,
@@ -59,7 +57,6 @@ class PIDStageService(PrivateComputationStageService):
         container_timeout: Optional[int] = None,
     ) -> None:
         self._pid_svc = pid_svc
-        self._pid_config = pid_config
         self._publisher_stage = publisher_stage
         self._partner_stage = partner_stage
         self._protocol = protocol
@@ -126,7 +123,6 @@ class PIDStageService(PrivateComputationStageService):
         # Run pid
         pid_instance = await self._pid_svc.run_stage_or_next(
             instance_id=pid_instance.instance_id,
-            pid_config=self._pid_config,
             fail_fast=pc_instance.fail_fast,
             server_ips=server_ips,
             pid_union_stage=self._publisher_stage

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -90,7 +90,6 @@ class PrivateComputationService:
         pid_svc: PIDService,
         onedocker_svc: OneDockerService,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
-        pid_config: Dict[str, Any],
         post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
     ) -> None:
         """Constructor of PrivateComputationService
@@ -102,13 +101,11 @@ class PrivateComputationService:
         self.pid_svc = pid_svc
         self.onedocker_svc = onedocker_svc
         self.onedocker_binary_config_map = onedocker_binary_config_map
-        self.pid_config = pid_config
         self.post_processing_handlers: Dict[str, PostProcessingHandler] = (
             post_processing_handlers or {}
         )
         self.stage_service_args = PrivateComputationStageServiceArgs(
             self.pid_svc,
-            self.pid_config,
             self.onedocker_binary_config_map,
             self.mpc_svc,
             self.storage_svc,

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -31,7 +31,6 @@ class PrivateComputationStageServiceArgs:
     """
 
     pid_svc: PIDService
-    pid_config: Dict[str, Any]
     onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig]
     mpc_svc: MPCService
     storage_svc: StorageService

--- a/fbpcs/private_computation/test/service/test_id_match_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_match_stage_service.py
@@ -52,7 +52,6 @@ class TestIdMatchStageService(IsolatedAsyncioTestCase):
 
         stage_svc = IdMatchStageService(
             pid_svc_mock,
-            pid_config={},
             protocol=PIDProtocol.UNION_PID,
         )
         await stage_svc.run_async(pc_instance)

--- a/fbpcs/private_computation/test/service/test_pid_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_stage_service.py
@@ -35,7 +35,6 @@ class TestPIDStageService(IsolatedAsyncioTestCase):
 
         stage_svc = PIDStageService(
             pid_svc_mock,
-            pid_config={},
             publisher_stage=UnionPIDStage.PUBLISHER_SHARD,
             partner_stage=UnionPIDStage.ADV_SHARD,
             protocol=PIDProtocol.UNION_PID,
@@ -69,7 +68,6 @@ class TestPIDStageService(IsolatedAsyncioTestCase):
 
         stage_svc = PIDStageService(
             pid_svc_mock,
-            pid_config={},
             publisher_stage=UnionPIDStage.PUBLISHER_PREPARE,
             partner_stage=UnionPIDStage.ADV_PREPARE,
             protocol=PIDProtocol.UNION_PID,
@@ -108,7 +106,6 @@ class TestPIDStageService(IsolatedAsyncioTestCase):
 
         stage_svc = PIDStageService(
             pid_svc_mock,
-            pid_config={},
             publisher_stage=UnionPIDStage.PUBLISHER_RUN_PID,
             partner_stage=UnionPIDStage.ADV_RUN_PID,
             protocol=PIDProtocol.UNION_PID,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -147,7 +147,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             pid_svc=self.pid_service,
             onedocker_svc=self.onedocker_service,
             onedocker_binary_config_map=self.onedocker_binary_config_map,
-            pid_config={},
         )
 
         self.test_private_computation_id = "test_private_computation_id"

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -415,7 +415,6 @@ def _build_private_computation_service(
         ),
         onedocker_service,
         onedocker_binary_config_map,
-        pid_config,
         _get_post_processing_handlers(pph_config),
     )
 


### PR DESCRIPTION
Summary:
## What

* Big diff. It was all or nothing to delete this config unfortunately
* Delete all references to `pid_config` in PIDService and PCS

## Why

* Per S253185, IAM is deprecated and we must use SSO in pid. After this diff, it should be completely resolved in FBPCS (if my understanding is correct)
* Now that we no longer export credentials as ENV vars during PID RUN, this is dead code

Differential Revision: D32800018

