### PR TITLE
Change security group outbound rules

### DIFF
--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf
@@ -78,9 +78,34 @@ resource "aws_default_security_group" "default" {
   }
 
   egress {
+    description = "allow local traffic"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "Open ports 5000-15500 to other party VPC"
+    from_port   = 5000
+    to_port     = 15500
+    protocol    = "tcp"
+    cidr_blocks = [var.otherparty_vpc_cidr]
+  }
+
+  egress {
+    description = "Open port 80 for HTTP access"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Open port 443 for HTTPS access"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 


### PR DESCRIPTION
Summary:
As per T105173701 requested, the security group rules is open to all egress traffic. In this diff, I will limit egress rules as:
1. Open 80,443 to all(for accessing s3 bucket, 443 is also for future pulling fbpcs/onedocker image from Github registry)
S3 is using HTTP/HTTPS: https://docs.aws.amazon.com/general/latest/gr/s3.html
Docker is using HTTPS: https://docs.docker.com/engine/reference/commandline/pull/
2. Open all TCP to the other party vpc cidr
3. (Optional) allow all local traffic, this is to match with ingress rules, though this is not being used for study

Differential Revision: D32885504

