### PR TITLE
mpc metric dtype take inner value

### DIFF
--- a/fbpcs/kodiak/Cargo.toml
+++ b/fbpcs/kodiak/Cargo.toml
@@ -5,4 +5,5 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+derive_more = "0.99.3"
 log = { version = "0.4.14", features = ["kv_unstable", "kv_unstable_std"] }

--- a/fbpcs/kodiak/src/lib.rs
+++ b/fbpcs/kodiak/src/lib.rs
@@ -9,6 +9,7 @@ pub mod column_metadata;
 pub mod execution_config;
 pub mod mpc_game;
 pub mod mpc_metric;
+pub mod mpc_metric_dtype;
 pub mod mpc_role;
 pub mod mpc_view;
 pub mod mpc_view_builder;

--- a/fbpcs/kodiak/src/mpc_metric.rs
+++ b/fbpcs/kodiak/src/mpc_metric.rs
@@ -6,18 +6,8 @@
  */
 
 use crate::column_metadata::ColumnMetadata;
+use crate::mpc_metric_dtype::MPCMetricDType;
 use crate::row::Row;
-
-/// The type of data stored in a column
-pub enum MPCMetricDType {
-    // TODO: Will replace with MPCInt64 and such after FFI is available
-    MPCInt32(i32),
-    MPCInt64(i64),
-    MPCUInt32(u32),
-    MPCUInt64(u64),
-    MPCBool(bool),
-    Vec(Vec<MPCMetricDType>),
-}
 
 pub trait MPCMetric {
     /// Used to look up name and dependencies for this metric

--- a/fbpcs/kodiak/src/mpc_metric_dtype.rs
+++ b/fbpcs/kodiak/src/mpc_metric_dtype.rs
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use derive_more::TryInto;
+
+/// The type of data stored in a column
+// #[derive(Debug, PartialEq, TryInto)]
+#[derive(TryInto, Clone, PartialEq, Debug)]
+#[try_into(owned, ref, ref_mut)]
+pub enum MPCMetricDType {
+    // TODO: Will replace with MPCInt64 and such after FFI is available
+    MPCInt32(i32),
+    MPCInt64(i64),
+    MPCUInt32(u32),
+    MPCUInt64(u64),
+    MPCBool(bool),
+    Vec(Vec<MPCMetricDType>),
+}
+
+impl MPCMetricDType {
+    pub fn take_inner_val<T>(self) -> Result<T, <T as TryFrom<MPCMetricDType>>::Error>
+    where
+        T: std::convert::TryFrom<MPCMetricDType>,
+        <T as TryFrom<MPCMetricDType>>::Error: std::fmt::Debug,
+    {
+        T::try_from(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mpc_metric_dtype::MPCMetricDType;
+
+    #[test]
+    fn take_inner_val() {
+        assert_eq!(
+            MPCMetricDType::MPCInt32(32).take_inner_val::<i32>(),
+            Ok(32i32)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt64(64).take_inner_val::<i64>(),
+            Ok(64i64)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt32(32).take_inner_val::<u32>(),
+            Ok(32u32)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt64(64).take_inner_val::<u64>(),
+            Ok(64u64)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCBool(true).take_inner_val::<bool>(),
+            Ok(true)
+        );
+        assert_eq!(
+            MPCMetricDType::Vec(vec![MPCMetricDType::MPCBool(true)])
+                .take_inner_val::<Vec::<MPCMetricDType>>(),
+            Ok(vec![MPCMetricDType::MPCBool(true)])
+        );
+
+        assert!(
+            MPCMetricDType::MPCUInt64(6)
+                .take_inner_val::<i32>()
+                .is_err()
+        )
+    }
+
+    #[test]
+    fn try_into() {
+        assert_eq!(MPCMetricDType::MPCInt32(32).try_into(), Ok(32i32));
+        assert_eq!(MPCMetricDType::MPCInt64(64).try_into(), Ok(64i64));
+        assert_eq!(MPCMetricDType::MPCUInt32(32).try_into(), Ok(32u32));
+        assert_eq!(MPCMetricDType::MPCUInt64(64).try_into(), Ok(64u64));
+        assert_eq!(MPCMetricDType::MPCBool(true).try_into(), Ok(true));
+        assert_eq!(
+            MPCMetricDType::Vec(vec![MPCMetricDType::MPCBool(true)]).try_into(),
+            Ok(vec![MPCMetricDType::MPCBool(true)])
+        );
+    }
+}

--- a/fbpcs/kodiak/src/row.rs
+++ b/fbpcs/kodiak/src/row.rs
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use crate::mpc_metric::{MPCMetric, MPCMetricDType};
+use crate::mpc_metric::MPCMetric;
+use crate::mpc_metric_dtype::MPCMetricDType;
 
 pub struct Row {
     // Dynamic columns because we don't really care about the underlying "data"
@@ -22,7 +23,14 @@ impl Row {
         }
     }
 
-    fn get_data(&self, column_name: &str) -> Option<MPCMetricDType> {
-        Some(self.columns.get(column_name)?.data())
+    fn get_data<T: std::convert::From<MPCMetricDType>>(&self, column_name: &str) -> Option<T> {
+        Some(
+            self.columns
+                .get(column_name)?
+                .data()
+                // .clone()
+                .take_inner_val()
+                .unwrap(),
+        )
     }
 }


### PR DESCRIPTION
Summary:
## What

* derive try_into and try_from for mpc metric datatype

## Why

* it'll be useful later on when reading from the row

Reviewed By: gorel

Differential Revision: D34707247

