### PR TITLE
Fix emp::PUBLIC initialization

### DIFF
--- a/fbpcs/emp_games/attribution/Timestamp.cpp
+++ b/fbpcs/emp_games/attribution/Timestamp.cpp
@@ -25,7 +25,7 @@ emp::Bit Timestamp::equal(const Timestamp& rhs) const {
 }
 
 emp::Bit Timestamp::operator<(const int64_t rhs) const {
-  return !geq(Timestamp{rhs, emp::PUBLIC, minValue_, maxValue_, precision_});
+  return !geq(Timestamp{rhs, emp::ALICE, minValue_, maxValue_, precision_});
 }
 
 emp::Bit operator>(int64_t lhs, const Timestamp& rhs) {

--- a/fbpcs/emp_games/attribution/Timestamp.h
+++ b/fbpcs/emp_games/attribution/Timestamp.h
@@ -81,7 +81,7 @@ class Timestamp : public emp::Swappable<Timestamp>,
  public:
   explicit Timestamp(
       int64_t ts,
-      int party = emp::PUBLIC,
+      int party = emp::ALICE,
       int64_t minValue = kDefaultMinValue,
       int64_t maxValue = kDefaultMaxValue,
       Precision p = kDefaultPrecision)

--- a/fbpcs/emp_games/attribution/Touchpoint.h
+++ b/fbpcs/emp_games/attribution/Touchpoint.h
@@ -65,12 +65,12 @@ struct PrivateTouchpoint {
         campaignMetadata{_campaignMetadata} {}
 
   explicit PrivateTouchpoint()
-      : isValid{false, emp::PUBLIC},
-        isClick{false, emp::PUBLIC},
-        adId{INT_SIZE, -1, emp::PUBLIC},
+      : isValid{false},
+        isClick{false},
+        adId{INT_SIZE, -1},
         ts{-1},
-        id{INT_SIZE, INVALID_TP_ID, emp::PUBLIC},
-        campaignMetadata{INT_SIZE, -1, emp::PUBLIC} {}
+        id{INT_SIZE, INVALID_TP_ID},
+        campaignMetadata{INT_SIZE, -1} {}
 
   // emp::batcher based construction support
   explicit PrivateTouchpoint(int len, const emp::block* b)

--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp
@@ -103,9 +103,9 @@ std::function<void(std::shared_ptr<AggMetrics>)> constructAdObjectFormatThreshol
     int64_t threshold) {
   return [threshold](std::shared_ptr<AggMetrics> metrics) {
     const emp::Integer hiddenMetric{
-        INT_SIZE, kHiddenMetricConstant, emp::PUBLIC};
+        INT_SIZE, kHiddenMetricConstant};
     const emp::Integer kAnonymityLevel{
-        private_measurement::INT_SIZE, threshold, emp::PUBLIC};
+        private_measurement::INT_SIZE, threshold};
 
     for (const auto& [rule, metricsMap] : metrics->getAsMap()) {
       for (const auto& [aggregationName, aggregationData] :


### PR DESCRIPTION
Summary:
**What?**
- Task T104587386 pointed out some suspicious usages of initialization of emp::PUBLIC which may introduce privacy leaks.
- With minor changes trying to fix it in this diff.

Differential Revision: D32967533

