### PR TITLE
add tracker hash to automated github test

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -23,6 +23,10 @@ on:
         description: Version tag to use
         required: true
         default: rc
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 env:
   FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
@@ -41,6 +45,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash}}
+
       - name: One command runner
         run: |
           ./fbpcs/scripts/run_fbpcs.sh run_study \


### PR DESCRIPTION
Summary:
## What

* see title

## Why

* so that we can track the status of runs in conveyor

## How

* Copy-pasted from this: D34259086 (https://github.com/facebookresearch/fbpcs/commit/b5fc2734bc2f35b5ca70de16be16999a8a47e6f4)

Reviewed By: leegross

Differential Revision: D34406216

