### PR TITLE
macgyver support queued workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash }}
+
       - name: Print latest commit id
         run: echo ${{ github.sha }}
 
@@ -97,8 +100,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Print Tracker Hash
-        run: echo ${{ github.event.inputs.tracker_hash }}
 
       - name: Cleanup ECS running tasks and previous running results
         run: |


### PR DESCRIPTION
Summary:
## What

* move tracker hash for onedocker publish to beginning of file (build can take like 10 minutes)
* get rid of some magic numbers in magyver (instead of returning 0, return None)
* don't raise an error if no jobs are found for a run id, since it's possible that the workflow is just queued (hence no jobs yet)

## Why

The new "build image" action status syncing is broken and showing in error in conveyor because queued workflows don't create jobs right away.

Differential Revision: D34573508

