### PR TITLE
Deployment UI: Added a explicit url for health check from kubernete, which interms fixes couple of bugs

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -119,6 +119,11 @@ public class DeployController {
     return new APIReturn(APIReturn.Status.STATUS_ERROR, output, rootNode);
   }
 
+  @GetMapping(path = "/v2/deployment/healthCheck", produces = "application/json")
+  public void checkHealth() {
+    logger.info("checkHealth: Received status request");
+  }
+
   @GetMapping(path = "/v1/deployment/streamLogs", produces = "application/json")
   public List<String> deploymentStreamLogs() {
     logger.info("Received getStream log request");


### PR DESCRIPTION
Summary:
A bug that was hunting the whole team is finally fixed :D

Analysis :

We have a backend java based spring server which does the deployment. and it runs in a separate pod in kubernete. The issue lies in the getStatus API which was also registered as a health check end point from kubernete.

As the API actually reset couple of variable, any call from kubernete to check health also mangles with the normal getStatus call from deployment UI. There by resetting certain state as assumed by application.

This diff provides 2 immediate changes to fix :

1. Added a new REST end point to do health check, which is just a dummy end point.

2. Changed kubernete health check end point to point to the new one.

What's coming in future?

1. Fix to make sure get API doesn't end up in change in resources. Move it to a post api or refactor code to make the code behave like a getter while setting any state during a user defined operation.

2. More refactor to move the overall logic to a kotlin based

Reviewed By: marksliva

Differential Revision: D34602935

