### PR TITLE
Fix cloudwatch url retriever on publisher side issue

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - In logging the cost for MPC runs, added few more fields in CostEstimation.cpp
   - Added log_cost argument to MPC stage services
 ### Changed
+  - Changed LogRetriever to cover the publisher side use case.
 
 ### Removed
 

--- a/fbpcs/experimental/cloud_logs/test/test_log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/test/test_log_retriever.py
@@ -35,3 +35,10 @@ class TestLogRetriever(unittest.TestCase):
         container_id = "fancy_container"
         with self.assertRaises(NotImplementedError):
             retriever.get_log_url(container_id)
+
+    def test_get_log_url_shared_log_group_on_publisher(self):
+        retriever = LogRetriever(CloudProvider.AWS)
+        container_id = "arn:aws:ecs:us-west-2:539290649537:task/onedocker-cluster-ee9bc805f22e40f9bbc107d5f006b6e1/3a5e4213036b4456a6c16695b938b361"
+        expected = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-shared-us-west-2/log-events/ecs$252Fonedocker-container-shared-us-west-2$252F3a5e4213036b4456a6c16695b938b361"
+        actual = retriever.get_log_url(container_id)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Summary:
On the publisher side, if the PCE is generated by using the PCE management tool, the log group will be using the shared log group.

Example: the container name is `onedocker-container-ee9bc805f22e40f9bbc107d5f006b6e1` while in the url, the log group name will contain `onedocker-container-shared-us-west-2`.

The fix is to replace the last part of the container name string with "-shared-<region>" if the last part matches regex (32 bit includes 0-9 and a-z).

This is hacky but the log_retriever method is already hacky :)

The edge case is that the advertiser is also using a 32bit string with 0-9 and a-z, but that should rarely happen.

Reviewed By: Olivia-liu

Differential Revision: D33592515

