### PR TITLE
Add mpc game and metrics skeletons

### DIFF
--- a/fbpcs/kodiak/Cargo.toml
+++ b/fbpcs/kodiak/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kodiak"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+
+[dependencies]

--- a/fbpcs/kodiak/src/lib.rs
+++ b/fbpcs/kodiak/src/lib.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/fbpcs/kodiak/src/mpc_column.rs
+++ b/fbpcs/kodiak/src/mpc_column.rs
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub trait MPCColumn {
+    /// The type of data stored in this column
+    type DType;
+
+    /// Used to get keys for our map
+    fn name() -> String;
+
+    /// List of columns required by this column
+    fn requires() -> Vec<Box<dyn MPCColumn>>;
+
+    /// Compute this value - assume requirements are satisfied
+    fn compute(&mut self, r: Row) -> Result<()>;
+
+    /// Aggregate this row with another (basically enable `reduce`)
+    fn aggregate(&self, other: &Self) -> Self;
+
+    /// Get the *value* for this metric as JSON
+    /// This is a hack to work around the type system.
+    /// One metric can return "123" while another can
+    /// return "[200, 100, 20, 3, 0]" - the compiler will
+    /// allow both since they're just strings.
+    fn json_value(&self) -> String;
+
+    /// Retrieve the data in this column
+    fn data(&self) -> DType;
+}

--- a/fbpcs/kodiak/src/mpc_config.rs
+++ b/fbpcs/kodiak/src/mpc_config.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCConfig {
+    role: MPCRole,
+    base_port: u16,
+    concurrency: u32,
+}
+
+impl MPCConfig {
+    pub fn new(role: MPCRole, base_port: u16, concurrency: u32) -> Self {
+        Self {
+            role,
+            base_port,
+            concurrency,
+        }
+    }
+}

--- a/fbpcs/kodiak/src/mpc_config_builder.rs
+++ b/fbpcs/kodiak/src/mpc_config_builder.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCConfigBuilder {
+    role: MPCRole,
+    base_port: u16,
+    concurrency: u32,
+}
+
+impl MPCConfigBuilder {
+    pub fn new() -> Self {
+        Self {
+            role: MPCRole::Publisher,
+            base_port: 8080,
+            concurrency: 1,
+        }
+    }
+
+    pub fn with_role(&mut self, role: MPCRole) -> Self {
+        self.role = role;
+        self
+    }
+
+    pub fn with_base_port(&mut self, base_port: u16) -> Self {
+        self.base_port = base_port;
+        self
+    }
+
+    pub fn with_concurrency(&mut self, concurrency: u32) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
+    pub fn build(&self) -> MPCConfig {
+        MPCConfig {
+            role: self.role,
+            base_port: self.base_port,
+            concurrency: self.concurrency,
+        }
+    }
+}

--- a/fbpcs/kodiak/src/mpc_game.rs
+++ b/fbpcs/kodiak/src/mpc_game.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCGame {
+    mpc_config: MPCConfig,
+    metrics: MPCMetrics,
+}
+
+impl MPCGame {
+    pub fn new(mpc_config: MPCConfig, metrics: MPCMetrics) -> Self {
+        Self {
+            mpc_config,
+            metrics,
+        }
+    }
+
+    pub fn play(&mut self) {
+        // TODO
+    }
+
+    pub fn reveal(&mut self) {
+        // TODO
+    }
+}

--- a/fbpcs/kodiak/src/mpc_metrics.rs
+++ b/fbpcs/kodiak/src/mpc_metrics.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCMetrics {
+    input_columns: Vec<Box<dyn MPCColumn>>,
+    metrics: Vec<dyn MPCColumn>,
+    grouping_sets: Vec<Vec<dyn MPCColumn>>,
+}
+
+impl MPCMetrics {
+    pub fn new(
+        input_columns: Vec<Box<dyn MPCColumn>>,
+        metrics: Vec<dyn MPCColumn>,
+        grouping_sets: Vec<Vec<dyn MPCColumn>>,
+    ) -> Self {
+        Self {
+            input_columns,
+            metrics,
+            grouping_sets,
+        }
+    }
+}

--- a/fbpcs/kodiak/src/mpc_metrics_builder.rs
+++ b/fbpcs/kodiak/src/mpc_metrics_builder.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub struct MPCMetricsBuilder {
+    input_columns: Vec<Box<dyn MPCColumn>>,
+    metrics: Vec<dyn MPCColumn>,
+    grouping_sets: Vec<Vec<dyn MPCColumn>>,
+}
+
+impl MPCMetricsBuilder {
+    pub fn new() -> Self {
+        Self {
+            input_columns: Vec::new(),
+            metrics: Vec::new(),
+            grouping_sets: Vec::new(),
+        }
+    }
+
+    pub fn with_input_column(&mut self, role: MPCRole, col: Box<dyn MPCColumn>) -> Self {
+        input_columns.push(col);
+        self
+    }
+
+    pub fn with_metric(&mut self, metric: Box<dyn MPCColumn>) -> Self {
+        metrics.push(metric);
+        self
+    }
+
+    pub fn with_grouping_set(&mut self, grouping_set: Vec<Box<dyn MPCColumn>>) -> Self {
+        grouping_sets.push(grouping_set);
+        self
+    }
+
+    pub fn build(&self) -> MPCMetrics {
+        MPCMetrics {
+            input_columns,
+            metrics,
+            grouping_sets,
+        }
+    }
+}

--- a/fbpcs/kodiak/src/mpc_role.rs
+++ b/fbpcs/kodiak/src/mpc_role.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub enum MPCRole {
+    Publisher,
+    Partner,
+}

--- a/fbpcs/kodiak/src/row.rs
+++ b/fbpcs/kodiak/src/row.rs
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+struct Row;


### PR DESCRIPTION
Summary:
skeleton code denoting a "game" and how metrics could be defined.
Also defines the trait representing a column of data

Differential Revision: D34648407

