### PR TITLE
Removing legacy attribution game reference from on call script.

### DIFF
--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -39,22 +39,6 @@ target_link_libraries(
   empgamecommon)
 install(TARGETS lift_calculator DESTINATION bin)
 
-# attribution
-file(GLOB attribution_src
-  "fbpcs/emp_games/attribution/**.c"
-  "fbpcs/emp_games/attribution/**.cpp"
-  "fbpcs/emp_games/attribution/**.h"
-  "fbpcs/emp_games/attribution/**.hpp")
-list(FILTER attribution_src EXCLUDE REGEX ".*Test.*")
-add_executable(
-  attribution_calculator
-  ${attribution_src})
-target_link_libraries(
-  attribution_calculator
-  empgamecommon
-  perftools)
-install(TARGETS attribution_calculator DESTINATION bin)
-
 # generic shard_aggregator
 file(GLOB shard_aggregator_src
   "fbpcs/emp_games/attribution/shard_aggregator/AggMetrics.cpp",

--- a/docker/emp_games/run-attribution-sample.sh
+++ b/docker/emp_games/run-attribution-sample.sh
@@ -15,7 +15,7 @@ docker run --rm \
     -v "$SCRIPT_DIR/../../fbpcs/emp_games/attribution/test/shard_test_input/publisher:/input" \
     -v "$USERDIR/sample-output:/output" \
     --network=host emp-games:latest \
-        attribution_calculator \
+        decoupled_attribution_calculator \
         --party=1 \
         --attribution_rules=last_click_1d \
         --aggregators=measurement \
@@ -29,7 +29,7 @@ docker run --rm \
     -v "$SCRIPT_DIR/../../fbpcs/emp_games/attribution/test/shard_test_input/partner:/input" \
     -v "$USERDIR/sample-output:/output" \
     --network=host emp-games:latest \
-        attribution_calculator \
+        decoupled_attribution_calculator \
         --party=2 \
         --server_ip=127.0.0.1 \
         --input_base_path=/input/partner_correctness_clickonly_clicktouch_input.csv \

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -66,7 +66,6 @@ WORKDIR /usr/local/bin
 RUN for b in $(ls attribution* lift* pid* shard* private-id* decoupled*); do ln -s $(pwd)/$b /home/pcs/onedocker/package/$b; done
 
 # Link binaries name to match with onedocker binaries name
-RUN ln -s attribution_calculator /home/pcs/onedocker/package/compute
 RUN ln -s decoupled_attribution_calculator /home/pcs/onedocker/package/decoupled_attribution
 RUN ln -s decoupled_aggregation_calculator /home/pcs/onedocker/package/decoupled_aggregation
 RUN ln -s lift_calculator /home/pcs/onedocker/package/lift

--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -44,7 +44,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 if [ "$PACKAGE" = "emp_games" ]; then
 docker create -ti --name temp_container "fbpcs/emp-games:${TAG}"
 docker cp temp_container:/usr/local/bin/lift_calculator "$SCRIPT_DIR/binaries_out/."
-docker cp temp_container:/usr/local/bin/attribution_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/decoupled_attribution_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/decoupled_aggregation_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/shard_aggregator "$SCRIPT_DIR/binaries_out/."


### PR DESCRIPTION
Summary:
# Context
Decoupled attribution is now the default flow in production. We have done 5 successful pilots using the same. Thus at this time, it's safe to remove legacy attribution code. In this stack removing all references to the legacy attribution code.

# This Diff
In this diff, removing references to legacy attribution game in on call code used for building and promoting binaries to production.

Differential Revision: D33439178

