### PR TITLE
don't change root log level

### DIFF
--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -162,8 +162,9 @@ def main(argv: Optional[List[str]] = None) -> None:
     log_level = logging.DEBUG if arguments["--verbose"] else logging.INFO
     instance_id = arguments["<instance_id>"]
 
-    logging.basicConfig(filename=log_path, level=log_level)
+    logging.basicConfig(filename=log_path, level=logging.INFO)
     logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
 
     if arguments["create_instance"]:
         logger.info(f"Create instance: {instance_id}")


### PR DESCRIPTION
Summary:
## What

* Don't set log level for root logger - only set log level for the PC-CLI logger.
    * I.e. don't set a global log level for every python logger. It is up to each library to decide what the log level is and how it should be changed.

## Why

* We don't need logging information from third party libraries
    * the libraries are expected to raise appropriate exceptions which we can then log.
    * logging everything from every library we use results in massive, extremely difficult to read log files.

Differential Revision: D33558540

