### PR TITLE
Fix missing type annotation

### DIFF
--- a/fbpcs/utils/tests/integration_test.py
+++ b/fbpcs/utils/tests/integration_test.py
@@ -22,8 +22,7 @@ def test_s3_file_helper() -> None:
     content: Optional[str] = None
     print("Start reader")
     with abstract_file_ctx.abstract_file_reader_path(s3_path) as reader:
-        # pyre-fixme[16]: `Path` has no attribute `read`.
-        content = reader.read()
+        content = reader.read_text()
     print("Reader done")
 
     assert content == "abcdef"


### PR DESCRIPTION
Summary:
Pyre skips type check for the unannotated functions. There was a missing return type annotation in the function at:
/fbsource/fbcode/fbpcs/utils/tests/integration_test.py

This uncovered another problem with improper use of deprecated function pathlib.Path().read(). Replaced with pathlib.Path().read_text()

Differential Revision: D33828513

