### PR TITLE
add resource parameters to create policy CLI command

### DIFF
--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -100,6 +100,34 @@ def aws_create_iam_policy_parser_arguments(aws_parser: argparse):
         "--policy_name", type=str, required=False, help="Policy name to be created"
     )
 
+    iam_policy_command_group.add_argument(
+        "--firehose_stream_name", type=str, required=False, help="Firehose stream name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--data_bucket_name", type=str, required=False, help="Data bucket name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--config_bucket_name", type=str, required=False, help="Config bucket name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--database_name", type=str, required=False, help="Database name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--data_ingestion_kms_key", type=str, required=False, help="Data ingestion bucket KMS key"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--cluster_name", type=str, required=False, help="ECS cluster name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--ecs_task_execution_role_name", type=str, required=False, help="ECS task execution role name"
+    )
+
 
 def aws_destroy_iam_user_parser_arguments(aws_parser: argparse):
     iam_user_command_group = aws_parser.add_argument_group(

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -11,6 +11,7 @@ from string import Template
 import boto3
 from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
+from .policy_params import PolicyParams
 
 
 class AwsDeploymentHelper:
@@ -117,13 +118,14 @@ class AwsDeploymentHelper:
                     f"Unexpected error occured in deletion of user {user_name}"
                 )
 
-    def create_policy(self, policy_name: str, user_name: str = None):
+    def create_policy(self, policy_name: str, policy_params: PolicyParams, user_name: str = None):
 
         # directly reading the json file from iam_policies folder
         # TODO: pass the policy to be added from cli.py when we need more granular control
 
         policy_json_data = self.read_json_file(
-            file_name="iam_policies/fb_pc_iam_policy.json"
+            file_name="iam_policies/fb_pc_iam_policy.json",
+            policy_params=policy_params
         )
 
         try:
@@ -225,19 +227,19 @@ class AwsDeploymentHelper:
             )
         return access_key_list
 
-    def read_json_file(self, file_name: str, read_mode: str = "r"):
+    def read_json_file(self, file_name: str, policy_params: PolicyParams, read_mode: str = "r"):
 
         # this can be replaced with a json file which is written in deploy.sh
         interpolation_data = {
             "REGION": self.region,
             "ACCOUNT_ID": self.account_id,
-            "CLUSTER_NAME": "",
-            "DATA_BUCKET_NAME": "",
-            "CONFIG_BUCKET_NAME": "",
-            "DATA_INGESTION_KMS_KEY": "",
-            "ECS_TASK_EXECUTION_ROLE_NAME": "",
-            "FIREHOSE_STREAM_NAME": "",
-            "DATEBASE_NAME": "",
+            "CLUSTER_NAME": policy_params.cluster_name,
+            "DATA_BUCKET_NAME": policy_params.data_bucket_name,
+            "CONFIG_BUCKET_NAME": policy_params.config_bucket_name,
+            "DATA_INGESTION_KMS_KEY": policy_params.data_ingestion_kms_key,
+            "ECS_TASK_EXECUTION_ROLE_NAME": policy_params.ecs_task_execution_role_name,
+            "FIREHOSE_STREAM_NAME": policy_params.firehose_stream_name,
+            "DATEBASE_NAME": policy_params.database_name,
         }
 
         file_path = os.path.join(os.path.dirname(__file__), file_name)

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -6,6 +6,7 @@
 import argparse
 
 from .aws_deployment_helper import AwsDeploymentHelper
+from .policy_params import PolicyParams
 
 
 class AwsDeploymentHelperTool:
@@ -33,8 +34,18 @@ class AwsDeploymentHelperTool:
                 raise Exception(
                     "Need policy name to add IAM policy. Please add username using --policy_name argument in cli.py"
                 )
+            policy_params = PolicyParams(
+                firehose_stream_name=self.cli_args.firehose_stream_name,
+                data_bucket_name=self.cli_args.data_bucket_name,
+                config_bucket_name=self.cli_args.config_bucket_name,
+                database_name=self.cli_args.database_name,
+                data_ingestion_kms_key=self.cli_args.data_ingestion_kms_key,
+                cluster_name=self.cli_args.cluster_name,
+                ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
+            )
             self.aws_deployment_helper_obj.create_policy(
-                policy_name=self.cli_args.policy_name
+                policy_name=self.cli_args.policy_name,
+                policy_params=policy_params
             )
 
     def destroy(self):

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+@dataclass
+class PolicyParams:
+    firehose_stream_name: str
+    data_bucket_name: str
+    config_bucket_name: str
+    database_name: str
+    data_ingestion_kms_key: str
+    cluster_name: str
+    ecs_task_execution_role_name: str


### PR DESCRIPTION
Summary:
Add all of the AWS resource params to the add_iam_policy command so that the
policy statements can be scoped to the necessary resources that have been
created by the deploy.sh script.

Reviewed By: ankushksingh

Differential Revision: D32942608

