### PR TITLE
update newly published coordinator docker image tag from latest to rc

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -53,7 +53,7 @@ jobs:
        run: |
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:latest
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ env.LOCAL_IMAGE_TAG }} ${{ env.REGISTRY_IMAGE_NAME }}:rc
 
      - name: Push image to registry
        run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ env:
   LOCAL_IMAGE_NAME: fbpcs/onedocker
   RC_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/rc/onedocker
   PROD_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/onedocker
-  COORDINATOR_IMAGE: ghcr.io/facebookresearch/fbpcs/coordinator:latest
+  COORDINATOR_IMAGE: ghcr.io/facebookresearch/fbpcs/coordinator:rc
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
@@ -366,7 +366,7 @@ jobs:
      - name: Tag image
        run: |
         docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
-        docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:latest
+        docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:rc
         docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
 
      - name: Push docker image to prod registry


### PR DESCRIPTION
Summary:
we plan to use 'latest' as the prod tag, so changing this tag to rc

note we probably shouldn't use 'latest' as prod, but meanwhile since 'latest' is used throughout the codebase as prod, removing it for now.

Reviewed By: yutong-w

Differential Revision: D33955349

