### PR TITLE
add permissions to github action - publish_image_to_ecr

### DIFF
--- a/.github/workflows/publish_image_to_ecr.yml
+++ b/.github/workflows/publish_image_to_ecr.yml
@@ -39,7 +39,9 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Summary: add permissions to github action - publish_image_to_ecr

Differential Revision: D34317392

