### PR TITLE
refactor: move to correct test case

### DIFF
--- a/fbpcs/emp_games/lift/common/DataFrame.h
+++ b/fbpcs/emp_games/lift/common/DataFrame.h
@@ -385,7 +385,8 @@ T parse(const std::string& value) {
  */
 template <typename T>
 std::vector<T> parseVector(const std::string& value) {
-  if (value.at(0) != '[' || value.at(value.size() - 1) != ']') {
+  if (value.empty() || value.at(0) != '[' ||
+      value.at(value.size() - 1) != ']') {
     auto typeName = std::string{"std::vector<"} + typeid(T).name() + ">";
     throw ParseException{value, typeName};
   }

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -251,10 +251,6 @@ TEST(FunctionalTest, MapWith) {
   c1.mapWithInPlace(c2, [](int64_t a, int64_t b) { return a + b + 1; });
   Column<int64_t> expected2{6, 8, 10};
   EXPECT_EQ(c1, expected2);
-
-  c2.mapWithScalarInPlace(100, [](int64_t a, int64_t b) { return b - a; });
-  Column<int64_t> expected3{96, 95, 94};
-  EXPECT_EQ(c2, expected3);
 }
 
 TEST(FunctionalTest, MapWithScalar) {
@@ -264,6 +260,10 @@ TEST(FunctionalTest, MapWithScalar) {
   Column<int64_t> expected{10, 20, 30};
   auto actual = c1.mapWithScalar(s, [](int64_t a, int64_t b) { return a * b; });
   EXPECT_EQ(expected, actual);
+
+  c1.mapWithScalarInPlace(100, [](int64_t a, int64_t b) { return b - a; });
+  Column<int64_t> expected2{99, 98, 97};
+  EXPECT_EQ(c1, expected2);
 }
 
 TEST(ColumnTest, Reduce) {

--- a/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/ColumnTest.cpp
@@ -80,11 +80,10 @@ TEST(ColumnTest, FromVectorRValueReference) {
 }
 
 TEST(ColumnTest, FromInitializerList) {
-  Column<int64_t> c{2, 4, 6};
-  ASSERT_EQ(c.size(), 3);
+  Column<int64_t> c{2, 4};
+  ASSERT_EQ(c.size(), 2);
   EXPECT_EQ(c.at(0), 2);
   EXPECT_EQ(c.at(1), 4);
-  EXPECT_EQ(c.at(2), 6);
 }
 
 TEST(ColumnTest, FromColumnReference) {

--- a/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
+++ b/fbpcs/emp_games/lift/common/test/DataFrameTest.cpp
@@ -75,11 +75,17 @@ TEST(DataFrameDetail, ParseVector) {
   EXPECT_EQ(expected, detail::parseVector<int64_t>("[1,2,3]"));
   EXPECT_THROW(detail::parseVector<int64_t>("abc"), ParseException);
   // Missing trailing ']'
+  EXPECT_THROW(detail::parseVector<int64_t>("["), ParseException);
   EXPECT_THROW(detail::parseVector<int64_t>("[1,2,3"), ParseException);
   // Missing both brackets
   EXPECT_THROW(detail::parseVector<int64_t>("1,2,3"), ParseException);
   // Not a vector
   EXPECT_THROW(detail::parseVector<int64_t>("1"), ParseException);
+  // Empty string
+  EXPECT_THROW(detail::parseVector<int64_t>(""), ParseException);
+  // Empty vector
+  std::vector<int64_t> expected2{};
+  EXPECT_EQ(expected2, detail::parseVector<int64_t>("[]"));
 }
 
 TEST(DataFrameTest, Keys) {


### PR DESCRIPTION
Summary: This diff corrects the placement of a mapWithScalarInPlace test case in the right place.

Differential Revision: D33012908

