### PR TITLE
generate a validation report when running the CLI

### DIFF
--- a/fbpcs/input_data_validation/constants.py
+++ b/fbpcs/input_data_validation/constants.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+INPUT_DATA_TMP_FILE_PATH = "/tmp"

--- a/fbpcs/input_data_validation/enums.py
+++ b/fbpcs/input_data_validation/enums.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+
+class ValidationResult(Enum):
+    SUCCESS = "success"
+    FAILED = "failed"

--- a/fbpcs/input_data_validation/input_data_validation_cli.py
+++ b/fbpcs/input_data_validation/input_data_validation_cli.py
@@ -15,6 +15,7 @@ Usage:
     input_data_validation_cli
         --input-file-path=<input-file-path>
         --cloud-provider=<cloud-provider>
+        --region=<region>
         [--access-key-id=<access-key-id>]
         [--access-key-data=<access-key-data>]
         [--start-timestamp=<start-timestamp>]
@@ -30,6 +31,7 @@ from schema import Schema, Optional, Or, Use
 
 INPUT_FILE_PATH = "--input-file-path"
 CLOUD_PROVIDER = "--cloud-provider"
+REGION = "--region"
 ACCESS_KEY_ID = "--access-key-id"
 ACCESS_KEY_DATA = "--access-key-data"
 START_TIMESTAMP = "--start-timestamp"
@@ -45,6 +47,7 @@ def main() -> None:
         {
             INPUT_FILE_PATH: str,
             CLOUD_PROVIDER: cloud_provider_from_string,
+            REGION: str,
             Optional(ACCESS_KEY_ID): optional_string,
             Optional(ACCESS_KEY_DATA): optional_string,
             Optional(START_TIMESTAMP): optional_string,
@@ -58,6 +61,7 @@ def main() -> None:
     ValidationRunner(
         arguments[INPUT_FILE_PATH],
         arguments[CLOUD_PROVIDER],
+        arguments[REGION],
         arguments[ACCESS_KEY_ID],
         arguments[ACCESS_KEY_DATA],
     )

--- a/fbpcs/input_data_validation/input_data_validation_cli.py
+++ b/fbpcs/input_data_validation/input_data_validation_cli.py
@@ -25,6 +25,7 @@ Usage:
 
 
 from docopt import docopt
+from fbpcs.input_data_validation.enums import ValidationResult
 from fbpcs.input_data_validation.validation_runner import ValidationRunner
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 from schema import Schema, Optional, Or, Use
@@ -58,13 +59,26 @@ def main() -> None:
     arguments = s.validate(docopt(__doc__))
     assert arguments
     print("Parsed input_data_validation_cli arguments")
-    ValidationRunner(
+
+    validation_runner = ValidationRunner(
         arguments[INPUT_FILE_PATH],
         arguments[CLOUD_PROVIDER],
         arguments[REGION],
         arguments[ACCESS_KEY_ID],
         arguments[ACCESS_KEY_DATA],
     )
+    validation_report = validation_runner.run()
+
+    validation_report_status = validation_report["status"]
+    if validation_report_status == ValidationResult.FAILED.value:
+        raise Exception(validation_report)
+    elif validation_report_status == ValidationResult.SUCCESS.value:
+        print(f"Success: {validation_report}")
+    else:
+        raise Exception(
+            "Unknown validation_report status: {validation_report_status}.\n"
+            + "Validation report: {validation_report}"
+        )
 
 
 if __name__ == "__main__":

--- a/fbpcs/input_data_validation/input_data_validation_cli.py
+++ b/fbpcs/input_data_validation/input_data_validation_cli.py
@@ -24,6 +24,7 @@ Usage:
 
 
 from docopt import docopt
+from fbpcs.input_data_validation.validation_runner import ValidationRunner
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 from schema import Schema, Optional, Or, Use
 
@@ -54,6 +55,12 @@ def main() -> None:
     arguments = s.validate(docopt(__doc__))
     assert arguments
     print("Parsed input_data_validation_cli arguments")
+    ValidationRunner(
+        arguments[INPUT_FILE_PATH],
+        arguments[CLOUD_PROVIDER],
+        arguments[ACCESS_KEY_ID],
+        arguments[ACCESS_KEY_DATA],
+    )
 
 
 if __name__ == "__main__":

--- a/fbpcs/input_data_validation/tests/validation_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validation_runner_test.py
@@ -8,6 +8,8 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, Mock
 
+from fbpcs.input_data_validation.constants import INPUT_DATA_TMP_FILE_PATH
+from fbpcs.input_data_validation.enums import ValidationResult
 from fbpcs.input_data_validation.validation_runner import ValidationRunner
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
@@ -45,3 +47,49 @@ class TestValidationRunner(TestCase):
         self.assertEqual(
             validation_runner._storage_service, constructed_storage_service
         )
+
+    @patch("fbpcs.input_data_validation.validation_runner.time")
+    @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
+    def test_run_validations_success(
+        self, storage_service_mock: Mock, time_mock: Mock
+    ) -> None:
+        timestamp = 1644538741.077141
+        time_mock.time.return_value = timestamp
+        input_file_path = "s3://test-bucket/data.csv"
+        cloud_provider = CloudProvider.AWS
+        expected_temp_filepath = f"{INPUT_DATA_TMP_FILE_PATH}/data.csv-{timestamp}"
+        expected_report = {
+            "status": ValidationResult.SUCCESS.value,
+            "message": f"File: {input_file_path} was validated successfully",
+        }
+        storage_service_mock.__init__(return_value=storage_service_mock)
+
+        validation_runner = ValidationRunner(
+            input_file_path, cloud_provider, "us-west-2"
+        )
+        report = validation_runner.run()
+
+        self.assertEqual(validation_runner._local_file_path, expected_temp_filepath)
+        self.assertEqual(report, expected_report)
+        storage_service_mock.copy.assert_called_with(
+            input_file_path, expected_temp_filepath
+        )
+
+    @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
+    def test_run_validations_failure(self, storage_service_mock: Mock) -> None:
+        exception_message = "failed to copy"
+        input_file_path = "s3://test-bucket/data.csv"
+        cloud_provider = CloudProvider.AWS
+        expected_report = {
+            "status": ValidationResult.FAILED.value,
+            "message": f"File: {input_file_path} failed validation. Error: {exception_message}",
+        }
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.copy.side_effect = Exception(exception_message)
+
+        validation_runner = ValidationRunner(
+            input_file_path, cloud_provider, "us-west-2"
+        )
+        report = validation_runner.run()
+
+        self.assertEqual(report, expected_report)

--- a/fbpcs/input_data_validation/tests/validation_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validation_runner_test.py
@@ -15,10 +15,13 @@ TEST_INPUT_FILE_PATH = "s3://test-bucket/data.csv"
 
 
 class TestValidationRunner(TestCase):
-    def test_initializating_the_validation_runner_fields(self) -> None:
+    @patch("fbpcp.service.storage_s3.S3StorageService")
+    def test_initializating_the_validation_runner_fields(self, _mock) -> None:
         cloud_provider = CloudProvider.AWS
 
-        validation_runner = ValidationRunner(TEST_INPUT_FILE_PATH, cloud_provider)
+        validation_runner = ValidationRunner(
+            TEST_INPUT_FILE_PATH, cloud_provider, "us-west-2"
+        )
 
         self.assertEqual(validation_runner._input_file_path, TEST_INPUT_FILE_PATH)
         self.assertEqual(validation_runner._cloud_provider, cloud_provider)
@@ -30,16 +33,15 @@ class TestValidationRunner(TestCase):
         cloud_provider = CloudProvider.AWS
         access_key_id = "id1"
         access_key_data = "data2"
+        region = "us-east-2"
         constructed_storage_service = MagicMock()
         mock_storage_service.__init__(return_value=constructed_storage_service)
 
         validation_runner = ValidationRunner(
-            TEST_INPUT_FILE_PATH, cloud_provider, access_key_id, access_key_data
+            TEST_INPUT_FILE_PATH, cloud_provider, region, access_key_id, access_key_data
         )
 
-        mock_storage_service.assert_called_with(
-            "us-west-1", access_key_id, access_key_data
-        )
+        mock_storage_service.assert_called_with(region, access_key_id, access_key_data)
         self.assertEqual(
             validation_runner._storage_service, constructed_storage_service
         )

--- a/fbpcs/input_data_validation/tests/validation_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validation_runner_test.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, Mock
+
+from fbpcs.input_data_validation.validation_runner import ValidationRunner
+from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+
+TEST_INPUT_FILE_PATH = "s3://test-bucket/data.csv"
+
+
+class TestValidationRunner(TestCase):
+    def test_initializating_the_validation_runner_fields(self) -> None:
+        cloud_provider = CloudProvider.AWS
+
+        validation_runner = ValidationRunner(TEST_INPUT_FILE_PATH, cloud_provider)
+
+        self.assertEqual(validation_runner._input_file_path, TEST_INPUT_FILE_PATH)
+        self.assertEqual(validation_runner._cloud_provider, cloud_provider)
+
+    @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
+    def test_initializing_the_validation_runner_storage_service(
+        self, mock_storage_service: Mock
+    ) -> None:
+        cloud_provider = CloudProvider.AWS
+        access_key_id = "id1"
+        access_key_data = "data2"
+        constructed_storage_service = MagicMock()
+        mock_storage_service.__init__(return_value=constructed_storage_service)
+
+        validation_runner = ValidationRunner(
+            TEST_INPUT_FILE_PATH, cloud_provider, access_key_id, access_key_data
+        )
+
+        mock_storage_service.assert_called_with(
+            "us-west-1", access_key_id, access_key_data
+        )
+        self.assertEqual(
+            validation_runner._storage_service, constructed_storage_service
+        )

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+"""
+This is the main class that runs all of the validations.
+
+This class handles the overall logic to:
+* Copy the file to local storage
+* Run the validations
+* Generate a validation report
+
+Error handling:
+* If an unhandled error occurs, it will be returned in the report
+"""
+
+from typing import Optional
+
+from fbpcp.service.storage_s3 import S3StorageService
+from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+
+
+class ValidationRunner:
+    def __init__(
+        self,
+        input_file_path: str,
+        cloud_provider: CloudProvider,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+        start_timestamp: Optional[str] = None,
+        end_timestamp: Optional[str] = None,
+        valid_threshold_override: Optional[str] = None,
+    ) -> None:
+        self._input_file_path = input_file_path
+        self._cloud_provider = cloud_provider
+        self._storage_service = S3StorageService(
+            "us-west-1", access_key_id, access_key_data
+        )

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -29,6 +29,7 @@ class ValidationRunner:
         self,
         input_file_path: str,
         cloud_provider: CloudProvider,
+        region: str,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         start_timestamp: Optional[str] = None,
@@ -37,6 +38,4 @@ class ValidationRunner:
     ) -> None:
         self._input_file_path = input_file_path
         self._cloud_provider = cloud_provider
-        self._storage_service = S3StorageService(
-            "us-west-1", access_key_id, access_key_data
-        )
+        self._storage_service = S3StorageService(region, access_key_id, access_key_data)

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -18,9 +18,12 @@ Error handling:
 * If an unhandled error occurs, it will be returned in the report
 """
 
-from typing import Optional
+import time
+from typing import Dict, Optional
 
 from fbpcp.service.storage_s3 import S3StorageService
+from fbpcs.input_data_validation.constants import INPUT_DATA_TMP_FILE_PATH
+from fbpcs.input_data_validation.enums import ValidationResult
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
 
@@ -37,5 +40,33 @@ class ValidationRunner:
         valid_threshold_override: Optional[str] = None,
     ) -> None:
         self._input_file_path = input_file_path
+        self._local_file_path: str = self._get_local_filepath()
         self._cloud_provider = cloud_provider
         self._storage_service = S3StorageService(region, access_key_id, access_key_data)
+
+    def _get_local_filepath(self) -> str:
+        now = time.time()
+        filename = self._input_file_path.split("/")[-1]
+        return f"{INPUT_DATA_TMP_FILE_PATH}/{filename}-{now}"
+
+    def run(self) -> Dict[str, str]:
+        try:
+            self._storage_service.copy(self._input_file_path, self._local_file_path)
+        except Exception as e:
+            return self._format_validation_result(
+                ValidationResult.FAILED,
+                f"File: {self._input_file_path} failed validation. Error: {e}",
+            )
+
+        return self._format_validation_result(
+            ValidationResult.SUCCESS,
+            f"File: {self._input_file_path} was validated successfully",
+        )
+
+    def _format_validation_result(
+        self, status: ValidationResult, message: str
+    ) -> Dict[str, str]:
+        return {
+            "status": status.value,
+            "message": message,
+        }


### PR DESCRIPTION
Summary:
The validation CLI now copies the remote input_data file into a /tmp location
for fast access during the validations, which will be added later. If the copy
fails, an error is raised and the CLI returns an exit code 1. Else in the
success case a 0 is returned.

Differential Revision: D34161482

