### PR TITLE
Fix emp::PUBLIC initialization

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/Touchpoint.h
@@ -59,9 +59,9 @@ struct PrivateTouchpoint {
       : isClick{_isClick}, ts{_ts}, id{_id} {}
 
   explicit PrivateTouchpoint()
-      : isClick{false, emp::PUBLIC},
-        ts{-1},
-        id{INT_SIZE, INVALID_TP_ID, emp::PUBLIC} {}
+      : isClick{false, emp::ALICE},
+        ts{-1, emp::ALICE},
+        id{INT_SIZE, INVALID_TP_ID, emp::ALICE} {}
 
   PrivateTouchpoint select(const emp::Bit& useRhs, const PrivateTouchpoint& rhs)
       const {


### PR DESCRIPTION
Summary:
**What?**
- Task T104587386 pointed out some suspicious usages of initialization of emp::PUBLIC which may introduce privacy leaks.

Differential Revision: D33066746

