### PR TITLE
Add dummy row when shard file size is 0

### DIFF
--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
@@ -136,6 +136,13 @@ UnionPIDDataPreparerResults UnionPIDDataPreparer::prepare() const {
              << private_lift::logging::formatNumber(res.duplicateIdCount)
              << " duplicate ids.";
 
+  if (res.linesProcessed == 0) {
+    XLOG(INFO) << "The file is empty. Adding random dummy row";
+    // Using random value to avoid accidental match with other-side data
+    auto randomDummyRow = std::to_string(folly::Random::secureRand64());
+    *tmpFile << randomDummyRow << "\n";
+  }
+
   XLOG(INFO) << "Now copying prepared data to final output path";
   // Reset underlying unique_ptr to ensure buffer gets flushed
   tmpFile.reset();

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cstdint>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
@@ -37,6 +38,23 @@ static void validateFileContents(
     const std::filesystem::path& path,
     bool shouldAssert = false) {
   auto actual = readFile(path);
+  if (shouldAssert) {
+    ASSERT_EQ(expected, actual);
+  } else {
+    EXPECT_EQ(expected, actual);
+  }
+}
+
+static void validateRowCounts(
+    const std::int32_t& expected,
+    const std::filesystem::path& path,
+    bool shouldAssert = false) {
+  std::ifstream f{path};
+  std::string line;
+  std::int32_t actual = 0;
+  while (getline(f, line)) {
+    actual++;
+  }
   if (shouldAssert) {
     ASSERT_EQ(expected, actual);
   } else {
@@ -101,6 +119,18 @@ TEST(UnionPIDDataPreparerTest, ValidTest) {
   UnionPIDDataPreparer preparer{inpath, outpath, "/tmp/"};
   preparer.prepare();
   validateFileContents(expected, outpath);
+}
+
+TEST(UnionPIDDataPreparerTest, RowCountTest) {
+  std::vector<std::string> lines = {"id_"};
+  std::int32_t rowCountExpected = 1;
+  std::filesystem::path inpath{tmpnam(nullptr)};
+  std::filesystem::path outpath{tmpnam(nullptr)};
+  writeLinesToFile(inpath, lines);
+
+  UnionPIDDataPreparer preparer{inpath, outpath, "/tmp/"};
+  preparer.prepare();
+  validateRowCounts(rowCountExpected, outpath);
 }
 
 } // namespace measurement::pid


### PR DESCRIPTION
Summary:
# Context
MARISA has been experiencing failure for more than 10 days as mentioned in [the post](https://fb.workplace.com/groups/331044242148818/posts/422172903035951). The links to all the investigation is summarized in [the quip](https://fb.quip.com/WraiAhmVOV8u).

As the result of investigation, we have found that empty shard data is causing the failure. We are able to reproduce the same failure on local PID protocol run with having server data empty.

# Details
As the temporary solution, we have determined to add dummy data for those empty shard data. In this diff, we are adding dummy data in the tmp file during PID prepare stage. Then, the tmp file with dummy data would be copied to actual S3 data file path to be used as the input for PID protocol.

Differential Revision: D34437953

