### PR TITLE
instance base add created_ts field (#508)

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
   - Add class variable `cloud_provider` to `PCEConfig`
+  - Added PC instance, PID instance, and MPC instance serde versioning tests
+  - Added support for decoupled attribution stage cancellation
+  - Validate that config.yml doesn't contain TOODs
 
 ### Changed
   - Cleanup and move sharding/sharding_cpp to service/sharing_service

--- a/fbpcs/common/entity/exceptions.py
+++ b/fbpcs/common/entity/exceptions.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class InstanceDeserializationError(Exception):
+    pass
+
+
+class InstanceVersionMismatchError(ValueError, InstanceDeserializationError):
+    pass

--- a/fbpcs/common/entity/instance_base.py
+++ b/fbpcs/common/entity/instance_base.py
@@ -11,6 +11,7 @@ import hashlib
 import inspect
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Type, TypeVar
 
@@ -33,16 +34,20 @@ class InstanceBase(DataClassJsonMixin):
     Public attributes:
         version_hash: hash for instance schema. If schema changes, hash changes
         dirty: boolean that indicates if schema has changed since serialization
+        created_ts: unixtime at which the instance was created
     """
 
     # ignored by constructor
     version_hash: str = field(init=False)
     # ignored by constructor
     dirty: bool = field(init=False)
+    # ignored by constructor
+    created_ts: int = field(init=False)
 
     def __post_init__(self) -> None:
         self.version_hash = self.generate_version_hash()
         self.dirty = False
+        self.created_ts = int(time.time())
 
     # TODO(T108616043): [PCS][BE] delete get_instance_id; make instance_id required field
     @abc.abstractmethod
@@ -76,6 +81,7 @@ class InstanceBase(DataClassJsonMixin):
         self.version_hash = instance_json_dict.get("version_hash", "")
         # if dirty field DNE in json, then instance is old (and thus is dirty)
         self.dirty = instance_json_dict.get("dirty", True)
+        self.created_ts = instance_json_dict.get("created_ts", 0)
 
     @classmethod
     def loads_schema(cls: Type[T], json_schema_str: str, strict: bool = False) -> T:

--- a/fbpcs/common/entity/instance_base.py
+++ b/fbpcs/common/entity/instance_base.py
@@ -7,14 +7,44 @@
 # pyre-strict
 
 import abc
-from typing import Type, TypeVar
+import hashlib
+import inspect
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Type, TypeVar
 
 from dataclasses_json import DataClassJsonMixin
 
 T = TypeVar("T", bound="InstanceBase")
 
+from fbpcs.common.entity.exceptions import (
+    InstanceDeserializationError,
+    InstanceVersionMismatchError,
+)
 
+
+@dataclass
 class InstanceBase(DataClassJsonMixin):
+    """Base class for all your PCS instance needs
+
+    Provides json serde and versioning out of the box.
+
+    Public attributes:
+        version_hash: hash for instance schema. If schema changes, hash changes
+        dirty: boolean that indicates if schema has changed since serialization
+    """
+
+    # ignored by constructor
+    version_hash: str = field(init=False)
+    # ignored by constructor
+    dirty: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.version_hash = self.generate_version_hash()
+        self.dirty = False
+
+    # TODO(T108616043): [PCS][BE] delete get_instance_id; make instance_id required field
     @abc.abstractmethod
     def get_instance_id(self) -> str:
         pass
@@ -23,8 +53,69 @@ class InstanceBase(DataClassJsonMixin):
         return self.dumps_schema()
 
     def dumps_schema(self) -> str:
+        """Serializes the instance, returns as a string"""
         return self.schema().dumps(self)
 
     @classmethod
-    def loads_schema(cls: Type[T], json_schema_str: str) -> T:
-        return cls.schema().loads(json_schema_str, many=None)
+    def generate_version_hash(cls: Type[T]) -> str:
+        """
+        1. Retrieve the source code for the class
+        2. hash it
+
+        If the class changes, the hash changes.
+        """
+        cls_source_code_bytes = inspect.getsource(cls).encode()
+        return hashlib.md5(cls_source_code_bytes).hexdigest()
+
+    def _loads_non_init_fields(self, instance_json_dict: Dict[str, Any]) -> None:
+        """Reads non-init fields from instance dict and sets them on instance
+
+        Arguments:
+            instance_json_dict: a dictionary rendering of a json serialized instance
+        """
+        self.version_hash = instance_json_dict.get("version_hash", "")
+        # if dirty field DNE in json, then instance is old (and thus is dirty)
+        self.dirty = instance_json_dict.get("dirty", True)
+
+    @classmethod
+    def loads_schema(cls: Type[T], json_schema_str: str, strict: bool = False) -> T:
+        """Deserializes an instance.
+
+        Arguments:
+            json_schema_str: the serialized instance string
+            strict: should an error be thrown if the instance is dirty?
+
+        Raises:
+            InstanceVersionMismatchError: thrown if schema version changed (instance is dirty)
+            InstanceDeserializationError: Catch-all exception for unexpected errors
+
+        Returns:
+            A deserialized instance of type T (same as the calling cls)
+        """
+        try:
+            # deserializes instance
+            instance = cls.schema().loads(json_schema_str, many=None)
+
+            # some fields are ignored by json-dataclasses deserializer because init=False
+            # manually load them
+            instance._loads_non_init_fields(json.loads(json_schema_str))
+
+            # if the instance was previously dirty or version hash has changed, mark instance as dirty
+            instance.dirty = (
+                instance.dirty or instance.version_hash != cls.generate_version_hash()
+            )
+            if instance.dirty:
+                instance_id = instance.get_instance_id()
+                if strict:
+                    raise InstanceVersionMismatchError(
+                        f"{cls.__name__} dataclass schema version has changed since initial serialization of {instance_id=}."
+                    )
+                else:
+                    logging.warning(
+                        f"Instance dataclass schema for {cls.__name__} has changed since initial serialization of {instance_id=}!"
+                    )
+            return instance
+        except InstanceVersionMismatchError:
+            raise
+        except Exception as e:
+            raise InstanceDeserializationError(str(e)) from e

--- a/fbpcs/common/entity/pcs_mpc_instance.py
+++ b/fbpcs/common/entity/pcs_mpc_instance.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstance
@@ -17,6 +18,7 @@ from fbpcp.entity.mpc_instance import (
 from fbpcs.common.entity.instance_base import InstanceBase
 
 
+@dataclass
 class PCSMPCInstance(MPCInstance, InstanceBase):
     @classmethod
     def create_instance(

--- a/fbpcs/common/tests/entity/test_instance_base.py
+++ b/fbpcs/common/tests/entity/test_instance_base.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+from dataclasses import dataclass
+
+from fbpcs.common.entity.exceptions import InstanceVersionMismatchError
+from fbpcs.common.entity.instance_base import InstanceBase
+
+
+@dataclass
+class DummyInstanceV1(InstanceBase):
+    """Dummy instance class to be used in unit tests"""
+
+    instance_id: str
+
+    def get_instance_id(self) -> str:
+        return self.instance_id
+
+
+@dataclass
+class DummyInstanceV2(InstanceBase):
+    """Dummy instance class to be used in unit tests"""
+
+    instance_id: str
+    new_field: str = "default"
+
+    def get_instance_id(self) -> str:
+        return self.instance_id
+
+
+class TestInstanceBase(unittest.TestCase):
+    def test_basic_serde(self):
+        """Test that serialization followed by deserialization results in a replica"""
+
+        instance = DummyInstanceV1(instance_id="123")
+        serialized_instance = instance.dumps_schema()
+        deserialized_instance = DummyInstanceV1.loads_schema(serialized_instance)
+        self.assertEqual(instance, deserialized_instance)
+
+        # The schema never changed, so the instance should not be dirty
+        self.assertFalse(instance.dirty)
+
+    def test_dirty_deserialization_non_strict_new_hash(self):
+        """Test that dirty flag is set if instance schema changes"""
+
+        # version hashes should be different
+        self.assertNotEqual(
+            DummyInstanceV1.generate_version_hash(),
+            DummyInstanceV2.generate_version_hash(),
+        )
+
+        instance = DummyInstanceV1(instance_id="123")
+        # a never serialized instance should not be dirty
+        self.assertFalse(instance.dirty)
+
+        serialized_instance = instance.dumps_schema()
+        deserialized_instance = DummyInstanceV2.loads_schema(
+            serialized_instance, strict=False
+        )
+
+        # since the schema has changed, the instance should be marked dirty
+        self.assertTrue(deserialized_instance.dirty)
+
+        # we keep the original version hash, even though the schema has changed
+        self.assertEqual(instance.version_hash, deserialized_instance.version_hash)
+
+    def test_dirty_deserialization_non_strict_previously_dirty(self):
+        """Test that a dirty flag always persists through subsequent serde"""
+
+        instance = DummyInstanceV1(instance_id="123")
+        instance.dirty = True
+        serialized_instance = instance.dumps_schema()
+        deserialized_instance = DummyInstanceV1.loads_schema(serialized_instance)
+        self.assertEqual(instance, deserialized_instance)
+
+        # Sanity check: The schema never changed but it was marked dirty at some point, so it should remain dirty
+        self.assertTrue(instance.dirty)
+
+    def test_dirty_deserialization_strict(self):
+        """Test that an exception is thrown if strict mode is set"""
+
+        instance = DummyInstanceV1(instance_id="123")
+
+        serialized_instance = instance.dumps_schema()
+        with self.assertRaises(InstanceVersionMismatchError):
+            DummyInstanceV2.loads_schema(serialized_instance, strict=True)
+
+        # strict won't result in exception if instance is not dirty
+        DummyInstanceV1.loads_schema(serialized_instance, strict=True)

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -132,6 +132,7 @@ class PrivateComputationInstance(InstanceBase):
     _stage_flow_cls_name: str = "PrivateComputationStageFlow"
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         if self.num_pid_containers > self.num_mpc_containers:
             raise ValueError(
                 f"num_pid_containers must be less than or equal to num_mpc_containers. Received num_pid_containers = {self.num_pid_containers} and num_mpc_containers = {self.num_mpc_containers}"

--- a/fbpcs/utils/config_yaml/config_yaml_dict.py
+++ b/fbpcs/utils/config_yaml/config_yaml_dict.py
@@ -6,7 +6,10 @@
 
 from typing import Any, Dict
 
-from fbpcs.utils.config_yaml.exceptions import ConfigYamlFieldNotFoundError
+from fbpcs.utils.config_yaml.exceptions import (
+    ConfigYamlFieldNotFoundError,
+    ConfigYamlValidationError,
+)
 
 
 class ConfigYamlDict(Dict[str, Any]):
@@ -16,9 +19,17 @@ class ConfigYamlDict(Dict[str, Any]):
     def __getitem__(self, key: str) -> Any:
         """Override of dict key access, e.g. x = my_dict[key]"""
         try:
-            return super().__getitem__(key)
+            val = super().__getitem__(key)
         except KeyError:
             raise ConfigYamlFieldNotFoundError(key) from None
+
+        if val == "TODO":
+            raise ConfigYamlValidationError(
+                key,
+                "TODOs found in config",
+                "Fill in remaining TODO entries in config.yml",
+            )
+        return val
 
     def __setitem__(self, key: str, value: Any) -> None:
         """Override of dict item setting, e.g. my_dict[key] = x.

--- a/fbpcs/utils/config_yaml/exceptions.py
+++ b/fbpcs/utils/config_yaml/exceptions.py
@@ -5,9 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+class ConfigYamlBaseException(Exception):
+    pass
 
 
-class ConfigYamlFieldNotFoundError(KeyError):
+class ConfigYamlFieldNotFoundError(KeyError, ConfigYamlBaseException):
     """Raised when a ConfigYamlDict key access fails"""
 
     def __init__(self, key: str) -> None:
@@ -15,7 +17,7 @@ class ConfigYamlFieldNotFoundError(KeyError):
         super().__init__(msg)
 
 
-class ConfigYamlModuleImportError(ImportError):
+class ConfigYamlModuleImportError(ImportError, ConfigYamlBaseException):
     """Raised when a module path cannot be imported"""
 
     def __init__(self, class_path: str) -> None:
@@ -23,7 +25,7 @@ class ConfigYamlModuleImportError(ImportError):
         super().__init__(msg)
 
 
-class ConfigYamlClassNotFoundError(AttributeError):
+class ConfigYamlClassNotFoundError(AttributeError, ConfigYamlBaseException):
     """Raised when a class is not found at a given module path"""
 
     def __init__(self, class_path: str) -> None:
@@ -31,7 +33,7 @@ class ConfigYamlClassNotFoundError(AttributeError):
         super().__init__(msg)
 
 
-class ConfigYamlWrongClassConfiguredError(AssertionError):
+class ConfigYamlWrongClassConfiguredError(AssertionError, ConfigYamlBaseException):
     """Raised when the type of a class loaded through reflection is different than expected"""
 
     def __init__(self, class_path: str, target_class_name: str) -> None:
@@ -39,9 +41,17 @@ class ConfigYamlWrongClassConfiguredError(AssertionError):
         super().__init__(msg)
 
 
-class ConfigYamlWrongConstructorError(TypeError):
+class ConfigYamlWrongConstructorError(TypeError, ConfigYamlBaseException):
     """Raised when the arguments passed to a constructor are incorrect"""
 
     def __init__(self, class_name: str, cause: str) -> None:
         msg = f"{class_name} (specified in your config.yml) does not have the correct arguments. {cause}. Please make sure that your config is up to date."
+        super().__init__(msg)
+
+
+class ConfigYamlValidationError(ValueError, ConfigYamlBaseException):
+    """Raise when a config.yml fails validation"""
+
+    def __init__(self, class_name: str, cause: str, remediation: str) -> None:
+        msg = f"{class_name} (specified in your config.yml) failed validation. Cause: {cause}. Suggested remediation: {remediation}"
         super().__init__(msg)

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -12,6 +12,7 @@ from fbpcp.util.reflect import get_class as fbpcp_get_class
 from fbpcs.utils.config_yaml.exceptions import (
     ConfigYamlModuleImportError,
     ConfigYamlClassNotFoundError,
+    ConfigYamlValidationError,
     ConfigYamlWrongClassConfiguredError,
     ConfigYamlWrongConstructorError,
 )
@@ -59,15 +60,23 @@ def get_instance(config: Dict[str, Any], target_class: Type[T]) -> T:
 
     Raises:
         ConfigYamlWrongConstructorError: incorrect arguments passed to class constructor
+        ConfigYamlValidationError: invalid arguments passed to class constructor
 
     Returns:
         instance of type target_class
-
-
     """
     cls = get_class(config["class"], target_class)
     try:
-        instance = cls(**config.get("constructor", {}))
+        args_dict = config.get("constructor", {})
+        if "TODO" in args_dict.values():
+            raise ConfigYamlValidationError(
+                cls.__name__,
+                "TODOs found in config",
+                "Fill in remaining TODO entries in config.yml",
+            )
+        instance = cls(**args_dict)
+    except ConfigYamlValidationError:
+        raise
     except TypeError as e:
         raise ConfigYamlWrongConstructorError(cls.__name__, str(e)) from None
     return instance


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/508

## What is this diff stack

* **A series of diffs aiming to detect computations that started before an update**
    * detect changes to instance schema
    * compare instance creation timestamp to thrift server startup timestamp

## What is this diff

* Add `created_ts` to instance base

## Why

* Will be helpful in detecting if a new release has occurred
* Generally helpful metadata to keep

## Next diffs

* **with created_timestamp on instance...**
    * compare it to thrift server start up time
    * if the instance was created before the thrift server start up, then the thrift server has restarted at some point (usually due to a new release)
    * **If instance created_ts < thrift server startup ts, we can be reasonably confident (but not 100% confident) that a new release occurred**

Differential Revision: D33285462

