### PR TITLE
Add input_validation_stage service to the stage flow

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -17,6 +17,9 @@ from fbpcs.private_computation.service.compute_metrics_stage_service import (
 from fbpcs.private_computation.service.dummy_stage_service import (
     DummyStageService,
 )
+from fbpcs.private_computation.service.input_data_validation_stage_service import (
+    InputDataValidationStageService,
+)
 from fbpcs.private_computation.service.pid_stage_service import PIDStageService
 from fbpcs.private_computation.service.post_processing_stage_service import (
     PostProcessingStageService,
@@ -46,7 +49,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS PREPARE COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
+    _order_ = "CREATED INPUT_DATA_VALIDATION PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS PREPARE COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -54,6 +57,12 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.CREATION_STARTED,
         PrivateComputationInstanceStatus.CREATED,
         PrivateComputationInstanceStatus.CREATION_FAILED,
+        False,
+    )
+    INPUT_DATA_VALIDATION = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_STARTED,
+        PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED,
+        PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_FAILED,
         False,
     )
     PID_SHARD = PrivateComputationStageFlowData(
@@ -122,6 +131,8 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         """
         if self is self.CREATED:
             return DummyStageService()
+        elif self is self.INPUT_DATA_VALIDATION:
+            return InputDataValidationStageService(args.storage_svc)
         elif self is self.PID_SHARD:
             return PIDStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
 
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
@@ -20,8 +21,8 @@ from fbpcs.private_computation.service.input_data_validation_stage_service impor
 
 
 class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
-    async def test_run_async_changes_the_status(self) -> None:
-        pc_instance = PrivateComputationInstance(
+    def setUp(self):
+        self._pc_instance = PrivateComputationInstance(
             instance_id="123",
             role=PrivateComputationRole.PARTNER,
             instances=[],
@@ -35,7 +36,13 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
             output_dir="789",
         )
 
-        stage_service = InputDataValidationStageService()
+    @patch("fbpcp.service.storage.StorageService")
+    async def test_run_async_changes_the_status_when_the_file_exists(
+        self, mock_storage_service
+    ) -> None:
+        pc_instance = self._pc_instance
+        mock_storage_service.file_exists.return_value = True
+        stage_service = InputDataValidationStageService(mock_storage_service)
 
         self.assertEqual(
             pc_instance.status,
@@ -46,4 +53,23 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
         self.assertEqual(
             pc_instance.status,
             PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED,
+        )
+
+    @patch("fbpcp.service.storage.StorageService")
+    async def test_run_async_fails_when_the_file_does_not_exist(
+        self, mock_storage_service
+    ) -> None:
+        pc_instance = self._pc_instance
+        mock_storage_service.file_exists.return_value = False
+        stage_service = InputDataValidationStageService(mock_storage_service)
+
+        self.assertEqual(
+            pc_instance.status,
+            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_STARTED,
+        )
+
+        await stage_service.run_async(pc_instance)
+        self.assertEqual(
+            pc_instance.status,
+            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_FAILED,
         )


### PR DESCRIPTION
Summary:
New behavior added:
* The data input validation stage will now always run
* A file exists validation now runs in the validation stage

Future followup:
* The basic file check validation will be moved into the validation library

Differential Revision: D33920840

