### PR TITLE
add rc tag to testing docker image to fix build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,7 +72,10 @@ jobs:
         run: |
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{env.VERSION_TAG}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{env.VERSION_TAG}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{env.VERSION_TAG}}
-
+          # temporarily tagging with rc because the task definition
+          # (fbpcs-github-cicd:4 https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/taskDefinitions/fbpcs-github-cicd/4)
+          # points at :rc instead of latest-build
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{env.VERSION_TAG}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:rc
       - name: Push image with to rc registry
         run: |
           docker push --all-tags ${{ env.RC_REGISTRY_IMAGE_NAME }}


### PR DESCRIPTION
Summary:
publish docker image job is broken because the tests fail because the task definition points at the old tag instead of the new tag.

We should update the task definition but because I don't know who the owner/what else that task definition is used for, I am meanwhile adding the tag its expecting back. We should remove this in the future once the task definition is updated.

Differential Revision: D34369800

