### PR TITLE
Add PS3I binary name into one docker names and fix bug in release.

### DIFF
--- a/fbpcs/onedocker_binary_names.py
+++ b/fbpcs/onedocker_binary_names.py
@@ -23,5 +23,9 @@ class OneDockerBinaryNames(Enum):
 
     PID_CLIENT = "pid/private-id-client"
     PID_SERVER = "pid/private-id-server"
+    CROSS_PSI_SERVER = "pid/cross-psi-server"
+    CROSS_PSI_CLIENT = "pid/cross-psi-client"
+    CROSS_PSI_COR_SERVER = "pid/cross-psi-xor-server"
+    CROSS_PSI_COR_CLIENT = "pid/cross-psi-xor-client"
 
     LIFT_COMPUTE = "private_lift/lift"


### PR DESCRIPTION
Summary:
Context
- When adding the binary name in one docker enum I realize the path to PS3I binary is still private ID. So we need to fix that.

This diff
- Fix PS3I path in the release script
- Add PS3I binary name into one docker enum

Reviewed By: jrodal98

Differential Revision: D32967556

