### PR TITLE
Fix multiple issues related to S257290

### DIFF
--- a/fbpcs/emp_games/common/SecretSharing.hpp
+++ b/fbpcs/emp_games/common/SecretSharing.hpp
@@ -419,7 +419,10 @@ inline const std::vector<emp::Integer> multiplyBitmask(
   std::vector<emp::Integer> out;
   out.reserve(vec.size());
 
-  const emp::Integer zero{INT_SIZE, 0, emp::PUBLIC};
+  // If vec.size() is zero, the created int doesn't matter since the loop
+  // will never execute.
+  auto sz = static_cast<int32_t>(vec.size() > 0 ? vec.at(0).size() : INT_SIZE);
+  const emp::Integer zero{sz, 0, emp::PUBLIC};
 
   for (std::vector<emp::Integer>::size_type i = 0; i < vec.size(); ++i) {
     // emp::If(condition, true_case, false_case)
@@ -454,7 +457,11 @@ inline const std::vector<std::vector<emp::Integer>> multiplyBitmask(
   out.reserve(vec.size());
   for (size_t i = 0; i < vec.size(); ++i) {
     out.emplace_back();
-    const emp::Integer zero{INT_SIZE, 0, emp::PUBLIC};
+    // If vec.size() is zero, the created int doesn't matter since the loop
+    // will never execute.
+    auto sz = static_cast<int32_t>(
+        vec.at(i).size() > 0 ? vec.at(i).at(0).size() : INT_SIZE);
+    const emp::Integer zero{sz, 0, emp::PUBLIC};
     for (size_t j = 0; j < vec.at(i).size(); ++j) {
       out.back().push_back(zero.select(bitmask.at(i), vec.at(i).at(j)));
     }

--- a/fbpcs/emp_games/lift/calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/calculator/InputData.cpp
@@ -286,7 +286,7 @@ void InputData::addFromCSV(
 std::vector<int64_t> InputData::bitmaskFor(int64_t groupId) const {
   std::vector<int64_t> res(numRows_);
   for (std::size_t i = 0; i < res.size(); ++i) {
-    res[i] = groupIds_.at(i) == groupId ? 1 : 0;
+    res[i] = groupIds_.size() > i && groupIds_.at(i) == groupId ? 1 : 0;
   }
   return res;
 }


### PR DESCRIPTION
Summary:
# Two issues
1. SecretSharing.hpp is constructing `zero` sentinel incorrectly; previous version of EMP seemingly did integer extension for us automatically, but now the caller is responsible. Code hasn't been changed since Dec 2020 (oof)
2. If only one party supplies bitmasks, we assume *both* will and don't do a vector check (this was our range error). This has also existed as bug for a *long* time (July 2020). We never caught it by some miracle / anti-miracle. Now that advlift is sending publisher breakdowns to every PL study, we encounter it in *every* run.

Reviewed By: corbantek

Differential Revision: D33543637

