### PR TITLE
Use enum+constants for attribution rules and aggregators

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -52,6 +52,8 @@ class AttributionRule(Enum):
     LAST_TOUCH_1D = "last_touch_1d"
     LAST_TOUCH_7D = "last_touch_7d"
     LAST_TOUCH_28D = "last_touch_28d"
+    LAST_CLICK_2_7D = "last_click_2_7d"
+    LAST_TOUCH_2_7D = "last_touch_2_7d"
 
 
 class AggregationType(Enum):


### PR DESCRIPTION
Summary: Very simple diff, just replaces all python usages of string attribution rules or string aggregators with the appropriate constant/enum value.

Differential Revision: D33255743

