### PR TITLE
use dynamically generated start and failed statuses

### DIFF
--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -31,22 +31,6 @@ NUM_NEW_SHARDS_PER_FILE: int = round(
     MAX_ROWS_PER_PID_CONTAINER / TARGET_ROWS_PER_MPC_CONTAINER
 )
 
-# List of stages with 'STARTED' status.
-STAGE_STARTED_STATUSES: List[PrivateComputationInstanceStatus] = [
-    PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
-    PrivateComputationInstanceStatus.COMPUTATION_STARTED,
-    PrivateComputationInstanceStatus.AGGREGATION_STARTED,
-    PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,
-]
-
-# List of stages with 'FAILED' status.
-STAGE_FAILED_STATUSES: List[PrivateComputationInstanceStatus] = [
-    PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
-    PrivateComputationInstanceStatus.COMPUTATION_FAILED,
-    PrivateComputationInstanceStatus.AGGREGATION_FAILED,
-    PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
-]
-
 DEFAULT_K_ANONYMITY_THRESHOLD = 100
 DEFAULT_PID_PROTOCOL: PIDProtocol = PIDProtocol.UNION_PID
 DEFAULT_HMAC_KEY: str = ""

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -34,8 +34,6 @@ from fbpcs.private_computation.repository.private_computation_instance import (
 )
 from fbpcs.private_computation.service.constants import (
     NUM_NEW_SHARDS_PER_FILE,
-    STAGE_STARTED_STATUSES,
-    STAGE_FAILED_STATUSES,
     DEFAULT_CONCURRENCY,
     DEFAULT_HMAC_KEY,
     DEFAULT_K_ANONYMITY_THRESHOLD,
@@ -349,7 +347,9 @@ class PrivateComputationService:
         private_computation_instance = self.get_instance(instance_id)
 
         # pre-checks to make sure it's in a cancel-able state
-        if private_computation_instance.status not in STAGE_STARTED_STATUSES:
+        if not private_computation_instance.stage_flow.is_started_status(
+            private_computation_instance.status
+        ):
             raise ValueError(
                 f"Instance {instance_id} has status {private_computation_instance.status}. Nothing to cancel."
             )
@@ -373,7 +373,10 @@ class PrivateComputationService:
         private_computation_instance = self._update_instance(
             private_computation_instance=private_computation_instance
         )
-        if private_computation_instance.status not in STAGE_FAILED_STATUSES:
+
+        if not private_computation_instance.stage_flow.is_failed_status(
+            private_computation_instance.status
+        ):
             raise ValueError(
                 f"Failed to cancel the current stage unexpectedly. Instance {instance_id} has status {private_computation_instance.status}"
             )

--- a/fbpcs/stage_flow/stage_flow.py
+++ b/fbpcs/stage_flow/stage_flow.py
@@ -119,6 +119,8 @@ class StageFlow(Enum, metaclass=StageFlowMeta):
         """Post hook ran after class instantiation. Initialize the started status map."""
         super().__init_subclass__()
         cls._stage_flow_started_statuses = set()
+        cls._stage_flow_completed_statuses = set()
+        cls._stage_flow_failed_statuses = set()
 
     def __new__(cls: Type[C], data: StageFlowData[Status]) -> C:
         """Override instance creation to map from status -> stage and add start statuses to set"""
@@ -131,6 +133,10 @@ class StageFlow(Enum, metaclass=StageFlowMeta):
 
         if data.started_status:
             cls._stage_flow_started_statuses.add(data.started_status)
+        if data.completed_status:
+            cls._stage_flow_completed_statuses.add(data.completed_status)
+        if data.failed_status:
+            cls._stage_flow_failed_statuses.add(data.failed_status)
 
         return member
 
@@ -215,6 +221,14 @@ class StageFlow(Enum, metaclass=StageFlowMeta):
     @classmethod
     def is_started_status(cls: Type[C], status: Status) -> bool:
         return status in cls._stage_flow_started_statuses
+
+    @classmethod
+    def is_completed_status(cls: Type[C], status: Status) -> bool:
+        return status in cls._stage_flow_completed_statuses
+
+    @classmethod
+    def is_failed_status(cls: Type[C], status: Status) -> bool:
+        return status in cls._stage_flow_failed_statuses
 
     @cached_property
     def next_stage(self: C) -> Optional[C]:

--- a/fbpcs/stage_flow/test/test_stage_flow.py
+++ b/fbpcs/stage_flow/test/test_stage_flow.py
@@ -59,6 +59,58 @@ class TestStageFlow(TestCase):
             )
         )
 
+    def test_is_completed_status(self):
+        completed_statuses = [
+            DummyStageFlowStatus.STAGE_1_COMPLETED,
+            DummyStageFlowStatus.STAGE_2_COMPLETED,
+            DummyStageFlowStatus.STAGE_3_COMPLETED,
+        ]
+        other_statuses = [
+            DummyStageFlowStatus.STAGE_1_FAILED,
+            DummyStageFlowStatus.STAGE_1_STARTED,
+            DummyStageFlowStatus.STAGE_2_FAILED,
+            DummyStageFlowStatus.STAGE_2_STARTED,
+            DummyStageFlowStatus.STAGE_3_FAILED,
+            DummyStageFlowStatus.STAGE_3_STARTED,
+        ]
+
+        self.assertTrue(
+            all(
+                DummyStageFlow.is_completed_status(status)
+                for status in completed_statuses
+            )
+        )
+        self.assertTrue(
+            all(
+                not DummyStageFlow.is_completed_status(status)
+                for status in other_statuses
+            )
+        )
+
+    def test_is_failed_status(self):
+        failed_statuses = [
+            DummyStageFlowStatus.STAGE_1_FAILED,
+            DummyStageFlowStatus.STAGE_2_FAILED,
+            DummyStageFlowStatus.STAGE_3_FAILED,
+        ]
+        other_statuses = [
+            DummyStageFlowStatus.STAGE_1_COMPLETED,
+            DummyStageFlowStatus.STAGE_1_STARTED,
+            DummyStageFlowStatus.STAGE_2_COMPLETED,
+            DummyStageFlowStatus.STAGE_2_STARTED,
+            DummyStageFlowStatus.STAGE_3_COMPLETED,
+            DummyStageFlowStatus.STAGE_3_STARTED,
+        ]
+
+        self.assertTrue(
+            all(DummyStageFlow.is_failed_status(status) for status in failed_statuses)
+        )
+        self.assertTrue(
+            all(
+                not DummyStageFlow.is_failed_status(status) for status in other_statuses
+            )
+        )
+
     def test_get_stage_from_status(self):
         stage_1_statuses = [
             DummyStageFlowStatus.STAGE_1_COMPLETED,


### PR DESCRIPTION
Summary:
## What

* Use `is_started_status` and `is_failed_status` stage flow APIs in PCS `cancel_stage`

## Why

* Hardcoded list of statuses are bad
* Before my diff, the decoupled attribution MPC stages were not valid stages for cancel_stage api. Post diff, they are supported.

Differential Revision: D33010577

