### PR TITLE
pdate input_data_validation_cli (#690)

### DIFF
--- a/fbpcs/input_data_validation/constants.py
+++ b/fbpcs/input_data_validation/constants.py
@@ -10,6 +10,7 @@ import re
 from typing import Dict, List, Pattern
 
 INPUT_DATA_TMP_FILE_PATH = "/tmp"
+INPUT_DATA_VALIDATOR_NAME = "Input Data Validator"
 
 ID_FIELD = "id_"
 CONVERSION_VALUE_FIELD = "conversion_value"

--- a/fbpcs/input_data_validation/input_data_validation_cli.py
+++ b/fbpcs/input_data_validation/input_data_validation_cli.py
@@ -69,14 +69,14 @@ def main() -> None:
     )
     validation_report = validator.validate()
 
-    validation_report_status = validation_report["status"]
-    if validation_report_status == ValidationResult.FAILED.value:
+    validation_result = validation_report.validation_result
+    if validation_result == ValidationResult.FAILED:
         raise Exception(validation_report)
-    elif validation_report_status == ValidationResult.SUCCESS.value:
+    elif validation_result == ValidationResult.SUCCESS:
         print(f"Success: {validation_report}")
     else:
         raise Exception(
-            "Unknown validation_report status: {validation_report_status}.\n"
+            "Unknown validation result: {validation_result}.\n"
             + "Validation report: {validation_report}"
         )
 

--- a/fbpcs/input_data_validation/tests/validation_report_test.py
+++ b/fbpcs/input_data_validation/tests/validation_report_test.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+
+from fbpcs.input_data_validation.enums import ValidationResult
+from fbpcs.input_data_validation.validation_report import ValidationReport
+
+
+class TestValidationReport(TestCase):
+    def test_get_str_for_report_with_details(self) -> None:
+        expected_report_str = """Validation Report: test_validator_name
+Result: success
+Message: test_message
+Details:
+{
+    "test_key_1": 5,
+    "test_key_2": {
+        "test_key_3": {
+            "test_key_4": 1
+        },
+        "test_key_5": {
+            "test_key_6": 1,
+            "test_key_7": 2
+        }
+    }
+}"""
+        report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name="test_validator_name",
+            message="test_message",
+            details={
+                "test_key_1": 5,
+                "test_key_2": {
+                    "test_key_3": {
+                        "test_key_4": 1,
+                    },
+                    "test_key_5": {
+                        "test_key_6": 1,
+                        "test_key_7": 2,
+                    },
+                },
+            },
+        )
+        self.assertEqual(expected_report_str, str(report))
+
+    def test_get_str_for_report_without_details(self) -> None:
+        expected_report_str = """Validation Report: test_validator_name
+Result: failed
+Message: test_message"""
+        report = ValidationReport(
+            validation_result=ValidationResult.FAILED,
+            validator_name="test_validator_name",
+            message="test_message",
+        )
+        self.assertEqual(expected_report_str, str(report))

--- a/fbpcs/input_data_validation/tests/validators_runner_test.py
+++ b/fbpcs/input_data_validation/tests/validators_runner_test.py
@@ -1,0 +1,117 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+
+from fbpcs.input_data_validation.enums import ValidationResult
+from fbpcs.input_data_validation.validation_report import ValidationReport
+from fbpcs.input_data_validation.validator import Validator
+from fbpcs.input_data_validation.validators_runner import run_validators
+
+
+class TestDummyValidator(Validator):
+    def __init__(self, dummy_report: ValidationReport) -> None:
+        self.dummy_report: ValidationReport = dummy_report
+
+    @property
+    def name(self) -> str:
+        return self.dummy_report.validator_name
+
+    def __validate__(self) -> ValidationReport:
+        return self.dummy_report
+
+
+class TestExceptionValidator(Validator):
+    @property
+    def name(self) -> str:
+        return "TestExceptionValidator"
+
+    def __validate__(self) -> ValidationReport:
+        raise Exception("test error message")
+
+
+TEST_SUCCESSFUL_REPORT_1 = ValidationReport(
+    validation_result=ValidationResult.SUCCESS,
+    validator_name="validator 1",
+    message="message 1",
+    details={
+        "test_key_1": 5,
+    },
+)
+
+TEST_SUCCESSFUL_REPORT_2 = ValidationReport(
+    validation_result=ValidationResult.SUCCESS,
+    validator_name="validator 2",
+    message="message 2",
+    details={
+        "test_key_2": 5,
+    },
+)
+
+TEST_FAILED_REPORT_1 = ValidationReport(
+    validation_result=ValidationResult.FAILED,
+    validator_name="validator 3",
+    message="message 3",
+    details={
+        "test_key_3": 5,
+    },
+)
+
+
+class TestValidationReport(TestCase):
+    def test_all_validators_succeed(self) -> None:
+        expected_aggregated_result = ValidationResult.SUCCESS
+        expected_aggregated_report = (
+            f"{TEST_SUCCESSFUL_REPORT_1}\n\n{TEST_SUCCESSFUL_REPORT_2}"
+        )
+
+        (actual_result, actual_report) = run_validators(
+            [
+                TestDummyValidator(TEST_SUCCESSFUL_REPORT_1),
+                TestDummyValidator(TEST_SUCCESSFUL_REPORT_2),
+            ]
+        )
+
+        self.assertEqual(expected_aggregated_result, actual_result)
+        self.assertEqual(expected_aggregated_report, actual_report)
+
+    def test_a_validator_fails(self) -> None:
+        expected_aggregated_result = ValidationResult.FAILED
+        expected_aggregated_report = (
+            f"{TEST_SUCCESSFUL_REPORT_1}\n\n{TEST_FAILED_REPORT_1}"
+        )
+
+        (actual_result, actual_report) = run_validators(
+            [
+                TestDummyValidator(TEST_SUCCESSFUL_REPORT_1),
+                TestDummyValidator(TEST_FAILED_REPORT_1),
+            ]
+        )
+
+        self.assertEqual(expected_aggregated_result, actual_result)
+        self.assertEqual(expected_aggregated_report, actual_report)
+
+    def test_a_validator_throws_exception(self) -> None:
+        expected_report_thrown_by_validator = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name="TestExceptionValidator",
+            message="WARNING: TestExceptionValidator throws an unexpected error: test error message",
+        )
+        expected_aggregated_result = ValidationResult.SUCCESS
+        expected_aggregated_report = (
+            f"{TEST_SUCCESSFUL_REPORT_1}\n\n{expected_report_thrown_by_validator}"
+        )
+
+        (actual_result, actual_report) = run_validators(
+            [
+                TestDummyValidator(TEST_SUCCESSFUL_REPORT_1),
+                TestExceptionValidator(),
+            ]
+        )
+
+        self.assertEqual(expected_aggregated_result, actual_result)
+        self.assertEqual(expected_aggregated_report, actual_report)

--- a/fbpcs/input_data_validation/validation_report.py
+++ b/fbpcs/input_data_validation/validation_report.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import json
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+from dataclasses_json import dataclass_json
+from fbpcs.input_data_validation.enums import ValidationResult
+
+
+@dataclass_json
+@dataclass
+class ValidationReport:
+    validation_result: ValidationResult
+    validator_name: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+
+    def __str__(self) -> str:
+        if self.details:
+            return (
+                f"Validation Report: {self.validator_name}\n"
+                f"Result: {self.validation_result.value}\n"
+                f"Message: {self.message}\n"
+                f"Details:\n{json.dumps(self.details, sort_keys=True, indent=4)}"
+            )
+        else:
+            return (
+                f"Validation Report: {self.validator_name}\n"
+                f"Result: {self.validation_result.value}\n"
+                f"Message: {self.message}"
+            )

--- a/fbpcs/input_data_validation/validator.py
+++ b/fbpcs/input_data_validation/validator.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+
+from fbpcs.input_data_validation.enums import ValidationResult
+from fbpcs.input_data_validation.validation_report import ValidationReport
+
+
+class Validator(abc.ABC):
+    def validate(self) -> ValidationReport:
+        """A wrapper for __validator__().
+
+        In case an unexpected exception is thrown, this method will still return a SUCCESS report
+        so that a bug will not block a PC run.
+        """
+        try:
+            return self.__validate__()
+        except Exception as e:
+            return ValidationReport(
+                ValidationResult.SUCCESS,
+                self.name,
+                f"WARNING: {self.name} throws an unexpected error: {e}",
+            )
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """str: the name of the validator"""
+        pass
+
+    @abc.abstractmethod
+    def __validate__(self) -> ValidationReport:
+        """Perform a validation for a PC run.
+
+        When implementing this method, ensure that no exceptions will be thrown from the method.
+        """
+        pass

--- a/fbpcs/input_data_validation/validators_runner.py
+++ b/fbpcs/input_data_validation/validators_runner.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List, Tuple
+
+from fbpcs.input_data_validation.enums import ValidationResult
+from fbpcs.input_data_validation.validation_report import ValidationReport
+from fbpcs.input_data_validation.validator import Validator
+
+
+def run_validators(validators: List[Validator]) -> Tuple[ValidationResult, str]:
+    # run each validator once
+    validation_reports: List[ValidationReport] = [
+        validator.validate() for validator in validators
+    ]
+
+    # aggregated result is SUCCESS only if all validators succeed.
+    validator_results = [
+        report.validation_result == ValidationResult.SUCCESS
+        for report in validation_reports
+    ]
+    aggregated_result = (
+        ValidationResult.SUCCESS if all(validator_results) else ValidationResult.FAILED
+    )
+
+    aggregated_report = "\n\n".join([str(report) for report in validation_reports])
+
+    return (aggregated_result, aggregated_report)


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/690

We decide to make the following refactorings to the start up validator CLI:

1. Validation CLI will be initialized with a list of Validators.
2. Validation CLI will invoke each and every validator once and consolidate all ValidationReports
3. Validators are self-contained and encapsulate one or more related validation rules.

Implication: this means the current header_validator, line_ending_validator, and row_validator are not qualified as Validators, because the latter two will only be executed if header_validator does not throw an exception. They will be bundled into 1 top-level validator, which will actually be more desirable/efficient because we will only need to download the input data file once.

{F710945886}

execution plan: https://docs.google.com/document/d/1GgD4VqTL_RdJlOGIedjpkzVwEgAcCzoVNINYmegOr-0/edit#

Differential Revision: D34914515

