### PR TITLE
renamed PrivateLiftPublisherInstance to be PrivateComputationPublisherInstance

### DIFF
--- a/fbpcs/pl_coordinator/pc_publisher_instance.py
+++ b/fbpcs/pl_coordinator/pc_publisher_instance.py
@@ -28,8 +28,7 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
 )
 
 
-# TODO(T107103749): [BE] rename PrivateLiftPublisherInstance
-class PrivateLiftPublisherInstance(PrivateLiftCalcInstance):
+class PrivateComputationPublisherInstance(PrivateLiftCalcInstance):
     """
     Representation of a publisher instance.
     """

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -25,7 +25,9 @@ from fbpcs.pl_coordinator.constants import (
 )
 from fbpcs.pl_coordinator.exceptions import PLInstanceCalculationException
 from fbpcs.pl_coordinator.pc_partner_instance import PrivateLiftPartnerInstance
-from fbpcs.pl_coordinator.pc_publisher_instance import PrivateLiftPublisherInstance
+from fbpcs.pl_coordinator.pc_publisher_instance import (
+    PrivateComputationPublisherInstance,
+)
 from fbpcs.pl_coordinator.pl_graphapi_utils import PLGraphAPIClient
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
@@ -171,7 +173,9 @@ class PLInstanceRunner:
     ) -> None:
         self.logger = logger
         self.instance_id = instance_id
-        self.publisher = PrivateLiftPublisherInstance(instance_id, logger, client)
+        self.publisher = PrivateComputationPublisherInstance(
+            instance_id, logger, client
+        )
         self.partner = PrivateLiftPartnerInstance(
             instance_id=instance_id,
             config=config,


### PR DESCRIPTION
Summary:
T107103749
In fbcpc renamed renamed PrivateLiftPublisherInstance to PrivateComputationPublisherInstance

Reviewed By: jrodal98

Differential Revision: D34820379

