### PR TITLE
update input parameters of build jobs for build node

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -8,12 +8,21 @@ on:
       name:
         description: 'Manually running this workflow to build a coordinator image'
         default: 'Run'
+      new_tag:
+        description: 'The new tag of the docker image'
+        required: false
+        type: string
+        default: latest-build
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 
 env:
   DISTRO: ubuntu
   REGISTRY: ghcr.io
-  VERSION_TAG: latest-build
+  VERSION_TAG: ${{ github.event.inputs.new_tag }}
   LOCAL_IMAGE_NAME: coordinator-local
   REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/coordinator
 
@@ -27,6 +36,8 @@ jobs:
 
    steps:
      - uses: actions/checkout@v2
+     - name: Print Tracker Hash
+       run: echo ${{ github.event.inputs.tracker_hash }}
 
      - name: Build image
        run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,15 +8,24 @@ on:
       name:
         description: 'Manually running this workflow will skip "Check New Commits" step and build image directly'
         default: 'Run'
+      new_tag:
+        description: 'The new tag of the docker image'
+        required: false
+        type: string
+        default: latest-build
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
 
 env:
   DISTRO: ubuntu
   REGISTRY: ghcr.io
-  VERSION_TAG: latest-build
+  VERSION_TAG: ${{ github.event.inputs.new_tag }}
   LOCAL_IMAGE_NAME: fbpcs/onedocker
   RC_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/rc/onedocker
   PROD_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/onedocker
-  COORDINATOR_IMAGE: ghcr.io/facebookresearch/fbpcs/coordinator:latest-build
+  COORDINATOR_IMAGE: ghcr.io/facebookresearch/fbpcs/coordinator:${{ github.event.inputs.new_tag }}
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
@@ -90,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Print Tracker Hash
+       run: echo ${{ github.event.inputs.tracker_hash }}
 
       - name: Cleanup ECS running tasks and previous running results
         run: |


### PR DESCRIPTION
Summary:
for hotfixes, we need to support triggering builds ourselves

in order to trigger builds ourselves, we need to:
1) support the tracker_hash input parameter which enables us to track github job status from our macgyver node
2) support adding a tag other than build-latest, since in the case of a hotfix, we will likely want to tag it directly with the bundle id

Reviewed By: gorel

Differential Revision: D34460336

