### PR TITLE
fix one command runner test

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -6,15 +6,15 @@ on:
       study_id:
         description: Lift study id
         required: true
-        default: 25402204995942
+        default: 32102205110410
       objective_id:
         description: Lift objective id
         required: true
-        default: 49502203606212
+        default: 23502204952992
       input_path:
         description: S3 path to synthetic data
         required: true
-        default: https://fbpcs-e2e-dev.s3.us-west-2.amazonaws.com/lift/partner/partner_e2e_input.csv
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
       tag:
         description: Version tag to use
         required: true


### PR DESCRIPTION
Summary:
## What

* change the default input file used in the test

## Why

* the github aws access it pretty locked down. We can only read from this bucket

## Also

I created a new study with more objectives for testing, hence why that changed. The new study has 14 objectives instead of 6: P480697948. This will help ensure there is always an objective you can use to test (since you can only run an objective once every 18 or 24 hours)

Differential Revision: D34262738

