### PR TITLE
Adding cli options to delete S3 buckets from AWS account

### DIFF
--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -54,6 +54,8 @@ def main():
     aws_attach_iam_policy_parser_arguments(aws_create_parser)
     aws_detach_iam_policy_parser_arguments(aws_destroy_parser)
 
+    delete_s3_buckets_arguments(aws_destroy_parser)
+
     cli_args = cli_parser.parse_args()
 
     if cli_args.platform == "aws":
@@ -191,6 +193,23 @@ def aws_detach_iam_policy_parser_arguments(aws_parser: argparse):
     )
     iam_policy_command_group.add_argument(
         "--iam_user_name", type=str, required=False, help="Detach policy from user"
+    )
+
+
+def delete_s3_buckets_arguments(aws_parser: argparse):
+    delete_s3_bucket_command_group = aws_parser.add_argument_group(
+        "s3_bucket", "Arguments to delete S3 buckets"
+    )
+
+    delete_s3_bucket_command_group.add_argument(
+        "--delete_s3_bucket", action="store_true", help="Deletes S3 bucket from AWS"
+    )
+
+    delete_s3_bucket_command_group.add_argument(
+        "--s3_bucket_names",
+        nargs="+",
+        required=False,
+        help="List buckets which needs to be deleted separated by space",
     )
 
 

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -85,3 +85,12 @@ class AwsDeploymentHelperTool:
                 policy_name=self.cli_args.iam_policy_name,
                 user_name=self.cli_args.iam_user_name,
             )
+        if self.cli_args.delete_s3_bucket:
+            if self.cli_args.s3_bucket_names is None:
+                raise Exception(
+                    "Need s3 bucket name to delete s3 buckets from AWS. Please use"
+                    " --s3_bucket_names in cli.py"
+                )
+            self.aws_deployment_helper_obj.delete_s3_bucket(
+                s3_bucket_names=self.cli_args.s3_bucket_names,
+            )


### PR DESCRIPTION
Summary:
We recently run into issues of s3 buckets limit exceed in `fb-ads-crypto-dev` AWS account. This diff lets user delete S3 buckets from cli.

Ways to run the script:
2. [preferred] Install virtual env in laptop and install boto3
2. install boto3 in laptop
3. Bring up CB container

cli to call:
`python3 cli.py destroy aws --delete_s3_bucket --s3_bucket_name_contains mar22`

location of cli.py
`fbsource/fbcode/fbpcs/infra/cloud_bridge`

Differential Revision: D34684571

