### PR TITLE
Move cloud_provider enum

### DIFF
--- a/fbpcs/experimental/cloud_logs/log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/log_retriever.py
@@ -4,12 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from enum import Enum
-
-
-class CloudProvider(Enum):
-    AWS = 1
-    GCP = 2
+from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
 
 class LogRetriever:

--- a/fbpcs/private_computation/entity/cloud_provider.py
+++ b/fbpcs/private_computation/entity/cloud_provider.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+
+class CloudProvider(Enum):
+    AWS = 1
+    GCP = 2


### PR DESCRIPTION
Summary: Move it out of log retriever for more generic use cases.

Reviewed By: jrodal98

Differential Revision: D33052890

