### PR TITLE
Pin the TF AWS provider to the latest 3.x

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -7,6 +7,12 @@ provider "archive" {}
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
 }
 
 data "archive_file" "zip_lambda" {

--- a/fbpcs/infra/cloud_bridge/data_validation/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_validation/main.tf
@@ -7,6 +7,12 @@ provider "archive" {}
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
 }
 
 data "archive_file" "lambda_source_package" {

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/main.tf
@@ -7,4 +7,10 @@ provider "archive" {}
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
 }

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/main.tf
@@ -10,4 +10,10 @@ provider "aws" {
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
 }

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/main.tf
@@ -5,4 +5,10 @@ provider "aws" {
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
 }

--- a/fbpcs/infra/pce/aws_terraform_template/partner/vpc_peering/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/partner/vpc_peering/main.tf
@@ -5,6 +5,12 @@ provider "aws" {
 
 terraform {
   backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
 }
 
 resource "aws_vpc_peering_connection" "vpc_peering_conn" {


### PR DESCRIPTION
Summary:
The newest release of the Terraform AWS provider 4.0.0 no longer picks up the
AWS access_key and secret env vars. This release also deprecated other features
we are using for the data_ingestion deployment:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade
To fix these regressions, we pin the AWS provider version to the
latest 3.x stable version.

Differential Revision: D34194577

