### PR TITLE
Remove KMS from the resources policy

### DIFF
--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -120,13 +120,6 @@ def aws_create_iam_policy_parser_arguments(aws_parser: argparse):
     )
 
     iam_policy_command_group.add_argument(
-        "--data_ingestion_kms_key",
-        type=str,
-        required=False,
-        help="Data ingestion bucket KMS key",
-    )
-
-    iam_policy_command_group.add_argument(
         "--cluster_name", type=str, required=False, help="ECS cluster name"
     )
 

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -287,7 +287,6 @@ class AwsDeploymentHelper:
             "CLUSTER_NAME": policy_params.cluster_name,
             "DATA_BUCKET_NAME": policy_params.data_bucket_name,
             "CONFIG_BUCKET_NAME": policy_params.config_bucket_name,
-            "DATA_INGESTION_KMS_KEY": policy_params.data_ingestion_kms_key,
             "ECS_TASK_EXECUTION_ROLE_NAME": policy_params.ecs_task_execution_role_name,
             "FIREHOSE_STREAM_NAME": policy_params.firehose_stream_name,
             "DATEBASE_NAME": policy_params.database_name,

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -41,7 +41,6 @@ class AwsDeploymentHelperTool:
                 data_bucket_name=self.cli_args.data_bucket_name,
                 config_bucket_name=self.cli_args.config_bucket_name,
                 database_name=self.cli_args.database_name,
-                data_ingestion_kms_key=self.cli_args.data_ingestion_kms_key,
                 cluster_name=self.cli_args.cluster_name,
                 ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
             )

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
@@ -44,15 +44,6 @@
         },
         {
             "Effect": "Allow",
-            "Action": [
-                "kms:*"
-            ],
-            "Resource": [
-                "arn:aws:kms:${REGION}:${ACCOUNT_ID}:key/${DATA_INGESTION_KMS_KEY}"
-            ]
-        },
-        {
-            "Effect": "Allow",
             "Action": "ecs:*",
             "Resource": [
                 "arn:aws:ecs:*:${ACCOUNT_ID}:task/*",

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -12,6 +12,5 @@ class PolicyParams:
     data_bucket_name: str
     config_bucket_name: str
     database_name: str
-    data_ingestion_kms_key: str
     cluster_name: str
     ecs_task_execution_role_name: str


### PR DESCRIPTION
Summary: We don't need the KMS key anymore so removing the places that is using it.

Reviewed By: marksliva

Differential Revision: D34632602

