### PR TITLE
Remove KMS policy for semi-automated pipeline

### DIFF
--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue.tf
@@ -51,27 +51,6 @@ resource "aws_iam_role_policy" "s3_policy" {
 EOF
 }
 
-resource "aws_iam_role_policy" "kms_policy_glue" {
-  name   = "kms-policy${var.tag_postfix}"
-  role   = aws_iam_role.glue_ETL_role.id
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "kms:*",
-      "Resource": [
-        "arn:aws:kms:*:${var.aws_account_id}:key/*",
-        "arn:aws:kms:*:${var.aws_account_id}:alias/*"
-      ]
-    }
-  ]
-}
-EOF
-}
-
-
 resource "aws_glue_job" "glue_job" {
   name     = "glue-ETL${var.tag_postfix}"
   role_arn = aws_iam_role.glue_ETL_role.arn

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
@@ -1,7 +1,3 @@
-resource "aws_kms_key" "s3_kms_key" {
-  description = "This key is used to encrypt bucket objects"
-}
-
 data "archive_file" "zip_lambda" {
   type        = "zip"
   source_file = "lambda_trigger.py"
@@ -76,24 +72,4 @@ resource "aws_iam_role_policy_attachment" "lambda_glue_service_role" {
 resource "aws_iam_role_policy_attachment" "lambda_cloudwatch" {
   role       = aws_iam_role.lambda_iam.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-resource "aws_iam_role_policy" "kms_policy_lambda" {
-  name   = "lambda-kms-policy${var.tag_postfix}"
-  role   = aws_iam_role.lambda_iam.id
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "kms:*",
-      "Resource": [
-        "arn:aws:kms:*:${var.aws_account_id}:key/*",
-        "arn:aws:kms:*:${var.aws_account_id}:alias/*"
-      ]
-    }
-  ]
-}
-EOF
 }


### PR DESCRIPTION
Summary: We have changed the SSE type on the data bucket to SSE-S3. So the KMS policy won't be needed for the semi-auto pipeline resources to access the data bucket

Reviewed By: marksliva

Differential Revision: D34627097

