### PR TITLE
Implement PIDPostProcessingExportToScribeHandler

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -74,6 +74,7 @@ class PrivateComputationService:
         onedocker_svc: OneDockerService,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
+        pid_post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
     ) -> None:
         """Constructor of PrivateComputationService
         instance_repository -- repository to CRUD PrivateComputationInstance
@@ -87,12 +88,16 @@ class PrivateComputationService:
         self.post_processing_handlers: Dict[str, PostProcessingHandler] = (
             post_processing_handlers or {}
         )
+        self.pid_post_processing_handlers: Dict[str, PostProcessingHandler] = (
+            pid_post_processing_handlers or {}
+        )
         self.stage_service_args = PrivateComputationStageServiceArgs(
             self.pid_svc,
             self.onedocker_binary_config_map,
             self.mpc_svc,
             self.storage_svc,
             self.post_processing_handlers,
+            self.pid_post_processing_handlers,
             self.onedocker_svc,
         )
         self.logger: logging.Logger = logging.getLogger(__name__)

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -35,6 +35,7 @@ class PrivateComputationStageServiceArgs:
     mpc_svc: MPCService
     storage_svc: StorageService
     post_processing_handlers: Dict[str, PostProcessingHandler]
+    pid_post_processing_handlers: Dict[str, PostProcessingHandler]
     onedocker_svc: OneDockerService
 
 


### PR DESCRIPTION
Summary:
# TL;DR
In this diff, we are adding a new `PostProcessingHandler` called `PIDPostProcessingExportToScribeHandler`. Then, adding a new arg `pid_post_processing_handler` to
Please see the attached task for more overview.

# Details
1. Created new Scribe [private_id_results](https://www.internalfb.com/intern/scribe/view/?category=private_id_results), [private_id_results_test](https://www.internalfb.com/intern/scribe/view/?category=private_id_results_test)
2. Create `PIDExportToScribeHandler` in  [post_processing_handlers](https://fburl.com/code/bntznh2r)
    a. iterate and read each metric results
    b. aggregate metric results
    c. json.dumps
    d. export to scribe
3. Add `pid_post_processing_handlers` to `HandlerConfig` in [handler_config.py](https://fburl.com/code/ldlgmkak)
4. Add `pid_post_processing_handlers` to `PrivateComputationService` in [handler.py](https://fburl.com/code/97itud9d) + [private_computation.py](https://fburl.com/code/a53ahvul)
5. Add `pid_post_processing_handlers` to [PrivateComputationStageServiceArgs](https://fburl.com/code/dxscxn9g) in [private_computation_stage_service.py](https://fburl.com/code/ra2teate)

Differential Revision: D33304175

