### PR TITLE
fbpcs enable black autoformatting

### DIFF
--- a/fbpcs/data_processing/pid_preparer/union_pid_preparer_cpp.py
+++ b/fbpcs/data_processing/pid_preparer/union_pid_preparer_cpp.py
@@ -173,7 +173,9 @@ class CppUnionPIDDataPreparerService(UnionPIDDataPreparerService):
             # Busy wait until the container is finished
             if wait_for_container:
                 container = (
-                    await RunBinaryBaseService.wait_for_containers_async(onedocker_svc, [container])
+                    await RunBinaryBaseService.wait_for_containers_async(
+                        onedocker_svc, [container]
+                    )
                 )[0]
                 status = container.status
             else:

--- a/fbpcs/experimental/cloud_logs/log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/log_retriever.py
@@ -18,6 +18,7 @@ class LogRetriever:
     Private attributes:
         _cloud_provider: Cloud Provider for which this log retriever was initialized
     """
+
     def __init__(self, cloud_provider: CloudProvider) -> None:
         self._cloud_provider = cloud_provider
 

--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -117,7 +117,10 @@ def aws_create_iam_policy_parser_arguments(aws_parser: argparse):
     )
 
     iam_policy_command_group.add_argument(
-        "--data_ingestion_kms_key", type=str, required=False, help="Data ingestion bucket KMS key"
+        "--data_ingestion_kms_key",
+        type=str,
+        required=False,
+        help="Data ingestion bucket KMS key",
     )
 
     iam_policy_command_group.add_argument(
@@ -125,7 +128,10 @@ def aws_create_iam_policy_parser_arguments(aws_parser: argparse):
     )
 
     iam_policy_command_group.add_argument(
-        "--ecs_task_execution_role_name", type=str, required=False, help="ECS task execution role name"
+        "--ecs_task_execution_role_name",
+        type=str,
+        required=False,
+        help="ECS task execution role name",
     )
 
 

--- a/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
@@ -3,203 +3,217 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from unittest import TestCase
-from data_transformation_lambda import lambda_handler, _parse_client_user_agent
 import base64
 import json
+from unittest import TestCase
+
+from data_transformation_lambda import lambda_handler, _parse_client_user_agent
+
 
 class TestDataIngestion(TestCase):
     def setUp(self):
-        self.sample_context = {} # Not used by the lambda for now
+        self.sample_context = {}  # Not used by the lambda for now
 
-        self.sample_record_data = {'serverSideEvent': {
-                    'event_time': 1234,
-                    'custom_data': {'currency': 'usd', 'value': 2},
-                    'event_name': 'Purchase',
-                    'user_data': {
-                        'em': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11111111111111111111111111111111',
-                        'madid': 'bbbbbbbbbbbbbbbb2222222222222222'
-                    },
-                    'action_source': 'website'
+        self.sample_record_data = {
+            "serverSideEvent": {
+                "event_time": 1234,
+                "custom_data": {"currency": "usd", "value": 2},
+                "event_name": "Purchase",
+                "user_data": {
+                    "em": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11111111111111111111111111111111",
+                    "madid": "bbbbbbbbbbbbbbbb2222222222222222",
                 },
-                'pixelId': '4321'
+                "action_source": "website",
+            },
+            "pixelId": "4321",
         }
 
     def test_non_encoded_data_is_transformed(self):
         event = self.sample_event(self.sample_record_data)
         result = lambda_handler(event, self.sample_context)
-        self.assertEqual(result['records'][0]['recordId'], event["records"][0]['recordId'])
-        self.assertEqual(result['records'][0]['result'], 'Ok')
+        self.assertEqual(
+            result["records"][0]["recordId"], event["records"][0]["recordId"]
+        )
+        self.assertEqual(result["records"][0]["result"], "Ok")
 
     def test_encoded_data_is_transformed(self):
         event = self.sample_event(self.sample_record_data)
         result = lambda_handler(event, self.sample_context)
-        encoded_data = result['records'][0]['data']
+        encoded_data = result["records"][0]["data"]
         decoded_data = base64.b64decode(encoded_data)
         decoded_dict = json.loads(decoded_data)
-        server_side_event = self.sample_record_data['serverSideEvent']
+        server_side_event = self.sample_record_data["serverSideEvent"]
 
-        self.assertEqual(decoded_dict['data_source_id'], self.sample_record_data['pixelId'])
-        self.assertEqual(decoded_dict['timestamp'], server_side_event['event_time'])
-        self.assertEqual(decoded_dict['currency_type'], server_side_event['custom_data']['currency'])
-        self.assertEqual(decoded_dict['conversion_value'], server_side_event['custom_data']['value'])
-        self.assertEqual(decoded_dict['event_type'], server_side_event['event_name'])
-        self.assertEqual(decoded_dict['user_data']['email'], server_side_event['user_data']['em'])
-        self.assertEqual(decoded_dict['user_data']['device_id'], server_side_event['user_data']['madid'])
-        self.assertEqual(decoded_dict['action_source'], server_side_event['action_source'])
+        self.assertEqual(
+            decoded_dict["data_source_id"], self.sample_record_data["pixelId"]
+        )
+        self.assertEqual(decoded_dict["timestamp"], server_side_event["event_time"])
+        self.assertEqual(
+            decoded_dict["currency_type"], server_side_event["custom_data"]["currency"]
+        )
+        self.assertEqual(
+            decoded_dict["conversion_value"], server_side_event["custom_data"]["value"]
+        )
+        self.assertEqual(decoded_dict["event_type"], server_side_event["event_name"])
+        self.assertEqual(
+            decoded_dict["user_data"]["email"], server_side_event["user_data"]["em"]
+        )
+        self.assertEqual(
+            decoded_dict["user_data"]["device_id"],
+            server_side_event["user_data"]["madid"],
+        )
+        self.assertEqual(
+            decoded_dict["action_source"], server_side_event["action_source"]
+        )
 
     def test_server_side_event_error(self):
-        malformed_dict = {"a" : "b"}
+        malformed_dict = {"a": "b"}
         event = self.sample_event(malformed_dict)
         result = lambda_handler(event, self.sample_context)
 
         # Assert the malformed row gets skipped!
-        self.assertEqual(len(result['records']), 0)
+        self.assertEqual(len(result["records"]), 0)
 
     def test_null_row_skipped(self):
-        null_dict = {'serverSideEvent': {
-                'custom_data': {},
-                'user_data': {},
-                'action_source': 'website'
+        null_dict = {
+            "serverSideEvent": {
+                "custom_data": {},
+                "user_data": {},
+                "action_source": "website",
             },
-            'pixelId': '4321'
+            "pixelId": "4321",
         }
         event = self.sample_event(null_dict)
         result = lambda_handler(event, self.sample_context)
 
-        self.assertEqual(len(result['records']), 0)
+        self.assertEqual(len(result["records"]), 0)
 
     def test_user_data_fields(self):
         record = self.sample_record_data
-        server_side_event = record['serverSideEvent']
-        server_side_event['user_data'] = {
-            'em': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11111111111111111111111111111111',
-            'madid': 'bbbbbbbbbbbbbbbb2222222222222222',
-            'ph': 'cccccccccccccccccccccccccccccccc33333333333333333333333333333333',
-            'client_ip_address': '123.123.123.123',
-            'client_user_agent': ''.join([
-                'Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_5 like Mac OS X) ',
-                'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 ',
-                'Mobile/15E148 Safari/604.1',
-            ]),
-            'fbc': 'fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890',
-            'fbp': 'fb.1.1558571054389.1098115397'
+        server_side_event = record["serverSideEvent"]
+        server_side_event["user_data"] = {
+            "em": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11111111111111111111111111111111",
+            "madid": "bbbbbbbbbbbbbbbb2222222222222222",
+            "ph": "cccccccccccccccccccccccccccccccc33333333333333333333333333333333",
+            "client_ip_address": "123.123.123.123",
+            "client_user_agent": "".join(
+                [
+                    "Mozilla/5.0 (iPhone; CPU iPhone OS 12_5_5 like Mac OS X) ",
+                    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 ",
+                    "Mobile/15E148 Safari/604.1",
+                ]
+            ),
+            "fbc": "fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890",
+            "fbp": "fb.1.1558571054389.1098115397",
         }
         event = self.sample_event(record)
         result = lambda_handler(event, self.sample_context)
-        encoded_data = result['records'][0]['data']
+        encoded_data = result["records"][0]["data"]
         decoded_data = base64.b64decode(encoded_data)
         decoded_dict = json.loads(decoded_data)
 
         self.assertEqual(
-            server_side_event['user_data']['em'],
-            decoded_dict['user_data']['email']
+            server_side_event["user_data"]["em"], decoded_dict["user_data"]["email"]
         )
         self.assertEqual(
-            server_side_event['user_data']['madid'],
-            decoded_dict['user_data']['device_id']
+            server_side_event["user_data"]["madid"],
+            decoded_dict["user_data"]["device_id"],
         )
         self.assertEqual(
-            server_side_event['user_data']['ph'],
-            decoded_dict['user_data']['phone']
+            server_side_event["user_data"]["ph"], decoded_dict["user_data"]["phone"]
         )
         self.assertEqual(
-            server_side_event['user_data']['client_ip_address'],
-            decoded_dict['user_data']['client_ip_address']
+            server_side_event["user_data"]["client_ip_address"],
+            decoded_dict["user_data"]["client_ip_address"],
         )
         self.assertEqual(
-            server_side_event['user_data']['client_user_agent'],
-            decoded_dict['user_data']['client_user_agent']
+            server_side_event["user_data"]["client_user_agent"],
+            decoded_dict["user_data"]["client_user_agent"],
         )
         self.assertEqual(
-            server_side_event['user_data']['fbc'],
-            decoded_dict['user_data']['click_id']
+            server_side_event["user_data"]["fbc"], decoded_dict["user_data"]["click_id"]
         )
         self.assertEqual(
-            server_side_event['user_data']['fbp'],
-            decoded_dict['user_data']['login_id']
+            server_side_event["user_data"]["fbp"], decoded_dict["user_data"]["login_id"]
         )
-        self.assertEqual(
-            'Mobile Safari',
-            decoded_dict['user_data']['browser_name']
-        )
-        self.assertEqual(
-            'iOS',
-            decoded_dict['user_data']['device_os']
-        )
-        self.assertEqual(
-            '12.5.5',
-            decoded_dict['user_data']['device_os_version']
-        )
+        self.assertEqual("Mobile Safari", decoded_dict["user_data"]["browser_name"])
+        self.assertEqual("iOS", decoded_dict["user_data"]["device_os"])
+        self.assertEqual("12.5.5", decoded_dict["user_data"]["device_os_version"])
 
     def test_empty_user_data(self):
         record = {
-            'serverSideEvent': {
-                'event_time': 1234,
-                'custom_data': {'currency': 'usd', 'value': 2},
-                'event_name': 'Purchase',
-                'user_data': {},
-                'action_source': 'website'
+            "serverSideEvent": {
+                "event_time": 1234,
+                "custom_data": {"currency": "usd", "value": 2},
+                "event_name": "Purchase",
+                "user_data": {},
+                "action_source": "website",
             },
-            'pixelId': '4321'
+            "pixelId": "4321",
         }
         event = self.sample_event(record)
         result = lambda_handler(event, self.sample_context)
-        encoded_data = result['records'][0]['data']
+        encoded_data = result["records"][0]["data"]
         decoded_data = base64.b64decode(encoded_data)
         decoded_dict = json.loads(decoded_data)
 
-        self.assertEqual({}, decoded_dict['user_data'])
+        self.assertEqual({}, decoded_dict["user_data"])
 
     def test_required_user_fields(self):
-        fields = ['em', 'madid', 'ph', 'fbc', 'fbp']
+        fields = ["em", "madid", "ph", "fbc", "fbp"]
         for field in fields:
-            record =  {
-                'serverSideEvent': {
-                    'user_data': {
-                        field: 'test',
+            record = {
+                "serverSideEvent": {
+                    "user_data": {
+                        field: "test",
                     }
                 }
             }
             event = self.sample_event(record)
             result = lambda_handler(event, self.sample_context)
-            self.assertEqual(len(result['records']), 1)
+            self.assertEqual(len(result["records"]), 1)
 
     def test_parse_user_agent(self):
-        client_user_agent1 = ''.join([
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) ',
-            'AppleWebKit/537.36 (KHTML, like ',
-            'Gecko) Chrome/94.0.4606.81 Safari/537.36',
-        ])
+        client_user_agent1 = "".join(
+            [
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) ",
+                "AppleWebKit/537.36 (KHTML, like ",
+                "Gecko) Chrome/94.0.4606.81 Safari/537.36",
+            ]
+        )
         parsed1 = _parse_client_user_agent(client_user_agent1)
-        self.assertEqual(parsed1['browser_name'], 'Chrome Desktop')
-        self.assertEqual(parsed1['device_os'], 'Mac OS X')
-        self.assertEqual(parsed1['device_os_version'], '10.13.6')
+        self.assertEqual(parsed1["browser_name"], "Chrome Desktop")
+        self.assertEqual(parsed1["device_os"], "Mac OS X")
+        self.assertEqual(parsed1["device_os_version"], "10.13.6")
 
-        client_user_agent2 = ''.join([
-            'Mozilla/5.0 (Linux; Android 7.1.1; CPH1725) ',
-            'AppleWebKit/537.36 (KHTML, like Gecko) ',
-            'Chrome/93.0.4577.82 Mobile Safari/537.36',
-        ])
+        client_user_agent2 = "".join(
+            [
+                "Mozilla/5.0 (Linux; Android 7.1.1; CPH1725) ",
+                "AppleWebKit/537.36 (KHTML, like Gecko) ",
+                "Chrome/93.0.4577.82 Mobile Safari/537.36",
+            ]
+        )
         parsed2 = _parse_client_user_agent(client_user_agent2)
-        self.assertEqual(parsed2['browser_name'], 'Chrome Mobile')
-        self.assertEqual(parsed2['device_os'], 'Android')
-        self.assertEqual(parsed2['device_os_version'], '7.1.1')
+        self.assertEqual(parsed2["browser_name"], "Chrome Mobile")
+        self.assertEqual(parsed2["device_os"], "Android")
+        self.assertEqual(parsed2["device_os_version"], "7.1.1")
 
     def test_parse_user_agent_no_minor_version(self):
-        client_user_agent = ''.join([
-            'Mozilla/5.0 (Linux; Android 11.0; CPH1725) ',
-            'AppleWebKit/537.36 (KHTML, like Gecko) ',
-            'Chrome/93.0.4577.82 Mobile Safari/537.36',
-        ])
+        client_user_agent = "".join(
+            [
+                "Mozilla/5.0 (Linux; Android 11.0; CPH1725) ",
+                "AppleWebKit/537.36 (KHTML, like Gecko) ",
+                "Chrome/93.0.4577.82 Mobile Safari/537.36",
+            ]
+        )
         parsed = _parse_client_user_agent(client_user_agent)
 
-        self.assertEqual(parsed['browser_name'], 'Chrome Mobile')
-        self.assertEqual(parsed['device_os'], 'Android')
-        self.assertEqual(parsed['device_os_version'], '11.0')
+        self.assertEqual(parsed["browser_name"], "Chrome Mobile")
+        self.assertEqual(parsed["device_os"], "Android")
+        self.assertEqual(parsed["device_os_version"], "11.0")
 
     def sample_event(self, event):
-        sample_encoded_data = base64.b64encode(json.dumps(event).encode('utf-8'))
+        sample_encoded_data = base64.b64encode(json.dumps(event).encode("utf-8"))
         return {
             "invocationId": "invocationIdExample",
             "deliveryStreamArn": "arn:aws:kinesis:EXAMPLE",
@@ -208,7 +222,7 @@ class TestDataIngestion(TestCase):
                 {
                     "recordId": "49546986683135544286507457936321625675700192471156785154",
                     "approximateArrivalTimestamp": 1495072949453,
-                    "data": sample_encoded_data
+                    "data": sample_encoded_data,
                 }
-            ]
+            ],
         }

--- a/fbpcs/infra/cloud_bridge/data_validation/validation_utility/lambda_main.py
+++ b/fbpcs/infra/cloud_bridge/data_validation/validation_utility/lambda_main.py
@@ -3,98 +3,104 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import boto3
 import os
 import urllib
-import validation
-
 from datetime import datetime
 
-DEBUG_MODE = str(os.environ.get('VALIDATION_DEBUG_MODE')) == '1'
-DEFAULT_VALIDATION_RESULTS_S3_KEY = 'events-validation-results'
+import boto3
+import validation
+
+DEBUG_MODE = str(os.environ.get("VALIDATION_DEBUG_MODE")) == "1"
+DEFAULT_VALIDATION_RESULTS_S3_KEY = "events-validation-results"
+
 
 def debug_log(msg: str) -> None:
     if DEBUG_MODE:
-        print(f'{msg}\n')
+        print(f"{msg}\n")
 
-def write_result_to_s3(bucket_name: str, bucket_key: str, file_name: str, file_contents: str) -> None:
+
+def write_result_to_s3(
+    bucket_name: str, bucket_key: str, file_name: str, file_contents: str
+) -> None:
     debug_log(
-        '\n'.join([
-            'write_result_to_s3:',
-            f'bucket_name: {bucket_name}',
-            f'bucket_key: {bucket_key}',
-            f'file_name: {file_name}',
-            f'file_contents: {file_contents}',
-        ])
+        "\n".join(
+            [
+                "write_result_to_s3:",
+                f"bucket_name: {bucket_name}",
+                f"bucket_key: {bucket_key}",
+                f"file_name: {file_name}",
+                f"file_contents: {file_contents}",
+            ]
+        )
     )
-    s3_client = boto3.client('s3')
-    key = bucket_key + '/' + file_name
+    s3_client = boto3.client("s3")
+    key = bucket_key + "/" + file_name
     response = s3_client.put_object(
-        Body=file_contents.encode('utf-8'),
-        Bucket=bucket_name,
-        Key=key
+        Body=file_contents.encode("utf-8"), Bucket=bucket_name, Key=key
     )
     debug_log(response)
 
+
 def validate_and_generate_report(bucket: str, key: str) -> str:
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
     response = s3_client.get_object(Bucket=bucket, Key=key)
-    body = response['Body']
+    body = response["Body"]
     try:
         return validation.generate_from_body(body)
     except BaseException as e:
-        error_message = f'Something went wrong while validating the data. Exception details if available:\n{e}'
+        error_message = f"Something went wrong while validating the data. Exception details if available:\n{e}"
         debug_log(error_message)
         return error_message
 
+
 # context type is: awslambdaric.lambda_context.LambdaContext
 def lambda_handler(event, context):
-    output_bucket = os.environ.get('UPLOAD_AND_VALIDATION_S3_BUCKET')
+    output_bucket = os.environ.get("UPLOAD_AND_VALIDATION_S3_BUCKET")
     if not output_bucket:
-        raise Exception(f'Exception: missing output_bucket: `{output_bucket}`')
+        raise Exception(f"Exception: missing output_bucket: `{output_bucket}`")
 
-    output_key_override = os.environ.get('VALIDATION_RESULTS_S3_KEY')
+    output_key_override = os.environ.get("VALIDATION_RESULTS_S3_KEY")
 
     debug_log(
-        f'output bucket: {output_bucket}\noutput key override: {output_key_override}'
+        f"output bucket: {output_bucket}\noutput key override: {output_key_override}"
     )
 
     try:
-        for record in event['Records']:
-            input_bucket = record['s3']['bucket']['name']
-            input_key = urllib.parse.unquote_plus(record['s3']['object']['key'], encoding='utf-8')
-            debug_log(
-                f'input bucket: {input_bucket}\ninput key: {input_key}'
+        for record in event["Records"]:
+            input_bucket = record["s3"]["bucket"]["name"]
+            input_key = urllib.parse.unquote_plus(
+                record["s3"]["object"]["key"], encoding="utf-8"
             )
+            debug_log(f"input bucket: {input_bucket}\ninput key: {input_key}")
             validation_results = validate_and_generate_report(input_bucket, input_key)
 
-            path_split = input_key.split('/')
+            path_split = input_key.split("/")
             input_filename = path_split[-1]
-            input_key_path = '/'.join(path_split[:-1])
+            input_key_path = "/".join(path_split[:-1])
 
             if output_key_override:
-                output_key = f'{input_key_path}/{output_key_override}'
+                output_key = f"{input_key_path}/{output_key_override}"
             else:
-                output_key = f'{input_key_path}/{DEFAULT_VALIDATION_RESULTS_S3_KEY}'
+                output_key = f"{input_key_path}/{DEFAULT_VALIDATION_RESULTS_S3_KEY}"
 
-            debug_log(
-                f'output key: {output_key}'
+            debug_log(f"output key: {output_key}")
+
+            validation_result_file_path = "_".join(
+                [
+                    input_filename,
+                    "validation-results",
+                    datetime.now().isoformat(),
+                ]
             )
-
-            validation_result_file_path = '_'.join([
-                input_filename,
-                'validation-results',
-                datetime.now().isoformat(),
-            ])
 
             write_result_to_s3(
                 output_bucket,
                 output_key,
                 validation_result_file_path,
-                validation_results
+                validation_results,
             )
     except BaseException as e:
-        print(f'Unexpected error occurred: {e}')
+        print(f"Unexpected error occurred: {e}")
 
-    debug_log('Finished validation processing')
-    return {'records': []}
+    debug_log("Finished validation processing")
+    return {"records": []}

--- a/fbpcs/infra/cloud_bridge/data_validation/validation_utility/validation.py
+++ b/fbpcs/infra/cloud_bridge/data_validation/validation_utility/validation.py
@@ -223,9 +223,9 @@ def generate_from_body(body: StreamingBody) -> str:
         if not valid_line_ending:
             skip_row_processing_offset = 1 if valid_header_row else 0
             line_number = (
-                validation_state.total_rows +
-                HEADER_ROW_OFFSET +
-                skip_row_processing_offset
+                validation_state.total_rows
+                + HEADER_ROW_OFFSET
+                + skip_row_processing_offset
             )
             validation_state.validation_messages.extend(
                 [

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -11,6 +11,7 @@ from string import Template
 import boto3
 from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
+
 from .policy_params import PolicyParams
 
 
@@ -118,14 +119,15 @@ class AwsDeploymentHelper:
                     f"Unexpected error occured in deletion of user {user_name}"
                 )
 
-    def create_policy(self, policy_name: str, policy_params: PolicyParams, user_name: str = None):
+    def create_policy(
+        self, policy_name: str, policy_params: PolicyParams, user_name: str = None
+    ):
 
         # directly reading the json file from iam_policies folder
         # TODO: pass the policy to be added from cli.py when we need more granular control
 
         policy_json_data = self.read_json_file(
-            file_name="iam_policies/fb_pc_iam_policy.json",
-            policy_params=policy_params
+            file_name="iam_policies/fb_pc_iam_policy.json", policy_params=policy_params
         )
 
         try:
@@ -227,7 +229,9 @@ class AwsDeploymentHelper:
             )
         return access_key_list
 
-    def read_json_file(self, file_name: str, policy_params: PolicyParams, read_mode: str = "r"):
+    def read_json_file(
+        self, file_name: str, policy_params: PolicyParams, read_mode: str = "r"
+    ):
 
         # this can be replaced with a json file which is written in deploy.sh
         interpolation_data = {

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -44,8 +44,7 @@ class AwsDeploymentHelperTool:
                 ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
             )
             self.aws_deployment_helper_obj.create_policy(
-                policy_name=self.cli_args.policy_name,
-                policy_params=policy_params
+                policy_name=self.cli_args.policy_name, policy_params=policy_params
             )
 
     def destroy(self):

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -5,6 +5,7 @@
 
 from dataclasses import dataclass
 
+
 @dataclass
 class PolicyParams:
     firehose_stream_name: str

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py
@@ -18,7 +18,7 @@ client = boto3.client("glue")
 
 # Variables for the job:
 # same name as the aws_glue_job resource in glue.tf
-glueJobName = 'TO_BE_UPDATED_DURING_DEPLOYMENT'
+glueJobName = "TO_BE_UPDATED_DURING_DEPLOYMENT"
 
 # Define Lambda function
 def lambda_handler(event, context):
@@ -38,7 +38,7 @@ def lambda_handler(event, context):
         s3_bucket = s3_info["bucket"]["name"]
         s3_object_key = s3_info["object"]["key"]
         s3_read_path = s3_bucket + "/" + s3_object_key
-        s3_write_path = 'TO_BE_UPDATED_DURING_DEPLOYMENT'
+        s3_write_path = "TO_BE_UPDATED_DURING_DEPLOYMENT"
         logger.info("s3_read_path: " + s3_read_path)
         response = client.start_job_run(
             JobName=glueJobName,

--- a/fbpcs/onedocker_binary_names.py
+++ b/fbpcs/onedocker_binary_names.py
@@ -11,15 +11,15 @@ from enum import Enum
 
 class OneDockerBinaryNames(Enum):
     ATTRIBUTION_ID_SPINE_COMBINER = "data_processing/attribution_id_combiner"
-    LIFT_ID_SPINE_COMBINER        = "data_processing/lift_id_combiner"
-    SHARDER                       = "data_processing/sharder"
-    SHARDER_HASHED_FOR_PID        = "data_processing/sharder_hashed_for_pid"
-    UNION_PID_PREPARER            = "data_processing/pid_preparer"
+    LIFT_ID_SPINE_COMBINER = "data_processing/lift_id_combiner"
+    SHARDER = "data_processing/sharder"
+    SHARDER_HASHED_FOR_PID = "data_processing/sharder_hashed_for_pid"
+    UNION_PID_PREPARER = "data_processing/pid_preparer"
 
     DECOUPLED_ATTRIBUTION = "private_attribution/decoupled_attribution"
     DECOUPLED_AGGREGATION = "private_attribution/decoupled_aggregation"
     ATTRIBUTION_COMPUTE = "private_attribution/compute"
-    SHARD_AGGREGATOR    = "private_attribution/shard-aggregator"
+    SHARD_AGGREGATOR = "private_attribution/shard-aggregator"
 
     PID_CLIENT = "pid/private-id-client"
     PID_SERVER = "pid/private-id-server"

--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -63,7 +63,9 @@ class PIDInstance(InstanceBase):
     data_path: Optional[str] = None
     spine_path: Optional[str] = None
     hmac_key: Optional[str] = None
-    stages_containers: Dict[UnionPIDStage, List[ContainerInstance]] = field(default_factory=dict)
+    stages_containers: Dict[UnionPIDStage, List[ContainerInstance]] = field(
+        default_factory=dict
+    )
     stages_status: Dict[UnionPIDStage, PIDStageStatus] = field(default_factory=dict)
     status: PIDInstanceStatus = PIDInstanceStatus.UNKNOWN
     current_stage: Optional[UnionPIDStage] = None

--- a/fbpcs/pid/service/pid_service/pid_execution_map.py
+++ b/fbpcs/pid/service/pid_service/pid_execution_map.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Dict
+
 from fbpcs.pid.entity.pid_instance import PIDProtocol, PIDRole
 from fbpcs.pid.entity.pid_stages import PIDFlowUnsupportedError, UnionPIDStage
 from fbpcs.pid.service.pid_service.pid_flow_structs import (
     PIDExecutionFlowLookupKey,
     PIDFlow,
 )
-from typing import Dict
 
 
 UnionPIDPublisherFlow = PIDFlow(

--- a/fbpcs/pid/service/pid_service/tests/test_pid.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid.py
@@ -18,9 +18,9 @@ from fbpcs.pid.entity.pid_instance import (
     PIDProtocol,
     PIDRole,
 )
+from fbpcs.pid.entity.pid_stages import UnionPIDStage
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.pid.service.pid_service.pid_dispatcher import PIDDispatcher
-from fbpcs.pid.entity.pid_stages import UnionPIDStage
 
 
 TEST_INSTANCE_ID = "123"

--- a/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
@@ -20,7 +20,6 @@ from libfb.py.asyncio.mock import AsyncMock
 from libfb.py.testutil import data_provider
 
 
-
 class TestPIDProtocolRunStage(unittest.TestCase):
     def setUp(self):
         self.onedocker_binary_config = OneDockerBinaryConfig(
@@ -71,7 +70,9 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         ip = "192.0.2.0"
         container = ContainerInstance(instance_id="123", ip_address=ip)
         mock_onedocker_service.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_service.wait_for_pending_containers = AsyncMock(return_value=[container])
+        mock_onedocker_service.wait_for_pending_containers = AsyncMock(
+            return_value=[container]
+        )
         container.status = (
             ContainerInstanceStatus.COMPLETED
             if wait_for_containers
@@ -166,8 +167,14 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         ip = "192.0.2.0"
         container = ContainerInstance(instance_id="123", ip_address=ip)
         mock_onedocker_service.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_service.wait_for_pending_containers = AsyncMock(return_value=[container])
-        container.status = ContainerInstanceStatus.COMPLETED if wait_for_containers else ContainerInstanceStatus.STARTED
+        mock_onedocker_service.wait_for_pending_containers = AsyncMock(
+            return_value=[container]
+        )
+        container.status = (
+            ContainerInstanceStatus.COMPLETED
+            if wait_for_containers
+            else ContainerInstanceStatus.STARTED
+        )
         mock_wait_for_containers_async.return_value = [container]
 
         with patch.object(
@@ -205,8 +212,12 @@ class TestPIDProtocolRunStage(unittest.TestCase):
             # if we are waiting for containers, then the stage should finish
             # otherwise, it should start and then return
             self.assertEqual(
-                PIDStageStatus.COMPLETED if wait_for_containers else PIDStageStatus.STARTED,
-                await adv_run_stage.run(stage_input=stage_input, wait_for_containers=wait_for_containers),
+                PIDStageStatus.COMPLETED
+                if wait_for_containers
+                else PIDStageStatus.STARTED,
+                await adv_run_stage.run(
+                    stage_input=stage_input, wait_for_containers=wait_for_containers
+                ),
             )
 
             # Check create_instances_async was called with the correct parameters

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -46,7 +46,9 @@ class TestPIDShardStage(unittest.TestCase):
     @data_provider(
         lambda: ({"wait_for_containers": True}, {"wait_for_containers": False})
     )
-    @patch("fbpcs.data_processing.service.sharding_service.ShardingService.wait_for_containers_async")
+    @patch(
+        "fbpcs.data_processing.service.sharding_service.ShardingService.wait_for_containers_async"
+    )
     @patch("fbpcp.service.storage.StorageService")
     @patch("fbpcp.service.onedocker.OneDockerService")
     @patch("fbpcs.pid.repository.pid_instance.PIDInstanceRepository")

--- a/fbpcs/pl_coordinator/pc_calc_instance.py
+++ b/fbpcs/pl_coordinator/pc_calc_instance.py
@@ -18,14 +18,14 @@ from fbpcs.pl_coordinator.constants import (
 )
 from fbpcs.pl_coordinator.exceptions import PLInstanceCalculationException
 from fbpcs.pl_coordinator.pl_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 
 

--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -12,9 +12,6 @@ from typing import Any, Dict, List, Optional
 
 from fbpcs.pl_coordinator.constants import WAIT_VALID_STATUS_TIMEOUT
 from fbpcs.pl_coordinator.pc_calc_instance import PrivateLiftCalcInstance
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -27,6 +24,9 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     cancel_current_stage,

--- a/fbpcs/pl_coordinator/pc_publisher_instance.py
+++ b/fbpcs/pl_coordinator/pc_publisher_instance.py
@@ -17,14 +17,14 @@ from fbpcs.pl_coordinator.pl_graphapi_utils import (
     GraphAPIGenericException,
     PLGraphAPIClient,
 )
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 
 

--- a/fbpcs/pl_coordinator/pl_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pl_graphapi_utils.py
@@ -79,7 +79,13 @@ class PLGraphAPIClient:
         return r
 
     def create_pa_instance(
-        self, dataset_id: str, attribution_rule: str, start_date: str, end_date: str, num_containers: str, result_type: str
+        self,
+        dataset_id: str,
+        attribution_rule: str,
+        start_date: str,
+        end_date: str,
+        num_containers: str,
+        result_type: str,
     ) -> requests.Response:
         params = self.params.copy()
         params["attribution_rule"] = attribution_rule
@@ -90,7 +96,6 @@ class PLGraphAPIClient:
         r = requests.post(f"{URL}/{dataset_id}/instance", params=params)
         self._check_err(r, "creating fb pa instance")
         return r
-
 
     def invoke_operation(self, instance_id: str, operation: str) -> None:
         params = self.params.copy()
@@ -108,7 +113,9 @@ class PLGraphAPIClient:
         self._check_err(r, "getting study data")
         return r
 
-    def get_attribution_dataset_info(self, dataset_id: str, fields: List[str]) -> requests.Response:
+    def get_attribution_dataset_info(
+        self, dataset_id: str, fields: List[str]
+    ) -> requests.Response:
         params = self.params.copy()
         params["fields"] = ",".join(fields)
         r = requests.get(f"{URL}/{dataset_id}", params=params)

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -27,9 +27,6 @@ from fbpcs.pl_coordinator.exceptions import PLInstanceCalculationException
 from fbpcs.pl_coordinator.pc_partner_instance import PrivateLiftPartnerInstance
 from fbpcs.pl_coordinator.pc_publisher_instance import PrivateLiftPublisherInstance
 from fbpcs.pl_coordinator.pl_graphapi_utils import PLGraphAPIClient
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -39,6 +36,9 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 
 
@@ -88,7 +88,7 @@ def run_instance(
         aggregation_type,
         concurrency,
         num_files_per_mpc_container,
-        k_anonymity_threshold
+        k_anonymity_threshold,
     )
     logger.info(f"Running private lift for instance {instance_id}")
     instance_runner.run()

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -23,11 +23,11 @@ from fbpcs.pl_coordinator.pl_graphapi_utils import (
 from fbpcs.pl_coordinator.pl_instance_runner import (
     run_instances,
 )
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 
 # study information fields

--- a/fbpcs/post_processing_handler/tests/dummy_handler.py
+++ b/fbpcs/post_processing_handler/tests/dummy_handler.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from fbpcs.post_processing_handler.exception import PostProcessingHandlerRuntimeError
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
+
 if TYPE_CHECKING:
     from fbpcs.private_computation.entity.private_computation_instance import (
         PrivateComputationInstance,

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -12,10 +12,11 @@ from enum import Enum
 from typing import List, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Type
+
     from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
         PrivateComputationBaseStageFlow,
     )
-    from typing import Type
 
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcs.common.entity.instance_base import InstanceBase

--- a/fbpcs/private_computation/entity/private_computation_status.py
+++ b/fbpcs/private_computation/entity/private_computation_status.py
@@ -8,6 +8,7 @@
 
 from enum import Enum
 
+
 class PrivateComputationInstanceStatus(Enum):
     UNKNOWN = "UNKNOWN"
     CREATION_STARTED = "CREATION_STARTED"

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -22,8 +22,8 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )

--- a/fbpcs/private_computation/service/dummy_stage_service.py
+++ b/fbpcs/private_computation/service/dummy_stage_service.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
-    PrivateComputationInstanceStatus
+    PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -45,4 +45,3 @@ class DummyStageService(PrivateComputationStageService):
         Does nothing except return pc_instance.status back to caller
         """
         return pc_instance.status
-

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 
-from fbpcs.private_computation.entity.private_computation_instance import PrivateComputationInstanceStatus
 import asyncio
 import logging
 from typing import Dict, List, Optional
@@ -23,6 +22,9 @@ from fbpcs.post_processing_handler.post_processing_instance import (
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -117,7 +119,6 @@ class PostProcessingStageService(PrivateComputationStageService):
             pc_instance.status = pc_instance.current_stage.completed_status
         return pc_instance
 
-
     async def _run_post_processing_handler(
         self,
         private_computation_instance: PrivateComputationInstance,
@@ -143,7 +144,6 @@ class PostProcessingStageService(PrivateComputationStageService):
             ] = PostProcessingHandlerStatus.FAILED
             post_processing_instance.status = PostProcessingInstanceStatus.FAILED
 
-
     def get_status(
         self,
         pc_instance: PrivateComputationInstance,
@@ -168,7 +168,10 @@ class PostProcessingStageService(PrivateComputationStageService):
             stage = pc_instance.current_stage
             if post_processing_instance_status is PostProcessingInstanceStatus.STARTED:
                 status = stage.started_status
-            elif post_processing_instance_status is PostProcessingInstanceStatus.COMPLETED:
+            elif (
+                post_processing_instance_status
+                is PostProcessingInstanceStatus.COMPLETED
+            ):
                 status = stage.completed_status
             elif post_processing_instance_status is PostProcessingInstanceStatus.FAILED:
                 status = stage.failed_status

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -21,12 +21,6 @@ from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
 from fbpcs.private_computation.entity.pce_config import PCEConfig
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -34,9 +28,6 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
-)
-from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
-    PrivateComputationStageFlow,
 )
 from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
@@ -60,6 +51,15 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageServiceArgs,
 )
 from fbpcs.private_computation.service.utils import get_log_urls
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
+    PrivateComputationDecoupledStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
+)
 from fbpcs.utils.optional import unwrap_or_default
 
 T = TypeVar("T")

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -229,7 +229,9 @@ def get_log_urls(
             return res
         containers = last_instance.stages_containers[pid_current_stage]
         for i, container in enumerate(containers):
-            res[f"{pid_current_stage}_{i}"] = log_retriever.get_log_url(container.instance_id)
+            res[f"{pid_current_stage}_{i}"] = log_retriever.get_log_url(
+                container.instance_id
+            )
     elif isinstance(last_instance, PCSMPCInstance):
         containers = last_instance.containers
         for i, container in enumerate(containers):

--- a/fbpcs/private_computation/stage_flows/exceptions.py
+++ b/fbpcs/private_computation/stage_flows/exceptions.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+
 class PCStageFlowException(Exception):
     pass
+
 
 class PCStageFlowNotFoundException(PCStageFlowException):
     pass

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -4,10 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-    PrivateComputationStageFlowData,
-)
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -29,6 +25,10 @@ from fbpcs.private_computation.service.prepare_data_stage_service import (
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
 )
 
 

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -4,10 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-    PrivateComputationStageFlowData,
-)
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -34,6 +30,10 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
+)
 
 
 class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
@@ -51,9 +51,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = (
-        "CREATED ID_MATCH PREPARE DECOUPLED_ATTRIBUTION DECOUPLED_AGGREGATION AGGREGATE POST_PROCESSING_HANDLERS"
-    )
+    _order_ = "CREATED ID_MATCH PREPARE DECOUPLED_ATTRIBUTION DECOUPLED_AGGREGATION AGGREGATE POST_PROCESSING_HANDLERS"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -4,10 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-    PrivateComputationStageFlowData,
-)
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -29,6 +25,10 @@ from fbpcs.private_computation.service.prepare_data_stage_service import (
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
 )
 
 

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -5,10 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from fbpcs.pid.entity.pid_instance import UnionPIDStage
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-    PrivateComputationStageFlowData,
-)
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -31,6 +27,10 @@ from fbpcs.private_computation.service.prepare_data_stage_service import (
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
 )
 
 

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -11,9 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationInstanceStatus,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AttributionRule,
     PrivateComputationGameType,
@@ -27,6 +24,9 @@ from fbpcs.private_computation.service.constants import (
 )
 from fbpcs.private_computation.service.decoupled_aggregation_stage_service import (
     AggregationStageService,
+)
+from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
+    PrivateComputationInstanceStatus,
 )
 
 

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -25,21 +25,12 @@ from fbpcs.pid.entity.pid_instance import (
     UnionPIDStage,
 )
 from fbpcs.pid.service.pid_service.pid import PIDService
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
     UnionedPCInstance,
-)
-from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
-    PrivateComputationStageFlow,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.errors import (
@@ -59,6 +50,15 @@ from fbpcs.private_computation.service.utils import (
     gen_mpc_game_args_to_retry,
     map_private_computation_role_to_mpc_party,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
+    PrivateComputationDecoupledStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
 )
 
 # TODO T94666166: libfb won't work in OSS

--- a/fbpcs/private_computation/test/service/test_wait_for_containers.py
+++ b/fbpcs/private_computation/test/service/test_wait_for_containers.py
@@ -15,6 +15,7 @@ from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
 
+
 class TestWaitForContainersAsync(IsolatedAsyncioTestCase):
     @patch("fbpcp.service.container.ContainerService")
     def setUp(self, MockContainerService):

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -42,19 +42,19 @@ from docopt import docopt
 from fbpcp.util import yaml
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
 from fbpcs.pl_coordinator.pl_study_runner import run_study
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
     PrivateComputationRole,
     PrivateComputationGameType,
 )
+from fbpcs.private_computation.pc_attribution_runner import get_attribution_dataset_info
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
 )
-from fbpcs.private_computation.pc_attribution_runner import get_attribution_dataset_info
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     cancel_current_stage,
     create_instance,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -23,9 +23,6 @@ from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.repository.pid_instance import PIDInstanceRepository
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -38,6 +35,9 @@ from fbpcs.private_computation.repository.private_computation_instance import (
 )
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 from fbpcs.utils.config_yaml import reflect
 

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -17,9 +17,6 @@ from fbpcs.pl_coordinator.pl_instance_runner import (
     PLInstanceRunner,
     PLInstanceCalculationException,
 )
-from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
-    PrivateComputationBaseStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -31,11 +28,14 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )
-from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
-    PrivateComputationStageFlow,
-)
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
 )
 
 

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -71,7 +71,6 @@ class TestPrivateComputationCli(TestCase):
         pc_cli.main(argv)
         validate_mock.assert_called_once()
 
-
     @patch("fbpcs.private_computation_cli.private_computation_cli.run_next")
     def test_run_next(self, run_next_mock):
         argv = [
@@ -241,9 +240,12 @@ class TestPrivateComputationCli(TestCase):
         ]
         pc_cli.main(argv)
         print_instance_mock.assert_called_once()
-    @patch("fbpcs.private_computation_cli.private_computation_cli.get_attribution_dataset_info")
+
+    @patch(
+        "fbpcs.private_computation_cli.private_computation_cli.get_attribution_dataset_info"
+    )
     def test_get_attribution_dataset_info(self, get_attribution_dataset_info_mock):
-        argv=[
+        argv = [
             "get_attribution_dataset_info",
             "--dataset_id=dataset123",
             f"--config={self.temp_filename}",

--- a/fbpcs/scripts/tests/test_gen_config.py
+++ b/fbpcs/scripts/tests/test_gen_config.py
@@ -38,11 +38,7 @@ class TestGenConfig(unittest.TestCase):
             self.assertEqual(res, "baz")
 
     def test_build_replacements_from_config(self):
-        config = {
-            "a": "123",
-            "b": ["1", "2", "3"],
-            "c": {"d": "e"}
-        }
+        config = {"a": "123", "b": ["1", "2", "3"], "c": {"d": "e"}}
         # This will look weird, but basically we expect to keep all "leaf"
         # nodes as replacement values, but also including basic lists
         expected = {

--- a/fbpcs/stage_flow/stage_flow.py
+++ b/fbpcs/stage_flow/stage_flow.py
@@ -64,7 +64,9 @@ class StageFlowMeta(EnumMeta):
         try:
             return super().__getitem__(item.upper())
         except KeyError:
-            raise StageFlowStageNotFoundError(f"{item} is not a stage in {self.__name__}. Valid stages: {self!r}") from None
+            raise StageFlowStageNotFoundError(
+                f"{item} is not a stage in {self.__name__}. Valid stages: {self!r}"
+            ) from None
 
 
 class StageFlow(Enum, metaclass=StageFlowMeta):

--- a/fbpcs/stage_flow/test/dummy_stage_flow.py
+++ b/fbpcs/stage_flow/test/dummy_stage_flow.py
@@ -23,8 +23,8 @@ class DummyStageFlowStatus(Enum):
     STAGE_3_FAILED = auto()
 
 
-
 DummyStageFlowData = StageFlowData[DummyStageFlowStatus]
+
 
 class DummyStageFlow(StageFlow):
     STAGE_1 = DummyStageFlowData(
@@ -42,4 +42,3 @@ class DummyStageFlow(StageFlow):
         DummyStageFlowStatus.STAGE_3_COMPLETED,
         DummyStageFlowStatus.STAGE_3_FAILED,
     )
-

--- a/fbpcs/utils/config_yaml/config_yaml_dict.py
+++ b/fbpcs/utils/config_yaml/config_yaml_dict.py
@@ -5,7 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any, Dict
+
 from fbpcs.utils.config_yaml.exceptions import ConfigYamlFieldNotFoundError
+
 
 class ConfigYamlDict(Dict[str, Any]):
     """Wrapper around dict that throws a custom KeyError exception to inform the user
@@ -33,4 +35,3 @@ class ConfigYamlDict(Dict[str, Any]):
         for k, v in d.items():
             my_dict[k] = v
         return my_dict
-

--- a/fbpcs/utils/config_yaml/exceptions.py
+++ b/fbpcs/utils/config_yaml/exceptions.py
@@ -6,14 +6,18 @@
 
 # pyre-strict
 
+
 class ConfigYamlFieldNotFoundError(KeyError):
     """Raised when a ConfigYamlDict key access fails"""
+
     def __init__(self, key: str) -> None:
         msg = f"{key} is expected in your config.yml file but was not found. Please make sure your config is up to date."
         super().__init__(msg)
 
+
 class ConfigYamlModuleImportError(ImportError):
     """Raised when a module path cannot be imported"""
+
     def __init__(self, class_path: str) -> None:
         msg = f"{class_path} (specified in your config.yml) could not be imported (module not found). Please make sure that your config is up to date."
         super().__init__(msg)
@@ -21,6 +25,7 @@ class ConfigYamlModuleImportError(ImportError):
 
 class ConfigYamlClassNotFoundError(AttributeError):
     """Raised when a class is not found at a given module path"""
+
     def __init__(self, class_path: str) -> None:
         msg = f"{class_path} (specified in your config.yml) could not be imported (class not found). Please make sure that your config is up to date."
         super().__init__(msg)
@@ -28,13 +33,15 @@ class ConfigYamlClassNotFoundError(AttributeError):
 
 class ConfigYamlWrongClassConfiguredError(AssertionError):
     """Raised when the type of a class loaded through reflection is different than expected"""
+
     def __init__(self, class_path: str, target_class_name: str) -> None:
         msg = f"{class_path} (specified in your config.yml) is the wrong type - it should be a {target_class_name}. Please make sure that your config is up to date."
         super().__init__(msg)
 
+
 class ConfigYamlWrongConstructorError(TypeError):
     """Raised when the arguments passed to a constructor are incorrect"""
+
     def __init__(self, class_name: str, cause: str) -> None:
         msg = f"{class_name} (specified in your config.yml) does not have the correct arguments. {cause}. Please make sure that your config is up to date."
         super().__init__(msg)
-

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -18,6 +18,7 @@ from fbpcs.utils.config_yaml.exceptions import (
 
 T = TypeVar("T")
 
+
 def get_class(class_path: str, target_class: Type[T]) -> Type[T]:
     """Convert a python module class path to a class object. Class path expected to be extracted from private computation config.yml file.
 
@@ -45,6 +46,7 @@ def get_class(class_path: str, target_class: Type[T]) -> Type[T]:
             class_path, target_class.__name__
         ) from None
     return cls
+
 
 def get_instance(config: Dict[str, Any], target_class: Type[T]) -> T:
     """Constructs an instance of type target_class from config.yml dict structure.


### PR DESCRIPTION
Summary:
## What

* Enable black autoformatting on our fbpcs python files
* Followed instructions here to opt-in: https://fb.prod.workplace.com/groups/pythonfoundation/permalink/2990917737888352/

## Why

* This makes it so that `arc lint` applies black on our files
* I already run black on all of my diffs (it's integrated into my vim configuration), now you can too :p
* The code is much cleaner this way

Differential Revision: D33001503

