### PR TITLE
fix broken github test validation step

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -56,7 +56,7 @@ jobs:
         # the fbpcs_instances directory is where instances are written to (feature of run_fbpcs.sh)
         # the config.yml specifies that /fbpcs_instances is the instance repo, which is the source of the "/{}"
         run: |
-          find fbpcs_instances -name '[0-9]*[0-9]' | xargs -I {} ./fbpcs/scripts/run_fbpcs.sh \
+          find fbpcs_instances -regex 'fbpcs_instances/[0-9]+' | xargs -I {} ./fbpcs/scripts/run_fbpcs.sh \
           validate \
           "/{}" \
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \


### PR DESCRIPTION
Summary:
## What

* determine the instance names to pass to validation script based on **regex** and not **globbing**

## Why

* I misunderstood how globbing works and mistested the edge case I was trying to prevent :p

Differential Revision: D34381919

