### PR TITLE
Remove run_fbpcs.sh deprecated command message

### DIFF
--- a/fbpcs/scripts/run_fbpcs.sh
+++ b/fbpcs/scripts/run_fbpcs.sh
@@ -67,29 +67,6 @@ function parse_args() {
 
     docker_cmd=( python3.8 -m fbpcs.private_computation_cli.private_computation_cli )
 
-    RED='\033[0;31m'
-    NC='\033[0m' # No Color
-
-    case $1 in
-        lift )
-            echo -e "${RED}********************************************************"
-            echo -e "Because you specified game name \"$1\", it looks like you're running a deprecated version of this command."
-            echo -e "Please remove \"$1\" from the command and try again."
-            echo -e "********************************************************${NC}"
-            exit 1
-            ;;
-        attribution )
-            echo -e "${RED}********************************************************"
-            echo -e "Because you specified game name \"$1\", it looks like you're running a deprecated version of this command."
-            echo -e "Please modify your commands according to the instruction below and try again:"
-            echo -e "1. Remove \"attribution\" right after \"run_fbpcs\""
-            echo -e "2. Add a new argument \"--game_type=attribution\" to the \"run_fbpcs.sh create_instance ...\" command"
-            echo -e "3. Replace \"compute_attribution\" with \"compute_metrics\""
-            echo -e "********************************************************${NC}"
-            exit 1
-            ;;
-    esac
-
     # PC-CLI arguments
     for arg in "$@"
     do


### PR DESCRIPTION
Summary: I [communicated](https://fb.workplace.com/groups/164332244998024/permalink/746739240090652/) with SolEngs on Nov 1, 2021 with the new commands, so rn no one should still be using the deprecated commands, so this message shouldn't be relevant anymore.

Differential Revision: D33586357

