### PR TITLE
adding pcf 2.0 binaries to oneDockerBinaryNames

### DIFF
--- a/fbpcs/onedocker_binary_names.py
+++ b/fbpcs/onedocker_binary_names.py
@@ -18,6 +18,8 @@ class OneDockerBinaryNames(Enum):
 
     DECOUPLED_ATTRIBUTION = "private_attribution/decoupled_attribution"
     DECOUPLED_AGGREGATION = "private_attribution/decoupled_aggregation"
+    PCF2_ATTRIBUTION = "private_attribution/pcf2_attribution"
+    PCF2_AGGREGATION = "private_attribution/pcf2_aggregation"
     SHARD_AGGREGATOR = "private_attribution/shard-aggregator"
 
     PID_CLIENT = "pid/private-id-client"

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -20,6 +20,8 @@ class GameNames(Enum):
     SHARD_AGGREGATOR = "shard_aggregator"
     DECOUPLED_ATTRIBUTION = "decoupled_attribution"
     DECOUPLED_AGGREGATION = "decoupled_aggregation"
+    PCF2_ATTRIBUTION = "pcf2_attribution"
+    PCF2_AGGREGATION = "pcf2_aggregation"
 
 
 class OneDockerArgument(TypedDict):
@@ -72,6 +74,39 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
     },
     GameNames.DECOUPLED_AGGREGATION.value: {
         "onedocker_package_name": OneDockerBinaryNames.DECOUPLED_AGGREGATION.value,
+        "arguments": [
+            OneDockerArgument({"name": "aggregators", "required": True}),
+            OneDockerArgument({"name": "input_base_path", "required": True}),
+            OneDockerArgument(
+                {"name": "input_base_path_secret_share", "required": True}
+            ),
+            OneDockerArgument({"name": "output_base_path", "required": True}),
+            OneDockerArgument({"name": "attribution_rules", "required": False}),
+            OneDockerArgument({"name": "concurrency", "required": True}),
+            OneDockerArgument({"name": "num_files", "required": True}),
+            OneDockerArgument({"name": "file_start_index", "required": True}),
+            OneDockerArgument({"name": "use_xor_encryption", "required": True}),
+            OneDockerArgument({"name": "use_postfix", "required": True}),
+            OneDockerArgument({"name": "log_cost", "required": False}),
+        ],
+    },
+    GameNames.PCF2_ATTRIBUTION.value: {
+        "onedocker_package_name": OneDockerBinaryNames.PCF2_ATTRIBUTION.value,
+        "arguments": [
+            OneDockerArgument({"name": "input_base_path", "required": True}),
+            OneDockerArgument({"name": "output_base_path", "required": True}),
+            OneDockerArgument({"name": "attribution_rules", "required": True}),
+            OneDockerArgument({"name": "aggregators", "required": False}),
+            OneDockerArgument({"name": "concurrency", "required": True}),
+            OneDockerArgument({"name": "num_files", "required": True}),
+            OneDockerArgument({"name": "file_start_index", "required": True}),
+            OneDockerArgument({"name": "use_xor_encryption", "required": True}),
+            OneDockerArgument({"name": "use_postfix", "required": True}),
+            OneDockerArgument({"name": "log_cost", "required": False}),
+        ],
+    },
+    GameNames.PCF2_AGGREGATION.value: {
+        "onedocker_package_name": OneDockerBinaryNames.PCF2_AGGREGATION.value,
         "arguments": [
             OneDockerArgument({"name": "aggregators", "required": True}),
             OneDockerArgument({"name": "input_base_path", "required": True}),

--- a/fbpcs/private_computation/service/private_computation_service_data.py
+++ b/fbpcs/private_computation/service/private_computation_service_data.py
@@ -92,6 +92,18 @@ class PrivateComputationServiceData:
         service=None,
     )
 
+    PCF2_ATTRIBUTION_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.PCF2_ATTRIBUTION.value,
+        game_name=BINARY_NAME_TO_GAME_NAME[OneDockerBinaryNames.PCF2_ATTRIBUTION.value],
+        service=None,
+    )
+
+    PCF2_AGGREGATION_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.PCF2_AGGREGATION.value,
+        game_name=BINARY_NAME_TO_GAME_NAME[OneDockerBinaryNames.PCF2_AGGREGATION.value],
+        service=None,
+    )
+
     @classmethod
     def get(
         cls, game_type: PrivateComputationGameType


### PR DESCRIPTION
Summary:
# Context
With the Open sourcing of PCF 2.0, we will also be releasing attribution and aggregation based on PCF 2.0 to production. While promoting the PCF 2.0 games to production and making them the default games for production runs, we would also like to keep an option to run the current production games (i.e. attribution and aggregation game based on PCF 1.0) in prod for disaster recovery/fall back scenarios.

Thus in this stack of diffs
1. I will be adding a new flow for PCF 2.0 games in PCS. The new flow will be
    -  CREATED -> INPUT_DATA_VALIDATION -> ID_MATCH -> ID_MATCH_POST_PROCESS -> PREPARE -> PCF2_ATTRIBUTION -> PCF2_AGGREGATION -> AGGREGATE POST_PROCESSING_HANDLERS

2.Will be adding new service for PCF 2.0 attribution
3.Will be adding a new service for  PCF 2.0 aggregation.
4.Directory where PCF 2.0 attribution and aggregation binaries are placed would be -

```
private_attribution/prf2_attribution and private_attribution/pcf2_aggregation
 ```
5.Adding end to end tests for the new path.

# Technical decision
Leveraging the dynamic stage flow architecture in PCS to efficiently manage the stages without many changes that would break backward compatibility. While this approach does involve some temporary duplication of code, the duplicate code will be soon removed, as legacy attribution and aggregation games will be marked deprecated once we release PCF 2.0 to production and after 5 successful production runs (setting this number as we used the same number last half), we will remove the legacy code and flow.
This is least error prone way to manage different flows as will make it easier for us to fallback on the legacy flow in case of any errors/issues on new flow.

# This Diff
 1.Adding path for pcf_attribution and pcf2_aggregation as
```
private_attribution/prf2_attribution and private_attribution/pcf2_aggregation
 ```
this is where the binaries will need to be placed in S3 bucket.

2.Adding entries for PCF2.0 to private_computation_game.py and private_computation_service_data.py

# This Stack
1. Specify path for PCF 2.0 binaries and add entries for them in private_computation_game.
2. Create service for pcf2 attribution.
3. Create service for pcf 2 aggregation.
4. Create new flow for PCF2.
5. Create additional test in fbpcs_e2e_runner.
6. Create additional test in automated_e2e_runner.

Differential Revision: D34634024

