### PR TITLE
Adding attribution rule, aggregation type and game type to the initial args to make cli compatible with Private Attribution

### DIFF
--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -16,6 +16,10 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
+    AggregationType,
+    AttributionRule,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -45,6 +49,12 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
         input_path: str,
         num_shards: int,
         logger: logging.Logger,
+        game_type: PrivateComputationGameType,
+        attribution_rule: Optional[AttributionRule] = None,
+        aggregation_type: Optional[AggregationType] = None,
+                concurrency: Optional[int] = None,
+        num_files_per_mpc_container: Optional[int] = None,
+        k_anonymity_threshold: Optional[int] = None,
     ) -> None:
         super().__init__(instance_id, logger, PrivateComputationRole.PARTNER)
         self.config: Dict[str, Any] = config
@@ -60,12 +70,17 @@ class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
                 config=self.config,
                 instance_id=self.instance_id,
                 role=PrivateComputationRole.PARTNER,
-                game_type=PrivateComputationGameType.LIFT,
+                game_type=game_type,
                 logger=self.logger,
                 input_path=self.input_path,
                 output_dir=self.output_dir,
                 num_pid_containers=num_shards,
                 num_mpc_containers=num_shards,
+                attribution_rule=attribution_rule,
+                aggregation_type=aggregation_type,
+                concurrency=concurrency,
+                num_files_per_mpc_container=num_files_per_mpc_container,
+                k_anonymity_threshold=k_anonymity_threshold,
             ).status
         self.wait_valid_status(WAIT_VALID_STATUS_TIMEOUT)
 

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -30,6 +30,13 @@ from fbpcs.pl_coordinator.pl_graphapi_utils import PLGraphAPIClient
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
+from fbpcs.private_computation.entity.private_computation_instance import (
+    AggregationType,
+    AttributionRule,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
+)
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -51,6 +58,12 @@ def run_instance(
     num_shards: int,
     stage_flow: Type[PrivateComputationBaseStageFlow],
     logger: logging.Logger,
+    game_type: PrivateComputationGameType,
+    attribution_rule: Optional[AttributionRule] = None,
+    aggregation_type: Optional[AggregationType] = None,
+    concurrency: Optional[int] = None,
+    num_files_per_mpc_container: Optional[int] = None,
+    k_anonymity_threshold: Optional[int] = None,
     num_tries: Optional[int] = 2,  # this is number of tries per stage
     dry_run: Optional[bool] = False,
 ) -> None:
@@ -66,8 +79,14 @@ def run_instance(
         logger,
         client,
         num_tries,
+        game_type,
         dry_run,
         stage_flow,
+        attribution_rule,
+        aggregation_type,
+        concurrency,
+        num_files_per_mpc_container,
+        k_anonymity_threshold
     )
     logger.info(f"Running private lift for instance {instance_id}")
     instance_runner.run()
@@ -106,6 +125,7 @@ def run_instances(
                     "num_shards": num_shards,
                     "stage_flow": stage_flow,
                     "logger": LoggerAdapter(logger=logger, prefix=instance_id),
+                    "game_type": PrivateComputationGameType.LIFT,
                     "num_tries": num_tries,
                     "dry_run": dry_run,
                 },
@@ -136,8 +156,14 @@ class PLInstanceRunner:
         logger: logging.Logger,
         client: PLGraphAPIClient,
         num_tries: int,
+        game_type: PrivateComputationGameType,
         dry_run: Optional[bool],
         stage_flow: Type[PrivateComputationBaseStageFlow],
+        attribution_rule: Optional[AttributionRule] = None,
+        aggregation_type: Optional[AggregationType] = None,
+        concurrency: Optional[int] = None,
+        num_files_per_mpc_container: Optional[int] = None,
+        k_anonymity_threshold: Optional[int] = None,
     ) -> None:
         self.logger = logger
         self.instance_id = instance_id
@@ -146,6 +172,12 @@ class PLInstanceRunner:
             instance_id=instance_id,
             config=config,
             input_path=input_path,
+            game_type=game_type,
+            attribution_rule=attribution_rule,
+            aggregation_type=aggregation_type,
+            concurrency=concurrency,
+            num_files_per_mpc_container=num_files_per_mpc_container,
+            k_anonymity_threshold=k_anonymity_threshold,
             num_shards=num_shards,
             logger=logger,
         )

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -225,6 +225,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             config=config,
             instance_id=instance_id,
             input_path=arguments["--input_path"],
+            game_type=arguments["--game_type"],
             num_shards=arguments["--num_shards"],
             stage_flow=stage_flow,
             logger=logger,

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -21,6 +21,8 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
+    AggregationType,
+    AttributionRule,
     PrivateComputationGameType,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -325,6 +327,9 @@ class TestPlInstanceRunner(TestCase):
             config={},
             instance_id=self.instance_id,
             input_path="fake_input_path",
+            game_type=PrivateComputationGameType.LIFT,
+            attribution_rule=AttributionRule.LAST_CLICK_1D,
+            aggregation_type=AggregationType.MEASUREMENT,
             num_shards=self.num_shards,
             logger=self.mock_logger,
             client=self.mock_graph_api_client,


### PR DESCRIPTION
Summary: Adding game_type as an argument to the run_instance function and making Attribution Rule and Aggregation Type Optional default variables from the top

Reviewed By: yanglu-fb, Olivia-liu

Differential Revision: D32937948

