### PR TITLE
test constructor with initializer for column class

### DIFF
--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -80,11 +80,10 @@ TEST(ColumnTest, FromVectorRValueReference) {
 }
 
 TEST(ColumnTest, FromInitializerList) {
-  Column<int64_t> c{2, 4, 6};
-  ASSERT_EQ(c.size(), 3);
+  Column<int64_t> c{2, 4};
+  ASSERT_EQ(c.size(), 2);
   EXPECT_EQ(c.at(0), 2);
   EXPECT_EQ(c.at(1), 4);
-  EXPECT_EQ(c.at(2), 6);
 }
 
 TEST(ColumnTest, FromColumnReference) {


### PR DESCRIPTION
Summary:
Rewriting the test for braced initialization of Column, which should invoke the constructor with an initializer_list.

The new test case makes it more explicit that braced initialization should invoke the initializer_list constructor rather than the filling constructor.

Differential Revision: D33011644

