### PR TITLE
update local image name in coordinator-publish action

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -14,7 +14,7 @@ env:
   DISTRO: ubuntu
   REGISTRY: ghcr.io
   VERSION_TAG: latest-build
-  LOCAL_IMAGE_NAME: ${{ github.event.repository.name }}/coordinator
+  LOCAL_IMAGE_NAME: coordinator-local
   REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/coordinator
 
 jobs:


### PR DESCRIPTION
Summary:
Not sure why this was working beforehand, but it looks like github.event.repo.name is empty, which causes an error. Changing the name of the local container
{F701147986}

Reviewed By: jrodal98

Differential Revision: D34217819

