### PR TITLE
Support use-row-numbers for Private ID and enable it for Amazon for publisher side

### DIFF
--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -70,6 +70,7 @@ class PIDInstance(InstanceBase):
     status: PIDInstanceStatus = PIDInstanceStatus.UNKNOWN
     current_stage: Optional[UnionPIDStage] = None
     server_ips: List[str] = field(default_factory=list)
+    pid_use_row_numbers: bool = False
 
     def get_instance_id(self) -> str:
         return self.instance_id

--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -60,6 +60,7 @@ class PIDService:
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         hmac_key: Optional[str] = None,
+        pid_use_row_numbers: bool = False,
     ) -> PIDInstance:
         self.logger.info(f"Creating PID instance: {instance_id}")
         instance = PIDInstance(
@@ -75,6 +76,7 @@ class PIDService:
             data_path=data_path,
             spine_path=spine_path,
             hmac_key=hmac_key,
+            pid_use_row_numbers=pid_use_row_numbers,
         )
         self.instance_repository.create(instance)
         return instance
@@ -210,5 +212,6 @@ class PIDService:
             data_path=instance.data_path,
             spine_path=instance.spine_path,
             hmac_key=instance.hmac_key,
+            pid_use_row_numbers=instance.pid_use_row_numbers,
         )
         return dispatcher

--- a/fbpcs/pid/service/pid_service/pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/pid_dispatcher.py
@@ -55,6 +55,7 @@ class PIDDispatcher(Dispatcher):
         data_path: Optional[str] = None,
         spine_path: Optional[str] = None,
         hmac_key: Optional[str] = None,
+        pid_use_row_numbers: bool = False,
     ) -> None:
         flow_map = pid_execution_map.get_execution_flow(role, protocol)
 
@@ -97,6 +98,7 @@ class PIDDispatcher(Dispatcher):
                 is_validating,
                 synthetic_shard_path,
                 hmac_key,
+                pid_use_row_numbers=pid_use_row_numbers,
             )
 
             if (

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -80,6 +80,8 @@ class PIDProtocolRunStage(PIDStage):
         await self.update_instance_status(
             instance_id=instance_id, status=PIDStageStatus.STARTED
         )
+        if stage_input.pid_use_row_numbers:
+            self.logger.info("use-row-numbers is enabled for Private ID")
         if self.stage_type is UnionPIDStage.PUBLISHER_RUN_PID:
             # Run publisher commands in container
             self.logger.info("Publisher spinning up containers")
@@ -91,6 +93,7 @@ class PIDProtocolRunStage(PIDStage):
                         input_path=input_paths[0],
                         output_path=output_paths[0],
                         num_shards=num_shards,
+                        use_row_numbers=stage_input.pid_use_row_numbers,
                     ),
                     env_vars=self._gen_env_vars(),
                     timeout=timeout,
@@ -152,6 +155,7 @@ class PIDProtocolRunStage(PIDStage):
                         output_path=output_paths[0],
                         num_shards=num_shards,
                         server_hostnames=hostnames,
+                        use_row_numbers=stage_input.pid_use_row_numbers,
                     ),
                     env_vars=self._gen_env_vars(),
                     timeout=timeout,
@@ -193,6 +197,7 @@ class PIDProtocolRunStage(PIDStage):
         input_path: str,
         output_path: str,
         num_shards: int,
+        use_row_numbers: bool,
         server_hostnames: Optional[List[str]] = None,
         port: int = 15200,
     ) -> List[str]:
@@ -208,6 +213,7 @@ class PIDProtocolRunStage(PIDStage):
                     output_path=self.get_sharded_filepath(output_path, i),
                     port=port,
                     server_hostname=server_hostnames[i],
+                    use_row_numbers=use_row_numbers,
                 )
                 for i in range(num_shards)
             ]
@@ -219,6 +225,7 @@ class PIDProtocolRunStage(PIDStage):
                     output_path=self.get_sharded_filepath(output_path, i),
                     port=port,
                     server_hostname=None,
+                    use_row_numbers=use_row_numbers,
                 )
                 for i in range(num_shards)
             ]
@@ -229,6 +236,7 @@ class PIDProtocolRunStage(PIDStage):
         output_path: str,
         port: int,
         server_hostname: Optional[str] = None,
+        use_row_numbers: bool = False,
     ) -> str:
         if server_hostname:
             return " ".join(
@@ -237,6 +245,7 @@ class PIDProtocolRunStage(PIDStage):
                     f"--input {input_path}",
                     f"--output {output_path}",
                     "--no-tls",
+                    "--use-row-numbers" if use_row_numbers else "",
                 ]
             )
         else:
@@ -246,6 +255,7 @@ class PIDProtocolRunStage(PIDStage):
                     f"--input {input_path}",
                     f"--output {output_path}",
                     "--no-tls",
+                    "--use-row-numbers" if use_row_numbers else "",
                 ]
             )
 

--- a/fbpcs/pid/service/pid_service/pid_stage_input.py
+++ b/fbpcs/pid/service/pid_service/pid_stage_input.py
@@ -17,6 +17,7 @@ class PIDStageInput:
     is_validating: Optional[bool] = False
     synthetic_shard_path: Optional[str] = None
     hmac_key: Optional[str] = None
+    pid_use_row_numbers: bool = False
 
     def add_to_inputs(self, input_path: str) -> None:
         self.input_paths.append(input_path)

--- a/fbpcs/pid/service/pid_service/pid_stage_mapper.py
+++ b/fbpcs/pid/service/pid_service/pid_stage_mapper.py
@@ -38,6 +38,7 @@ class PIDStageMapper:
         onedocker_svc: OneDockerService,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         server_ips: Optional[List[str]] = None,
+        use_row_numbers: bool = False,
     ) -> PIDStage:
         if stage is UnionPIDStage.PUBLISHER_SHARD:
             return PIDShardStage(
@@ -110,6 +111,7 @@ class PIDStageMapper:
         is_validating: Optional[bool] = False,
         synthetic_shard_path: Optional[str] = None,
         hmac_key: Optional[str] = None,
+        pid_use_row_numbers: bool = False,
     ) -> PIDStageInput:
         try:
             return PIDStageInput(
@@ -120,6 +122,7 @@ class PIDStageMapper:
                 is_validating=is_validating,
                 synthetic_shard_path=synthetic_shard_path,
                 hmac_key=hmac_key,
+                pid_use_row_numbers=pid_use_row_numbers,
             )
         except KeyError:
             raise ValueError(

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -151,6 +151,10 @@ class PrivateComputationInstance(InstanceBase):
 
     result_visibility: ResultVisibility = ResultVisibility.PUBLIC
 
+    # this is used by Private ID protocol to indicate whether we should
+    # enable 'use-row-numbers' argument.
+    pid_use_row_numbers: bool = False
+
     def __post_init__(self) -> None:
         if self.num_pid_containers > self.num_mpc_containers:
             raise ValueError(

--- a/fbpcs/private_computation/service/id_match_stage_service.py
+++ b/fbpcs/private_computation/service/id_match_stage_service.py
@@ -83,6 +83,7 @@ class IdMatchStageService(PrivateComputationStageService):
             synthetic_shard_path=self._synthetic_shard_path
             or pc_instance.synthetic_shard_path,
             hmac_key=pc_instance.hmac_key,
+            pid_use_row_numbers=pc_instance.pid_use_row_numbers,
         )
 
         # Run pid

--- a/fbpcs/private_computation/service/pid_stage_service.py
+++ b/fbpcs/private_computation/service/pid_stage_service.py
@@ -106,6 +106,7 @@ class PIDStageService(PrivateComputationStageService):
                 synthetic_shard_path=self._synthetic_shard_path
                 or pc_instance.synthetic_shard_path,
                 hmac_key=pc_instance.hmac_key,
+                pid_use_row_numbers=pc_instance.pid_use_row_numbers,
             )
         else:
             # If there no previous instance, then we should run shard first

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -128,6 +128,7 @@ class PrivateComputationService:
         stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
         result_visibility: ResultVisibility = ResultVisibility.PUBLIC,
         tier: Optional[str] = None,
+        pid_use_row_numbers: bool = False,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -171,6 +172,7 @@ class PrivateComputationService:
             ).get_cls_name(),
             result_visibility=result_visibility,
             tier=tier,
+            pid_use_row_numbers=pid_use_row_numbers,
         )
 
         self.instance_repository.create(instance)


### PR DESCRIPTION
Summary:
## Context
- Private ID protocol support a `user-row-numbers` parameter when running the Private ID binary
- This argument can replace the private ID into row number in the PID output

- However, current arguments for PID is hardcoded and we can't change it.

## This changes
- Added a new field in `PrivateComputationInstance`, 'PIDInstance' and `PIDStageInput` in order to pass this argument all the way to the call site of PID binary
- Pass this argument from PrivateComputationInstance all the way to pid_run_protocol_stage.py

Reviewed By: jrodal98

Differential Revision: D34594328

