### PR TITLE
Introducing the run_attribution endpoint

### DIFF
--- a/fbpcs/pl_coordinator/pl_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pl_graphapi_utils.py
@@ -81,10 +81,10 @@ class PLGraphAPIClient:
     def create_pa_instance(
         self,
         dataset_id: str,
-        attribution_rule: str,
         start_date: str,
         end_date: str,
-        num_containers: str,
+        attribution_rule: str,
+        num_containers: int,
         result_type: str,
     ) -> requests.Response:
         params = self.params.copy()
@@ -120,6 +120,12 @@ class PLGraphAPIClient:
         params["fields"] = ",".join(fields)
         r = requests.get(f"{URL}/{dataset_id}", params=params)
         self._check_err(r, "getting dataset information")
+        return r
+
+    def get_existing_pa_instances(self, dataset_id: str) -> requests.Response:
+        params = self.params.copy()
+        r = requests.get(f"{URL}/{dataset_id}/instances", params=params)
+        self._check_err(r, "getting attribution instances tied to the dataset")
         return r
 
     def _check_err(self, r: requests.Response, msg: str) -> None:

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -7,10 +7,21 @@
 
 import json
 import logging
-from typing import Dict, Any
+from typing import Type, Optional, Dict, Any
 
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     PLGraphAPIClient,
+)
+from fbpcs.pl_coordinator.pl_instance_runner import (
+    run_instance,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    AttributionRule,
+    AggregationType,
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
 )
 
 
@@ -27,6 +38,9 @@ class LoggerAdapter(logging.LoggerAdapter):
 AD_OBJECT_ID = "ad_object_id"
 TARGET_OBJECT_TYPE = "target_object_type"
 DATASETS_INFORMATION = "datasets_information"
+INSTANCES = "instances"
+NUM_SHARDS = "num_shards"
+NUM_CONTAINERS = "num_containers"
 
 
 POLL_INTERVAL = 60
@@ -40,9 +54,130 @@ MAX_TRIES = 2
 RETRY_INTERVAL = 60
 
 MIN_NUM_INSTANCES = 1
-MAX_NUM_INSTANCES = 5
 PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 14400  # 2 hr instance sla, 2 tries per stage, total 4 hrs.
+
+"""
+The input to this function will be the input path, the dataset_id as well as the following params to choose
+a specific dataset range to create and run a PA instance on
+1) start_date - start date of the FB Opportunity data
+2) end_date - end date of the FB Opportunity data
+3) attribution_rule - attribution rule for the selected data
+4) result_type - result type for the selected data
+"""
+
+
+def run_attribution(
+    config: Dict[str, Any],
+    dataset_id: str,
+    input_path: str,
+    start_date: str,
+    end_date: str,
+    attribution_rule: AttributionRule,
+    aggregation_type: AggregationType,
+    concurrency: int,
+    num_files_per_mpc_container: int,
+    k_anonymity_threshold: int,
+    result_type: str,
+    stage_flow: Type[PrivateComputationBaseStageFlow],
+    logger: logging.Logger,
+    num_tries: Optional[int] = 2,  # this is number of tries per stage
+) -> None:
+
+    ## Step 1: Validation. Function arguments and  for private lift run.
+    # obtain the values in the dataset info vector.
+    client = PLGraphAPIClient(config["graphapi"]["access_token"], logger)
+    datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
+    datasets = datasets_info[DATASETS_INFORMATION]
+    matched_data = {}
+    attribution_rule_str = attribution_rule.value
+    # Verify that input has matching dataset info:
+    # a. appropriate date range
+    # b. attribution rule
+    # c. result type
+    for data in datasets:
+        unmatched_start_date = data["start_date"] != start_date
+        unmatched_end_date = data["end_date"] != end_date
+        unmatched_attribution_rule = data["attribution_rule"] != attribution_rule_str
+        unmatched_result_type = data["result_type"] != result_type
+
+        if (
+            unmatched_start_date
+            or unmatched_end_date
+            or unmatched_result_type
+            or unmatched_attribution_rule
+        ):
+            continue
+        matched_data = data
+        break
+
+    if len(matched_data) == 0:
+        raise ValueError("No dataset matching to the information provided")
+
+    # Step 2: Validate what instances need to be created vs what already exist
+    dataset_instance_data = _get_existing_pa_instances(client, dataset_id)
+    existing_instances = dataset_instance_data["data"]
+    if len(existing_instances) == 0:
+        instance_id = _create_new_instance(
+            dataset_id,
+            start_date,
+            end_date,
+            attribution_rule_str,
+            result_type,
+            client,
+            logger,
+        )
+    else:
+        instance_id = existing_instances[0]["id"]
+
+    instance_data = _get_pa_instance_info(client, instance_id, logger)
+    num_pid_containers = instance_data[NUM_CONTAINERS]
+    num_mpc_containers = instance_data[NUM_SHARDS]
+
+    ## Step 3. Run Instances. Run maximum number of instances in parallel
+    logger.info(f"Start running instance {instance_id}.")
+    run_instance(
+        config,
+        instance_id,
+        input_path,
+        num_pid_containers,
+        num_mpc_containers,
+        stage_flow,
+        logger,
+        PrivateComputationGameType.ATTRIBUTION,
+        attribution_rule,
+        AggregationType.MEASUREMENT,
+        concurrency,
+        num_files_per_mpc_container,
+        k_anonymity_threshold,
+        num_tries,
+    )
+    logger.info(f"Finished running instances {instance_id}.")
+
+
+def _create_new_instance(
+    dataset_id: str,
+    start_date: str,
+    end_date: str,
+    attribution_rule: str,
+    result_type: str,
+    client: PLGraphAPIClient,
+    logger: logging.Logger,
+) -> str:
+    instance_id = json.loads(
+        client.create_pa_instance(
+            dataset_id,
+            start_date,
+            end_date,
+            attribution_rule,
+            2,
+            result_type,
+        ).text
+    )["id"]
+    logger.info(
+        f"Created instance {instance_id} for dataset {dataset_id} and attribution rule {attribution_rule}"
+    )
+    return instance_id
 
 
 def get_attribution_dataset_info(
@@ -56,3 +191,24 @@ def get_attribution_dataset_info(
             [AD_OBJECT_ID, TARGET_OBJECT_TYPE, DATASETS_INFORMATION],
         ).text
     )
+
+
+def _get_pa_instance_info(
+    client: PLGraphAPIClient, instance_id: str, logger: logging.Logger
+) -> Any:
+    return json.loads(client.get_instance(instance_id).text)
+
+
+def _get_attribution_dataset_info(
+    client: PLGraphAPIClient, dataset_id: str, logger: logging.Logger
+) -> Any:
+    return json.loads(
+        client.get_attribution_dataset_info(
+            dataset_id,
+            [AD_OBJECT_ID, TARGET_OBJECT_TYPE, DATASETS_INFORMATION],
+        ).text
+    )
+
+
+def _get_existing_pa_instances(client: PLGraphAPIClient, dataset_id: str) -> Any:
+    return json.loads(client.get_existing_pa_instances(dataset_id).text)

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -24,6 +24,7 @@ Usage:
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
+    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --start_date=<start_date> --end_date=<end_date> --attribution_rule=<attribution_rule> --result_type=<result_type> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>[options]
 
 
 Options:
@@ -48,9 +49,15 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
     PrivateComputationGameType,
 )
-from fbpcs.private_computation.pc_attribution_runner import get_attribution_dataset_info
+from fbpcs.private_computation.pc_attribution_runner import (
+    get_attribution_dataset_info,
+    run_attribution,
+)
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
+    PrivateComputationDecoupledStageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
@@ -84,6 +91,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             "run_instance": bool,
             "run_instances": bool,
             "run_study": bool,
+            "run_attribution": bool,
             "cancel_current_stage": bool,
             "print_instance": bool,
             "get_attribution_dataset_info": bool,
@@ -118,6 +126,9 @@ def main(argv: Optional[List[str]] = None) -> None:
             "--num_mpc_containers": schema.Or(None, schema.Use(int)),
             "--aggregation_type": schema.Or(None, schema.Use(AggregationType)),
             "--attribution_rule": schema.Or(None, schema.Use(AttributionRule)),
+            "--result_type": schema.Or(None, str),
+            "--start_date": schema.Or(None, str),
+            "--end_date": schema.Or(None, str),
             "--num_files_per_mpc_container": schema.Or(None, schema.Use(int)),
             "--num_shards": schema.Or(None, schema.Use(int)),
             "--num_shards_list": schema.Or(
@@ -257,6 +268,25 @@ def main(argv: Optional[List[str]] = None) -> None:
             num_tries=arguments["--tries_per_stage"],
             dry_run=arguments["--dry_run"],
         )
+    elif arguments["run_attribution"]:
+        stage_flow = PrivateComputationDecoupledStageFlow
+        run_attribution(
+            config=config,
+            dataset_id=arguments["--dataset_id"],
+            input_path=arguments["--input_path"],
+            start_date=arguments["--start_date"],
+            end_date=arguments["--end_date"],
+            attribution_rule=arguments["--attribution_rule"],
+            aggregation_type=arguments["--aggregation_type"],
+            concurrency=arguments["--concurrency"],
+            num_files_per_mpc_container=arguments["--num_files_per_mpc_container"],
+            k_anonymity_threshold=arguments["--k_anonymity_threshold"],
+            result_type=arguments["--result_type"],
+            logger=logger,
+            stage_flow=stage_flow,
+            num_tries=2,
+        )
+
     elif arguments["cancel_current_stage"]:
         logger.info(f"Canceling the current running stage of instance: {instance_id}")
         cancel_current_stage(


### PR DESCRIPTION
Summary:
Adding the 'run_attribution' endpoint to pc-cli
(1) depending on the params provided the correct dataset has to picked from the dataset_id

NOTE: dataset_id is tied to an ad object and can have datasets tied to different date ranges

(2) create the instance tied to the dataset selected

(3) run_instance, which effectively runs through the steps of PA

Reviewed By: yanglu-fb

Differential Revision: D32711518

