### PR TITLE
Validate each line ending

### DIFF
--- a/fbpcs/input_data_validation/constants.py
+++ b/fbpcs/input_data_validation/constants.py
@@ -5,6 +5,11 @@
 
 # pyre-strict
 
+
+import re
+from typing import Pattern
+
 INPUT_DATA_TMP_FILE_PATH = "/tmp"
 PA_FIELDS = ["id_", "conversion_value", "conversion_timestamp", "conversion_metadata"]
 PL_FIELDS = ["id_", "value", "event_timestamp"]
+VALID_LINE_ENDING_REGEX: Pattern[str] = re.compile(r".*(\S|\S\n)$")

--- a/fbpcs/input_data_validation/constants.py
+++ b/fbpcs/input_data_validation/constants.py
@@ -6,3 +6,5 @@
 # pyre-strict
 
 INPUT_DATA_TMP_FILE_PATH = "/tmp"
+PA_FIELDS = ["id_", "conversion_value", "conversion_timestamp", "conversion_metadata"]
+PL_FIELDS = ["id_", "value", "event_timestamp"]

--- a/fbpcs/input_data_validation/header_validator.py
+++ b/fbpcs/input_data_validation/header_validator.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from typing import Sequence
+
+from fbpcs.input_data_validation.constants import PA_FIELDS, PL_FIELDS
+
+
+class HeaderValidator:
+    def validate(self, header_row: Sequence[str]) -> None:
+        if not header_row:
+            raise Exception("The header row was empty.")
+
+        match_pa_fields = len(set(PA_FIELDS).intersection(set(header_row))) == len(
+            PA_FIELDS
+        )
+        match_pl_fields = len(set(PL_FIELDS).intersection(set(header_row))) == len(
+            PL_FIELDS
+        )
+
+        if not (match_pa_fields or match_pl_fields):
+            raise Exception(
+                f"Failed to parse the header row. The header row fields must be either: {PL_FIELDS} or: {PA_FIELDS}"
+            )

--- a/fbpcs/input_data_validation/line_ending_validator.py
+++ b/fbpcs/input_data_validation/line_ending_validator.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from fbpcs.input_data_validation.constants import VALID_LINE_ENDING_REGEX
+
+
+class LineEndingValidator:
+    def validate(self, line: str) -> None:
+        if not VALID_LINE_ENDING_REGEX.match(line):
+            raise Exception(
+                "Detected an unexpected line ending. The only supported line ending is '\\n'"
+            )

--- a/fbpcs/input_data_validation/tests/validation_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validation_runner_test.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+import os
+from typing import Iterable
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, Mock
 
@@ -14,9 +16,22 @@ from fbpcs.input_data_validation.validation_runner import ValidationRunner
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
 TEST_INPUT_FILE_PATH = "s3://test-bucket/data.csv"
+TEST_REGION = "us-west-2"
+TEST_TIMESTAMP = 1644538741.077141
+TEST_TEMP_FILEPATH = f"{INPUT_DATA_TMP_FILE_PATH}/data.csv-{TEST_TIMESTAMP}"
 
 
 class TestValidationRunner(TestCase):
+    def setUp(self) -> None:
+        open(TEST_TEMP_FILEPATH, "a").close()
+
+    def tearDown(self) -> None:
+        os.remove(TEST_TEMP_FILEPATH)
+
+    def write_lines_to_file(self, lines: Iterable[bytes]) -> None:
+        with open(TEST_TEMP_FILEPATH, "wb") as tmp_csv_file:
+            tmp_csv_file.writelines(lines)
+
     @patch("fbpcp.service.storage_s3.S3StorageService")
     def test_initializating_the_validation_runner_fields(self, _mock) -> None:
         cloud_provider = CloudProvider.AWS
@@ -48,33 +63,6 @@ class TestValidationRunner(TestCase):
             validation_runner._storage_service, constructed_storage_service
         )
 
-    @patch("fbpcs.input_data_validation.validation_runner.time")
-    @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
-    def test_run_validations_success(
-        self, storage_service_mock: Mock, time_mock: Mock
-    ) -> None:
-        timestamp = 1644538741.077141
-        time_mock.time.return_value = timestamp
-        input_file_path = "s3://test-bucket/data.csv"
-        cloud_provider = CloudProvider.AWS
-        expected_temp_filepath = f"{INPUT_DATA_TMP_FILE_PATH}/data.csv-{timestamp}"
-        expected_report = {
-            "status": ValidationResult.SUCCESS.value,
-            "message": f"File: {input_file_path} was validated successfully",
-        }
-        storage_service_mock.__init__(return_value=storage_service_mock)
-
-        validation_runner = ValidationRunner(
-            input_file_path, cloud_provider, "us-west-2"
-        )
-        report = validation_runner.run()
-
-        self.assertEqual(validation_runner._local_file_path, expected_temp_filepath)
-        self.assertEqual(report, expected_report)
-        storage_service_mock.copy.assert_called_with(
-            input_file_path, expected_temp_filepath
-        )
-
     @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
     def test_run_validations_failure(self, storage_service_mock: Mock) -> None:
         exception_message = "failed to copy"
@@ -83,6 +71,7 @@ class TestValidationRunner(TestCase):
         expected_report = {
             "status": ValidationResult.FAILED.value,
             "message": f"File: {input_file_path} failed validation. Error: {exception_message}",
+            "rows_processed_count": "0",
         }
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.copy.side_effect = Exception(exception_message)
@@ -92,4 +81,31 @@ class TestValidationRunner(TestCase):
         )
         report = validation_runner.run()
 
-        self.assertEqual(report, expected_report)
+        self.assertDictEqual(report, expected_report)
+
+    @patch("fbpcs.input_data_validation.validation_runner.S3StorageService")
+    @patch("fbpcs.input_data_validation.validation_runner.time")
+    def test_run_validations_reads_the_local_csv_rows(
+        self, time_mock: Mock, _storage_service_mock: Mock
+    ) -> None:
+        time_mock.time.return_value = TEST_TIMESTAMP
+        cloud_provider = CloudProvider.AWS
+        lines = [
+            b"id_,value,timestamp\n",
+            b"abcd/1234+WXYZ=,100,1645157987\n",
+            b"abcd/1234+WXYZ=,100,1645157987\n",
+            b"abcd/1234+WXYZ=,100,1645157987\n",
+        ]
+        self.write_lines_to_file(lines)
+        expected_report = {
+            "status": ValidationResult.SUCCESS.value,
+            "message": f"File: {TEST_INPUT_FILE_PATH} was validated successfully",
+            "rows_processed_count": "3",
+        }
+
+        validation_runner = ValidationRunner(
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+        )
+        report = validation_runner.run()
+
+        self.assertDictEqual(report, expected_report)

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -25,6 +25,7 @@ from typing import Dict, Optional
 from fbpcp.service.storage_s3 import S3StorageService
 from fbpcs.input_data_validation.constants import INPUT_DATA_TMP_FILE_PATH
 from fbpcs.input_data_validation.enums import ValidationResult
+from fbpcs.input_data_validation.header_validator import HeaderValidator
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
 
@@ -56,6 +57,11 @@ class ValidationRunner:
             self._storage_service.copy(self._input_file_path, self._local_file_path)
             with open(self._local_file_path) as local_file:
                 csv_reader = csv.DictReader(local_file)
+                field_names = csv_reader.fieldnames or []
+
+                header_validator = HeaderValidator()
+                header_validator.validate(field_names)
+
                 for _ in csv_reader:
                     rows_processed_count += 1
         except Exception as e:

--- a/fbpcs/input_data_validation/validation_runner.py
+++ b/fbpcs/input_data_validation/validation_runner.py
@@ -26,6 +26,7 @@ from fbpcp.service.storage_s3 import S3StorageService
 from fbpcs.input_data_validation.constants import INPUT_DATA_TMP_FILE_PATH
 from fbpcs.input_data_validation.enums import ValidationResult
 from fbpcs.input_data_validation.header_validator import HeaderValidator
+from fbpcs.input_data_validation.line_ending_validator import LineEndingValidator
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
 
@@ -62,8 +63,16 @@ class ValidationRunner:
                 header_validator = HeaderValidator()
                 header_validator.validate(field_names)
 
-                for _ in csv_reader:
+            with open(self._local_file_path, "rb") as local_file:
+                line_ending_validator = LineEndingValidator()
+                header_line = local_file.readline().decode("utf-8")
+                line_ending_validator.validate(header_line)
+
+                while raw_line := local_file.readline():
+                    line = raw_line.decode("utf-8")
+                    line_ending_validator.validate(line)
                     rows_processed_count += 1
+
         except Exception as e:
             return self._format_validation_result(
                 ValidationResult.FAILED,


### PR DESCRIPTION
Summary:
The only supported line ending is the plain newline character `\n`. Error when
an unsupported newline is detected at the end of a line.

Differential Revision: D34410313

