### PR TITLE
Decoupling - Ad Id Compression on Aggregation.

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Added version argument to run_fbpcs.sh
 
 ### Changed
+- Add Ad Id compression logic to decoupled aggregation game.
 
 ### Removed
   - Removed pl_coordinator.py and pa_coordinator.py which already only had deprecation messages and no logic

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregation.hpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregation.hpp
@@ -33,10 +33,10 @@ const AttributionResult ATTRIBUTION_RESULTS_PADDING_VALUE{
     /* is_attributed */ false};
 
 const MeasurementTouchpointMedata MEASUREMENT_TOUCHPOINT_PADDING_VALUE{
-    /* ad_id */ -1};
+    /* ad_id */ 0};
 
 const MeasurementConversionMetadata MEASUREMENT_CONVERSION_PADDING_VALUE{
-    /* conv_value */ -1};
+    /* conv_value */ 0};
 
 // privately sharing attribution results from publisher side.
 template <int MY_ROLE>
@@ -164,21 +164,13 @@ const std::vector<AggregationFormat> shareAggregationFormats(
 // ad Ids will be used as keys for aggregation in Measurement aggregator.
 // sharing the Ids with partner.
 template <int MY_ROLE>
-const std::vector<int64_t> shareValidAdIds(
-    const std::vector<std::vector<TouchpointMetadata>>& tpmArrays) {
+const std::vector<int64_t> shareValidAdIds(const std::vector<int64_t>& adIds) {
   // Compute and then send over the integer ad ids.
-  std::vector<int64_t> adIds;
   int64_t numValidAdIds = 0;
   if (MY_ROLE == aggregation::private_aggregation::PUBLISHER) {
     XLOG(DBG, "Computing valid ad ids for sending to partner");
     std::unordered_set<int64_t> adIdSet;
-    for (const auto& tmpArray : tpmArrays) {
-      for (const auto& tpm : tmpArray) {
-        adIdSet.insert(tpm.adId);
-      }
-    }
-    adIds.insert(adIds.end(), adIdSet.begin(), adIdSet.end());
-    numValidAdIds = adIdSet.size();
+    numValidAdIds = adIds.size();
   }
 
   const emp::Integer empNumValidAdIds{INT_SIZE, numValidAdIds, PUBLISHER};
@@ -243,8 +235,7 @@ AggregationOutputMetrics computeAggregations(
   const auto aggregationFormats =
       shareAggregationFormats<MY_ROLE>(inputData.getAggregationFormats());
 
-  const auto& adIds =
-      shareValidAdIds<MY_ROLE>(inputData.getTouchpointMetadata());
+  const auto& adIds = shareValidAdIds<MY_ROLE>(inputData.getOriginalAdIds());
 
   MeasurementTpmArrays privateTpmArrays;
   MeasurementCvmArrays privateCvmArrays;

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.h
@@ -182,6 +182,10 @@ class AggregationInputMetrics {
     return ids_;
   }
 
+  const std::vector<int64_t>& getOriginalAdIds() const {
+    return originalAdIds_;
+  }
+
   const std::vector<std::string>& getAttributionRules() const {
     return attributionRules_;
   }
@@ -212,6 +216,7 @@ class AggregationInputMetrics {
 
  private:
   std::vector<int64_t> ids_;
+  std::vector<int64_t> originalAdIds_;
   std::vector<std::string> attributionRules_;
   std::vector<AggregationFormat> aggregationFormats_;
   AggregationMetrics::AttributionResultsList touchpointSecretShare_;

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.h
@@ -10,6 +10,7 @@
 #include <fbpcf/mpc/EmpGame.h>
 #include <math.h>
 #include <memory>
+#include <vector>
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/AttributionResult.h"
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/Constants.h"
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/ConversionMetadata.h"
@@ -93,6 +94,7 @@ class Aggregator {
 
  protected:
   const fbpcf::Visibility outputVisibility_;
+  std::vector<int64_t> validOriginalAdIds_;
 };
 
 struct AggregationContext {

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Constants.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Constants.h
@@ -16,6 +16,7 @@ enum AGGREGATION_FORMAT { AD_OBJECT_FORMAT = 1 };
 
 const int64_t INT_SIZE = 64;
 const int64_t INT_SIZE_32 = 32;
+const int64_t INT_SIZE_16 = 16;
 const int64_t PUBLISHER = emp::ALICE;
 const int64_t PARTNER = emp::BOB;
 

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/TouchPointMetadata.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/TouchPointMetadata.h
@@ -18,10 +18,11 @@
 namespace aggregation::private_aggregation {
 
 struct TouchpointMetadata {
-  int64_t adId;
+  int64_t originalAdId;
   int64_t ts;
   bool isClick;
   int64_t campaignMetadata;
+  uint16_t adId;
 
   /**
    * If both are clicks, or both are views, the earliest one comes first.
@@ -33,7 +34,7 @@ struct TouchpointMetadata {
 };
 
 struct MeasurementTouchpointMedata {
-  const int64_t adId;
+  const uint16_t adId;
 
   // privatelyShareArrayFrom support
   friend bool operator==(
@@ -56,10 +57,10 @@ struct PrivateMeasurementTouchpointMetadata {
       MeasurementTouchpointMedata tpm,
       int party)
       : PrivateMeasurementTouchpointMetadata(
-            emp::Integer(INT_SIZE, tpm.adId, party)) {}
+            emp::Integer(INT_SIZE_16, tpm.adId, party)) {}
 
   explicit PrivateMeasurementTouchpointMetadata()
-      : adId{INT_SIZE, -1, emp::PUBLIC} {}
+      : adId{INT_SIZE_16, 0, emp::PUBLIC} {}
 
   explicit PrivateMeasurementTouchpointMetadata(const emp::Integer& _adId)
       : adId{_adId} {}


### PR DESCRIPTION
Summary:
# Context

In Diff D32621605 we added Ad ID compression for PCF 2.0 aggregation game. As there is still some time for PCF 2.0 framework as well as games to launch, adding the same optimization to existing production game. So that we achieve more performance gains in upcoming pilots.

Please check the summary of D32621605 for detailed analysis on the functionality.

Differential Revision: D33539669

