### PR TITLE
Pyre strict for fbcode/fbpcs/private_computation/test/repository/test_private_computation_game.py

### DIFF
--- a/fbpcs/private_computation/test/repository/test_private_computation_game.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_game.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import unittest
 from typing import List
 from unittest.mock import patch
@@ -29,10 +31,10 @@ class TestPrivateComputationGameRepository(unittest.TestCase):
             },
         },
     )
-    def setUp(self):
+    def setUp(self) -> None:
         self.game_repository = PrivateComputationGameRepository()
 
-    def test_get_game(self):
+    def test_get_game(self) -> None:
         game_config = self.game_repository.private_computation_game_config
         expected_game_name = "attribution_compute_dev"
         expected_onedocker_package_name = game_config[expected_game_name][
@@ -51,7 +53,7 @@ class TestPrivateComputationGameRepository(unittest.TestCase):
         )
         self.assertEqual(attribution_game_config.arguments, expected_arguments)
 
-    def test_unsupported_game(self):
+    def test_unsupported_game(self) -> None:
         unsupported_game_name = "unsupported game"
         with self.assertRaisesRegex(
             ValueError, f"Game {unsupported_game_name} is not supported."


### PR DESCRIPTION
Summary: Add pyre strict for test_private_computation_game.py

Reviewed By: corbantek

Differential Revision: D33537090

