### PR TITLE
Fix broken hotfix workflow

### DIFF
--- a/.github/workflows/create-hotfix.yml
+++ b/.github/workflows/create-hotfix.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           git config --global user.name "GithubActions CreateHotfix"
           git config --global user.email "pc_release@fb.com"
-          # git remote set-url origin https://${{ secrets.GITHUB_TOKEN }}@github.com/facebookresearch/fbpcs.git
           git checkout ${{ github.event.inputs.base_commit }} -b ${{ github.event.inputs.branch_name }}
           git cherry-pick ${{ github.event.inputs.hotfix_commit }}
           git push -u origin ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/create-hotfix.yml
+++ b/.github/workflows/create-hotfix.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.PC_RELEASE_GITHUB_TOKEN }}
 
       - name: Print Tracker Hash
         run: echo ${{ github.event.inputs.tracker_hash }}
@@ -40,7 +41,7 @@ jobs:
         run: |
           git config --global user.name "GithubActions CreateHotfix"
           git config --global user.email "pc_release@fb.com"
-          git remote set-url origin https://${{ secrets.GITHUB_TOKEN }}@github.com/facebookresearch/fbpcs.git
+          # git remote set-url origin https://${{ secrets.GITHUB_TOKEN }}@github.com/facebookresearch/fbpcs.git
           git checkout ${{ github.event.inputs.base_commit }} -b ${{ github.event.inputs.branch_name }}
           git cherry-pick ${{ github.event.inputs.hotfix_commit }}
           git push -u origin ${{ github.event.inputs.branch_name }}


### PR DESCRIPTION
## What

* use pc-release user's token (stored as a secret in the repository)

## Why

* Because it has the workflow permission enabled