### PR TITLE
Fix semi-automated pipeline issues

### DIFF
--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
@@ -52,6 +52,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.lambda_trigger.arn
     events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "${var.data_upload_key_path}/"
     filter_suffix       = ".csv"
   }
 }


### PR DESCRIPTION
Summary:
I noticed two issues when doing testing on the semi-automated pipeline:
1. We had this diff D33001503 (https://github.com/facebookresearch/fbpcs/commit/60eecfadb302a23941f0c55e61c70ce50c03ff05) to change single quote to double quotes, and our this file is affected https://www.internalfb.com/code/fbsource/[44d68c3e293fbbab93723becdd0c9890413adb39]/fbcode/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda_trigger.py?lines=21%2C41. Especially for line `glueJobName = "TO_BE_UPDATED_DURING_DEPLOYMENT"` and `s3_write_path = "TO_BE_UPDATED_DURING_DEPLOYMENT"`. But in the deploy.sh script, we are using `sed` command to look for the placeholder string with single quotes. Example: `sed -i "s/glueJobName = 'TO_BE_UPDATED_DURING_DEPLOYMENT'/glueJobName = 'glue-ETL$tag_postfix'/g" lambda_trigger.py`. It means the two placeholder string won't be replaced with the correct value.
2. We added the data validation into the deploy.sh in this diff D32152934 (https://github.com/facebookresearch/fbpcs/commit/3d1d650db84e42f7aedc072ca7a42bbf4b7a1f83), but unfortunately there is a `aws_s3_bucket_notification` rule (https://www.internalfb.com/code/fbsource/[44d68c3e293fbbab93723becdd0c9890413adb39]/fbcode/fbpcs/infra/cloud_bridge/data_validation/main.tf?lines=96-101) overrieds the same one in the semi-automated pipeline (https://www.internalfb.com/code/fbsource/[44d68c3e293fbbab93723becdd0c9890413adb39]/fbcode/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf?lines=56-60). It causes when you upload a csv file to the `semi-automated-data-ingestion/` folder, it won't trigger the correct lambda function.

To fix these two issues,
for 1, change the single quote to double quote in the deploy.sh.
for 2, remove the data_validation from the deploy.sh. Initially I tried to remove the overlapped `aws_s3_bucket_notification` rule but turns out you can only have one `aws_s3_bucket_notification` on one bucket. If you have two, the 2nd one will override the previous one and the previous one is gone. (source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification)

The broken changes were released with the latest CB release which around the end of Jan. It won't affect existing advertisers. But if the advertisers did a new deploy after Jan and they want to use the semi-automated pipeline, they will be affected. I'll work with the SolEng to find these advertisers and provide the walkaround solution - basically manually modify the S3 bucket and lambda function.

Reviewed By: marksliva

Differential Revision: D34635951

