### PR TITLE
update coordinator-publish to run on the same schedule as docker-publish

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -1,12 +1,8 @@
 name: Publish Coordinator Image
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'fbpcs/private_computation_cli/**'
-      - 'fbpcs/pip_requirements.txt'
-      - 'fbpcs/Dockerfile'
+  schedule:
+    - cron: '0 16 * * 1-5'
   workflow_dispatch:
     inputs:
       name:


### PR DESCRIPTION
Summary:
as title

we do it one hour earlier because the onedocker image depends on this image, so we want some buffer for this to finish

Reviewed By: jrodal98

Differential Revision: D34087468

