### PR TITLE
add pid metric export stage to github e2e test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -158,6 +158,17 @@ jobs:
         ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
        working-directory: ./fbpcs/tests/github/
 
+     - name: Lift - PID export metrics
+       run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_metric_export
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Check Status
+       timeout-minutes: 5
+       run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+       working-directory: ./fbpcs/tests/github/
+
      - name: Lift - Prepare Compute Input
        run: |
         ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} prepare_compute_input
@@ -236,6 +247,17 @@ jobs:
        timeout-minutes: 5
        run: |
         ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Attribution - PID export metrics
+       run: |
+        ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} pid_metric_export
+       working-directory: ./fbpcs/tests/github/
+
+     - name: Check Status
+       timeout-minutes: 5
+       run: |
+        ./check_status.sh ${{ env.PL_CONTAINER_NAME }} attribution
        working-directory: ./fbpcs/tests/github/
 
      - name: Attribution - Prepare Compute Input

--- a/fbpcs/tests/github/attribution_run_stages.sh
+++ b/fbpcs/tests/github/attribution_run_stages.sh
@@ -46,7 +46,7 @@ case "$stage" in
             --aggregation_type="$ATTRIBUTION_TYPE"
             ;;
     # Stages without passing IP addresses
-    prepare_compute_input )
+    prepare_compute_input | pid_metric_export )
         echo "Attribution Publisher $stage starts"
         $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"

--- a/fbpcs/tests/github/lift_run_stages.sh
+++ b/fbpcs/tests/github/lift_run_stages.sh
@@ -40,7 +40,7 @@ case "$stage" in
             --concurrency="$LIFT_CONCURRENCY"
             ;;
     # stages donot need IP exchange
-    prepare_compute_input | pid_shard | pid_prepare )
+    prepare_compute_input | pid_shard | pid_prepare | pid_metric_export )
         echo "Lift Publisher $stage starts"
         $docker_command run_next "$LIFT_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"


### PR DESCRIPTION
Summary:
## What

* add new pid metric stage to github e2e test

## Why

* because it's broken right now

## How

* Doing the same thing as this diff: D32295577 (https://github.com/facebookresearch/fbpcs/commit/d31b2050bfac0b0510b60faa3e3170763f5e5090)

Differential Revision: D33723265

