### PR TITLE
Launch the pc_pre_validation_cli on onedocker service

### DIFF
--- a/fbpcs/common/tests/test_stage_state_instance.py
+++ b/fbpcs/common/tests/test_stage_state_instance.py
@@ -31,8 +31,8 @@ class TestStageStateInstance(unittest.TestCase):
                     status=ContainerInstanceStatus.COMPLETED,
                 ),
             ],
-            start_time=1646642432,
-            end_time=1646642432 + 5,
+            creation_ts=1646642432,
+            end_ts=1646642432 + 5,
         )
 
     def test_server_ips(self) -> None:

--- a/fbpcs/onedocker_binary_names.py
+++ b/fbpcs/onedocker_binary_names.py
@@ -30,3 +30,5 @@ class OneDockerBinaryNames(Enum):
     CROSS_PSI_COR_CLIENT = "pid/cross-psi-xor-client"
 
     LIFT_COMPUTE = "private_lift/lift"
+
+    PC_PRE_VALIDATION = "validation/pc_pre_validation_cli"

--- a/fbpcs/private_computation/entity/pc_validator_config.py
+++ b/fbpcs/private_computation/entity/pc_validator_config.py
@@ -17,7 +17,9 @@ from dataclasses_json import dataclass_json
 @dataclass
 class PCValidatorConfig:
     region: str
-    pc_pre_validator_enabled: bool = True
+    # Temporarily disable the pre validator by default, until it
+    # is ready to be always run
+    pc_pre_validator_enabled: bool = False
     data_validation_threshold_overrides: Optional[Dict[str, float]] = None
 
     def __str__(self) -> str:

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -16,7 +16,12 @@ from typing import Any, Dict, List, Optional
 from fbpcp.entity.mpc_instance import MPCInstance, MPCParty
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcp.service.mpc import MPCService
+from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.common.entity.stage_state_instance import (
+    StageStateInstanceStatus,
+    StageStateInstance,
+)
 from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
 from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -132,6 +137,38 @@ def get_updated_pc_status_mpc_game(
             MPCInstanceStatus.FAILED,
             MPCInstanceStatus.CANCELED,
         ):
+            status = current_stage.failed_status
+
+    return status
+
+
+def get_pc_status_from_stage_state(
+    private_computation_instance: PrivateComputationInstance,
+    onedocker_svc: OneDockerService,
+) -> PrivateComputationInstanceStatus:
+    """Updates the StageStateInstances and gets latest PrivateComputationInstance status
+
+    Arguments:
+        private_computation_instance: The PC instance that is being updated
+        onedocker_svc: Used to get latest Containers to update StageState instance status
+
+    Returns:
+        The latest status for private_computation_instance
+    """
+    status = private_computation_instance.status
+    if private_computation_instance.instances:
+        last_instance = private_computation_instance.instances[-1]
+        if not isinstance(last_instance, StageStateInstance):
+            return status
+
+        # calling onedocker_svc to update newest containers in StageState
+        stage_state_instance_status = last_instance.update_status(onedocker_svc)
+        current_stage = private_computation_instance.current_stage
+        if stage_state_instance_status is StageStateInstanceStatus.STARTED:
+            status = current_stage.started_status
+        elif stage_state_instance_status is StageStateInstanceStatus.COMPLETED:
+            status = current_stage.completed_status
+        elif stage_state_instance_status is StageStateInstanceStatus.FAILED:
             status = current_stage.failed_status
 
     return status

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -131,7 +131,9 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         if self is self.CREATED:
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(args.pc_validator_config)
+            return InputDataValidationStageService(
+                args.pc_validator_config, args.onedocker_svc
+            )
         elif self is self.ID_MATCH:
             return IdMatchStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -131,7 +131,9 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         if self is self.CREATED:
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(args.pc_validator_config)
+            return InputDataValidationStageService(
+                args.pc_validator_config, args.onedocker_svc
+            )
         elif self is self.ID_MATCH:
             return IdMatchStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -132,7 +132,9 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         if self is self.CREATED:
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(args.pc_validator_config)
+            return InputDataValidationStageService(
+                args.pc_validator_config, args.onedocker_svc
+            )
         elif self is self.PID_SHARD:
             return PIDStageService(
                 args.pid_svc,

--- a/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
@@ -4,9 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import Mock
+from unittest.mock import patch, MagicMock
 
+from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.pc_validator_config import (
+    PCValidatorConfig,
+)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationGameType,
     PrivateComputationInstance,
@@ -32,23 +37,103 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=1,
             num_files_per_mpc_container=1,
             game_type=PrivateComputationGameType.LIFT,
-            input_path="456",
+            input_path="https://a-test-bucket.s3.us-west-2.amazonaws.com/lift/test/input_data1.csv",
             output_dir="789",
         )
 
-    async def test_run_async_changes_the_status_when_there_are_no_issues(self) -> None:
+    @patch(
+        "fbpcs.private_computation.service.input_data_validation_stage_service.StageStateInstance"
+    )
+    async def test_run_async_when_there_are_no_issues_running_onedocker_service(
+        self, mock_stage_state_instance
+    ) -> None:
         pc_instance = self._pc_instance
-        mock_pc_validator_config = Mock("PC Validator Config")
-        stage_service = InputDataValidationStageService(mock_pc_validator_config)
-
-        self.assertEqual(stage_service._pc_validator_config, mock_pc_validator_config)
-        self.assertEqual(
-            pc_instance.status,
-            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_STARTED,
+        threshold_overrides = {
+            "id_": 0.95,
+            "value": 0.8,
+        }
+        threshold_overrides_str = json.dumps(threshold_overrides)
+        mock_container_instance = MagicMock()
+        mock_onedocker_svc = MagicMock()
+        mock_onedocker_svc.start_container.side_effect = [mock_container_instance]
+        region = "us-west-1"
+        expected_cmd_args = " ".join(
+            [
+                f"--input-file-path={self._pc_instance.input_path}",
+                "--cloud-provider=AWS",
+                f"--region={region}",
+                f"--valid-threshold-override='{threshold_overrides_str}'",
+            ]
+        )
+        pc_validator_config = PCValidatorConfig(
+            region=region,
+            pc_pre_validator_enabled=True,
+            data_validation_threshold_overrides=threshold_overrides,
+        )
+        stage_service = InputDataValidationStageService(
+            pc_validator_config, mock_onedocker_svc
         )
 
         await stage_service.run_async(pc_instance)
-        self.assertEqual(
-            pc_instance.status,
-            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED,
+
+        mock_onedocker_svc.start_container.assert_called_with(
+            package_name=OneDockerBinaryNames.PC_PRE_VALIDATION.value,
+            timeout=1200,
+            cmd_args=expected_cmd_args,
         )
+        mock_stage_state_instance.assert_called_with(
+            self._pc_instance.instance_id,
+            self._pc_instance.current_stage.name,
+            containers=[mock_container_instance],
+        )
+        self.assertEqual(pc_instance.instances, [mock_stage_state_instance()])
+
+    @patch(
+        "fbpcs.private_computation.service.input_data_validation_stage_service.get_pc_status_from_stage_state"
+    )
+    async def test_run_async_completes_when_the_pre_validator_is_not_enabled(
+        self, mock_get_pc_status_from_stage_state
+    ) -> None:
+        pc_instance = self._pc_instance
+        expected_status = (
+            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED
+        )
+        mock_onedocker_svc = MagicMock()
+        pc_validator_config = PCValidatorConfig(
+            region="us-west-1",
+            pc_pre_validator_enabled=False,
+        )
+        stage_service = InputDataValidationStageService(
+            pc_validator_config, mock_onedocker_svc
+        )
+
+        await stage_service.run_async(pc_instance)
+        status = stage_service.get_status(pc_instance)
+
+        mock_onedocker_svc.start_container.assert_not_called()
+        mock_get_pc_status_from_stage_state.assert_not_called()
+        self.assertEqual(status, expected_status)
+
+    @patch(
+        "fbpcs.private_computation.service.input_data_validation_stage_service.get_pc_status_from_stage_state"
+    )
+    def test_get_status_returns_the_stage_status_from_stage_state(
+        self, mock_get_pc_status_from_stage_state
+    ):
+        pc_instance = self._pc_instance
+        expected_status = (
+            PrivateComputationInstanceStatus.INPUT_DATA_VALIDATION_COMPLETED
+        )
+        mock_onedocker_svc = MagicMock()
+        pc_validator_config = PCValidatorConfig(
+            region="us-west-1",
+            pc_pre_validator_enabled=True,
+        )
+
+        stage_service = InputDataValidationStageService(
+            pc_validator_config, mock_onedocker_svc
+        )
+        mock_get_pc_status_from_stage_state.side_effect = [expected_status]
+        status = stage_service.get_status(pc_instance)
+
+        self.assertEqual(status, expected_status)

--- a/fbpcs/private_computation_cli/config.yml
+++ b/fbpcs/private_computation_cli/config.yml
@@ -43,11 +43,11 @@ private_computation:
     PCValidatorConfig:
       class: fbpcs.private_computation.entity.pc_validator_config.PCValidatorConfig
       constructor:
-        # Toggle running the PCPreValidator
-        pc_pre_validator_enabled: true
-        # AWS region - ex. us-west-2
+        ### AWS region - ex. us-west-2
         region: TODO
-        # Overrides for the passing validation thresholds
+        ### Toggle running the PCPreValidator
+        # pc_pre_validator_enabled: false
+        ### Overrides for the passing validation thresholds
         # data_validation_threshold_overrides:
         #   id_: 0.6
         #   event_timestamp: 0.7


### PR DESCRIPTION
Summary:
The CLI will be started only when the config.yml contains
`pc_pre_validator_enabled: true`. The config.yml now instead contains an
example for switching it off, since it will later be turned on by default once
the feature has been released.

Differential Revision: D34953086

