### PR TITLE
Removing legacy attribution game reference from co-ordinator code.

### DIFF
--- a/fbpcs/onedocker_binary_names.py
+++ b/fbpcs/onedocker_binary_names.py
@@ -18,7 +18,6 @@ class OneDockerBinaryNames(Enum):
 
     DECOUPLED_ATTRIBUTION = "private_attribution/decoupled_attribution"
     DECOUPLED_AGGREGATION = "private_attribution/decoupled_aggregation"
-    ATTRIBUTION_COMPUTE = "private_attribution/compute"
     SHARD_AGGREGATOR = "private_attribution/shard-aggregator"
 
     PID_CLIENT = "pid/private-id-client"

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -15,7 +15,6 @@ from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 class GameNames(Enum):
     LIFT = "lift"
     SHARD_AGGREGATOR = "shard_aggregator"
-    ATTRIBUTION_COMPUTE = "attribution_compute"
     DECOUPLED_ATTRIBUTION = "decoupled_attribution"
     DECOUPLED_AGGREGATION = "decoupled_aggregation"
 
@@ -40,19 +39,6 @@ PRIVATE_COMPUTATION_GAME_CONFIG = {
             {"name": "metrics_format_type", "required": True},
             {"name": "threshold", "required": True},
             {"name": "first_shard_index", "required": False},
-        ],
-    },
-    GameNames.ATTRIBUTION_COMPUTE.value: {
-        "onedocker_package_name": OneDockerBinaryNames.ATTRIBUTION_COMPUTE.value,
-        "arguments": [
-            {"name": "aggregators", "required": True},
-            {"name": "input_base_path", "required": True},
-            {"name": "output_base_path", "required": True},
-            {"name": "attribution_rules", "required": True},
-            {"name": "concurrency", "required": True},
-            {"name": "num_files", "required": True},
-            {"name": "file_start_index", "required": True},
-            {"name": "use_xor_encryption", "required": True},
         ],
     },
     GameNames.DECOUPLED_ATTRIBUTION.value: {

--- a/fbpcs/private_computation/service/private_computation_service_data.py
+++ b/fbpcs/private_computation/service/private_computation_service_data.py
@@ -76,14 +76,6 @@ class PrivateComputationServiceData:
         service=IdSpineCombinerService(),
     )
 
-    ATTRIBUTION_COMPUTE_STAGE_DATA: StageData = StageData(
-        binary_name=OneDockerBinaryNames.ATTRIBUTION_COMPUTE.value,
-        game_name=BINARY_NAME_TO_GAME_NAME[
-            OneDockerBinaryNames.ATTRIBUTION_COMPUTE.value
-        ],
-        service=None,
-    )
-
     DECOUPLED_ATTRIBUTION_STAGE_DATA: StageData = StageData(
         binary_name=OneDockerBinaryNames.DECOUPLED_ATTRIBUTION.value,
         game_name=BINARY_NAME_TO_GAME_NAME[
@@ -112,7 +104,7 @@ class PrivateComputationServiceData:
         elif game_type is PrivateComputationGameType.ATTRIBUTION:
             return cls(
                 combiner_stage=PrivateComputationServiceData.ATTRIBUTION_COMBINER_STAGE_DATA,
-                compute_stage=PrivateComputationServiceData.ATTRIBUTION_COMPUTE_STAGE_DATA,
+                compute_stage=PrivateComputationServiceData.DECOUPLED_ATTRIBUTION_STAGE_DATA,
             )
         else:
             raise ValueError("Unknown game type")


### PR DESCRIPTION
Summary:
# Context
Decoupled attribution is now the default flow in production. We have done 5 successful pilots using the same. Thus at this time, it's safe to remove legacy attribution code. In this stack removing all references to the legacy attribution code.

# This Diff
In this diff, removing references to legacy attribution game in co-ordinator code.

Differential Revision: D33438464

