### PR TITLE
add corner test cases for df::detail::parseVector

### DIFF
--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -385,7 +385,8 @@ T parse(const std::string& value) {
  */
 template <typename T>
 std::vector<T> parseVector(const std::string& value) {
-  if (value.at(0) != '[' || value.at(value.size() - 1) != ']') {
+  if (value.empty() || value.at(0) != '[' ||
+      value.at(value.size() - 1) != ']') {
     auto typeName = std::string{"std::vector<"} + typeid(T).name() + ">";
     throw ParseException{value, typeName};
   }

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -80,11 +80,10 @@ TEST(ColumnTest, FromVectorRValueReference) {
 }
 
 TEST(ColumnTest, FromInitializerList) {
-  Column<int64_t> c{2, 4, 6};
-  ASSERT_EQ(c.size(), 3);
+  Column<int64_t> c{2, 4};
+  ASSERT_EQ(c.size(), 2);
   EXPECT_EQ(c.at(0), 2);
   EXPECT_EQ(c.at(1), 4);
-  EXPECT_EQ(c.at(2), 6);
 }
 
 TEST(ColumnTest, FromColumnReference) {

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -75,11 +75,17 @@ TEST(DataFrameDetail, ParseVector) {
   EXPECT_EQ(expected, detail::parseVector<int64_t>("[1,2,3]"));
   EXPECT_THROW(detail::parseVector<int64_t>("abc"), ParseException);
   // Missing trailing ']'
+  EXPECT_THROW(detail::parseVector<int64_t>("["), ParseException);
   EXPECT_THROW(detail::parseVector<int64_t>("[1,2,3"), ParseException);
   // Missing both brackets
   EXPECT_THROW(detail::parseVector<int64_t>("1,2,3"), ParseException);
   // Not a vector
   EXPECT_THROW(detail::parseVector<int64_t>("1"), ParseException);
+  // Empty string
+  EXPECT_THROW(detail::parseVector<int64_t>(""), ParseException);
+  // Empty vector
+  std::vector<int64_t> expected2{};
+  EXPECT_EQ(expected2, detail::parseVector<int64_t>("[]"));
 }
 
 TEST(DataFrameTest, Keys) {


### PR DESCRIPTION
Summary:
This diff fixes a corner case not handled by the df::detail::parseVector function, which is when the input is an empty string.

The diff also adds some additional test cases to make it more complete.

Differential Revision: D33011828

