### PR TITLE
remove the placeholders in the validation stage service

### DIFF
--- a/fbpcs/private_computation/service/input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/service/input_data_validation_stage_service.py
@@ -9,7 +9,6 @@
 import logging
 from typing import List, Optional
 
-from fbpcp.service.storage import StorageService
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
 )
@@ -32,12 +31,7 @@ class InputDataValidationStageService(PrivateComputationStageService):
     It is implemented in a Cloud agnostic way.
     """
 
-    def __init__(
-        self,
-        storage_svc: StorageService,
-        validation_results_path: Optional[str] = None,
-    ) -> None:
-        self._storage_svc = storage_svc
+    def __init__(self) -> None:
         self._logger: logging.Logger = logging.getLogger(__name__)
         self._failed_status: PrivateComputationInstanceStatus = (
             PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_FAILED
@@ -53,21 +47,9 @@ class InputDataValidationStageService(PrivateComputationStageService):
         """
         self._logger.info("[InputDataValidation] - Starting stage")
         # TODO: call the data_input_validation library
-        validation_status = (
+        pc_instance.status = (
             PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED
         )
-        try:
-            if not self._storage_svc.file_exists(pc_instance.input_path):
-                validation_status = self._failed_status
-                self._logger.error(
-                    f"[InputDataValidation] Error - input_path {pc_instance.input_path} does not exist"
-                )
-        except ValueError as err:
-            validation_status = self._failed_status
-            self._logger.error(
-                f"[InputDataValidation] Error - input_path: {pc_instance.input_path} error: {err}"
-            )
-        pc_instance.status = validation_status
         self._logger.info("[InputDataValidation] - Finished stage")
         return pc_instance
 

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -131,7 +131,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         if self is self.CREATED:
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(args.storage_svc)
+            return InputDataValidationStageService()
         elif self is self.ID_MATCH:
             return IdMatchStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -131,7 +131,7 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         if self is self.CREATED:
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(args.storage_svc)
+            return InputDataValidationStageService()
         elif self is self.ID_MATCH:
             return IdMatchStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -132,7 +132,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         if self is self.CREATED:
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(args.storage_svc)
+            return InputDataValidationStageService()
         elif self is self.PID_SHARD:
             return PIDStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
 
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
@@ -36,13 +35,9 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
             output_dir="789",
         )
 
-    @patch("fbpcp.service.storage.StorageService")
-    async def test_run_async_changes_the_status_when_the_file_exists(
-        self, mock_storage_service
-    ) -> None:
+    async def test_run_async_changes_the_status_when_there_are_no_issues(self) -> None:
         pc_instance = self._pc_instance
-        mock_storage_service.file_exists.return_value = True
-        stage_service = InputDataValidationStageService(mock_storage_service)
+        stage_service = InputDataValidationStageService()
 
         self.assertEqual(
             pc_instance.status,
@@ -53,42 +48,4 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
         self.assertEqual(
             pc_instance.status,
             PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED,
-        )
-
-    @patch("fbpcp.service.storage.StorageService")
-    async def test_run_async_fails_when_the_file_does_not_exist(
-        self, mock_storage_service
-    ) -> None:
-        pc_instance = self._pc_instance
-        mock_storage_service.file_exists.return_value = False
-        stage_service = InputDataValidationStageService(mock_storage_service)
-
-        self.assertEqual(
-            pc_instance.status,
-            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_STARTED,
-        )
-
-        await stage_service.run_async(pc_instance)
-        self.assertEqual(
-            pc_instance.status,
-            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_FAILED,
-        )
-
-    @patch("fbpcp.service.storage.StorageService")
-    async def test_run_async_fails_when_a_value_error_occurs(
-        self, mock_storage_service
-    ) -> None:
-        pc_instance = self._pc_instance
-        mock_storage_service.file_exists.side_effect = ValueError("test error")
-        stage_service = InputDataValidationStageService(mock_storage_service)
-
-        self.assertEqual(
-            pc_instance.status,
-            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_STARTED,
-        )
-
-        await stage_service.run_async(pc_instance)
-        self.assertEqual(
-            pc_instance.status,
-            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_FAILED,
         )


### PR DESCRIPTION
Summary:
All of the input_data validations will be run in the onedocker container
instead.

Differential Revision: D34899858

