### PR TITLE
rename PrivateLiftPartnerInstance

### DIFF
--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -36,8 +36,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
 )
 
 
-# TODO(T107103724): [BE] rename PrivateLiftPartnerInstance
-class PrivateLiftPartnerInstance(PrivateLiftCalcInstance):
+class PrivateComputationPartnerInstance(PrivateLiftCalcInstance):
     """
     Representation of a partner instance.
     """

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -24,7 +24,7 @@ from fbpcs.pl_coordinator.constants import (
     CANCEL_STAGE_TIMEOUT,
 )
 from fbpcs.pl_coordinator.exceptions import PLInstanceCalculationException
-from fbpcs.pl_coordinator.pc_partner_instance import PrivateLiftPartnerInstance
+from fbpcs.pl_coordinator.pc_partner_instance import PrivateComputationPartnerInstance
 from fbpcs.pl_coordinator.pc_publisher_instance import (
     PrivateComputationPublisherInstance,
 )
@@ -176,7 +176,7 @@ class PLInstanceRunner:
         self.publisher = PrivateComputationPublisherInstance(
             instance_id, logger, client
         )
-        self.partner = PrivateLiftPartnerInstance(
+        self.partner = PrivateComputationPartnerInstance(
             instance_id=instance_id,
             config=config,
             input_path=input_path,


### PR DESCRIPTION
Summary: Rename PrivateLiftPartnerInstance to PrivateComputationPartnerInstance for the level 1 task.

Reviewed By: jrodal98

Differential Revision: D34859754

