### PR TITLE
Integrated AWS java SDK, and validating security credentials as a firtst step before starting deploy or undeploy

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/build.gradle
+++ b/fbpcs/infra/cloud_bridge/server/build.gradle
@@ -22,9 +22,9 @@ repositories {
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  implementation group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.988'
+  implementation 'com.amazonaws:aws-java-sdk-sts'
+  implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.+')
 }
-
 test {
   useJUnitPlatform()
 }


### PR DESCRIPTION
Summary:
Integrated long pending AWS java SDK, and validating security credentials as a first step before starting deploy or un-deploy.

This diff is initiated as part of fixing https://www.internalfb.com/tasks?p_nav=MY_TASKS&t=113372943 , and Handles the following:

1. Integrated AWS SDK support.
2. During the start phase of deploy/un-deploy we will validate the credentials to match with AWS account and if error we cancel the flow.

Up next
Application level diff is coming next

What's the future vision after this?
1.  Remove AWS specific usage from the deploy.sh and make a pre validation library which can be use like a pre pce-validator.

2. Migrate from java to kotlin for language consitency across org.

Differential Revision: D34804675

