### PR TITLE
fail fast on impossible statuses

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -7,5 +7,25 @@
 # pyre-strict
 
 
-class PLInstanceCalculationException(RuntimeError):
+class OneCommandRunnerBaseException(Exception):
+    def __init__(self, msg: str, cause: str, remediation: str) -> None:
+        super().__init__(
+            "\n".join((msg, f"Cause: {cause}", f"Remediation: {remediation}"))
+        )
+
+
+# TODO(T114624787): [BE][PCS] rename PLInstanceCalculationException to PCInstanceCalculationException
+class PLInstanceCalculationException(OneCommandRunnerBaseException, RuntimeError):
     pass
+
+
+class IncompatibleStageError(OneCommandRunnerBaseException, RuntimeError):
+    @classmethod
+    def make_error(
+        cls, publisher_stage_name: str, partner_stage_name: str
+    ) -> "IncompatibleStageError":
+        return cls(
+            msg=f"Publisher stage is {publisher_stage_name} but partner stage is {partner_stage_name}.",
+            cause="Possible causes include race time error during instance updating, unexpected instance deletion, or differing stageflows",
+            remediation="Wait 24 hours for the instance to expire or contact your representative at Meta.",
+        )

--- a/fbpcs/pl_coordinator/pc_calc_instance.py
+++ b/fbpcs/pl_coordinator/pc_calc_instance.py
@@ -76,7 +76,9 @@ class PrivateComputationCalcInstance:
                     return
                 sleep(POLL_INTERVAL)
             raise PLInstanceCalculationException(
-                f"Poll {self.role} status timed out after {timeout}s expecting valid status."
+                "Timeout",
+                f"Poll {self.role} status timed out after {timeout}s expecting valid status.",
+                "Try running again",
             )
 
     def wait_instance_status(
@@ -102,11 +104,15 @@ class PrivateComputationCalcInstance:
                 PrivateComputationInstanceStatus.TIMEOUT,
             ]:
                 raise PLInstanceCalculationException(
-                    f"{self.role} failed with status {self.status}. Expecting status {status}."
+                    f"{self.role} failed with status {self.status}. Expecting status {status}.",
+                    "unknown",
+                    "Try running again",
                 )
             sleep(POLL_INTERVAL)
         raise PLInstanceCalculationException(
-            f"Poll {self.role} status timed out after {timeout}s expecting status: {status}."
+            "Timeout",
+            f"Poll {self.role} status timed out after {timeout}s expecting status: {status}.",
+            "Try running again",
         )
 
     def ready_for_stage(self, stage: PrivateComputationBaseStageFlow) -> bool:

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -234,7 +234,9 @@ class PLInstanceRunner:
                 self.logger.info(f"Valid stage found: {valid_stage}")
                 return valid_stage
         raise PLInstanceCalculationException(
-            f"Waiting for valid stage timed out after {timeout}s."
+            "Timeout error",
+            f"Waiting for valid stage timed out after {timeout}s.",
+            "Try running again",
         )
 
     def is_finished(self) -> bool:
@@ -329,9 +331,13 @@ class PLInstanceRunner:
                     cancel_time += POLL_INTERVAL
                 else:
                     raise PLInstanceCalculationException(
-                        f"Stage {stage.name} failed. Publisher status: {self.publisher.status}. Partner status: {self.partner.status}."
+                        f"Stage {stage.name} failed.",
+                        f"Publisher status: {self.publisher.status}. Partner status: {self.partner.status}.",
+                        "Try running again",
                     )
             sleep(POLL_INTERVAL)
         raise PLInstanceCalculationException(
-            f"Stage {stage.name} timed out after {timeout}s. Publisher status: {self.publisher.status}. Partner status: {self.partner.status}."
+            f"Stage {stage.name} timed out after {timeout}s. Publisher status: {self.publisher.status}. Partner status: {self.partner.status}.",
+            "unknown",
+            "Try running again",
         )


### PR DESCRIPTION
Summary:
## What

* Raise an exception when the publisher and partner have unrecoverable stage status differences

## Why

* Fail fast > not failing fast
* part of validation workstream
* Makes the error experienced by playrix much more clear: https://fb.workplace.com/groups/331044242148818/permalink/435603908359517/
    * Previously, it would timeout after awhile due to not being in a valid state. Now, we fail instantly

Differential Revision: D34948833

