### PR TITLE
Add binaries accessibility validator

### DIFF
--- a/fbpcs/pc_pre_validation/binary_file_validator.py
+++ b/fbpcs/pc_pre_validation/binary_file_validator.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Optional, Dict, List
+
+from fbpcp.error.pcp import PcpError
+from fbpcp.service.storage_s3 import S3StorageService
+from fbpcs.pc_pre_validation.constants import (
+    BINARY_REPOSITORY,
+    BINARY_PATHS,
+    BINARY_FILE_VALIDATOR_NAME,
+)
+from fbpcs.pc_pre_validation.enums import ValidationResult
+from fbpcs.pc_pre_validation.validation_report import ValidationReport
+from fbpcs.pc_pre_validation.validator import Validator
+
+
+class BinaryFileValidator(Validator):
+    def __init__(
+        self,
+        region: str,
+        binary_repository: str = BINARY_REPOSITORY,
+        binary_paths: List[str] = BINARY_PATHS,
+        access_key_id: Optional[str] = None,
+        access_key_data: Optional[str] = None,
+    ) -> None:
+        self._storage_service = S3StorageService(region, access_key_id, access_key_data)
+        self._name: str = BINARY_FILE_VALIDATOR_NAME
+        self._binary_repository = binary_repository
+        self._binary_paths = binary_paths
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __validate__(self) -> ValidationReport:
+        details: Dict[str, str] = {}
+        for path in self._binary_paths:
+            binary_full_path = f"{self._binary_repository}/{path}"
+            try:
+                if not self._storage_service.file_exists(binary_full_path):
+                    details[binary_full_path] = "binary does not exist"
+            except PcpError as pcp_error:
+                # s3 throws the following error when an access is denied,
+                #    An error occurred (403) when calling the HeadObject operation: Forbidden
+                if "Forbidden" in str(pcp_error):
+                    details[binary_full_path] = str(pcp_error)
+                else:
+                    # rethrow unexpected error so validation runner will skip this validation with a WARNING message
+                    raise pcp_error
+
+        if details:
+            return ValidationReport(
+                validation_result=ValidationResult.FAILED,
+                validator_name=self.name,
+                message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+                details=details,
+            )
+        else:
+            return ValidationReport(
+                validation_result=ValidationResult.SUCCESS,
+                validator_name=self.name,
+                message="Completed binary accessibility validation successfuly",
+            )

--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -9,8 +9,10 @@
 import re
 from typing import Dict, List, Pattern
 
-INPUT_DATA_TMP_FILE_PATH = "/tmp"
 INPUT_DATA_VALIDATOR_NAME = "Input Data Validator"
+BINARY_FILE_VALIDATOR_NAME = "Binary File Validator"
+
+INPUT_DATA_TMP_FILE_PATH = "/tmp"
 
 ID_FIELD = "id_"
 CONVERSION_VALUE_FIELD = "conversion_value"
@@ -45,3 +47,21 @@ VALIDATION_REGEXES: Dict[str, Pattern[str]] = {
 }
 
 VALID_LINE_ENDING_REGEX: Pattern[str] = re.compile(r".*(\S|\S\n)$")
+
+BINARY_REPOSITORY = "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com"
+BINARY_PATHS = [
+    "data_processing/attribution_id_combiner/latest/attribution_id_combiner",
+    "data_processing/lift_id_combiner/latest/lift_id_combiner",
+    "data_processing/pid_preparer/latest/pid_preparer",
+    "data_processing/sharder_hashed_for_pid/latest/sharder_hashed_for_pid",
+    "pid/private-id-client/latest/cross-psi-client",
+    "pid/private-id-client/latest/cross-psi-xor-client",
+    "pid/private-id-client/latest/private-id-client",
+    "pid/private-id-server/latest/cross-psi-server",
+    "pid/private-id-server/latest/cross-psi-xor-server",
+    "pid/private-id-server/latest/private-id-server",
+    "private_attribution/compute/latest/compute",
+    "private_attribution/decoupled_aggregation/latest/decoupled_aggregation",
+    "private_attribution/shard-aggregator/latest/shard-aggregator",
+    "private_lift/lift/latest/lift",
+]

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -27,6 +27,7 @@ Usage:
 from typing import cast
 
 from docopt import docopt
+from fbpcs.pc_pre_validation.binary_file_validator import BinaryFileValidator
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.input_data_validator import InputDataValidator
 from fbpcs.pc_pre_validation.validator import Validator
@@ -74,7 +75,15 @@ def main() -> None:
                 arguments[ACCESS_KEY_ID],
                 arguments[ACCESS_KEY_DATA],
             ),
-        )
+        ),
+        cast(
+            Validator,
+            BinaryFileValidator(
+                region=arguments[REGION],
+                access_key_id=arguments[ACCESS_KEY_ID],
+                access_key_data=arguments[ACCESS_KEY_DATA],
+            ),
+        ),
     ]
 
     (aggregated_result, aggregated_report) = run_validators(validators)

--- a/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from fbpcp.error.pcp import PcpError
+from fbpcs.pc_pre_validation.binary_file_validator import BinaryFileValidator
+from fbpcs.pc_pre_validation.constants import BINARY_FILE_VALIDATOR_NAME
+from fbpcs.pc_pre_validation.enums import ValidationResult
+from fbpcs.pc_pre_validation.validation_report import ValidationReport
+
+TEST_REGION = "us-west-2"
+TEST_BINARY_REPO = "https://test.s3.us-west-2.amazonaws.com"
+TEST_BINARY_PATHS = ["path/to/binary/1", "path/to_binary_2", "path/to_binary_3"]
+
+
+class TestBinaryFileValidator(TestCase):
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_run_validations_success(self, storage_service_mock: Mock) -> None:
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message="Completed binary accessibility validation successfuly",
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.return_value = True
+
+        validator = BinaryFileValidator(
+            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
+        )
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_run_validations_binary_not_exist(self, storage_service_mock: Mock) -> None:
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.FAILED,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+            details={
+                f"{TEST_BINARY_REPO}/{TEST_BINARY_PATHS[0]}": "binary does not exist"
+            },
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.side_effect = [False, True, True]
+
+        validator = BinaryFileValidator(
+            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
+        )
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_run_validations_binary_access_denied(
+        self, storage_service_mock: Mock
+    ) -> None:
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.FAILED,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+            details={
+                f"{TEST_BINARY_REPO}/{TEST_BINARY_PATHS[2]}": "An error occurred (403) when calling the HeadObject operation: Forbidden"
+            },
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.side_effect = [
+            True,
+            True,
+            PcpError(
+                Exception(
+                    "An error occurred (403) when calling the HeadObject operation: Forbidden"
+                )
+            ),
+        ]
+        validator = BinaryFileValidator(
+            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
+        )
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_run_validations_unexpected_error(self, storage_service_mock: Mock) -> None:
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message=f"WARNING: {BINARY_FILE_VALIDATOR_NAME} throws an unexpected error: An internal error occurred (500)",
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.side_effect = PcpError(
+            Exception("An internal error occurred (500)")
+        )
+        validator = BinaryFileValidator(
+            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
+        )
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(storage_service_mock.file_exists.call_count, 1)


### PR DESCRIPTION
Summary:
Binaries accessibility validator will try accessing all PC binaries using the lightweight `file_exist()` method (which under the hood calls s3 head_object()),

Each file_exist() may return 4 types of response:
1. a boolean value of True: indicate that the file exists
2. a boolean value of False: indicate that the file does not exists,
3. a PcpError with "`An error occurred (403) when calling the HeadObject operation: Forbidden`" message: indicate that the access request was denied due to permission reasons.
4. other unexpected errors

The validator will return Success if and only if all file_exists() requests returns True, return Failed if any request returns False or 403, return Success with Warning if any request returns unexpected error.

Differential Revision: D34951703

