### PR TITLE
Change the SSE type of the data bucket to SSE-S3

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -53,26 +53,6 @@ resource "aws_iam_role_policy" "s3_policy" {
 EOF
 }
 
-resource "aws_iam_role_policy" "kms_policy_glue" {
-  name   = "kms-policy${var.tag_postfix}"
-  role   = aws_iam_role.glue_service_role.id
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "kms:*",
-      "Resource": [
-        "arn:aws:kms:*:${var.aws_account_id}:key/*",
-        "arn:aws:kms:*:${var.aws_account_id}:alias/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_glue_crawler" "mpc_events_crawler" {
   database_name = aws_glue_catalog_database.mpc_database.name
   name          = "mpc-events-crawler${var.tag_postfix}"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
@@ -12,8 +12,3 @@ output "firehose_stream_name" {
   value       = aws_kinesis_firehose_delivery_stream.extended_s3_stream.name
   description = "The Kinesis firehose stream name"
 }
-
-output "data_ingestion_kms_key" {
-  value       = aws_kms_key.s3_kms_key.id
-  description = "The data bucket KMS key"
-}


### PR DESCRIPTION
Summary:
The current SSE type of the data bucket is SSE-KMS. It caused the ECS task role couldn't access it. We could either to attach a policy to the ECS task role or change the SSE type to SSE-S3. This diff is the later because on the publisher side we are also using SSE-S3 and we need to keep them consistent.

This diff made following changes:
1. Change the SSE type of the s3 bucket to SSE-S3.
2. Removed the server side encryption setting on the Kinesis because it is redundent since the S3 bucket is already has SSE enabled. (source: https://stackoverflow.com/questions/53752246/kinesis-firehose-kms-encryption)
3. Removed the kms policy from the Kinesis firehose role since it won't need it to access s3 bucket.
4. Removed the kms policy from the Glue crawler role since it won'te need it to access s3 bucket.

Differential Revision: D34605656

