### PR TITLE
add permissions to github action

### DIFF
--- a/.github/workflows/extract_and_upload_binaries.yml
+++ b/.github/workflows/extract_and_upload_binaries.yml
@@ -38,6 +38,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/promote_binaries.yml
+++ b/.github/workflows/promote_binaries.yml
@@ -20,7 +20,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v2
     - uses: docker/login-action@v1


### PR DESCRIPTION
Summary:
wiki has been updated to include these permissions in the action: https://www.internalfb.com/intern/wiki/Cloud/Safe_Operation_in_the_Cloud/Examples_and_References/GitHub_Actions_-_Launching_Jobs_on_EKS/

example action: https://github.com/pytorch/torchx/blob/main/.github/workflows/aws-batch-integration-tests.yaml#L12

Differential Revision: D34224928

