### PR TITLE
correcting vector reserve value to reduce memory consumption.

### DIFF
--- a/fbpcs/emp_games/common/SecretSharing.hpp
+++ b/fbpcs/emp_games/common/SecretSharing.hpp
@@ -133,11 +133,8 @@ const std::vector<std::vector<O>> privatelyShareArraysFrom(
   if (MY_ROLE == SOURCE_ROLE) {
     XLOG(DBG, "padding arrays");
 
-    // POTENTIAL OPTIMIZATION: the value we reserve for the flattened
-    // padded array is an upper bound. We can probably do better, if we
-    // want to save memory.
     paddedLengths.reserve(numVals);
-    paddedArrays.reserve(numVals * maxArraySize);
+    paddedArrays.reserve(numVals);
 
     for (size_t i = 0; i < numVals; i++) {
       auto vec = in.at(i);


### PR DESCRIPTION
Summary:
# Change
In this diff changed the variable passed to paddedArrays.reserve() function from numVals * maxArraySize to numVals.

# Analysis
The reserve function will allocate this memory for outer vector paddedArrays. Thus in this case, we end up allocating more than required memory for the outerArray.

A better way to use reserve in this case is

```
paddedArrays.reserve(numVals, new vector<int>(maxArrays))
```
However, if look in the method, we are creating paddedVec vector at line 156 and pushing data to it on line 159. So the resizing that we are trying to avoid in this case, is happening anyways in the inner method.

Thus only reserving numVal locations for the outer vector in this case.

Differential Revision: D33821873

