### PR TITLE
Change to mpc-aem account

### DIFF
--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -23,7 +23,7 @@
 namespace fbpcs::performance_tools {
 
 CostEstimation::CostEstimation(const std::string& app) : application_{app} {
-  s3Bucket_ = "run-logs-mpc";
+  s3Bucket_ = "cost-estimation-logs";
   if (app == "attribution") {
     s3Path_ = "pa-logs";
   } else if (app == "computation_experimental") {


### PR DESCRIPTION
Summary:
We update the performance test script to use the mpc-aem account. The script now has to be called with input `--account=119557546360`.

The main changes involve updating the S3 buckets to new ones in the mpc-aem account, and updating the config files.

Reviewed By: wuman

Differential Revision: D33160497

