### PR TITLE
Update fbcode to use latest version of emp

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/TouchPointMetadata.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/TouchPointMetadata.h
@@ -77,7 +77,7 @@ struct PrivateMeasurementTouchpointMetadata {
     std::stringstream out;
 
     out << "Measurement Touchpoint Metadata { adId=";
-    out << adId.reveal<std::string>(party);
+    out << adId.reveal<int64_t>(party);
     out << "}";
 
     return out.str();

--- a/fbpcs/emp_games/attribution/decoupled_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/Touchpoint.h
@@ -83,7 +83,7 @@ struct PrivateTouchpoint {
 
     out << (isClick.reveal<bool>(party) ? "Click{" : "View{");
     out << "id=";
-    out << id.reveal<std::string>(party);
+    out << id.reveal<int64_t>(party);
     out << ", ts=";
     out << ts.reveal<int64_t>(party);
     out << "}";

--- a/fbpcs/emp_games/common/EmpOperationUtil.hpp
+++ b/fbpcs/emp_games/common/EmpOperationUtil.hpp
@@ -73,7 +73,7 @@ const int64_t sum(const std::vector<emp::Bit>& in) {
 }
 
 inline emp::Integer secretSum(const std::vector<emp::Integer>& in) {
-  const emp::Integer zero{in.at(0).size(), 0, emp::PUBLIC};
+  const emp::Integer zero{static_cast<int>(in.at(0).size()), 0, emp::PUBLIC};
   return std::accumulate(in.begin(), in.end(), zero);
 }
 

--- a/fbpcs/emp_games/lift/calculator/OutputMetrics.hpp
+++ b/fbpcs/emp_games/lift/calculator/OutputMetrics.hpp
@@ -342,7 +342,8 @@ OutputMetrics<MY_ROLE>::calculateValidPurchases() {
          std::vector<emp::Integer> purchaseTsArray) -> std::vector<emp::Bit> {
         std::vector<emp::Bit> vec;
         for (const auto& purchaseTs : purchaseTsArray) {
-          const emp::Integer ten{purchaseTs.size(), 10, emp::PUBLIC};
+          const emp::Integer ten{
+              static_cast<int>(purchaseTs.size()), 10, emp::PUBLIC};
           vec.push_back(purchaseTs + ten > oppTs);
         }
         return vec;
@@ -404,7 +405,9 @@ std::vector<std::vector<emp::Bit>> OutputMetrics<MY_ROLE>::calculateEvents(
               auto numConv = validPurchaseArray.size() - i;
               auto convSquared = static_cast<int64_t>(numConv * numConv);
               emp::Integer numConvSquaredIfValid{
-                  numConvSquared.size(), convSquared, emp::PUBLIC};
+                  static_cast<int>(numConvSquared.size()),
+                  convSquared,
+                  emp::PUBLIC};
               numConvSquared =
                   emp::If(newPurchase, numConvSquaredIfValid, numConvSquared);
 
@@ -542,8 +545,8 @@ void OutputMetrics<MY_ROLE>::calculateMatchCount(
       [](emp::Bit isUser,
          emp::Integer opportunityTimestamp,
          std::vector<emp::Integer> purchaseTimestampArray) -> emp::Bit {
-        const emp::Integer zero =
-            emp::Integer{opportunityTimestamp.size(), 0, emp::PUBLIC};
+        const emp::Integer zero = emp::Integer{
+            static_cast<int>(opportunityTimestamp.size()), 0, emp::PUBLIC};
         emp::Bit validOpportunity =
             (isUser &
              (opportunityTimestamp > zero)); // check if opportunity is valid
@@ -707,8 +710,10 @@ void OutputMetrics<MY_ROLE>::calculateValue(
                              "values are inconsistent.";
             }
             for (size_t i = 0; i < testEvents.size(); ++i) {
-              const emp::Integer zero =
-                  emp::Integer{purchaseValues.at(i).size(), 0, emp::PUBLIC};
+              const emp::Integer zero = emp::Integer{
+                  static_cast<int>(purchaseValues.at(i).size()),
+                  0,
+                  emp::PUBLIC};
               vec.emplace_back(
                   emp::If(testEvents.at(i), purchaseValues.at(i), zero));
             }
@@ -725,8 +730,8 @@ void OutputMetrics<MY_ROLE>::calculateValue(
            emp::Bit reached) -> std::vector<emp::Integer> {
           std::vector<emp::Integer> vec;
           for (const auto& validValue : validValues) {
-            const emp::Integer zero =
-                emp::Integer{validValue.size(), 0, emp::PUBLIC};
+            const emp::Integer zero = emp::Integer{
+                static_cast<int>(validValue.size()), 0, emp::PUBLIC};
             vec.emplace_back(emp::If(reached, validValue, zero));
           }
           return vec;
@@ -782,7 +787,9 @@ void OutputMetrics<MY_ROLE>::calculateValueSquared(
       [](std::vector<emp::Bit> events,
          std::vector<emp::Integer> purchaseValuesSquared) -> emp::Integer {
         emp::Integer sumSquared{
-            purchaseValuesSquared.at(0).size(), 0, emp::PUBLIC};
+            static_cast<int>(purchaseValuesSquared.at(0).size()),
+            0,
+            emp::PUBLIC};
         if (events.size() != purchaseValuesSquared.size()) {
           XLOG(FATAL) << "Numbers of event bits and purchase values squared "
                          "are inconsistent.";


### PR DESCRIPTION
Summary:
This diff updates fbcode to use:
- emp-tool 0.2.3
- emp-ot 0.2.2
- emp-sh2pc 0.2.2

I followed the instructions [here](https://www.internalfb.com/intern/wiki/Third_Party2/Usage/#update-fbcode-symlink) and made some code changes to fix build errors.

Reviewed By: ashiquemfb

Differential Revision: D32933871

