### PR TITLE
Fixes to handle copying & generating config.yml file , and Ui enhancements, and log stream improvements

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -49,7 +49,7 @@ RUN terraform --version
 ##########################################
 # Copy deploy.sh, Terraform scripts, and config.yml template
 ##########################################
-RUN mkdir /terraform_deployment
+RUN mkdir -p /terraform_deployment/config
 COPY deploy.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/deploy.sh
 COPY util.sh /terraform_deployment
@@ -57,7 +57,7 @@ RUN chmod +x /terraform_deployment/util.sh
 COPY aws_terraform_template /terraform_deployment/terraform_scripts
 COPY data_ingestion /terraform_deployment/terraform_scripts/data_ingestion
 COPY semi_automated_data_ingestion /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
-COPY config.yml /terraform_deployment
+COPY config.yml /terraform_deployment/config
 COPY data_validation /terraform_deployment/terraform_scripts/data_validation
 COPY cli.py /terraform_deployment
 COPY deployment_helper /terraform_deployment/deployment_helper

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -21,8 +21,6 @@ public class DeploymentRunner extends Thread {
   private Runnable deploymentFinishedCallback;
   private Process provisioningProcess;
   private BufferedWriter deployLogFile;
-  private BufferedReader deployStreamFile;
-
   private int exitValue;
 
   public int getExitValue() {
@@ -81,26 +79,9 @@ public class DeploymentRunner extends Thread {
 
     try {
       deployLogFile = new BufferedWriter(new FileWriter("/tmp/deploy.log", true));
-      File file = new File(Constants.DEPLOYMENT_STREAMING_LOG_FILE);
-      file.createNewFile();
-      deployStreamFile =
-          new BufferedReader(new FileReader(Constants.DEPLOYMENT_STREAMING_LOG_FILE));
     } catch (IOException e) {
       logger.error("An exception happened: ", e.getMessage());
     }
-  }
-
-  public ArrayList<String> getStreamingLogs() {
-    String s = null;
-    ArrayList<String> messages = new ArrayList<String>();
-    try {
-      while (deployStreamFile.ready() && (s = deployStreamFile.readLine()) != null) {
-        messages.add(s);
-      }
-    } catch (final Exception e) {
-      logger.error("An exception happened during reading: " + e.getMessage());
-    }
-    return messages;
   }
 
   private void buildDeployCommand(boolean shouldDeploy, DeploymentParams deployment) {
@@ -182,7 +163,6 @@ public class DeploymentRunner extends Thread {
     deploymentState = DeploymentState.STATE_HALTED;
     try {
       deployLogFile.close();
-      deployStreamFile.close();
     } catch (IOException e) {
       logger.error("Failed to close Logger File");
     }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/LogStreamer.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/LogStreamer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+import java.io.*;
+import java.util.ArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogStreamer {
+  private BufferedReader deploymentStreamFileReader;
+  private FileInputStream deploymentFileStream;
+  private Logger logger = LoggerFactory.getLogger(DeployController.class);
+
+  enum LogStreamerState {
+    STATE_NOT_STARTED("not started"),
+    STATE_PAUSED("paused"),
+    STATE_RUNNING("running");
+    private String state;
+
+    private LogStreamerState(String state) {
+      this.state = state;
+    }
+  };
+
+  private LogStreamerState state = LogStreamerState.STATE_NOT_STARTED;
+
+  public LogStreamerState getState() {
+    return state;
+  }
+
+  public void startFresh() {
+    try {
+      // ensure reset
+      reset();
+      // ensure file is created & erased, or truncated to 0 if it existed before
+      new PrintWriter(Constants.DEPLOYMENT_STREAMING_LOG_FILE).close();
+      deploymentFileStream = new FileInputStream(Constants.DEPLOYMENT_STREAMING_LOG_FILE);
+      deploymentStreamFileReader = new BufferedReader(new InputStreamReader(deploymentFileStream));
+      state = LogStreamerState.STATE_RUNNING;
+    } catch (IOException e) {
+      logger.error("An exception happened during start: " + e.getMessage());
+    }
+  }
+
+  public void pause() {
+    state = LogStreamerState.STATE_PAUSED;
+  }
+
+  private void resume() {
+    if (state != LogStreamerState.STATE_NOT_STARTED) {
+      state = LogStreamerState.STATE_RUNNING;
+    }
+  }
+
+  public void reset() {
+    if (state == LogStreamerState.STATE_NOT_STARTED) return;
+    try {
+      deploymentFileStream.close();
+      deploymentStreamFileReader.close();
+    } catch (final Exception e) {
+      logger.error("An exception happened during reset: " + e.getMessage());
+    } finally {
+      state = LogStreamerState.STATE_NOT_STARTED;
+    }
+  }
+
+  public ArrayList<String> getStreamingLogs(boolean reset) {
+    String s = null;
+    ArrayList<String> messages = new ArrayList<String>();
+    if (reset) {
+      resume();
+    }
+    if (state == LogStreamerState.STATE_PAUSED || state == LogStreamerState.STATE_NOT_STARTED) {
+      return messages;
+    }
+    try {
+      if (reset) {
+        // seek to beginning of the file
+        deploymentFileStream.getChannel().position(0);
+        deploymentStreamFileReader =
+            new BufferedReader(new InputStreamReader(deploymentFileStream));
+      }
+      while (deploymentStreamFileReader.ready()
+          && (s = deploymentStreamFileReader.readLine()) != null) {
+        messages.add(s);
+      }
+    } catch (final Exception e) {
+      logger.error("An exception happened during reading: " + e.getMessage());
+    }
+    return messages;
+  }
+}

--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -90,6 +90,14 @@ validate_bucket_name() {
 
 }
 
+cleanup_generated_resources() {
+    # check if previously existed config.yml is present, if yes then remove it
+    cd /terraform_deployment || return
+    rm config.yml || true
+    # copy config.yml template
+    cp /terraform_deployment/config/config.yml /terraform_deployment
+}
+
 validateDeploymentResources () {
     local region=$1
     local pce_id=$2


### PR DESCRIPTION
Summary:
This diff:
1. Fixes to handle copying & generating Config.yml file
2. UI enhancements to show spinner.
3. log stream improvements when user reload the page

1. Fixes to handle copying & generating Config.yml file

   previously our code design was to just copy the existing config.yml file and replace the todos, but if advertiser subsequently undeploy and redeploy the code logic didn't have sifficient way to handle copy previous config.yml template which had TODOs , this diff handles that.

here are 2 config.yml files generated after 2 subsequent deploy :

{F711563970}

{F711563979}

2. UI enhancements to show spinner.

We have added a spinner now to show ongoing progress:

3. log stream improvements when user reload the page

This was tricky as our stream implementation in backend relies on user fetch, this diff separates stream logic to another file thereby controlling the refresh and end of stream based on user action. Now we can handle populating old logs on UI when user refresh

https://pxl.cl/20Tdn

All of the above fix, we have got during our last dog fooding.

Differential Revision: D34949311

