### PR TITLE
Add results visibility to Private Computation Instance.

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -8,7 +8,7 @@
 
 import os
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import List, Union, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -58,6 +58,13 @@ class AttributionRule(Enum):
 
 class AggregationType(Enum):
     MEASUREMENT = "measurement"
+
+
+# This is the visibility defined in https://fburl.com/code/i1itu32l
+class ResultVisibility(IntEnum):
+    PUBLIC = 0
+    PUBLISHER = 1
+    PARTNER = 2
 
 
 UnionedPCInstance = Union[PIDInstance, PCSMPCInstance, PostProcessingInstance]
@@ -132,6 +139,8 @@ class PrivateComputationInstance(InstanceBase):
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name
     _stage_flow_cls_name: str = "PrivateComputationStageFlow"
+
+    result_visibility: ResultVisibility = ResultVisibility.PUBLIC
 
     def __post_init__(self) -> None:
         if self.num_pid_containers > self.num_mpc_containers:

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -21,6 +21,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
+    ResultVisibility,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
@@ -142,6 +143,11 @@ class AggregateShardsStageService(PrivateComputationStageService):
                     "run_name": pc_instance.instance_id if self._log_cost_to_s3 else "",
                 },
             ]
+            # We should only export visibility to scribe when it's set
+            if pc_instance.result_visibility is not ResultVisibility.PUBLIC:
+                result_visibility = int(pc_instance.result_visibility)
+                for arg in game_args:
+                    arg["visibility"] = result_visibility
 
             mpc_instance = await create_and_start_mpc_instance(
                 mpc_svc=self._mpc_service,
@@ -168,6 +174,12 @@ class AggregateShardsStageService(PrivateComputationStageService):
                     "run_name": pc_instance.instance_id if self._log_cost_to_s3 else "",
                 },
             ]
+            # We should only export visibility to scribe when it's set
+            if pc_instance.result_visibility is not ResultVisibility.PUBLIC:
+                result_visibility = int(pc_instance.result_visibility)
+                for arg in game_args:
+                    arg["visibility"] = result_visibility
+
             mpc_instance = await create_and_start_mpc_instance(
                 mpc_svc=self._mpc_service,
                 instance_id=pc_instance.instance_id

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -28,6 +28,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
+    ResultVisibility,
 )
 from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
@@ -126,6 +127,7 @@ class PrivateComputationService:
         k_anonymity_threshold: Optional[int] = None,
         fail_fast: bool = False,
         stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
+        result_visibility: ResultVisibility = ResultVisibility.PUBLIC,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -168,6 +170,7 @@ class PrivateComputationService:
                 if game_type is PrivateComputationGameType.ATTRIBUTION
                 else PrivateComputationStageFlow,
             ).get_cls_name(),
+            result_visibility=result_visibility,
         )
 
         self.instance_repository.create(instance)


### PR DESCRIPTION
Summary:
## Overall Changes
- Create a new Enum called ResultVisibility
- Add it into PrivateComputationInstance, and all the create_instance function

Differential Revision: D33484965

