### PR TITLE
fbpcs/emp_games/lift/calculator/CalculatorApp.cpp and HybridCalculatorApp.cpp: use std::filesystem::path's "string", not "u8string" to avoid C++20 conflict (this change affects the text of two diagnostics)

### DIFF
--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
@@ -36,11 +36,12 @@ void CalculatorApp::run() {
 
     putOutputData(output);
   } catch (const std::exception& e) {
+    auto path = inputPath_.u8string();
     XLOGF(
         ERR,
         "Error: Exception caught in CalculatorApp run.\n \t error msg: {} \n \t input shard: {}.",
         e.what(),
-        inputPath_.u8string());
+        reinterpret_cast<const char*>(path.c_str()));
     std::exit(1);
   }
 };


### PR DESCRIPTION
Summary:
Avoid errors like the following and another nearly identical for HybridCalculatorApp.cpp:
```
buck-out/v2/gen/fbsource/6dbc4bb1b9a32829/third-party/fmt/___fmtFbcode__/headers/fmt/core.h:1711:3: error: static_assert failed due to requirement 'formattable_char' "Mixing character types is disallowed."
  static_assert(formattable_char, "Mixing character types is disallowed.");
  ^             ~~~~~~~~~~~~~~~~
buck-out/v2/gen/fbsource/6dbc4bb1b9a32829/third-party/fmt/___fmtFbcode__/headers/fmt/core.h:1854:23: note: in instantiation of function template specialization 'fmt::detail::make_arg<true, fmt::basic_format_context<fmt::appender, char>, fmt::detail::type::custom_type, const std::basic_string<char8_t> &, 0>' requested here
        data_{detail::make_arg<
                      ^
buck-out/v2/gen/fbsource/6dbc4bb1b9a32829/third-party/fmt/___fmtFbcode__/headers/fmt/core.h:1873:10: note: in instantiation of function template specialization 'fmt::format_arg_store<fmt::basic_format_context<fmt::appender, char>, const char *, std::basic_string<char8_t>>::format_arg_store<const char *const &, const std::basic_string<char8_t> &>' requested here
  return {std::forward<Args>(args)...};
         ^
buck-out/v2/gen/fbcode/6dbc4bb1b9a32829/folly/logging/__logging__/headers/folly/logging/LogStreamProcessor.h:371:36: note: in instantiation of function template specialization 'fmt::make_format_args<fmt::basic_format_context<fmt::appender, char>, const char *const &, const std::basic_string<char8_t> &>' requested here
        vformatLogString(fmt, fmt::make_format_args(args...), failed);
                                   ^
buck-out/v2/gen/fbcode/6dbc4bb1b9a32829/folly/logging/__logging__/headers/folly/logging/LogStreamProcessor.h:255:13: note: in instantiation of function template specialization 'folly::LogStreamProcessor::formatLogString<const char *, std::basic_string<char8_t>>' requested here
            formatLogString(fmt, std::forward<Args>(args)...)) {}
            ^
fbcode/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp:39:5: note: in instantiation of function template specialization 'folly::LogStreamProcessor::LogStreamProcessor<const char *, std::basic_string<char8_t>>' requested here
    XLOGF(
    ^
buck-out/v2/gen/fbcode/6dbc4bb1b9a32829/folly/logging/__logging__/headers/folly/logging/xlog.h:103:3: note: expanded from macro 'XLOGF'
  XLOG_IMPL(                               \
  ^
buck-out/v2/gen/fbcode/6dbc4bb1b9a32829/folly/logging/__logging__/headers/folly/logging/xlog.h:367:3: note: expanded from macro 'XLOG_IMPL'
  XLOG_ACTUAL_IMPL(                 \
  ^
buck-out/v2/gen/fbcode/6dbc4bb1b9a32829/folly/logging/__logging__/headers/folly/logging/xlog.h:420:11: note: expanded from macro 'XLOG_ACTUAL_IMPL'
          ::folly::LogStreamProcessor(                                     \
          ^
```

Differential Revision: D34101451

