### PR TITLE
Adding pcf2 attribution service.

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -191,6 +191,10 @@ class PrivateComputationInstance(InstanceBase):
         return self._get_stage_output_path("decoupled_attribution_stage", "json")
 
     @property
+    def pcf2_attribution_stage_output_base_path(self) -> str:
+        return self._get_stage_output_path("pcf2_attribution_stage", "json")
+
+    @property
     def decoupled_aggregation_stage_output_base_path(self) -> str:
         return self._get_stage_output_path("decoupled_aggregation_stage", "json")
 

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import logging
+from typing import Any, DefaultDict, Dict, List, Optional
+
+from fbpcp.service.mpc import MPCService
+from fbpcp.util.typing import checked_cast
+from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.private_computation_instance import (
+    AttributionRule,
+    PrivateComputationInstance,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+from fbpcs.private_computation.service.private_computation_service_data import (
+    PrivateComputationServiceData,
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+)
+from fbpcs.private_computation.service.utils import (
+    create_and_start_mpc_instance,
+    map_private_computation_role_to_mpc_party,
+    get_updated_pc_status_mpc_game,
+)
+
+
+class PCF2AttributionStageService(PrivateComputationStageService):
+    """Handles business logic for the pcf2.0 based private attribution stage
+
+    Private attributes:
+        _onedocker_binary_config_map: Stores a mapping from mpc game to OneDockerBinaryConfig (binary version and tmp directory)
+        _mpc_svc: creates and runs MPC instances
+        _is_validating: if a test shard is injected to do run time correctness validation
+        _log_cost_to_s3: if money cost of the computation will be logged to S3
+        _container_timeout: optional duration in seconds before cloud containers timeout
+    """
+
+    def __init__(
+        self,
+        onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
+        mpc_service: MPCService,
+        is_validating: bool = False,
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
+        container_timeout: Optional[int] = None,
+    ) -> None:
+        self._onedocker_binary_config_map = onedocker_binary_config_map
+        self._mpc_service = mpc_service
+        self._is_validating = is_validating
+        self._log_cost_to_s3 = log_cost_to_s3
+        self._container_timeout = container_timeout
+
+    # TODO T88759390: Make this function truly async. It is not because it calls blocking functions.
+    # Make an async version of run_async() so that it can be called by Thrift
+    async def run_async(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]] = None,
+    ) -> PrivateComputationInstance:
+        """Runs the pcf2.0 based private attribution stage
+
+        Args:
+            pc_instance: the private computation instance to run attribution stage
+            server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
+
+        Returns:
+            An updated version of pc_instance that stores an MPCInstance
+        """
+
+        # Prepare arguments
+        game_args = self._get_compute_metrics_game_args(
+            pc_instance,
+        )
+
+        # We do this check here because depends on how game_args is generated, len(game_args) could be different,
+        #   but we will always expect server_ips == len(game_args)
+        if server_ips and len(server_ips) != len(game_args):
+            raise ValueError(
+                f"Unable to rerun MPC attribution game because there is a mismatch between the number of server ips given ({len(server_ips)}) and the number of containers ({len(game_args)}) to be spawned."
+            )
+
+        # Create and start MPC instance to run MPC compute
+        logging.info("Starting to run MPC instance for pcf2.0 attribution.")
+        stage_data = PrivateComputationServiceData.PCF2_ATTRIBUTION_STAGE_DATA
+        binary_name = OneDockerBinaryNames.PCF2_ATTRIBUTION.value
+        game_name = checked_cast(str, stage_data.game_name)
+
+        binary_config = self._onedocker_binary_config_map[binary_name]
+        retry_counter_str = str(pc_instance.retry_counter)
+        mpc_instance = await create_and_start_mpc_instance(
+            mpc_svc=self._mpc_service,
+            instance_id=pc_instance.instance_id
+            + "_pcf2_attribution"
+            + retry_counter_str,
+            game_name=game_name,
+            mpc_party=map_private_computation_role_to_mpc_party(pc_instance.role),
+            num_containers=len(game_args),
+            binary_version=binary_config.binary_version,
+            server_ips=server_ips,
+            game_args=game_args,
+            container_timeout=self._container_timeout,
+        )
+
+        logging.info("MPC instance started running for pcf2.0 attribution.")
+
+        # Push MPC instance to PrivateComputationInstance.instances and update PA Instance status
+        pc_instance.instances.append(PCSMPCInstance.from_mpc_instance(mpc_instance))
+        return pc_instance
+
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """Updates the MPCInstances and gets latest PrivateComputationInstance status
+
+        Arguments:
+            private_computation_instance: The PC instance that is being updated
+
+        Returns:
+            The latest status for private_computation_instance
+        """
+        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
+
+    # For now, only passing the attribution game arguments, as this game is currently only used for PA.
+    def _get_compute_metrics_game_args(
+        self,
+        private_computation_instance: PrivateComputationInstance,
+    ) -> List[Dict[str, Any]]:
+        """Gets the game args passed to game binaries by onedocker
+
+        When onedocker spins up containers to run games, it unpacks a dictionary containing the
+        arguments required by the game binary being ran. This function prepares that dictionary.
+
+        Args:
+            pc_instance: the private computation instance to generate game args for
+
+        Returns:
+            MPC game args to be used by onedocker
+        """
+
+        attribution_rule = checked_cast(
+            AttributionRule, private_computation_instance.attribution_rule
+        )
+        common_game_args = {
+            "input_base_path": private_computation_instance.data_processing_output_path,
+            "output_base_path": private_computation_instance.pcf2_attribution_stage_output_base_path,
+            "num_files": private_computation_instance.num_files_per_mpc_container,
+            "concurrency": private_computation_instance.concurrency,
+            "run_name": private_computation_instance.instance_id
+            + "_"
+            + GameNames.PCF2_ATTRIBUTION.value
+            if self._log_cost_to_s3
+            else "",
+            "max_num_touchpoints": private_computation_instance.padding_size,
+            "max_num_conversions": private_computation_instance.padding_size,
+            "log_cost": self._log_cost_to_s3,
+            "attribution_rules": attribution_rule.value,
+            "use_xor_encryption": True,
+            "use_postfix": True,
+        }
+
+        game_args = [
+            {
+                **common_game_args,
+                **{
+                    "file_start_index": i
+                    * private_computation_instance.num_files_per_mpc_container,
+                },
+            }
+            for i in range(private_computation_instance.num_mpc_containers)
+        ]
+
+        return game_args

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import defaultdict
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.private_computation_instance import (
+    AttributionRule,
+    PrivateComputationGameType,
+    PrivateComputationInstance,
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.constants import (
+    NUM_NEW_SHARDS_PER_FILE,
+)
+from fbpcs.private_computation.service.pcf2_attribution_stage_service import (
+    PCF2AttributionStageService,
+)
+
+
+class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
+    @patch("fbpcp.service.mpc.MPCService")
+    def setUp(self, mock_mpc_svc) -> None:
+        self.mock_mpc_svc = mock_mpc_svc
+        self.mock_mpc_svc.create_instance = MagicMock()
+
+        onedocker_binary_config_map = defaultdict(
+            lambda: OneDockerBinaryConfig(
+                tmp_directory="/test_tmp_directory/", binary_version="latest"
+            )
+        )
+        self.stage_svc = PCF2AttributionStageService(
+            onedocker_binary_config_map, self.mock_mpc_svc
+        )
+
+    async def test_attribution_stage(self) -> None:
+        private_computation_instance = self._create_pc_instance()
+        mpc_instance = PCSMPCInstance.create_instance(
+            instance_id=private_computation_instance.instance_id + "_pcf2_attribution0",
+            game_name=GameNames.PCF2_ATTRIBUTION.value,
+            mpc_party=MPCParty.CLIENT,
+            num_workers=private_computation_instance.num_mpc_containers,
+        )
+
+        self.mock_mpc_svc.start_instance_async = AsyncMock(return_value=mpc_instance)
+
+        test_server_ips = [
+            f"192.0.2.{i}"
+            for i in range(private_computation_instance.num_mpc_containers)
+        ]
+        await self.stage_svc.run_async(private_computation_instance, test_server_ips)
+
+        self.assertEqual(mpc_instance, private_computation_instance.instances[0])
+
+    def test_get_game_args(self) -> None:
+        private_computation_instance = self._create_pc_instance()
+
+        common_game_args = {
+            "input_base_path": private_computation_instance.data_processing_output_path,
+            "output_base_path": private_computation_instance.pcf2_attribution_stage_output_base_path,
+            "num_files": private_computation_instance.num_files_per_mpc_container,
+            "concurrency": private_computation_instance.concurrency,
+            "run_name": private_computation_instance.instance_id
+            + "_"
+            + GameNames.PCF2_ATTRIBUTION.value
+            if self.stage_svc._log_cost_to_s3
+            else "",
+            "max_num_touchpoints": private_computation_instance.padding_size,
+            "max_num_conversions": private_computation_instance.padding_size,
+            "attribution_rules": AttributionRule.LAST_CLICK_1D.value,
+            "use_xor_encryption": True,
+            "use_postfix": True,
+            "log_cost": True,
+        }
+        test_game_args = [
+            {
+                **common_game_args,
+                "file_start_index": 0,
+            },
+            {
+                **common_game_args,
+                "file_start_index": private_computation_instance.num_files_per_mpc_container,
+            },
+        ]
+
+        self.assertEqual(
+            test_game_args,
+            self.stage_svc._get_compute_metrics_game_args(private_computation_instance),
+        )
+
+    def _create_pc_instance(self) -> PrivateComputationInstance:
+
+        return PrivateComputationInstance(
+            instance_id="test_instance_123",
+            role=PrivateComputationRole.PARTNER,
+            instances=[],
+            status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+            attribution_rule=AttributionRule.LAST_CLICK_1D,
+            status_update_ts=1600000000,
+            num_pid_containers=2,
+            num_mpc_containers=2,
+            num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
+            game_type=PrivateComputationGameType.ATTRIBUTION,
+            input_path="456",
+            output_dir="789",
+            padding_size=4,
+        )


### PR DESCRIPTION
Summary:
# Context
With the Open sourcing of PCF 2.0, we will also be releasing attribution and aggregation based on PCF 2.0 to production. While promoting the PCF 2.0 games to production and making them the default games for production runs, we would also like to keep an option to run the current production games (i.e. attribution and aggregation game based on PCF 1.0) in prod for disaster recovery/fall back scenarios.

Thus in this stack of diffs
1. I will be adding a new flow for PCF 2.0 games in PCS. The new flow will be
    -  CREATED -> INPUT_DATA_VALIDATION -> ID_MATCH -> ID_MATCH_POST_PROCESS -> PREPARE -> PCF2_ATTRIBUTION -> PCF2_AGGREGATION -> AGGREGATE POST_PROCESSING_HANDLERS

2.Will be adding new service for PCF 2.0 attribution
3.Will be adding a new service for  PCF 2.0 aggregation.
4.Directory where PCF 2.0 attribution and aggregation binaries are placed would be -

```
private_attribution/prf2_attribution and private_attribution/pcf2_aggregation
 ```
5.Adding end to end tests for the new path.

# Technical decision
Leveraging the dynamic stage flow architecture in PCS to efficiently manage the stages without many changes that would break backward compatibility. While this approach does involve some temporary duplication of code, the duplicate code will be soon removed, as legacy attribution and aggregation games will be marked deprecated once we release PCF 2.0 to production and after 5 successful production runs (setting this number as we used the same number last half), we will remove the legacy code and flow.
This is least error prone way to manage different flows as will make it easier for us to fallback on the legacy flow in case of any errors/issues on new flow.

# This Diff
Adding new service to support PCF 2.0 attribution as well as test cases for the same.

# This Stack
1. Specify path for PCF 2.0 binaries and add entries for them in private_computation_game.
2. Create service for pcf2 attribution.
3. Create service for pcf 2 aggregation.
4. Create new flow for PCF2.
5. Create additional test in fbpcs_e2e_runner.
6. Create additional test in automated_e2e_runner.

Differential Revision: D34635067

