### PR TITLE
Adding new fields in cost estimation logging

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -81,15 +81,21 @@ int main(int argc, char** argv) {
 
   cost.end();
   XLOG(INFO) << cost.getEstimatedCostString();
-  if (FLAGS_run_name != "") {
-    std::string runName = folly::to<std::string>(
-        cost.getApplication(),
-        "_",
-        FLAGS_run_name,
-        "_",
-        measurement::private_attribution::getDateString());
-    XLOG(INFO) << cost.writeToS3(
-        runName, cost.getEstimatedCostDynamic(runName));
+
+  if (FLAGS_log_cost) {
+    auto run_name = (FLAGS_run_name != "") ? FLAGS_run_name : "temp_run_name";
+    folly::dynamic extra_info = folly::dynamic::object(
+        "padding_size", FLAGS_padding_size)("spine_path", FLAGS_spine_path)(
+        "data_path",
+        FLAGS_data_path)("output_path", FLAGS_output_path)("sort_strategy", FLAGS_sort_strategy);
+
+    XLOGF(
+        INFO,
+        "{}",
+        cost.writeToS3(
+            "",
+            run_name,
+            cost.getEstimatedCostDynamic(run_name, "", extra_info)));
   }
 
   return 0;

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
@@ -25,3 +25,7 @@ DEFINE_string(
     sort_strategy,
     "sort",
     "Sorting strategy selected for the output data - options: (sort|keep_original)");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h
@@ -16,3 +16,4 @@ DECLARE_string(output_path);
 DECLARE_string(tmp_directory);
 DECLARE_string(run_name);
 DECLARE_string(sort_strategy);
+DECLARE_bool(log_cost);

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.cpp
@@ -56,3 +56,7 @@ DEFINE_string(
     "A user given run name that will be used in s3 filename");
 DEFINE_int32(max_num_touchpoints, 4, "Maximum touchpoints per user");
 DEFINE_int32(max_num_conversions, 4, "Maximum conversions per user");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.h
@@ -25,3 +25,4 @@ DECLARE_string(run_name);
 DECLARE_bool(use_postfix);
 DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
+DECLARE_bool(log_cost);

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOptions.cpp
@@ -51,3 +51,7 @@ DEFINE_bool(
     "A postfix number added to input/output files to accommodate sharding");
 DEFINE_int32(max_num_touchpoints, 4, "Maximum touchpoints per user");
 DEFINE_int32(max_num_conversions, 4, "Maximum conversions per user");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");

--- a/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOptions.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/AttributionOptions.h
@@ -24,3 +24,4 @@ DECLARE_string(run_name);
 DECLARE_bool(use_postfix);
 DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
+DECLARE_bool(log_cost);

--- a/fbpcs/emp_games/attribution/decoupled_attribution/main.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/main.cpp
@@ -10,6 +10,7 @@
 
 #include <fbpcf/mpc/EmpGame.h>
 #include "folly/Format.h"
+#include "folly/dynamic.h"
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
 
@@ -22,7 +23,7 @@
 
 int main(int argc, char* argv[]) {
   fbpcs::performance_tools::CostEstimation cost =
-      fbpcs::performance_tools::CostEstimation("computation_experimental");
+      fbpcs::performance_tools::CostEstimation("attributor", "decoupled");
   cost.start();
 
   folly::init(&argc, &argv);
@@ -109,15 +110,30 @@ int main(int argc, char* argv[]) {
   cost.end();
   XLOG(INFO, cost.getEstimatedCostString());
 
-  if (FLAGS_run_name != "" &&
-      FLAGS_party == static_cast<int>(fbpcf::Party::Alice)) {
+  if (FLAGS_log_cost) {
+    auto run_name = (FLAGS_run_name != "") ? FLAGS_run_name : "temp_run_name";
+    auto party = (FLAGS_party == static_cast<int>(fbpcf::Party::Alice))
+        ? "Publisher"
+        : "Partner";
+    folly::dynamic extra_info = folly::dynamic::object(
+        "publisher_input_basepath",
+        (std::strcmp(party, "Publisher") == 0) ? FLAGS_input_base_path : "")(
+        "partner_input_basepath",
+        (std::strcmp(party, "Partner") == 0) ? FLAGS_input_base_path : "")(
+        "publisher_output_basepath",
+        (std::strcmp(party, "Publisher") == 0) ? FLAGS_output_base_path : "")(
+        "partner_output_basepath",
+        (std::strcmp(party, "Partner") == 0) ? FLAGS_output_base_path : "")(
+        "num_files",
+        FLAGS_num_files)("file_start_index", FLAGS_file_start_index)("concurrency", FLAGS_concurrency)("use_xor_encryption", FLAGS_use_xor_encryption);
+
     XLOGF(
         INFO,
         "{}",
         cost.writeToS3(
-            FLAGS_run_name,
-            cost.getEstimatedCostDynamic(
-                FLAGS_run_name, FLAGS_attribution_rules, FLAGS_aggregators)));
+            party,
+            run_name,
+            cost.getEstimatedCostDynamic(run_name, party, extra_info)));
   }
 
   return 0;

--- a/fbpcs/performance_tools/CostEstimation.h
+++ b/fbpcs/performance_tools/CostEstimation.h
@@ -32,6 +32,7 @@ class CostEstimation {
   std::string s3Bucket_;
   std::string s3Path_;
   std::string application_;
+  std::string version_; // example: decoupled, pcf2
   double estimatedCost_;
   int64_t runningTimeInSec_;
   long networkRXBytes_; // Network Receive bytes
@@ -41,6 +42,7 @@ class CostEstimation {
 
  public:
   explicit CostEstimation(const std::string& app);
+  explicit CostEstimation(const std::string& app, const std::string& version);
 
   std::string& getApplication();
   double& getEstimatedCost();
@@ -51,14 +53,19 @@ class CostEstimation {
   std::string getEstimatedCostString();
   folly::dynamic getEstimatedCostDynamic(
       std::string run_name,
-      std::string attribution_rules,
-      std::string aggregators);
+      std::string party,
+      folly::dynamic info);
   folly::dynamic getEstimatedCostDynamic(std::string run_name);
 
   void start();
   void end();
 
+  std::string writeToS3(
+      std::string party,
+      std::string run_name,
+      folly::dynamic costDynamic);
   std::string writeToS3(std::string run_name, folly::dynamic costDynamic);
+  std::string _writeToS3(std::string filePath, folly::dynamic costDynamic);
 };
 
 } // namespace fbpcs::performance_tools


### PR DESCRIPTION
Summary:
**What?**
- Reshaping and adding some new fields in cost estimation.
- The changes reflect the plan in https://fb.quip.com/q9ZpAUak3MuD

The changes are:
- Few new fields are logged to S3 in `CostEstimation.cpp`
- Added a new flag in decoupled attribution to enable logging cost
- Added logging in both publisher and partner side

Differential Revision: D34104004

