### PR TITLE
fix the bugs in minimum permission policy

### DIFF
--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -120,6 +120,10 @@ def aws_create_iam_policy_parser_arguments(aws_parser: argparse):
     )
 
     iam_policy_command_group.add_argument(
+        "--table_name", type=str, required=False, help="Table name"
+    )
+
+    iam_policy_command_group.add_argument(
         "--cluster_name", type=str, required=False, help="ECS cluster name"
     )
 

--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -362,6 +362,7 @@ deploy_aws_resources() {
         --data_bucket_name "$s3_bucket_data_pipeline" \
         --config_bucket_name "$s3_bucket_for_storage" \
         --database_name "$database_name" \
+        --table_name "$table_name" \
         --cluster_name "$aws_ecs_cluster_name" \
         --ecs_task_execution_role_name "$ecs_task_execution_role_name"
     echo "######################## Finished deploy resources policy ########################"
@@ -387,7 +388,6 @@ else
     # s3_bucket_for_storage is set, but add tags to it
     s3_bucket_for_storage="$s3_bucket_for_storage$tag_postfix"
 fi
-database_name=${s3_bucket_for_storage//-/_}
 
 if [ -z ${s3_bucket_data_pipeline+x} ]
 then
@@ -399,6 +399,8 @@ else
 fi
 
 policy_name="fb-pc-policy${tag_postfix}"
+database_name="mpc-events-db${tag_postfix}"
+table_name=${s3_bucket_data_pipeline//-/_}
 data_upload_key_path="semi-automated-data-ingestion"
 events_data_upload_s3_key="events-data-validation"
 query_results_key_path="query-results"

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -290,6 +290,7 @@ class AwsDeploymentHelper:
             "ECS_TASK_EXECUTION_ROLE_NAME": policy_params.ecs_task_execution_role_name,
             "FIREHOSE_STREAM_NAME": policy_params.firehose_stream_name,
             "DATEBASE_NAME": policy_params.database_name,
+            "TABLE_NAME": policy_params.table_name,
         }
 
         file_path = os.path.join(os.path.dirname(__file__), file_name)

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -41,6 +41,7 @@ class AwsDeploymentHelperTool:
                 data_bucket_name=self.cli_args.data_bucket_name,
                 config_bucket_name=self.cli_args.config_bucket_name,
                 database_name=self.cli_args.database_name,
+                table_name=self.cli_args.table_name,
                 cluster_name=self.cli_args.cluster_name,
                 ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
             )

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
@@ -39,7 +39,8 @@
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:catalog",
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:database/default",
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:database/${DATEBASE_NAME}",
-                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/${DATEBASE_NAME}/*"
+                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/${DATEBASE_NAME}/*",
+                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/${TABLE_NAME}"
             ]
         },
         {

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -12,5 +12,6 @@ class PolicyParams:
     data_bucket_name: str
     config_bucket_name: str
     database_name: str
+    table_name: str
     cluster_name: str
     ecs_task_execution_role_name: str


### PR DESCRIPTION
Summary:
In computation UI, we need the user to provide the aws_access_key_id and aws_secret_access_key. Usually it's the admin credentials, but for the computation UI project, we have identified the policy with minimum permissions to run the calculation. This diff is to fix a few permissions.
1. We're using the wrong database name. It should be "mpc-events-db-<TAG>" instead of "fb_pc_data_<TAG>".
2. The "fb_pc_data_<TAG>" should be the table name.
3. Missed one resource for the GLUE permission.

Differential Revision: D34773691

