### PR TITLE
add tracker hash to publish image to ecr

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -23,6 +23,10 @@ on:
         description: Version tag to use
         required: true
         default: rc
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 env:
   FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
@@ -41,6 +45,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash}}
+
       - name: One command runner
         run: |
           ./fbpcs/scripts/run_fbpcs.sh run_study \

--- a/.github/workflows/publish_image_to_ecr.yml
+++ b/.github/workflows/publish_image_to_ecr.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: string
         default: us-west-2
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 env:
   REGISTRY: ghcr.io
@@ -44,6 +48,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v2
+    - name: Print Tracker Hash
+      run: echo ${{ github.event.inputs.tracker_hash}}
 
     - uses: docker/login-action@v1
       with:


### PR DESCRIPTION
Summary:
## What

* see title

## Why

* so that we can track the status of runs in conveyor

## How

* Copy-pasted from this: D34259086 (https://github.com/facebookresearch/fbpcs/commit/b5fc2734bc2f35b5ca70de16be16999a8a47e6f4)

Differential Revision: D34406378

