### PR TITLE
Add ID_MATCH_POST_PROCESS into PL/PA stage flow

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -74,6 +74,7 @@ class PrivateComputationService:
         onedocker_svc: OneDockerService,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
+        pid_post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
     ) -> None:
         """Constructor of PrivateComputationService
         instance_repository -- repository to CRUD PrivateComputationInstance
@@ -87,12 +88,16 @@ class PrivateComputationService:
         self.post_processing_handlers: Dict[str, PostProcessingHandler] = (
             post_processing_handlers or {}
         )
+        self.pid_post_processing_handlers: Dict[str, PostProcessingHandler] = (
+            pid_post_processing_handlers or {}
+        )
         self.stage_service_args = PrivateComputationStageServiceArgs(
             self.pid_svc,
             self.onedocker_binary_config_map,
             self.mpc_svc,
             self.storage_svc,
             self.post_processing_handlers,
+            self.pid_post_processing_handlers,
             self.onedocker_svc,
         )
         self.logger: logging.Logger = logging.getLogger(__name__)

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -35,6 +35,7 @@ class PrivateComputationStageServiceArgs:
     mpc_svc: MPCService
     storage_svc: StorageService
     post_processing_handlers: Dict[str, PostProcessingHandler]
+    pid_post_processing_handlers: Dict[str, PostProcessingHandler]
     onedocker_svc: OneDockerService
 
 

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -51,7 +51,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = "CREATED ID_MATCH PREPARE DECOUPLED_ATTRIBUTION DECOUPLED_AGGREGATION AGGREGATE POST_PROCESSING_HANDLERS"
+    _order_ = "CREATED ID_MATCH ID_MATCH_POST_PROCESS PREPARE DECOUPLED_ATTRIBUTION DECOUPLED_AGGREGATION AGGREGATE POST_PROCESSING_HANDLERS"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -66,6 +66,12 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         True,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
+        False,
     )
     PREPARE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.PREPARE_DATA_STARTED,
@@ -118,6 +124,10 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         elif self is self.ID_MATCH:
             return IdMatchStageService(
                 args.pid_svc,
+            )
+        elif self is self.ID_MATCH_POST_PROCESS:
+            return PostProcessingStageService(
+                args.storage_svc, args.pid_post_processing_handlers
             )
         elif self is self.PREPARE:
             return PrepareDataStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -46,7 +46,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH PREPARE COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
+    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS PREPARE COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -73,6 +73,12 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         True,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
+        False,
     )
     PREPARE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.PREPARE_DATA_STARTED,
@@ -133,6 +139,10 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
                 args.pid_svc,
                 UnionPIDStage.PUBLISHER_RUN_PID,
                 UnionPIDStage.ADV_RUN_PID,
+            )
+        elif self is self.ID_MATCH_POST_PROCESS:
+            return PostProcessingStageService(
+                args.storage_svc, args.pid_post_processing_handlers
             )
         elif self is self.PREPARE:
             return PrepareDataStageService(

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -517,7 +517,7 @@ class TestPlInstanceRunner(TestCase):
             ),
             ####################### NON JOINT STAGE TEST #################################3
             (
-                "ID_MATCH_COMPLETED",
+                "ID_MATCHING_POST_PROCESS_COMPLETED",
                 PrivateComputationStageFlow.PREPARE.previous_stage.completed_status,
                 PrivateComputationStageFlow.PREPARE,
                 True,
@@ -687,7 +687,7 @@ class TestPlInstanceRunner(TestCase):
             ),
             ####################### NON JOINT STAGE TEST #################################3
             (
-                "ID_MATCH_COMPLETED",
+                "ID_MATCHING_POST_PROCESS_COMPLETED",
                 PrivateComputationStageFlow.PREPARE.previous_stage.completed_status,
                 PrivateComputationStageFlow.PREPARE,
                 True,


### PR DESCRIPTION
Summary:
# Overview
Adding ID_MATCH_POST_PROCESS into PL/PA stage flow by following (Step_3:_Add_stage_to_stage_flow)[https://www.internalfb.com/intern/wiki/Private_Computation_Solutions/Internal_Developer_Guide/How_to_add_a_stage_to_PCS/Step_3:_Add_stage_to_stage_flow/].

# Details
We are re-using `PostProcessingStageService` which takes care of calling `PostProcessingHandler`. Via `PostProcessingStageService`, we are calling   `pid_post_processing_handlers`.

Differential Revision: D33304391

