### PR TITLE
Add required region param to the CLI

### DIFF
--- a/fbpcs/input_data_validation/input_data_validation_cli.py
+++ b/fbpcs/input_data_validation/input_data_validation_cli.py
@@ -15,6 +15,7 @@ Usage:
     input_data_validation_cli
         --input-file-path=<input-file-path>
         --cloud-provider=<cloud-provider>
+        --region=<region>
         [--access-key-id=<access-key-id>]
         [--access-key-data=<access-key-data>]
         [--start-timestamp=<start-timestamp>]
@@ -30,6 +31,7 @@ from schema import Schema, Optional, Or, Use
 
 INPUT_FILE_PATH = "--input-file-path"
 CLOUD_PROVIDER = "--cloud-provider"
+REGION = "--region"
 ACCESS_KEY_ID = "--access-key-id"
 ACCESS_KEY_DATA = "--access-key-data"
 START_TIMESTAMP = "--start-timestamp"
@@ -45,6 +47,7 @@ def main() -> None:
         {
             INPUT_FILE_PATH: str,
             CLOUD_PROVIDER: cloud_provider_from_string,
+            REGION: str,
             Optional(ACCESS_KEY_ID): optional_string,
             Optional(ACCESS_KEY_DATA): optional_string,
             Optional(START_TIMESTAMP): optional_string,
@@ -58,6 +61,7 @@ def main() -> None:
     ValidationRunner(
         arguments[INPUT_FILE_PATH],
         arguments[CLOUD_PROVIDER],
+        arguments[REGION],
         arguments[ACCESS_KEY_ID],
         arguments[ACCESS_KEY_DATA],
     )

--- a/fbpcs/input_data_validation/input_data_validation_cli.py
+++ b/fbpcs/input_data_validation/input_data_validation_cli.py
@@ -24,6 +24,7 @@ Usage:
 
 
 from docopt import docopt
+from fbpcs.input_data_validation.validation_runner import ValidationRunner
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 from schema import Schema, Optional, Or, Use
 
@@ -54,6 +55,12 @@ def main() -> None:
     arguments = s.validate(docopt(__doc__))
     assert arguments
     print("Parsed input_data_validation_cli arguments")
+    ValidationRunner(
+        arguments[INPUT_FILE_PATH],
+        arguments[CLOUD_PROVIDER],
+        arguments[ACCESS_KEY_ID],
+        arguments[ACCESS_KEY_DATA],
+    )
 
 
 if __name__ == "__main__":

--- a/fbpcs/input_data_validation/tests/validation_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validation_runner_test.py
@@ -15,10 +15,13 @@ TEST_INPUT_FILE_PATH = "s3://test-bucket/data.csv"
 
 
 class TestValidationRunner(TestCase):
-    def test_initializating_the_validation_runner_fields(self) -> None:
+    @patch("fbpcp.service.storage_s3.S3StorageService")
+    def test_initializating_the_validation_runner_fields(self, _mock) -> None:
         cloud_provider = CloudProvider.AWS
 
-        validation_runner = ValidationRunner(TEST_INPUT_FILE_PATH, cloud_provider)
+        validation_runner = ValidationRunner(
+            TEST_INPUT_FILE_PATH, cloud_provider, "us-west-2"
+        )
 
         self.assertEqual(validation_runner._input_file_path, TEST_INPUT_FILE_PATH)
         self.assertEqual(validation_runner._cloud_provider, cloud_provider)
@@ -30,16 +33,15 @@ class TestValidationRunner(TestCase):
         cloud_provider = CloudProvider.AWS
         access_key_id = "id1"
         access_key_data = "data2"
+        region = "us-east-2"
         constructed_storage_service = MagicMock()
         mock_storage_service.__init__(return_value=constructed_storage_service)
 
         validation_runner = ValidationRunner(
-            TEST_INPUT_FILE_PATH, cloud_provider, access_key_id, access_key_data
+            TEST_INPUT_FILE_PATH, cloud_provider, region, access_key_id, access_key_data
         )
 
-        mock_storage_service.assert_called_with(
-            "us-west-1", access_key_id, access_key_data
-        )
+        mock_storage_service.assert_called_with(region, access_key_id, access_key_data)
         self.assertEqual(
             validation_runner._storage_service, constructed_storage_service
         )

--- a/fbpcs/input_data_validation/tests/validation_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validation_runner_test.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, Mock
+
+from fbpcs.input_data_validation.validation_runner import ValidationRunner
+from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+
+TEST_INPUT_FILE_PATH = "s3://test-bucket/data.csv"
+
+
+class TestValidationRunner(TestCase):
+    def test_initializating_the_validation_runner_fields(self) -> None:
+        cloud_provider = CloudProvider.AWS
+
+        validation_runner = ValidationRunner(TEST_INPUT_FILE_PATH, cloud_provider)
+
+        self.assertEqual(validation_runner._input_file_path, TEST_INPUT_FILE_PATH)
+        self.assertEqual(validation_runner._cloud_provider, cloud_provider)
+
+    @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
+    def test_initializing_the_validation_runner_storage_service(
+        self, mock_storage_service: Mock
+    ) -> None:
+        cloud_provider = CloudProvider.AWS
+        access_key_id = "id1"
+        access_key_data = "data2"
+        constructed_storage_service = MagicMock()
+        mock_storage_service.__init__(return_value=constructed_storage_service)
+
+        validation_runner = ValidationRunner(
+            TEST_INPUT_FILE_PATH, cloud_provider, access_key_id, access_key_data
+        )
+
+        mock_storage_service.assert_called_with(
+            "us-west-1", access_key_id, access_key_data
+        )
+        self.assertEqual(
+            validation_runner._storage_service, constructed_storage_service
+        )

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+"""
+This is the main class that runs all of the validations.
+
+This class handles the overall logic to:
+* Copy the file to local storage
+* Run the validations
+* Generate a validation report
+
+Error handling:
+* If an unhandled error occurs, it will be returned in the report
+"""
+
+from typing import Optional
+
+from fbpcp.service.storage_s3 import S3StorageService
+from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+
+
+class ValidationRunner:
+    def __init__(
+        self,
+        input_file_path: str,
+        cloud_provider: CloudProvider,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        start_timestamp: Optional[str] = None,
+        end_timestamp: Optional[str] = None,
+        valid_threshold_override: Optional[str] = None,
+    ) -> None:
+        self._input_file_path = input_file_path
+        self._cloud_provider = cloud_provider
+        self._storage_service = S3StorageService(
+            "us-west-1", access_key_id, access_key_data
+        )

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -29,6 +29,7 @@ class ValidationRunner:
         self,
         input_file_path: str,
         cloud_provider: CloudProvider,
+        region: str,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         start_timestamp: Optional[str] = None,
@@ -37,6 +38,4 @@ class ValidationRunner:
     ) -> None:
         self._input_file_path = input_file_path
         self._cloud_provider = cloud_provider
-        self._storage_service = S3StorageService(
-            "us-west-1", access_key_id, access_key_data
-        )
+        self._storage_service = S3StorageService(region, access_key_id, access_key_data)


### PR DESCRIPTION
Summary:
The region should always be specified when accessing the CloudStorage. This way
the specified region will be the same as the one where the bucket was created.

Differential Revision: D34157710

