### PR TITLE
Adding gcp library linking support as fbpcf is linking google-cloud-cpp

### DIFF
--- a/docker/data_processing/CMakeLists.txt
+++ b/docker/data_processing/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   fbpcf
   ${AWSSDK_LINK_LIBRARIES}
   ${EMP-OT_LIBRARIES}
+  google-cloud-cpp::storage
   Folly::folly
   re2)
 
@@ -46,6 +47,7 @@ target_link_libraries(
   fbpcf
   ${AWSSDK_LINK_LIBRARIES}
   ${EMP-OT_LIBRARIES}
+  google-cloud-cpp::storage
   Folly::folly
   re2)
 

--- a/docker/emp_games/common.cmake
+++ b/docker/emp_games/common.cmake
@@ -23,5 +23,6 @@ target_link_libraries(
   fbpcf
   ${AWSSDK_LINK_LIBRARIES}
   ${EMP-OT_LIBRARIES}
+  google-cloud-cpp::storage
   Folly::folly
   re2)

--- a/docker/emp_games/perf_tools.cmake
+++ b/docker/emp_games/perf_tools.cmake
@@ -21,5 +21,6 @@ target_link_libraries(
   fbpcf
   ${AWSSDK_LINK_LIBRARIES}
   ${EMP-OT_LIBRARIES}
+  google-cloud-cpp::storage
   Folly::folly
   re2)


### PR DESCRIPTION
Summary:
As title, resolving linker issue when adding D33357687 in fbpcf
T111078872 is the original task

Differential Revision: D34123303

