### PR TITLE
Add mpc_config and mpc_role structs

### DIFF
--- a/fbpcs/kodiak/Cargo.toml
+++ b/fbpcs/kodiak/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kodiak"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+
+[dependencies]

--- a/fbpcs/kodiak/src/lib.rs
+++ b/fbpcs/kodiak/src/lib.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/fbpcs/kodiak/src/mpc_config.rs
+++ b/fbpcs/kodiak/src/mpc_config.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCConfig {
+    role: MPCRole,
+    base_port: u16,
+    concurrency: u32,
+}
+
+impl MPCConfig {
+    pub fn new(role: MPCRole, base_port: u16, concurrency: u32) -> Self {
+        Self {
+            role,
+            base_port,
+            concurrency,
+        }
+    }
+}

--- a/fbpcs/kodiak/src/mpc_config_builder.rs
+++ b/fbpcs/kodiak/src/mpc_config_builder.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCConfigBuilder {
+    role: MPCRole,
+    base_port: u16,
+    concurrency: u32,
+}
+
+impl MPCConfigBuilder {
+    pub fn new() -> Self {
+        Self {
+            role: MPCRole::Publisher,
+            base_port: 8080,
+            concurrency: 1,
+        }
+    }
+
+    pub fn with_role(&mut self, role: MPCRole) -> Self {
+        self.role = role;
+        self
+    }
+
+    pub fn with_base_port(&mut self, base_port: u16) -> Self {
+        self.base_port = base_port;
+        self
+    }
+
+    pub fn with_concurrency(&mut self, concurrency: u32) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
+    pub fn build(&self) -> MPCConfig {
+        MPCConfig {
+            role: self.role,
+            base_port: self.base_port,
+            concurrency: self.concurrency,
+        }
+    }
+}

--- a/fbpcs/kodiak/src/mpc_role.rs
+++ b/fbpcs/kodiak/src/mpc_role.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub enum MPCRole {
+    Publisher,
+    Partner,
+}


### PR DESCRIPTION
Summary: High-level config structs to pass data related to network settings

Differential Revision: D34648127

