### PR TITLE
stageflow store dynamically generated status

### DIFF
--- a/fbpcs/stage_flow/stage_flow.py
+++ b/fbpcs/stage_flow/stage_flow.py
@@ -119,6 +119,8 @@ class StageFlow(Enum, metaclass=StageFlowMeta):
         """Post hook ran after class instantiation. Initialize the started status map."""
         super().__init_subclass__()
         cls._stage_flow_started_statuses = set()
+        cls._stage_flow_completed_statuses = set()
+        cls._stage_flow_failed_statuses = set()
 
     def __new__(cls: Type[C], data: StageFlowData[Status]) -> C:
         """Override instance creation to map from status -> stage and add start statuses to set"""
@@ -131,6 +133,10 @@ class StageFlow(Enum, metaclass=StageFlowMeta):
 
         if data.started_status:
             cls._stage_flow_started_statuses.add(data.started_status)
+        if data.completed_status:
+            cls._stage_flow_completed_statuses.add(data.completed_status)
+        if data.failed_status:
+            cls._stage_flow_failed_statuses.add(data.failed_status)
 
         return member
 
@@ -215,6 +221,14 @@ class StageFlow(Enum, metaclass=StageFlowMeta):
     @classmethod
     def is_started_status(cls: Type[C], status: Status) -> bool:
         return status in cls._stage_flow_started_statuses
+
+    @classmethod
+    def is_completed_status(cls: Type[C], status: Status) -> bool:
+        return status in cls._stage_flow_completed_statuses
+
+    @classmethod
+    def is_failed_status(cls: Type[C], status: Status) -> bool:
+        return status in cls._stage_flow_failed_statuses
 
     @cached_property
     def next_stage(self: C) -> Optional[C]:

--- a/fbpcs/stage_flow/test/test_stage_flow.py
+++ b/fbpcs/stage_flow/test/test_stage_flow.py
@@ -59,6 +59,58 @@ class TestStageFlow(TestCase):
             )
         )
 
+    def test_is_completed_status(self):
+        completed_statuses = [
+            DummyStageFlowStatus.STAGE_1_COMPLETED,
+            DummyStageFlowStatus.STAGE_2_COMPLETED,
+            DummyStageFlowStatus.STAGE_3_COMPLETED,
+        ]
+        other_statuses = [
+            DummyStageFlowStatus.STAGE_1_FAILED,
+            DummyStageFlowStatus.STAGE_1_STARTED,
+            DummyStageFlowStatus.STAGE_2_FAILED,
+            DummyStageFlowStatus.STAGE_2_STARTED,
+            DummyStageFlowStatus.STAGE_3_FAILED,
+            DummyStageFlowStatus.STAGE_3_STARTED,
+        ]
+
+        self.assertTrue(
+            all(
+                DummyStageFlow.is_completed_status(status)
+                for status in completed_statuses
+            )
+        )
+        self.assertTrue(
+            all(
+                not DummyStageFlow.is_completed_status(status)
+                for status in other_statuses
+            )
+        )
+
+    def test_is_failed_status(self):
+        failed_statuses = [
+            DummyStageFlowStatus.STAGE_1_FAILED,
+            DummyStageFlowStatus.STAGE_2_FAILED,
+            DummyStageFlowStatus.STAGE_3_FAILED,
+        ]
+        other_statuses = [
+            DummyStageFlowStatus.STAGE_1_COMPLETED,
+            DummyStageFlowStatus.STAGE_1_STARTED,
+            DummyStageFlowStatus.STAGE_2_COMPLETED,
+            DummyStageFlowStatus.STAGE_2_STARTED,
+            DummyStageFlowStatus.STAGE_3_COMPLETED,
+            DummyStageFlowStatus.STAGE_3_STARTED,
+        ]
+
+        self.assertTrue(
+            all(DummyStageFlow.is_failed_status(status) for status in failed_statuses)
+        )
+        self.assertTrue(
+            all(
+                not DummyStageFlow.is_failed_status(status) for status in other_statuses
+            )
+        )
+
     def test_get_stage_from_status(self):
         stage_1_statuses = [
             DummyStageFlowStatus.STAGE_1_COMPLETED,


### PR DESCRIPTION
Summary:
## What

* Stage flow now dynamically stores failed and complete statuses in a set on the class (it already stores started status)

## Why

* I wrote this stack in October and forgot to submit it. Whoops
* Will be used to bring "cancel stage" support to decoupled attribution stages (and any other future MPC stage) in the next diff

Differential Revision: D33010578

