### PR TITLE
Don't require aggregated result path in CLI

### DIFF
--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -165,9 +165,11 @@ def run_study(
 
     ## Step 3. Run Instances. Run maximum number of instances in parallel
 
+    all_instance_ids = []
     chunks = _get_chunks(instances_input_path, MAX_NUM_INSTANCES)
     for chunk in chunks:
         instance_ids = list(chunk.keys())
+        all_instance_ids.extend(instance_ids)
         chunk_input_paths = list(map(lambda x: x["input_path"], chunk.values()))
         chunk_num_shards = list(map(lambda x: x["num_shards"], chunk.values()))
         logger.info(f"Start running instances {instance_ids}.")
@@ -199,7 +201,7 @@ def run_study(
     )
 
     try:
-        for instance_id in instance_ids:
+        for instance_id in all_instance_ids:
             if (
                 get_instance(config, instance_id, logger).status
                 is not PrivateComputationInstanceStatus.AGGREGATION_COMPLETED

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -11,7 +11,7 @@ CLI for running a Private Lift study
 
 Usage:
     pc-cli create_instance <instance_id> --config=<config_file> --role=<pl_role> --game_type=<game_type> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --padding_size=<padding_size> --k_anonymity_threshold=<k_anonymity_threshold> --hmac_key=<base64_key> --fail_fast --stage_flow=<stage_flow>] [options]
-    pc-cli validate <instance_id> --config=<config_file> --aggregated_result_path=<aggregated_result_path> --expected_result_path=<expected_result_path> [options]
+    pc-cli validate <instance_id> --config=<config_file> --expected_result_path=<expected_result_path> [--aggregated_result_path=<aggregated_result_path>] [options]
     pc-cli run_next <instance_id> --config=<config_file> [--server_ips=<server_ips>] [options]
     pc-cli run_stage <instance_id> --stage=<stage> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pc-cli get_instance <instance_id> --config=<config_file> [options]
@@ -226,7 +226,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         logger.info(f"Get MPC instance: {instance_id}")
         get_mpc(config, instance_id, logger)
     elif arguments["validate"]:
-        logger.info(f"Vallidate instance: {instance_id}")
+        logger.info(f"Validate instance: {instance_id}")
         validate(
             config=config,
             instance_id=instance_id,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -101,8 +101,8 @@ def validate(
     config: Dict[str, Any],
     instance_id: str,
     logger: logging.Logger,
-    aggregated_result_path: str,
     expected_result_path: str,
+    aggregated_result_path: Optional[str] = None,
 ) -> None:
     pc_service = _build_private_computation_service(
         config["private_computation"],


### PR DESCRIPTION
Summary:
## What

* Don't require aggregated result path in PC-CLI validation endpoint

## Why

* It's a property on the PC instance, so it's not needed
* this will make my life a lot easier when I add validation in the automated github e2e test

Differential Revision: D34292902

