### PR TITLE
Deprecate partial_container_retry_enabled field of PrivateComputationInstance

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -114,9 +114,10 @@ class PrivateComputationInstance(InstanceBase):
     aggregation_type: Optional[AggregationType] = None
 
     retry_counter: int = 0
-    partial_container_retry_enabled: bool = (
-        False  # TODO T98578624: once the product is stabilized, we can enable this
-    )
+
+    # this field is deprecated
+    partial_container_retry_enabled: bool = False
+
     is_validating: Optional[bool] = False
     synthetic_shard_path: Optional[str] = None
 

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -34,9 +34,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 from fbpcs.private_computation.service.utils import (
     create_and_start_mpc_instance,
-    gen_mpc_game_args_to_retry,
     map_private_computation_role_to_mpc_party,
-    ready_for_partial_container_retry,
     get_updated_pc_status_mpc_game,
 )
 
@@ -50,7 +48,6 @@ class ComputeMetricsStageService(PrivateComputationStageService):
         _is_validating: if a test shard is injected to do run time correctness validation
         _log_cost_to_s3: if money cost of the computation will be logged to S3
         _container_timeout: optional duration in seconds before cloud containers timeout
-        _skip_partial_container_retry: don't perform a partial container retry, even if conditions are met.
     """
 
     def __init__(
@@ -60,14 +57,12 @@ class ComputeMetricsStageService(PrivateComputationStageService):
         is_validating: bool = False,
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
-        skip_partial_container_retry: bool = False,
     ) -> None:
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._mpc_service = mpc_service
         self._is_validating = is_validating
         self._log_cost_to_s3 = log_cost_to_s3
         self._container_timeout = container_timeout
-        self._skip_partial_container_retry = skip_partial_container_retry
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of run_async() so that it can be called by Thrift
@@ -161,51 +156,31 @@ class ComputeMetricsStageService(PrivateComputationStageService):
         Returns:
             MPC game args to be used by onedocker
         """
+
+        common_compute_game_args = {
+            "input_base_path": private_computation_instance.data_processing_output_path,
+            "output_base_path": private_computation_instance.compute_stage_output_base_path,
+            "num_files": private_computation_instance.num_files_per_mpc_container,
+            "concurrency": private_computation_instance.concurrency,
+        }
+
         game_args = []
 
-        # If this is to recover from a previous MPC compute failure
+        # TODO: we eventually will want to get rid of the if-else here, which will be
+        #   easy to do once the Lift and Attribution MPC compute games are consolidated
         if (
-            ready_for_partial_container_retry(private_computation_instance)
-            and not self._skip_partial_container_retry
+            private_computation_instance.game_type
+            is PrivateComputationGameType.ATTRIBUTION
         ):
-            game_args_to_retry = gen_mpc_game_args_to_retry(
-                private_computation_instance
+            game_args = self._get_attribution_game_args(
+                private_computation_instance,
+                common_compute_game_args,
             )
-            if game_args_to_retry:
-                game_args = game_args_to_retry
 
-        # If this is a normal run, dry_run, or unable to get the game args to retry from mpc service
-        if not game_args:
-            num_containers = private_computation_instance.num_mpc_containers
-            # update num_containers if is_vaildating = true
-            if self._is_validating:
-                num_containers += 1
-
-            common_compute_game_args = {
-                "input_base_path": private_computation_instance.data_processing_output_path,
-                "output_base_path": private_computation_instance.compute_stage_output_base_path,
-                "num_files": private_computation_instance.num_files_per_mpc_container,
-                "concurrency": private_computation_instance.concurrency,
-            }
-
-            # TODO: we eventually will want to get rid of the if-else here, which will be
-            #   easy to do once the Lift and Attribution MPC compute games are consolidated
-            if (
-                private_computation_instance.game_type
-                is PrivateComputationGameType.ATTRIBUTION
-            ):
-                game_args = self._get_attribution_game_args(
-                    private_computation_instance,
-                    common_compute_game_args,
-                )
-
-            elif (
-                private_computation_instance.game_type
-                is PrivateComputationGameType.LIFT
-            ):
-                game_args = self._get_lift_game_args(
-                    private_computation_instance, common_compute_game_args
-                )
+        elif private_computation_instance.game_type is PrivateComputationGameType.LIFT:
+            game_args = self._get_lift_game_args(
+                private_computation_instance, common_compute_game_args
+            )
 
         return game_args
 

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -31,9 +31,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 from fbpcs.private_computation.service.utils import (
     create_and_start_mpc_instance,
-    gen_mpc_game_args_to_retry,
     map_private_computation_role_to_mpc_party,
-    ready_for_partial_container_retry,
     get_updated_pc_status_mpc_game,
 )
 
@@ -47,7 +45,6 @@ class AttributionStageService(PrivateComputationStageService):
         _is_validating: if a test shard is injected to do run time correctness validation
         _log_cost_to_s3: if money cost of the computation will be logged to S3
         _container_timeout: optional duration in seconds before cloud containers timeout
-        _skip_partial_container_retry: don't perform a partial container retry, even if conditions are met.
     """
 
     def __init__(
@@ -57,14 +54,12 @@ class AttributionStageService(PrivateComputationStageService):
         is_validating: bool = False,
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
-        skip_partial_container_retry: bool = False,
     ) -> None:
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._mpc_service = mpc_service
         self._is_validating = is_validating
         self._log_cost_to_s3 = log_cost_to_s3
         self._container_timeout = container_timeout
-        self._skip_partial_container_retry = skip_partial_container_retry
 
     # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
     # Make an async version of run_async() so that it can be called by Thrift
@@ -153,58 +148,36 @@ class AttributionStageService(PrivateComputationStageService):
         Returns:
             MPC game args to be used by onedocker
         """
-        game_args = []
 
-        # If this is to recover from a previous MPC compute failure
-        if (
-            ready_for_partial_container_retry(private_computation_instance)
-            and not self._skip_partial_container_retry
-        ):
-            game_args_to_retry = gen_mpc_game_args_to_retry(
-                private_computation_instance
-            )
-            if game_args_to_retry:
-                game_args = game_args_to_retry
+        attribution_rule = checked_cast(
+            AttributionRule, private_computation_instance.attribution_rule
+        )
+        common_game_args = {
+            "input_base_path": private_computation_instance.data_processing_output_path,
+            "output_base_path": private_computation_instance.decoupled_attribution_stage_output_base_path,
+            "num_files": private_computation_instance.num_files_per_mpc_container,
+            "concurrency": private_computation_instance.concurrency,
+            "run_name": private_computation_instance.instance_id
+            + "_decoupled_attribution"
+            if self._log_cost_to_s3
+            else "",
+            "max_num_touchpoints": private_computation_instance.padding_size,
+            "max_num_conversions": private_computation_instance.padding_size,
+            "log_cost": self._log_cost_to_s3,
+            "attribution_rules": attribution_rule.value,
+            "use_xor_encryption": True,
+            "use_postfix": True,
+        }
 
-        # If this is a normal run, dry_run, or unable to get the game args to retry from mpc service
-        if not game_args:
-            num_containers = private_computation_instance.num_mpc_containers
-            # update num_containers if is_vaildating = true
-            if self._is_validating:
-                num_containers += 1
-
-            attribution_rule = checked_cast(
-                AttributionRule, private_computation_instance.attribution_rule
-            )
-            common_game_args = {
-                "input_base_path": private_computation_instance.data_processing_output_path,
-                "output_base_path": private_computation_instance.decoupled_attribution_stage_output_base_path,
-                "num_files": private_computation_instance.num_files_per_mpc_container,
-                "concurrency": private_computation_instance.concurrency,
-                "run_name": private_computation_instance.instance_id
-                + "_decoupled_attribution"
-                if self._log_cost_to_s3
-                else "",
-                "max_num_touchpoints": private_computation_instance.padding_size,
-                "max_num_conversions": private_computation_instance.padding_size,
-                "log_cost": self._log_cost_to_s3,
-                "attribution_rules": attribution_rule.value,
-                "use_xor_encryption": True,
-                "use_postfix": True,
+        game_args = [
+            {
+                **common_game_args,
+                **{
+                    "file_start_index": i
+                    * private_computation_instance.num_files_per_mpc_container,
+                },
             }
-
-            attribution_rule = checked_cast(
-                AttributionRule, private_computation_instance.attribution_rule
-            )
-            game_args = [
-                {
-                    **common_game_args,
-                    **{
-                        "file_start_index": i
-                        * private_computation_instance.num_files_per_mpc_container,
-                    },
-                }
-                for i in range(private_computation_instance.num_mpc_containers)
-            ]
+            for i in range(private_computation_instance.num_mpc_containers)
+        ]
 
         return game_args

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Tuple
 from unittest.mock import MagicMock, call, patch
 from unittest.mock import Mock
 
-from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.service.mpc import MPCInstanceStatus, MPCParty, MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
@@ -47,7 +46,6 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 from fbpcs.private_computation.service.utils import (
     create_and_start_mpc_instance,
-    gen_mpc_game_args_to_retry,
     map_private_computation_role_to_mpc_party,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
 )
@@ -685,46 +683,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             PrivateComputationInstanceStatus.COMPUTATION_FAILED,
             private_computation_instance.status,
         )
-
-    def test_gen_game_args_to_retry(self) -> None:
-        test_input = "test_input_retry"
-        mpc_instance = PCSMPCInstance.create_instance(
-            instance_id="mpc_instance",
-            game_name=GameNames.LIFT.value,
-            mpc_party=MPCParty.SERVER,
-            num_workers=2,
-            status=MPCInstanceStatus.FAILED,
-            containers=[
-                ContainerInstance(
-                    instance_id="container_instance_0",
-                    status=ContainerInstanceStatus.FAILED,
-                ),
-                ContainerInstance(
-                    instance_id="container_instance_1",
-                    status=ContainerInstanceStatus.COMPLETED,
-                ),
-            ],
-            game_args=[
-                {
-                    "input_filenames": test_input,
-                },
-                {
-                    "input_filenames": "input_filenames",
-                },
-            ],
-        )
-        private_computation_instance = self.create_sample_instance(
-            status=PrivateComputationInstanceStatus.COMPUTATION_FAILED,
-            instances=[mpc_instance],
-        )
-
-        game_args = gen_mpc_game_args_to_retry(private_computation_instance)
-
-        # pyre-fixme[6]: For 1st param expected `Sized` but got
-        #  `Optional[List[Dict[str, typing.Any]]]`.
-        self.assertEqual(1, len(game_args))  # only 1 failed container
-        # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
-        self.assertEqual(test_input, game_args[0]["input_filenames"])
 
     def create_sample_instance(
         self,


### PR DESCRIPTION
Summary:
**Background**
This field was added in D29509689 more than half a year ago when I worked on the *partial container failure recovery* feature. The work stream was deprioritized, and the feature is not usable. I'm cleaning it up to avoid confusion and poor maintenance. If we still want this feature, I would recommend redesigning it.

**This diff**
1. Intentionally not deleting `partial_container_retry_enabled` from `PrivateComputationInstance` class because from what I know, there's no safe way to delete a field from the instance class;
2. This diff is not as huge/scary as it looks. The main thing I did was removing this if branch
```
     if (
            ready_for_partial_container_retry(private_computation_instance)
            and not self._skip_partial_container_retry
        ):
```

Differential Revision: D34565572

