### PR TITLE
add tracker_hash input to github actions

### DIFF
--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -15,6 +15,10 @@ on:
         description: 'The name of the docker image to tag'
         required: true
         type: string
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 
 env:
@@ -29,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Print Tracker Hash
+      run: echo ${{ github.event.inputs.tracker_hash}}
 
     - uses: docker/login-action@v1
       with:

--- a/.github/workflows/extract_and_upload_binaries.yml
+++ b/.github/workflows/extract_and_upload_binaries.yml
@@ -26,6 +26,10 @@ on:
         description: 'The version/aws subfolder name for the binaries'
         required: true
         type: string
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 env:
   REGISTRY: ghcr.io
@@ -44,6 +48,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Print Tracker Hash
+      run: echo ${{ github.event.inputs.tracker_hash}}
+
     - uses: docker/login-action@v1
       with:
          registry: ${{ env.REGISTRY }}

--- a/.github/workflows/promote_binaries.yml
+++ b/.github/workflows/promote_binaries.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: us-west-2
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 env:
   REGISTRY: ghcr.io
@@ -30,6 +34,10 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v2
+
+    - name: Print Tracker Hash
+      run: echo ${{ github.event.inputs.tracker_hash}}
+
     - uses: docker/login-action@v1
       with:
          registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
Summary: we need to add an input for a job tracker so that we can track the status within meta infra

Reviewed By: bigfootjon

Differential Revision: D34259086

