### PR TITLE
print a clean error message and config.yml file path when yaml.load() fails

### DIFF
--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -41,7 +41,6 @@ from typing import List, Optional
 
 import schema
 from docopt import docopt
-from fbpcp.util import yaml
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
 from fbpcs.pl_coordinator.pl_study_runner import run_study
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -158,7 +157,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     )
 
     arguments = s.validate(docopt(__doc__, argv))
-    config = ConfigYamlDict.from_dict(yaml.load(Path(arguments["--config"])))
+    config = ConfigYamlDict.from_file(arguments["--config"])
 
     log_path = arguments["--log_path"]
     log_level = logging.DEBUG if arguments["--verbose"] else logging.INFO

--- a/fbpcs/utils/config_yaml/config_yaml_dict.py
+++ b/fbpcs/utils/config_yaml/config_yaml_dict.py
@@ -4,12 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from pathlib import Path
 from typing import Any, Dict
 
+from fbpcp.util import yaml
 from fbpcs.utils.config_yaml.exceptions import (
     ConfigYamlFieldNotFoundError,
     ConfigYamlValidationError,
+    ConfigYamlFileParsingError,
 )
+from yaml import YAMLError
 
 
 class ConfigYamlDict(Dict[str, Any]):
@@ -46,3 +50,12 @@ class ConfigYamlDict(Dict[str, Any]):
         for k, v in d.items():
             my_dict[k] = v
         return my_dict
+
+    @classmethod
+    def from_file(cls, config_file_path: str) -> "ConfigYamlDict":
+        """Read a yaml file to a ConfigYamlDict"""
+        try:
+            config_dict = yaml.load(Path(config_file_path))
+        except YAMLError as e:
+            raise ConfigYamlFileParsingError(config_file_path, str(e))
+        return ConfigYamlDict.from_dict(config_dict)

--- a/fbpcs/utils/config_yaml/exceptions.py
+++ b/fbpcs/utils/config_yaml/exceptions.py
@@ -5,6 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+from yaml import YAMLError
+
+
 class ConfigYamlBaseException(Exception):
     pass
 
@@ -54,4 +57,12 @@ class ConfigYamlValidationError(ValueError, ConfigYamlBaseException):
 
     def __init__(self, class_name: str, cause: str, remediation: str) -> None:
         msg = f"{class_name} (specified in your config.yml) failed validation. Cause: {cause}. Suggested remediation: {remediation}"
+        super().__init__(msg)
+
+
+class ConfigYamlFileParsingError(YAMLError, ConfigYamlBaseException):
+    """Raised when the content of file is not in a valid YAML format"""
+
+    def __init__(self, file_name: str, cause: str) -> None:
+        msg = f"{file_name} is not a valid YAML file. Please make sure that your config file is valid YAML file.\nCause: {cause}."
         super().__init__(msg)

--- a/fbpcs/utils/tests/test_config_yaml_dict.py
+++ b/fbpcs/utils/tests/test_config_yaml_dict.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import unittest
+from unittest.mock import patch, mock_open
+
+from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
+from fbpcs.utils.config_yaml.exceptions import ConfigYamlFileParsingError
+
+
+class TestConfigYamlDict(unittest.TestCase):
+    test_filename = "./config.yaml"
+    test_dict = {
+        "test_dict": [
+            {"test_key_1": "test_value_1"},
+            {"test_key_1": "test_value_2"},
+        ]
+    }
+    valid_data = json.dumps(test_dict)
+    invalid_data = """
+    test_dict:
+        test_key_1: test_value_1
+        test_key_2
+    """
+
+    @patch("builtins.open", new_callable=mock_open, read_data=valid_data)
+    def test_load_from_file_success(self, mock_file):
+        self.assertEqual(open(self.test_filename).read(), self.valid_data)
+
+        load_data = ConfigYamlDict.from_file(self.test_filename)
+        self.assertEqual(load_data, self.test_dict)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=invalid_data)
+    def test_load_from_invalid_file(self, mock_file):
+        self.assertEqual(open(self.test_filename).read(), self.invalid_data)
+
+        with self.assertRaises(ConfigYamlFileParsingError) as error_context:
+            ConfigYamlDict.from_file(self.test_filename)
+            self.assertTrue(
+                str(error_context.exception).startswith(
+                    f"""
+                    {self.test_filename} is not a valid YAML file.
+                    Please make sure that the content of your config is a valid YAML.
+                    \nCause:"""
+                )
+            )


### PR DESCRIPTION
Summary:
when YAML.load fails, we should return more actionable information and clear remediation instruction.

```
ConfigYamlFileParsingError: ./config.yaml is not a valid YAML file. Suggested remediation: validate the content of ./config.yaml on http://www.yamllint.com/.
Cause: while parsing a flow node
expected the node content, but found '<stream end>'
```

In this example, the invalid input yaml was generated by PCS for canary. But invalid files could also be prepared by partners.
 https://fb.workplace.com/groups/331044242148818/posts/422172903035951/?comment_id=440970687822839

Reviewed By: jrodal98

Differential Revision: D34733332

