### PR TITLE
check for TODOs in config.yml parsing - non constructor

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [1.1.0] - 2022-01-05
 ### Added
   - Add class variable `cloud_provider` to `PCEConfig`
+  - Added PC instance, PID instance, and MPC instance serde versioning tests
+  - Added support for decoupled attribution stage cancellation
+  - Validate that config.yml doesn't contain TOODs
 
 ### Changed
   - Cleanup and move sharding/sharding_cpp to service/sharing_service

--- a/fbpcs/utils/config_yaml/config_yaml_dict.py
+++ b/fbpcs/utils/config_yaml/config_yaml_dict.py
@@ -6,7 +6,10 @@
 
 from typing import Any, Dict
 
-from fbpcs.utils.config_yaml.exceptions import ConfigYamlFieldNotFoundError
+from fbpcs.utils.config_yaml.exceptions import (
+    ConfigYamlFieldNotFoundError,
+    ConfigYamlValidationError,
+)
 
 
 class ConfigYamlDict(Dict[str, Any]):
@@ -16,9 +19,17 @@ class ConfigYamlDict(Dict[str, Any]):
     def __getitem__(self, key: str) -> Any:
         """Override of dict key access, e.g. x = my_dict[key]"""
         try:
-            return super().__getitem__(key)
+            val = super().__getitem__(key)
         except KeyError:
             raise ConfigYamlFieldNotFoundError(key) from None
+
+        if val == "TODO":
+            raise ConfigYamlValidationError(
+                key,
+                "TODOs found in config",
+                "Fill in remaining TODO entries in config.yml",
+            )
+        return val
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Override of dict item setting, e.g. my_dict[key] = x.

--- a/fbpcs/utils/config_yaml/exceptions.py
+++ b/fbpcs/utils/config_yaml/exceptions.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+class ConfigYamlBaseException(Exception):
+    pass
 
 
-class ConfigYamlFieldNotFoundError(KeyError):
+class ConfigYamlFieldNotFoundError(KeyError, ConfigYamlBaseException):
     """Raised when a ConfigYamlDict key access fails"""
 
     def __init__(self, key: str) -> None:
@@ -15,7 +17,7 @@ class ConfigYamlFieldNotFoundError(KeyError):
         super().__init__(msg)
 
 
-class ConfigYamlModuleImportError(ImportError):
+class ConfigYamlModuleImportError(ImportError, ConfigYamlBaseException):
     """Raised when a module path cannot be imported"""
 
     def __init__(self, class_path: str) -> None:
@@ -23,7 +25,7 @@ class ConfigYamlModuleImportError(ImportError):
         super().__init__(msg)
 
 
-class ConfigYamlClassNotFoundError(AttributeError):
+class ConfigYamlClassNotFoundError(AttributeError, ConfigYamlBaseException):
     """Raised when a class is not found at a given module path"""
 
     def __init__(self, class_path: str) -> None:
@@ -31,7 +33,7 @@ class ConfigYamlClassNotFoundError(AttributeError):
         super().__init__(msg)
 
 
-class ConfigYamlWrongClassConfiguredError(AssertionError):
+class ConfigYamlWrongClassConfiguredError(AssertionError, ConfigYamlBaseException):
     """Raised when the type of a class loaded through reflection is different than expected"""
 
     def __init__(self, class_path: str, target_class_name: str) -> None:
@@ -39,9 +41,17 @@ class ConfigYamlWrongClassConfiguredError(AssertionError):
         super().__init__(msg)
 
 
-class ConfigYamlWrongConstructorError(TypeError):
+class ConfigYamlWrongConstructorError(TypeError, ConfigYamlBaseException):
     """Raised when the arguments passed to a constructor are incorrect"""
 
     def __init__(self, class_name: str, cause: str) -> None:
         msg = f"{class_name} (specified in your config.yml) does not have the correct arguments. {cause}. Please make sure that your config is up to date."
+        super().__init__(msg)
+
+
+class ConfigYamlValidationError(ValueError, ConfigYamlBaseException):
+    """Raise when a config.yml fails validation"""
+
+    def __init__(self, class_name: str, cause: str, remediation: str) -> None:
+        msg = f"{class_name} (specified in your config.yml) failed validation. Cause: {cause}. Suggested remediation: {remediation}"
         super().__init__(msg)

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -12,6 +12,7 @@ from fbpcp.util.reflect import get_class as fbpcp_get_class
 from fbpcs.utils.config_yaml.exceptions import (
     ConfigYamlModuleImportError,
     ConfigYamlClassNotFoundError,
+    ConfigYamlValidationError,
     ConfigYamlWrongClassConfiguredError,
     ConfigYamlWrongConstructorError,
 )
@@ -59,15 +60,23 @@ def get_instance(config: Dict[str, Any], target_class: Type[T]) -> T:
 
     Raises:
         ConfigYamlWrongConstructorError: incorrect arguments passed to class constructor
+        ConfigYamlValidationError: invalid arguments passed to class constructor
 
     Returns:
         instance of type target_class
-
-
     """
     cls = get_class(config["class"], target_class)
     try:
-        instance = cls(**config.get("constructor", {}))
+        args_dict = config.get("constructor", {})
+        if "TODO" in args_dict.values():
+            raise ConfigYamlValidationError(
+                cls.__name__,
+                "TODOs found in config",
+                "Fill in remaining TODO entries in config.yml",
+            )
+        instance = cls(**args_dict)
+    except ConfigYamlValidationError:
+        raise
     except TypeError as e:
         raise ConfigYamlWrongConstructorError(cls.__name__, str(e)) from None
     return instance


### PR DESCRIPTION
Summary:
## What

* Raise exception if a TODO is detected in a field being directly accessed (i.e. isn't part of a class constructor config)

## Why

* Last diff only checked class constructors, this checks the other fields
* Inspiration: https://www.internalfb.com/diff/D33239531?dst_version_fbid=421256449672889&transaction_fbid=652563902760859

Differential Revision: D33240605

