### PR TITLE
allow mixed type binary assignment

### DIFF
--- a/fbpcs/emp_games/lift/common/Column.h
+++ b/fbpcs/emp_games/lift/common/Column.h
@@ -38,6 +38,7 @@ namespace df {
 template <typename T>
 class Column {
  public:
+  typedef T value_type;
   /* Basic constructors */
   Column() {}
   Column(const Column<T>& other) = default;
@@ -423,9 +424,12 @@ class Column {
   template <typename T2>
   void operator+=(T2& other) {
     if constexpr (is_specialization<T2, Column>::value) {
-      mapWithInPlace(other, [](const T& a, const T& b) { return a + b; });
+      mapWithInPlace(other, [](const T& a, const typename T2::value_type& b) {
+        return a + b;
+      });
     } else {
-      mapWithScalarInPlace(other, [](const T& a, const T& b) { return a + b; });
+      mapWithScalarInPlace(
+          other, [](const T& a, const T2& b) { return a + b; });
     }
   }
 

--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -385,7 +385,8 @@ T parse(const std::string& value) {
  */
 template <typename T>
 std::vector<T> parseVector(const std::string& value) {
-  if (value.at(0) != '[' || value.at(value.size() - 1) != ']') {
+  if (value.empty() || value.at(0) != '[' ||
+      value.at(value.size() - 1) != ']') {
     auto typeName = std::string{"std::vector<"} + typeid(T).name() + ">";
     throw ParseException{value, typeName};
   }

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -251,10 +251,6 @@ TEST(FunctionalTest, MapWith) {
   c1.mapWithInPlace(c2, [](int64_t a, int64_t b) { return a + b + 1; });
   Column<int64_t> expected2{6, 8, 10};
   EXPECT_EQ(c1, expected2);
-
-  c2.mapWithScalarInPlace(100, [](int64_t a, int64_t b) { return b - a; });
-  Column<int64_t> expected3{96, 95, 94};
-  EXPECT_EQ(c2, expected3);
 }
 
 TEST(FunctionalTest, MapWithScalar) {
@@ -264,6 +260,10 @@ TEST(FunctionalTest, MapWithScalar) {
   Column<int64_t> expected{10, 20, 30};
   auto actual = c1.mapWithScalar(s, [](int64_t a, int64_t b) { return a * b; });
   EXPECT_EQ(expected, actual);
+
+  c1.mapWithScalarInPlace(100, [](int64_t a, int64_t b) { return b - a; });
+  Column<int64_t> expected2{99, 98, 97};
+  EXPECT_EQ(c1, expected2);
 }
 
 TEST(ColumnTest, Reduce) {

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -80,11 +80,10 @@ TEST(ColumnTest, FromVectorRValueReference) {
 }
 
 TEST(ColumnTest, FromInitializerList) {
-  Column<int64_t> c{2, 4, 6};
-  ASSERT_EQ(c.size(), 3);
+  Column<int64_t> c{2, 4};
+  ASSERT_EQ(c.size(), 2);
   EXPECT_EQ(c.at(0), 2);
   EXPECT_EQ(c.at(1), 4);
-  EXPECT_EQ(c.at(2), 6);
 }
 
 TEST(ColumnTest, FromColumnReference) {

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdlib>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
@@ -307,6 +308,17 @@ TEST(BinaryOpTest, Plus) {
 
   EXPECT_EQ(expectedC, actualC);
   EXPECT_EQ(expectedS, actualS);
+
+  Column<char> c3{1, 2, 3};
+  Column<int64_t> expectedC2{2, 4, 6};
+  Column<std::string> c4{"a", "b", "c"};
+  Column<std::string> expectedS2{"a!", "b!", "c!"};
+  char s2 = '!';
+  auto actualC2 = c + c3;
+  auto actualS2 = c4 + s2;
+
+  EXPECT_EQ(expectedC2, actualC2);
+  EXPECT_EQ(expectedS2, actualS2);
 }
 
 TEST(BinaryOpTest, Minus) {
@@ -352,16 +364,31 @@ TEST(BinaryOpTest, Divide) {
 }
 
 TEST(BinaryAssignmentOpTest, Plus) {
-  Column<int64_t> c{9, 8, 7};
+  Column<int64_t> c1{9, 8, 7};
   Column<int64_t> c2{5, 4, 3};
+  Column<int32_t> c3{1, 3, 5};
+  Column<std::string> c4{"a", "b", "c"};
+  Column<char> c5{'x', 'y', 'z'};
   int64_t s = 2;
+  char s2 = '!';
 
-  c += c2;
+  c1 += c2;
   c2 += s;
   Column<int64_t> expected1{14, 12, 10};
   Column<int64_t> expected2{7, 6, 5};
-  EXPECT_EQ(expected1, c);
+  EXPECT_EQ(expected1, c1);
   EXPECT_EQ(expected2, c2);
+
+  c1 += c3;
+  Column<int64_t> expected3{15, 15, 15};
+  EXPECT_EQ(expected3, c1);
+
+  c4 += s2;
+  Column<std::string> expected4{"a!", "b!", "c!"};
+  EXPECT_EQ(expected4, c4);
+  c4 += c5;
+  Column<std::string> expected5{"a!x", "b!y", "c!z"};
+  EXPECT_EQ(expected5, c4);
 }
 
 TEST(BinaryAssignmentOpTest, Minus) {

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -75,11 +75,17 @@ TEST(DataFrameDetail, ParseVector) {
   EXPECT_EQ(expected, detail::parseVector<int64_t>("[1,2,3]"));
   EXPECT_THROW(detail::parseVector<int64_t>("abc"), ParseException);
   // Missing trailing ']'
+  EXPECT_THROW(detail::parseVector<int64_t>("["), ParseException);
   EXPECT_THROW(detail::parseVector<int64_t>("[1,2,3"), ParseException);
   // Missing both brackets
   EXPECT_THROW(detail::parseVector<int64_t>("1,2,3"), ParseException);
   // Not a vector
   EXPECT_THROW(detail::parseVector<int64_t>("1"), ParseException);
+  // Empty string
+  EXPECT_THROW(detail::parseVector<int64_t>(""), ParseException);
+  // Empty vector
+  std::vector<int64_t> expected2{};
+  EXPECT_EQ(expected2, detail::parseVector<int64_t>("[]"));
 }
 
 TEST(DataFrameTest, Keys) {


### PR DESCRIPTION
Summary:
This diff generalizes the binary assignment operator `+=` to allow mixed types.  I am assuming that this is intended because 1) `is_specialization` is checking for inheritance rather than exact type matching, and 2) both `operator+` and `mapWith` were written to allow mixed types.

I didn't do the same for the other operators because mixed type operations involving `-`, `*`, `/` are less intuitive and would probably be more confusing than being useful.

Differential Revision: D33013479

