### PR TITLE
Remove libfb.py dependency from fbpcs, unblock OSS repo test run

### DIFF
--- a/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_prepare_stage.py
@@ -6,8 +6,8 @@
 
 # pyre-strict
 import unittest
-from typing import Tuple, Dict, Union
-from unittest.mock import MagicMock, patch
+from typing import Tuple, Dict
+from unittest.mock import MagicMock, patch, AsyncMock
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcs.data_processing.pid_preparer.union_pid_preparer_cpp import (
@@ -19,29 +19,6 @@ from fbpcs.pid.entity.pid_stages import UnionPIDStage
 from fbpcs.pid.service.pid_service.pid_prepare_stage import PIDPrepareStage
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
-from libfb.py.asyncio.mock import AsyncMock
-from libfb.py.testutil import data_provider
-
-
-def data_test_prepare() -> Tuple[
-    Dict[str, Union[ContainerInstanceStatus, bool]],
-    Dict[str, Union[ContainerInstanceStatus, bool]],
-    Dict[str, Union[ContainerInstanceStatus, bool]],
-]:
-    return (
-        {
-            "wait_for_containers": True,
-            "expected_container_status": ContainerInstanceStatus.COMPLETED,
-        },
-        {
-            "wait_for_containers": True,
-            "expected_container_status": ContainerInstanceStatus.FAILED,
-        },
-        {
-            "wait_for_containers": False,
-            "expected_container_status": ContainerInstanceStatus.STARTED,
-        },
-    )
 
 
 def data_test_run() -> Tuple[
@@ -52,51 +29,68 @@ def data_test_run() -> Tuple[
 
 
 class TestPIDPrepareStage(unittest.TestCase):
-    @data_provider(data_test_prepare)
     @patch("fbpcs.pid.repository.pid_instance.PIDInstanceRepository")
     @to_sync
     async def test_prepare(
         self,
         mock_instance_repo: unittest.mock.MagicMock,
-        wait_for_containers: bool,
-        expected_container_status: ContainerInstanceStatus,
     ) -> None:
-        with patch.object(
-            CppUnionPIDDataPreparerService, "prepare_on_container_async"
-        ) as mock_prepare_on_container_async, patch.object(
-            PIDStage, "update_instance_containers"
-        ):
-            container = ContainerInstance(
-                instance_id="123",
-                ip_address="192.0.2.0",
-                status=expected_container_status,
-            )
-            mock_prepare_on_container_async.return_value = container
-            stage = PIDPrepareStage(
-                stage=UnionPIDStage.PUBLISHER_PREPARE,
-                instance_repository=mock_instance_repo,
-                storage_svc="STORAGE",  # pyre-ignore
-                onedocker_svc="ONEDOCKER",  # pyre-ignore
-                onedocker_binary_config=MagicMock(
-                    task_definition="offline-task:1#container",
-                    tmp_directory="/tmp/",
-                    binary_version="latest",
-                ),
-            )
+        async def _run_sub_test(
+            wait_for_containers: bool,
+            expected_container_status: ContainerInstanceStatus,
+        ) -> None:
+            with patch.object(
+                CppUnionPIDDataPreparerService, "prepare_on_container_async"
+            ) as mock_prepare_on_container_async, patch.object(
+                PIDStage, "update_instance_containers"
+            ):
+                container = ContainerInstance(
+                    instance_id="123",
+                    ip_address="192.0.2.0",
+                    status=expected_container_status,
+                )
+                mock_prepare_on_container_async.return_value = container
+                stage = PIDPrepareStage(
+                    stage=UnionPIDStage.PUBLISHER_PREPARE,
+                    instance_repository=mock_instance_repo,
+                    storage_svc="STORAGE",  # pyre-ignore
+                    onedocker_svc="ONEDOCKER",  # pyre-ignore
+                    onedocker_binary_config=MagicMock(
+                        task_definition="offline-task:1#container",
+                        tmp_directory="/tmp/",
+                        binary_version="latest",
+                    ),
+                )
 
-            res = await stage.prepare(
-                instance_id="123",
-                input_path="in",
-                output_path="out",
-                num_shards=1,
-                wait_for_containers=wait_for_containers,
-            )
-            self.assertEqual(
-                PIDStage.get_stage_status_from_containers([container]),
-                res,
-            )
+                res = await stage.prepare(
+                    instance_id="123",
+                    input_path="in",
+                    output_path="out",
+                    num_shards=1,
+                    wait_for_containers=wait_for_containers,
+                )
+                self.assertEqual(
+                    PIDStage.get_stage_status_from_containers([container]),
+                    res,
+                )
 
-    @data_provider(data_test_run)
+        data_tests = (
+            (True, ContainerInstanceStatus.COMPLETED),
+            (True, ContainerInstanceStatus.FAILED),
+            (False, ContainerInstanceStatus.STARTED),
+        )
+        for data_test in data_tests:
+            with self.subTest(
+                wait_for_containers=data_test[0],
+                expected_container_status=data_test[1],
+            ):
+                # reset mocks for each subTests
+                mock_instance_repo.reset_mock()
+                await _run_sub_test(
+                    data_test[0],
+                    data_test[1],
+                )
+
     @to_sync
     @patch(
         "fbpcs.private_computation.service.run_binary_base_service.RunBinaryBaseService.wait_for_containers_async"
@@ -110,47 +104,27 @@ class TestPIDPrepareStage(unittest.TestCase):
         mock_instance_repo: unittest.mock.MagicMock,
         mock_storage_svc: unittest.mock.MagicMock,
         mock_wait_for_containers_async: unittest.mock.MagicMock,
-        wait_for_containers: bool,
     ) -> None:
-        ip = "192.0.2.0"
-        container = ContainerInstance(
-            instance_id="123", ip_address=ip, status=ContainerInstanceStatus.STARTED
-        )
+        async def _run_sub_test(
+            wait_for_containers: bool,
+        ) -> None:
+            ip = "192.0.2.0"
+            container = ContainerInstance(
+                instance_id="123", ip_address=ip, status=ContainerInstanceStatus.STARTED
+            )
 
-        mock_onedocker_svc.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
-            return_value=[container]
-        )
+            mock_onedocker_svc.start_containers = MagicMock(return_value=[container])
+            mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
+                return_value=[container]
+            )
 
-        container.status = (
-            ContainerInstanceStatus.COMPLETED
-            if wait_for_containers
-            else ContainerInstanceStatus.STARTED
-        )
-        mock_wait_for_containers_async.return_value = [container]
+            container.status = (
+                ContainerInstanceStatus.COMPLETED
+                if wait_for_containers
+                else ContainerInstanceStatus.STARTED
+            )
+            mock_wait_for_containers_async.return_value = [container]
 
-        stage = PIDPrepareStage(
-            stage=UnionPIDStage.PUBLISHER_PREPARE,
-            instance_repository=mock_instance_repo,
-            storage_svc=mock_storage_svc,
-            onedocker_svc=mock_onedocker_svc,
-            onedocker_binary_config=MagicMock(
-                task_definition="offline-task:1#container",
-                tmp_directory="/tmp/",
-                binary_version="latest",
-            ),
-        )
-        instance_id = "444"
-        stage_input = PIDStageInput(
-            input_paths=["in"],
-            output_paths=["out"],
-            num_shards=2,
-            instance_id=instance_id,
-        )
-
-        # Basic test: All good
-        with patch.object(PIDPrepareStage, "files_exist") as mock_fe:
-            mock_fe.return_value = True
             stage = PIDPrepareStage(
                 stage=UnionPIDStage.PUBLISHER_PREPARE,
                 instance_repository=mock_instance_repo,
@@ -162,49 +136,17 @@ class TestPIDPrepareStage(unittest.TestCase):
                     binary_version="latest",
                 ),
             )
-            status = await stage.run(
-                stage_input, wait_for_containers=wait_for_containers
-            )
-            self.assertEqual(
-                PIDStageStatus.COMPLETED
-                if wait_for_containers
-                else PIDStageStatus.STARTED,
-                status,
+            instance_id = "444"
+            stage_input = PIDStageInput(
+                input_paths=["in"],
+                output_paths=["out"],
+                num_shards=2,
+                instance_id=instance_id,
             )
 
-            self.assertEqual(mock_onedocker_svc.start_containers.call_count, 2)
-            if wait_for_containers:
-                self.assertEqual(mock_wait_for_containers_async.call_count, 2)
-            else:
-                mock_wait_for_containers_async.assert_not_called()
-            mock_instance_repo.read.assert_called_with(instance_id)
-            self.assertEqual(mock_instance_repo.read.call_count, 4)
-            self.assertEqual(mock_instance_repo.update.call_count, 4)
-
-        with patch.object(PIDPrepareStage, "files_exist") as mock_fe, patch.object(
-            PIDPrepareStage, "prepare"
-        ) as mock_prepare:
-            mock_fe.return_value = True
-            status = await stage.run(
-                stage_input, wait_for_containers=wait_for_containers
-            )
-            mock_prepare.assert_called_with(
-                instance_id, "in", "out", 2, wait_for_containers, None
-            )
-
-        # Input not ready
-        with patch.object(PIDPrepareStage, "files_exist") as mock_fe:
-            mock_fe.return_value = False
-            status = await stage.run(
-                stage_input, wait_for_containers=wait_for_containers
-            )
-            self.assertEqual(PIDStageStatus.FAILED, status)
-
-        # Multiple input paths (invariant exception)
-        with patch.object(PIDPrepareStage, "files_exist") as mock_fe:
-            with self.assertRaises(ValueError):
+            # Basic test: All good
+            with patch.object(PIDPrepareStage, "files_exist") as mock_fe:
                 mock_fe.return_value = True
-                stage_input.input_paths = ["in1", "in2"]
                 stage = PIDPrepareStage(
                     stage=UnionPIDStage.PUBLISHER_PREPARE,
                     instance_repository=mock_instance_repo,
@@ -219,3 +161,70 @@ class TestPIDPrepareStage(unittest.TestCase):
                 status = await stage.run(
                     stage_input, wait_for_containers=wait_for_containers
                 )
+                self.assertEqual(
+                    PIDStageStatus.COMPLETED
+                    if wait_for_containers
+                    else PIDStageStatus.STARTED,
+                    status,
+                )
+
+                self.assertEqual(mock_onedocker_svc.start_containers.call_count, 2)
+                if wait_for_containers:
+                    self.assertEqual(mock_wait_for_containers_async.call_count, 2)
+                else:
+                    mock_wait_for_containers_async.assert_not_called()
+                mock_instance_repo.read.assert_called_with(instance_id)
+                self.assertEqual(mock_instance_repo.read.call_count, 4)
+                self.assertEqual(mock_instance_repo.update.call_count, 4)
+
+            with patch.object(PIDPrepareStage, "files_exist") as mock_fe, patch.object(
+                PIDPrepareStage, "prepare"
+            ) as mock_prepare:
+                mock_fe.return_value = True
+                status = await stage.run(
+                    stage_input, wait_for_containers=wait_for_containers
+                )
+                mock_prepare.assert_called_with(
+                    instance_id, "in", "out", 2, wait_for_containers, None
+                )
+
+            # Input not ready
+            with patch.object(PIDPrepareStage, "files_exist") as mock_fe:
+                mock_fe.return_value = False
+                status = await stage.run(
+                    stage_input, wait_for_containers=wait_for_containers
+                )
+                self.assertEqual(PIDStageStatus.FAILED, status)
+
+            # Multiple input paths (invariant exception)
+            with patch.object(PIDPrepareStage, "files_exist") as mock_fe:
+                with self.assertRaises(ValueError):
+                    mock_fe.return_value = True
+                    stage_input.input_paths = ["in1", "in2"]
+                    stage = PIDPrepareStage(
+                        stage=UnionPIDStage.PUBLISHER_PREPARE,
+                        instance_repository=mock_instance_repo,
+                        storage_svc=mock_storage_svc,
+                        onedocker_svc=mock_onedocker_svc,
+                        onedocker_binary_config=MagicMock(
+                            task_definition="offline-task:1#container",
+                            tmp_directory="/tmp/",
+                            binary_version="latest",
+                        ),
+                    )
+                    status = await stage.run(
+                        stage_input, wait_for_containers=wait_for_containers
+                    )
+
+        for data_test in data_test_run():
+            wait_for_containers = data_test["wait_for_containers"]
+            with self.subTest(
+                "Subtest with wait_for_containers: {wait_for_containers}",
+                wait_for_containers=wait_for_containers,
+            ):
+                # reset mocks for each subTests
+                mock_onedocker_svc.reset_mock()
+                mock_instance_repo.reset_mock()
+                mock_storage_svc.reset_mock()
+                mock_wait_for_containers_async.reset_mock()
+                await _run_sub_test(wait_for_containers)

--- a/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcp.service.onedocker import OneDockerService
@@ -16,8 +16,6 @@ from fbpcs.pid.entity.pid_stages import UnionPIDStage
 from fbpcs.pid.service.coordination.file_coordination import FileCoordinationService
 from fbpcs.pid.service.pid_service.pid_run_protocol_stage import PIDProtocolRunStage
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
-from libfb.py.asyncio.mock import AsyncMock
-from libfb.py.testutil import data_provider
 
 
 class TestPIDProtocolRunStage(unittest.TestCase):
@@ -51,9 +49,6 @@ class TestPIDProtocolRunStage(unittest.TestCase):
             await adv_run_stage._ready(stage_input=stage_input),
         )
 
-    @data_provider(
-        lambda: ({"wait_for_containers": True}, {"wait_for_containers": False})
-    )
     @to_sync
     @patch(
         "fbpcs.private_computation.service.run_binary_base_service.RunBinaryBaseService.wait_for_containers_async"
@@ -67,90 +62,103 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         mock_instance_repo,
         mock_storage_service,
         mock_wait_for_containers_async,
-        wait_for_containers: bool,
     ) -> None:
-        ip = "192.0.2.0"
-        container = ContainerInstance(instance_id="123", ip_address=ip)
-        mock_onedocker_service.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_service.wait_for_pending_containers = AsyncMock(
-            return_value=[container]
-        )
-        container.status = (
-            ContainerInstanceStatus.COMPLETED
-            if wait_for_containers
-            else ContainerInstanceStatus.STARTED
-        )
-        mock_wait_for_containers_async.return_value = [container]
-
-        with patch.object(
-            PIDProtocolRunStage, "files_exist"
-        ) as mock_files_exist, patch.object(
-            PIDProtocolRunStage, "put_server_ips"
-        ) as mock_put_server_ips:
-            mock_files_exist.return_value = True
-
-            num_shards = 2
-            input_path = "in"
-            output_path = "out"
-
-            # Run publisher
-            publisher_run_stage = PIDProtocolRunStage(
-                stage=UnionPIDStage.PUBLISHER_RUN_PID,
-                instance_repository=mock_instance_repo,
-                storage_svc=mock_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config=self.onedocker_binary_config,
+        async def _run_sub_test(wait_for_containers: bool) -> None:
+            ip = "192.0.2.0"
+            container = ContainerInstance(instance_id="123", ip_address=ip)
+            mock_onedocker_service.start_containers = MagicMock(
+                return_value=[container]
             )
-            instance_id = "123"
-            stage_input = PIDStageInput(
-                input_paths=[input_path],
-                output_paths=[output_path],
-                num_shards=num_shards,
-                instance_id=instance_id,
+            mock_onedocker_service.wait_for_pending_containers = AsyncMock(
+                return_value=[container]
             )
-
-            # if we are waiting for containers, then the stage should finish
-            # otherwise, it should start and then return
-            self.assertEqual(
-                PIDStageStatus.COMPLETED
+            container.status = (
+                ContainerInstanceStatus.COMPLETED
                 if wait_for_containers
-                else PIDStageStatus.STARTED,
-                await publisher_run_stage.run(
-                    stage_input=stage_input, wait_for_containers=wait_for_containers
-                ),
+                else ContainerInstanceStatus.STARTED
             )
+            mock_wait_for_containers_async.return_value = [container]
 
-            # Check create_instances_async was called with the correct parameters
-            if wait_for_containers:
-                mock_wait_for_containers_async.assert_called_once()
-            else:
-                mock_wait_for_containers_async.assert_not_called()
-            mock_onedocker_service.start_containers.assert_called_once()
-            (
-                _,
-                called_kwargs,
-            ) = mock_onedocker_service.start_containers.call_args_list[0]
-            self.assertEqual(num_shards, len(called_kwargs["cmd_args_list"]))
+            with patch.object(
+                PIDProtocolRunStage, "files_exist"
+            ) as mock_files_exist, patch.object(
+                PIDProtocolRunStage, "put_server_ips"
+            ) as mock_put_server_ips:
+                mock_files_exist.return_value = True
 
-            # Check `put_payload` was called with the correct parameters
-            mock_put_server_ips.assert_called_once_with(
-                instance_id=instance_id, server_ips=[ip]
-            )
+                num_shards = 2
+                input_path = "in"
+                output_path = "out"
 
-            # if wait for containers is False, there are 4 updates.
-            # if wait_for_containers is True, then there is another update
-            # that updates the instance status and containers to complete, so 5
-            mock_instance_repo.read.assert_called_with(instance_id)
-            self.assertEqual(
-                mock_instance_repo.read.call_count, 4 + int(wait_for_containers)
-            )
-            self.assertEqual(
-                mock_instance_repo.update.call_count, 4 + int(wait_for_containers)
-            )
+                # Run publisher
+                publisher_run_stage = PIDProtocolRunStage(
+                    stage=UnionPIDStage.PUBLISHER_RUN_PID,
+                    instance_repository=mock_instance_repo,
+                    storage_svc=mock_storage_service,
+                    onedocker_svc=mock_onedocker_service,
+                    onedocker_binary_config=self.onedocker_binary_config,
+                )
+                instance_id = "123"
+                stage_input = PIDStageInput(
+                    input_paths=[input_path],
+                    output_paths=[output_path],
+                    num_shards=num_shards,
+                    instance_id=instance_id,
+                )
 
-    @data_provider(
-        lambda: ({"wait_for_containers": True}, {"wait_for_containers": False})
-    )
+                # if we are waiting for containers, then the stage should finish
+                # otherwise, it should start and then return
+                self.assertEqual(
+                    PIDStageStatus.COMPLETED
+                    if wait_for_containers
+                    else PIDStageStatus.STARTED,
+                    await publisher_run_stage.run(
+                        stage_input=stage_input,
+                        wait_for_containers=wait_for_containers,
+                    ),
+                )
+
+                # Check create_instances_async was called with the correct parameters
+                if wait_for_containers:
+                    mock_wait_for_containers_async.assert_called_once()
+                else:
+                    mock_wait_for_containers_async.assert_not_called()
+                mock_onedocker_service.start_containers.assert_called_once()
+                (
+                    _,
+                    called_kwargs,
+                ) = mock_onedocker_service.start_containers.call_args_list[0]
+                self.assertEqual(num_shards, len(called_kwargs["cmd_args_list"]))
+
+                # Check `put_payload` was called with the correct parameters
+                mock_put_server_ips.assert_called_once_with(
+                    instance_id=instance_id, server_ips=[ip]
+                )
+
+                # if wait for containers is False, there are 4 updates.
+                # if wait_for_containers is True, then there is another update
+                # that updates the instance status and containers to complete, so 5
+                mock_instance_repo.read.assert_called_with(instance_id)
+                self.assertEqual(
+                    mock_instance_repo.read.call_count, 4 + int(wait_for_containers)
+                )
+                self.assertEqual(
+                    mock_instance_repo.update.call_count,
+                    4 + int(wait_for_containers),
+                )
+
+        for wait_for_containers in (True, False):
+            with self.subTest(
+                "Subtest with wait_for_containers: {wait_for_containers}",
+                wait_for_containers=wait_for_containers,
+            ):
+                # reset mocks for each subTests
+                mock_onedocker_service.reset_mock()
+                mock_instance_repo.reset_mock()
+                mock_storage_service.reset_mock()
+                mock_wait_for_containers_async.reset_mock()
+                await _run_sub_test(wait_for_containers)
+
     @to_sync
     @patch(
         "fbpcs.private_computation.service.run_binary_base_service.RunBinaryBaseService.wait_for_containers_async"
@@ -164,83 +172,97 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         mock_instance_repo,
         mock_storage_service,
         mock_wait_for_containers_async,
-        wait_for_containers: bool,
     ) -> None:
-        ip = "192.0.2.0"
-        container = ContainerInstance(instance_id="123", ip_address=ip)
-        mock_onedocker_service.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_service.wait_for_pending_containers = AsyncMock(
-            return_value=[container]
-        )
-        container.status = (
-            ContainerInstanceStatus.COMPLETED
-            if wait_for_containers
-            else ContainerInstanceStatus.STARTED
-        )
-        mock_wait_for_containers_async.return_value = [container]
-
-        with patch.object(
-            PIDProtocolRunStage, "files_exist"
-        ) as mock_files_exist, patch.object(
-            FileCoordinationService, "wait"
-        ) as mock_wait, patch.object(
-            FileCoordinationService, "get_payload"
-        ) as mock_get_payload:
-            mock_files_exist.return_value = True
-
-            input_path = "in"
-            output_path = "out"
-            ip_address = "192.0.2.0"
-            mock_wait.return_value = True
-            mock_get_payload.return_value = [ip_address]
-
-            # Run advertiser
-            adv_run_stage = PIDProtocolRunStage(
-                stage=UnionPIDStage.ADV_RUN_PID,
-                instance_repository=mock_instance_repo,
-                storage_svc=mock_storage_service,
-                onedocker_svc=mock_onedocker_service,
-                onedocker_binary_config=self.onedocker_binary_config,
-                server_ips=[ip_address],
+        async def _run_sub_test(wait_for_containers: bool) -> None:
+            ip = "192.0.2.0"
+            container = ContainerInstance(instance_id="123", ip_address=ip)
+            mock_onedocker_service.start_containers = MagicMock(
+                return_value=[container]
             )
-            instance_id = "456"
-            stage_input = PIDStageInput(
-                input_paths=[input_path],
-                output_paths=[output_path],
-                num_shards=1,
-                instance_id=instance_id,
+            mock_onedocker_service.wait_for_pending_containers = AsyncMock(
+                return_value=[container]
             )
-
-            # if we are waiting for containers, then the stage should finish
-            # otherwise, it should start and then return
-            self.assertEqual(
-                PIDStageStatus.COMPLETED
+            container.status = (
+                ContainerInstanceStatus.COMPLETED
                 if wait_for_containers
-                else PIDStageStatus.STARTED,
-                await adv_run_stage.run(
-                    stage_input=stage_input, wait_for_containers=wait_for_containers
-                ),
+                else ContainerInstanceStatus.STARTED
             )
+            mock_wait_for_containers_async.return_value = [container]
 
-            # Check create_instances_async was called with the correct parameters
-            if wait_for_containers:
-                mock_wait_for_containers_async.assert_called_once()
-            else:
-                mock_wait_for_containers_async.assert_not_called()
+            with patch.object(
+                PIDProtocolRunStage, "files_exist"
+            ) as mock_files_exist, patch.object(
+                FileCoordinationService, "wait"
+            ) as mock_wait, patch.object(
+                FileCoordinationService, "get_payload"
+            ) as mock_get_payload:
+                mock_files_exist.return_value = True
 
-            mock_onedocker_service.start_containers.assert_called_once()
-            (
-                _,
-                called_kwargs,
-            ) = mock_onedocker_service.start_containers.call_args_list[0]
+                input_path = "in"
+                output_path = "out"
+                ip_address = "192.0.2.0"
+                mock_wait.return_value = True
+                mock_get_payload.return_value = [ip_address]
 
-            # if wait for containers is False, there are 4 updates.
-            # if wait_for_containers is True, then there is another update
-            # that updates the instance status and containers to complete, so 5
-            mock_instance_repo.read.assert_called_with(instance_id)
-            self.assertEqual(
-                mock_instance_repo.read.call_count, 4 + int(wait_for_containers)
-            )
-            self.assertEqual(
-                mock_instance_repo.update.call_count, 4 + int(wait_for_containers)
-            )
+                # Run advertiser
+                adv_run_stage = PIDProtocolRunStage(
+                    stage=UnionPIDStage.ADV_RUN_PID,
+                    instance_repository=mock_instance_repo,
+                    storage_svc=mock_storage_service,
+                    onedocker_svc=mock_onedocker_service,
+                    onedocker_binary_config=self.onedocker_binary_config,
+                    server_ips=[ip_address],
+                )
+                instance_id = "456"
+                stage_input = PIDStageInput(
+                    input_paths=[input_path],
+                    output_paths=[output_path],
+                    num_shards=1,
+                    instance_id=instance_id,
+                )
+
+                # if we are waiting for containers, then the stage should finish
+                # otherwise, it should start and then return
+                self.assertEqual(
+                    PIDStageStatus.COMPLETED
+                    if wait_for_containers
+                    else PIDStageStatus.STARTED,
+                    await adv_run_stage.run(
+                        stage_input=stage_input, wait_for_containers=wait_for_containers
+                    ),
+                )
+
+                # Check create_instances_async was called with the correct parameters
+                if wait_for_containers:
+                    mock_wait_for_containers_async.assert_called_once()
+                else:
+                    mock_wait_for_containers_async.assert_not_called()
+
+                mock_onedocker_service.start_containers.assert_called_once()
+                (
+                    _,
+                    called_kwargs,
+                ) = mock_onedocker_service.start_containers.call_args_list[0]
+
+                # if wait for containers is False, there are 4 updates.
+                # if wait_for_containers is True, then there is another update
+                # that updates the instance status and containers to complete, so 5
+                mock_instance_repo.read.assert_called_with(instance_id)
+                self.assertEqual(
+                    mock_instance_repo.read.call_count, 4 + int(wait_for_containers)
+                )
+                self.assertEqual(
+                    mock_instance_repo.update.call_count, 4 + int(wait_for_containers)
+                )
+
+        for wait_for_containers in (True, False):
+            with self.subTest(
+                f"Subtest with wait_for_containers: {wait_for_containers}",
+                wait_for_containers=wait_for_containers,
+            ):
+                # reset mocks for each subTests
+                mock_onedocker_service.reset_mock()
+                mock_instance_repo.reset_mock()
+                mock_storage_service.reset_mock()
+                mock_wait_for_containers_async.reset_mock()
+                await _run_sub_test(wait_for_containers)

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcs.data_processing.service.sharding_service import ShardingService
@@ -16,8 +16,6 @@ from fbpcs.pid.entity.pid_stages import UnionPIDStage
 from fbpcs.pid.service.pid_service.pid_shard_stage import PIDShardStage
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
-from libfb.py.asyncio.unittest import AsyncMock
-from libfb.py.testutil import data_provider
 
 
 class TestPIDShardStage(unittest.TestCase):
@@ -47,9 +45,6 @@ class TestPIDShardStage(unittest.TestCase):
             res = await stage._ready(stage_input)
             self.assertTrue(res)
 
-    @data_provider(
-        lambda: ({"wait_for_containers": True}, {"wait_for_containers": False})
-    )
     @patch(
         "fbpcs.data_processing.service.sharding_service.ShardingService.wait_for_containers_async"
     )
@@ -63,44 +58,28 @@ class TestPIDShardStage(unittest.TestCase):
         mock_onedocker_svc,
         mock_storage_svc,
         mock_wait_for_containers_async,
-        wait_for_containers: bool,
     ) -> None:
-        ip = "192.0.2.0"
-        container = ContainerInstance(instance_id="123", ip_address=ip)
+        async def _run_sub_test(
+            wait_for_containers: bool,
+        ) -> None:
+            ip = "192.0.2.0"
+            container = ContainerInstance(instance_id="123", ip_address=ip)
 
-        mock_onedocker_svc.start_containers = MagicMock(return_value=[container])
-        mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
-            return_value=[container]
-        )
+            mock_onedocker_svc.start_containers = MagicMock(return_value=[container])
+            mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
+                return_value=[container]
+            )
 
-        container.status = (
-            ContainerInstanceStatus.COMPLETED
-            if wait_for_containers
-            else ContainerInstanceStatus.STARTED
-        )
-        mock_wait_for_containers_async.return_value = [container]
-        test_onedocker_binary_config = OneDockerBinaryConfig(
-            tmp_directory="/test_tmp_directory/",
-            binary_version="latest",
-        )
-        stage = PIDShardStage(
-            stage=UnionPIDStage.PUBLISHER_SHARD,
-            instance_repository=mock_instance_repo,
-            storage_svc=mock_storage_svc,
-            onedocker_svc=mock_onedocker_svc,
-            onedocker_binary_config=test_onedocker_binary_config,
-        )
-        instance_id = "444"
-        stage_input = PIDStageInput(
-            input_paths=["in"],
-            output_paths=["out"],
-            num_shards=123,
-            instance_id=instance_id,
-        )
-
-        # Basic test: All good
-        with patch.object(PIDShardStage, "files_exist") as mock_fe:
-            mock_fe.return_value = True
+            container.status = (
+                ContainerInstanceStatus.COMPLETED
+                if wait_for_containers
+                else ContainerInstanceStatus.STARTED
+            )
+            mock_wait_for_containers_async.return_value = [container]
+            test_onedocker_binary_config = OneDockerBinaryConfig(
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+            )
             stage = PIDShardStage(
                 stage=UnionPIDStage.PUBLISHER_SHARD,
                 instance_repository=mock_instance_repo,
@@ -108,39 +87,17 @@ class TestPIDShardStage(unittest.TestCase):
                 onedocker_svc=mock_onedocker_svc,
                 onedocker_binary_config=test_onedocker_binary_config,
             )
-            status = await stage.run(
-                stage_input, wait_for_containers=wait_for_containers
-            )
-            self.assertEqual(
-                PIDStageStatus.COMPLETED
-                if wait_for_containers
-                else PIDStageStatus.STARTED,
-                status,
+            instance_id = "444"
+            stage_input = PIDStageInput(
+                input_paths=["in"],
+                output_paths=["out"],
+                num_shards=123,
+                instance_id=instance_id,
             )
 
-            mock_onedocker_svc.start_containers.assert_called_once()
-            if wait_for_containers:
-                mock_wait_for_containers_async.assert_called_once()
-            else:
-                mock_wait_for_containers_async.assert_not_called()
-            # instance status is updated to READY, STARTED, then COMPLETED
-            mock_instance_repo.read.assert_called_with(instance_id)
-            self.assertEqual(mock_instance_repo.read.call_count, 4)
-            self.assertEqual(mock_instance_repo.update.call_count, 4)
-
-        # Input not ready
-        with patch.object(PIDShardStage, "files_exist") as mock_fe:
-            mock_fe.return_value = False
-            status = await stage.run(
-                stage_input, wait_for_containers=wait_for_containers
-            )
-            self.assertEqual(PIDStageStatus.FAILED, status)
-
-        # Multiple input paths (invariant exception)
-        with patch.object(PIDShardStage, "files_exist") as mock_fe:
-            with self.assertRaises(ValueError):
+            # Basic test: All good
+            with patch.object(PIDShardStage, "files_exist") as mock_fe:
                 mock_fe.return_value = True
-                stage_input.input_paths = ["in1", "in2"]
                 stage = PIDShardStage(
                     stage=UnionPIDStage.PUBLISHER_SHARD,
                     instance_repository=mock_instance_repo,
@@ -158,22 +115,58 @@ class TestPIDShardStage(unittest.TestCase):
                     status,
                 )
 
-    @data_provider(
-        lambda: (
-            {
-                "wait_for_containers": True,
-                "expected_container_status": ContainerInstanceStatus.COMPLETED,
-            },
-            {
-                "wait_for_containers": True,
-                "expected_container_status": ContainerInstanceStatus.FAILED,
-            },
-            {
-                "wait_for_containers": False,
-                "expected_container_status": ContainerInstanceStatus.STARTED,
-            },
-        )
-    )
+                mock_onedocker_svc.start_containers.assert_called_once()
+                if wait_for_containers:
+                    mock_wait_for_containers_async.assert_called_once()
+                else:
+                    mock_wait_for_containers_async.assert_not_called()
+                # instance status is updated to READY, STARTED, then COMPLETED
+                mock_instance_repo.read.assert_called_with(instance_id)
+                self.assertEqual(mock_instance_repo.read.call_count, 4)
+                self.assertEqual(mock_instance_repo.update.call_count, 4)
+
+            # Input not ready
+            with patch.object(PIDShardStage, "files_exist") as mock_fe:
+                mock_fe.return_value = False
+                status = await stage.run(
+                    stage_input, wait_for_containers=wait_for_containers
+                )
+                self.assertEqual(PIDStageStatus.FAILED, status)
+
+            # Multiple input paths (invariant exception)
+            with patch.object(PIDShardStage, "files_exist") as mock_fe:
+                with self.assertRaises(ValueError):
+                    mock_fe.return_value = True
+                    stage_input.input_paths = ["in1", "in2"]
+                    stage = PIDShardStage(
+                        stage=UnionPIDStage.PUBLISHER_SHARD,
+                        instance_repository=mock_instance_repo,
+                        storage_svc=mock_storage_svc,
+                        onedocker_svc=mock_onedocker_svc,
+                        onedocker_binary_config=test_onedocker_binary_config,
+                    )
+                    status = await stage.run(
+                        stage_input, wait_for_containers=wait_for_containers
+                    )
+                    self.assertEqual(
+                        PIDStageStatus.COMPLETED
+                        if wait_for_containers
+                        else PIDStageStatus.STARTED,
+                        status,
+                    )
+
+        for wait_for_containers in (True, False):
+            with self.subTest(
+                "Subtest with wait_for_containers: {wait_for_containers}",
+                wait_for_containers=wait_for_containers,
+            ):
+                # reset mocks for each subTests
+                mock_instance_repo.reset_mock()
+                mock_onedocker_svc.reset_mock()
+                mock_storage_svc.reset_mock()
+                mock_wait_for_containers_async.reset_mock()
+                await _run_sub_test(wait_for_containers)
+
     @patch.object(ShardingService, "start_containers")
     @patch("fbpcp.service.storage.StorageService")
     @patch("fbpcp.service.onedocker.OneDockerService")
@@ -185,47 +178,69 @@ class TestPIDShardStage(unittest.TestCase):
         mock_onedocker_svc,
         mock_storage_svc,
         mock_sharder,
-        wait_for_containers: bool,
-        expected_container_status: ContainerInstanceStatus,
     ) -> None:
-        with patch.object(PIDStage, "update_instance_containers"):
-            test_onedocker_binary_config = OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/",
-                binary_version="latest",
-            )
-            container = ContainerInstance(
-                instance_id="123",
-                ip_address="192.0.2.0",
-                status=expected_container_status,
-            )
-            mock_sharder.return_value = [container]
-            stage = PIDShardStage(
-                stage=UnionPIDStage.PUBLISHER_SHARD,
-                instance_repository=mock_instance_repo,
-                storage_svc=mock_storage_svc,
-                onedocker_svc=mock_onedocker_svc,
-                onedocker_binary_config=test_onedocker_binary_config,
-            )
+        async def _run_sub_test(
+            wait_for_containers: bool,
+            expected_container_status: ContainerInstanceStatus,
+        ) -> None:
+            with patch.object(PIDStage, "update_instance_containers"):
+                test_onedocker_binary_config = OneDockerBinaryConfig(
+                    tmp_directory="/test_tmp_directory/",
+                    binary_version="latest",
+                )
+                container = ContainerInstance(
+                    instance_id="123",
+                    ip_address="192.0.2.0",
+                    status=expected_container_status,
+                )
+                mock_sharder.return_value = [container]
+                stage = PIDShardStage(
+                    stage=UnionPIDStage.PUBLISHER_SHARD,
+                    instance_repository=mock_instance_repo,
+                    storage_svc=mock_storage_svc,
+                    onedocker_svc=mock_onedocker_svc,
+                    onedocker_binary_config=test_onedocker_binary_config,
+                )
 
-            test_input_path = "foo"
-            test_output_path = "bar"
-            test_num_shards = 1
-            test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
+                test_input_path = "foo"
+                test_output_path = "bar"
+                test_num_shards = 1
+                test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
 
-            shard_path = PIDShardStage.get_sharded_filepath(test_output_path, 0)
-            self.assertEqual(f"{test_output_path}_0", shard_path)
+                shard_path = PIDShardStage.get_sharded_filepath(test_output_path, 0)
+                self.assertEqual(f"{test_output_path}_0", shard_path)
 
-            res = await stage.shard(
-                "123",
-                test_input_path,
-                test_output_path,
-                test_num_shards,
-                test_hmac_key,
-                wait_for_containers=wait_for_containers,
-            )
-            self.assertEqual(
-                PIDStage.get_stage_status_from_containers([container]),
-                res,
-            )
+                res = await stage.shard(
+                    "123",
+                    test_input_path,
+                    test_output_path,
+                    test_num_shards,
+                    test_hmac_key,
+                    wait_for_containers=wait_for_containers,
+                )
+                self.assertEqual(
+                    PIDStage.get_stage_status_from_containers([container]),
+                    res,
+                )
 
-            mock_sharder.assert_called_once()
+                mock_sharder.assert_called_once()
+
+        data_tests = (
+            (True, ContainerInstanceStatus.COMPLETED),
+            (True, ContainerInstanceStatus.FAILED),
+            (False, ContainerInstanceStatus.STARTED),
+        )
+        for data_test in data_tests:
+            with self.subTest(
+                wait_for_containers=data_test[0],
+                expected_container_status=data_test[1],
+            ):
+                # reset mocks for each subTests
+                mock_instance_repo.reset_mock()
+                mock_onedocker_svc.reset_mock()
+                mock_storage_svc.reset_mock()
+                mock_sharder.reset_mock()
+                await _run_sub_test(
+                    data_test[0],
+                    data_test[1],
+                )


### PR DESCRIPTION
Summary:
Remove libfb.py dependency from fbpcs
Code under fbpcs/ is open sourced. We have test code in the file mentioned in the title which references libfb.py. This is a problem because libfb.py is not open sourced (therefore, this test does not run in our OSS repo!).

Differential Revision: D34640514

