### PR TITLE
create the AWS policy on deploy

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -20,8 +20,10 @@ RUN apk --update --no-cache add \
 RUN pip install \
     awscli
 
+# Note: the dataclasses backport can be removed once Python 3 is upgraded to 3.7
 RUN pip3 install \
-    boto3
+    boto3 \
+    dataclasses
 
 ##########################################
 # Install Terraform

--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -100,6 +100,34 @@ def aws_create_iam_policy_parser_arguments(aws_parser: argparse):
         "--policy_name", type=str, required=False, help="Policy name to be created"
     )
 
+    iam_policy_command_group.add_argument(
+        "--firehose_stream_name", type=str, required=False, help="Firehose stream name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--data_bucket_name", type=str, required=False, help="Data bucket name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--config_bucket_name", type=str, required=False, help="Config bucket name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--database_name", type=str, required=False, help="Database name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--data_ingestion_kms_key", type=str, required=False, help="Data ingestion bucket KMS key"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--cluster_name", type=str, required=False, help="ECS cluster name"
+    )
+
+    iam_policy_command_group.add_argument(
+        "--ecs_task_execution_role_name", type=str, required=False, help="ECS task execution role name"
+    )
+
 
 def aws_destroy_iam_user_parser_arguments(aws_parser: argparse):
     iam_user_command_group = aws_parser.add_argument_group(

--- a/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
@@ -7,3 +7,13 @@ output "data_processing_output_bucket_arn" {
   value       = aws_s3_bucket.bucket.arn
   description = "The arn of S3 bucked used to store data processing outputs"
 }
+
+output "firehose_stream_name" {
+  value       = aws_kinesis_firehose_delivery_stream.extended_s3_stream.name
+  description = "The Kinesis firehose stream name"
+}
+
+output "data_ingestion_kms_key" {
+  value       = aws_kms_key.s3_kms_key.id
+  description = "The data bucket KMS key"
+}

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -6,6 +6,7 @@
 import argparse
 
 from .aws_deployment_helper import AwsDeploymentHelper
+from .policy_params import PolicyParams
 
 
 class AwsDeploymentHelperTool:
@@ -33,8 +34,18 @@ class AwsDeploymentHelperTool:
                 raise Exception(
                     "Need policy name to add IAM policy. Please add username using --policy_name argument in cli.py"
                 )
+            policy_params = PolicyParams(
+                firehose_stream_name=self.cli_args.firehose_stream_name,
+                data_bucket_name=self.cli_args.data_bucket_name,
+                config_bucket_name=self.cli_args.config_bucket_name,
+                database_name=self.cli_args.database_name,
+                data_ingestion_kms_key=self.cli_args.data_ingestion_kms_key,
+                cluster_name=self.cli_args.cluster_name,
+                ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
+            )
             self.aws_deployment_helper_obj.create_policy(
-                policy_name=self.cli_args.policy_name
+                policy_name=self.cli_args.policy_name,
+                policy_params=policy_params
             )
 
     def destroy(self):

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+
+@dataclass
+class PolicyParams:
+    firehose_stream_name: str
+    data_bucket_name: str
+    config_bucket_name: str
+    database_name: str
+    data_ingestion_kms_key: str
+    cluster_name: str
+    ecs_task_execution_role_name: str

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/output.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/output.tf
@@ -12,3 +12,8 @@ output "onedocker_task_definition_container_definitons" {
   value       = aws_ecs_task_definition.onedocker_task_def.container_definitions
   description = "The container definitions in the onedocker task definition"
 }
+
+output "ecs_task_execution_role_name" {
+  value       = aws_iam_role.onedocker_ecs_task_execution_role.name
+  description = "The ECS task execution IAM role name"
+}


### PR DESCRIPTION
Summary:
Also delete the policy if it is not attached to any users. Partners will be
able to attach this policy to a new API system user in order to enable
communication to the AWS resources from CAPI-G that is required for the
automated PL flow.

Differential Revision: D32945097

