### PR TITLE
Fix emp::PUBLIC initialization

### DIFF
--- a/fbpcs/emp_games/attribution/Timestamp.h
+++ b/fbpcs/emp_games/attribution/Timestamp.h
@@ -81,7 +81,7 @@ class Timestamp : public emp::Swappable<Timestamp>,
  public:
   explicit Timestamp(
       int64_t ts,
-      int party = emp::PUBLIC,
+      int party = emp::ALICE,
       int64_t minValue = kDefaultMinValue,
       int64_t maxValue = kDefaultMaxValue,
       Precision p = kDefaultPrecision)

--- a/fbpcs/emp_games/attribution/Touchpoint.h
+++ b/fbpcs/emp_games/attribution/Touchpoint.h
@@ -72,12 +72,12 @@ struct PrivateTouchpoint {
         campaignMetadata{_campaignMetadata} {}
 
   explicit PrivateTouchpoint()
-      : isValid{false, emp::PUBLIC},
-        isClick{false, emp::PUBLIC},
-        adId{INT_SIZE, -1, emp::PUBLIC},
-        ts{-1},
-        id{INT_SIZE, INVALID_TP_ID, emp::PUBLIC},
-        campaignMetadata{INT_SIZE, -1, emp::PUBLIC} {}
+      : isValid{false, emp::ALICE},
+        isClick{false, emp::ALICE},
+        adId{INT_SIZE, -1, emp::ALICE},
+        ts{-1, emp::ALICE},
+        id{INT_SIZE, INVALID_TP_ID, emp::ALICE},
+        campaignMetadata{INT_SIZE, -1, emp::ALICE} {}
 
   PrivateTouchpoint select(const emp::Bit& useRhs, const PrivateTouchpoint& rhs)
       const {


### PR DESCRIPTION
Summary:
**What?**
- Task T104587386 pointed out some suspicious usages of initialization of `emp::PUBLIC` which may introduce privacy leaks.
- With minor changes trying to fix it in this diff.

Differential Revision: D32967105

