### PR TITLE
Pyre Strict in data_transformation_lambda.py

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -3,37 +3,40 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 from __future__ import print_function
 
 import base64
 import json
 import os
 import re
+from typing import Dict, List, Tuple
 
 # initiate
 print("Loading lambda function...")
 
-BROWSER_NAME_REGEXES = [
-    [re.compile(r".*Chrome.*Mobile Safari/[0-9.]+$"), "Chrome Mobile"],
-    [re.compile(r".*Chrome.*Safari/[0-9.]+$"), "Chrome Desktop"],
-    [re.compile(r".*Mobile.*Safari/[0-9.]+$"), "Mobile Safari"],
-    [re.compile(r".*FBIOS;.*"), "Facebook for iOS"],
-    [
+BROWSER_NAME_REGEXES: List[Tuple[re.Pattern, str]] = [
+    (re.compile(r".*Chrome.*Mobile Safari/[0-9.]+$"), "Chrome Mobile"),
+    (re.compile(r".*Chrome.*Safari/[0-9.]+$"), "Chrome Desktop"),
+    (re.compile(r".*Mobile.*Safari/[0-9.]+$"), "Mobile Safari"),
+    (re.compile(r".*FBIOS;.*"), "Facebook for iOS"),
+    (
         re.compile(r".*(CPU OS|iPhone OS|CPU iPhone).*Instagram.*"),
         "Instagram IAB for iOS",
-    ],
-    [re.compile(r".*Instagram.*Android.*"), "Instagram IAB for Android"],
-    [re.compile(r".*FB4A.*"), "Facebook for Android"],
+    ),
+    (re.compile(r".*Instagram.*Android.*"), "Instagram IAB for Android"),
+    (re.compile(r".*FB4A.*"), "Facebook for Android"),
 ]
 
-DEVICE_OS_REGEXES = [
-    [re.compile(r".*(CPU OS|iPhone OS|CPU iPhone).*"), "iOS"],
-    [re.compile(r".*Android.*"), "Android"],
-    [re.compile(r".*Windows NT.*"), "Windows NT"],
-    [re.compile(r".*Mac OS X.*"), "Mac OS X"],
+DEVICE_OS_REGEXES: List[Tuple[re.Pattern, str]] = [
+    (re.compile(r".*(CPU OS|iPhone OS|CPU iPhone).*"), "iOS"),
+    (re.compile(r".*Android.*"), "Android"),
+    (re.compile(r".*Windows NT.*"), "Windows NT"),
+    (re.compile(r".*Mac OS X.*"), "Mac OS X"),
 ]
 
-OS_VERSION_REGEXES = [
+OS_VERSION_REGEXES: List[re.Pattern] = [
     re.compile(r".*(CPU OS|iPhone OS|CPU iPhone) +(\d+)[_\.](\d+)(?:[_\.](\d+))?.*"),
     re.compile(r".*(Intel Mac OS X) +(\d+)[_\.](\d+)(?:[_\.](\d+))?.*"),
     re.compile(r".*(Android) +(\d+)[_\.](\d+)(?:[_\.](\d+))?.*"),
@@ -44,7 +47,9 @@ DEVICE_OS = "device_os"
 DEVICE_OS_VERSION = "device_os_version"
 
 
-def lambda_handler(event, context):
+def lambda_handler(
+    event: Dict[str, List[Dict[str, str]]], context: Dict[str, str]
+) -> Dict[str, List[Dict[str, str]]]:
     output = []
     ##### NOTE: this script assume the schema is correct, no missing items
     for record in event["records"]:
@@ -152,7 +157,7 @@ def lambda_handler(event, context):
     return {"records": output}
 
 
-def _parse_client_user_agent(client_user_agent):
+def _parse_client_user_agent(client_user_agent: str) -> Dict[str, str]:
     parsed_fields = {}
 
     for (regex, browserName) in BROWSER_NAME_REGEXES:


### PR DESCRIPTION
Summary:
Enabled pyre strict mode in `data_transformation_lambda.py`.

Annotated all parameters, return types, and attribute types in `data_transformation_lambda.py` with a non-Any type to comply with pyre strict mode rules.

Differential Revision: D33575503

