### PR TITLE
Fix for end to end test correctness error.

### DIFF
--- a/fbpcs/emp_games/attribution/test/attribution_e2e_test/partner_expected_result.json
+++ b/fbpcs/emp_games/attribution/test/attribution_e2e_test/partner_expected_result.json
@@ -2,8 +2,8 @@
     "last_touch_1d": {
         "measurement": {
             "4": {
-                "sales": 0,
-                "convs": 0
+                "sales": -1,
+                "convs": -1
             },
             "3": {
                 "sales": 504800,
@@ -16,10 +16,6 @@
             "1": {
                 "sales": 1212700,
                 "convs": 1000
-            },
-            "0": {
-                "sales": 0,
-                "convs": 0
             }
         }
     }

--- a/fbpcs/emp_games/attribution/test/attribution_e2e_test/publisher_expected_result.json
+++ b/fbpcs/emp_games/attribution/test/attribution_e2e_test/publisher_expected_result.json
@@ -2,8 +2,8 @@
     "last_touch_1d": {
         "measurement": {
             "4": {
-                "sales": 0,
-                "convs": 0
+                "sales": -1,
+                "convs": -1
             },
             "3": {
                 "sales": 504800,
@@ -16,10 +16,6 @@
             "1": {
                 "sales": 1212700,
                 "convs": 1000
-            },
-            "0": {
-                "sales": 0,
-                "convs": 0
             }
         }
     }


### PR DESCRIPTION
Summary:
# Context
As part of diff D33539669 (https://github.com/facebookresearch/fbpcs/commit/e3be47b25d40788df019068f95834ce4a067780f), added Ad Id compression logic to aggregation game. This diff, broke the end to end tests for PA, as the end to end tests expected result has an entry for Ad Id 0. 0 is not a valid ad Id, and in the updated aggregation logic, it will not be included in the input (we instead use the value in computation to represent padded ad Ids).

#Fix
Ad ids are 64 bit integers, representing global ids. In actual runs, we would never have 0 or negative Ad Ids. Thus in this diff, removed 0 from the final expected results json.

Differential Revision: D33691060

