### PR TITLE
add data field quality threshold validation

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -32,6 +32,10 @@ PL_FIELDS: List[str] = [
     VALUE_FIELD,
     EVENT_TIMESTAMP_FIELD,
 ]
+VALUE_FIELDS: List[str] = [
+    VALUE_FIELD,
+    CONVERSION_VALUE_FIELD,
+]
 
 INTEGER_REGEX: Pattern[str] = re.compile(r"^[0-9]+$")
 TIMESTAMP_REGEX: Pattern[str] = re.compile(r"^[0-9]{10}$")
@@ -65,3 +69,13 @@ BINARY_PATHS = [
     "private_attribution/shard-aggregator/latest/shard-aggregator",
     "private_lift/lift/latest/lift",
 ]
+
+DEFAULT_VALID_THRESHOLDS: Dict[str, float] = {
+    ID_FIELD: 0.75,
+    VALUE_FIELD: 0.5,
+    CONVERSION_VALUE_FIELD: 0.5,
+    EVENT_TIMESTAMP_FIELD: 0.9,
+    CONVERSION_TIMESTAMP_FIELD: 0.9,
+    # This field is unused
+    CONVERSION_METADATA_FIELD: 0,
+}

--- a/fbpcs/pc_pre_validation/input_data_validation_issues.py
+++ b/fbpcs/pc_pre_validation/input_data_validation_issues.py
@@ -7,7 +7,7 @@
 
 
 from collections import Counter
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from fbpcs.pc_pre_validation.constants import (
     ID_FIELD,
@@ -22,7 +22,10 @@ from fbpcs.pc_pre_validation.constants import (
 class InputDataValidationIssues:
     def __init__(self) -> None:
         self.empty_counter: Counter[str] = Counter()
+        self.not_empty_counter: Counter[str] = Counter()
         self.format_error_counter: Counter[str] = Counter()
+        self.fields_under_threshold: List[str] = []
+        self.field_thresholds: Dict[str, float] = {}
 
     def get_as_dict(self) -> Dict[str, Any]:
         issues = {}
@@ -42,6 +45,9 @@ class InputDataValidationIssues:
     def count_empty_field(self, field: str) -> None:
         self.empty_counter[field] += 1
 
+    def count_not_empty_field(self, field: str) -> None:
+        self.not_empty_counter[field] += 1
+
     def count_format_error_field(self, field: str) -> None:
         self.format_error_counter[field] += 1
 
@@ -55,3 +61,9 @@ class InputDataValidationIssues:
             field_issues["bad_format"] = format_error_count
         if field_issues:
             issues[field] = field_issues
+
+    def add_field_under_threshold(self, field: str) -> None:
+        self.fields_under_threshold.append(field)
+
+    def set_field_threshold(self, field: str, threshold: float) -> None:
+        self.field_thresholds[field] = threshold

--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -19,17 +19,20 @@ Error handling:
 """
 
 import csv
+import json
 import time
-from typing import Sequence, Optional
+from typing import Dict, List, Sequence, Optional
 
 from fbpcp.service.storage_s3 import S3StorageService
 from fbpcs.pc_pre_validation.constants import (
+    DEFAULT_VALID_THRESHOLDS,
     INPUT_DATA_TMP_FILE_PATH,
     INPUT_DATA_VALIDATOR_NAME,
     PA_FIELDS,
     PL_FIELDS,
     VALID_LINE_ENDING_REGEX,
     VALIDATION_REGEXES,
+    VALUE_FIELDS,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.input_data_validation_issues import (
@@ -57,6 +60,9 @@ class InputDataValidator(Validator):
         self._cloud_provider = cloud_provider
         self._storage_service = S3StorageService(region, access_key_id, access_key_data)
         self._name: str = INPUT_DATA_VALIDATOR_NAME
+        self._valid_thresholds: Dict[str, float] = self._get_valid_thresholds(
+            valid_threshold_override
+        )
 
     @property
     def name(self) -> str:
@@ -68,6 +74,7 @@ class InputDataValidator(Validator):
         return f"{INPUT_DATA_TMP_FILE_PATH}/{filename}-{now}"
 
     def __validate__(self) -> ValidationReport:
+        field_names = []
         rows_processed_count = 0
         validation_issues = InputDataValidationIssues()
         try:
@@ -77,7 +84,7 @@ class InputDataValidator(Validator):
                 csv_reader = csv.DictReader(local_file)
                 field_names = csv_reader.fieldnames or []
                 header_row = ",".join(field_names)
-                self._validate_header(field_names)
+                field_names = self._validate_header(field_names)
 
             with open(self._local_file_path, "rb") as local_file:
                 header_line = local_file.readline().decode("utf-8")
@@ -100,6 +107,31 @@ class InputDataValidator(Validator):
                 validation_issues,
             )
 
+        self._check_validation_thresholds(
+            field_names, validation_issues, rows_processed_count
+        )
+
+        if validation_issues.fields_under_threshold:
+            fields_str = ",".join(validation_issues.fields_under_threshold)
+            validation_thresholds_required = {
+                key: value
+                for key, value in self._valid_thresholds.items()
+                if key in validation_issues.field_thresholds
+            }
+            error_message = "\n".join(
+                [
+                    f"Too many row values for '{fields_str}' are unusable:",
+                    f"Required data quality: {validation_thresholds_required}",
+                    f"Actual data quality: {validation_issues.field_thresholds}",
+                ]
+            )
+            return self._format_validation_report(
+                ValidationResult.FAILED,
+                f"File: {self._input_file_path} failed validation. Error: {error_message}",
+                rows_processed_count,
+                validation_issues,
+            )
+
         return self._format_validation_report(
             ValidationResult.SUCCESS,
             f"File: {self._input_file_path} completed validation successfully",
@@ -115,7 +147,7 @@ class InputDataValidator(Validator):
                 f"Failed to download the input file. Please check the file path and its permission.\n\t{e}"
             )
 
-    def _validate_header(self, header_row: Sequence[str]) -> None:
+    def _validate_header(self, header_row: Sequence[str]) -> List[str]:
         if not header_row:
             raise Exception("The header row was empty.")
 
@@ -126,10 +158,14 @@ class InputDataValidator(Validator):
             PL_FIELDS
         )
 
-        if not (match_pa_fields or match_pl_fields):
-            raise Exception(
-                f"Failed to parse the header row. The header row fields must be either: {PL_FIELDS} or: {PA_FIELDS}"
-            )
+        if match_pa_fields:
+            return PA_FIELDS
+        if match_pl_fields:
+            return PL_FIELDS
+
+        raise Exception(
+            f"Failed to parse the header row. The header row fields must be either: {PL_FIELDS} or: {PA_FIELDS}"
+        )
 
     def _validate_line_ending(self, line: str) -> None:
         if not VALID_LINE_ENDING_REGEX.match(line):
@@ -142,7 +178,10 @@ class InputDataValidator(Validator):
     ) -> None:
         if value.strip() == "":
             validation_issues.count_empty_field(field)
-        elif field in VALIDATION_REGEXES and not VALIDATION_REGEXES[field].match(value):
+            return
+
+        validation_issues.count_not_empty_field(field)
+        if field in VALIDATION_REGEXES and not VALIDATION_REGEXES[field].match(value):
             validation_issues.count_format_error_field(field)
 
     def _format_validation_report(
@@ -156,10 +195,13 @@ class InputDataValidator(Validator):
         validation_errors = validation_issues.get_as_dict()
 
         if validation_errors:
+            some_errors_str = (
+                ", with some errors." if result == ValidationResult.SUCCESS else ""
+            )
             return ValidationReport(
                 validation_result=result,
                 validator_name=INPUT_DATA_VALIDATOR_NAME,
-                message=f"{message}, with some errors.",
+                message=f"{message}{some_errors_str}",
                 details={
                     "rows_processed_count": rows_processed_count,
                     "validation_errors": validation_errors,
@@ -174,3 +216,50 @@ class InputDataValidator(Validator):
                     "rows_processed_count": rows_processed_count,
                 },
             )
+
+    def _get_valid_thresholds(
+        self, threshold_override: Optional[str]
+    ) -> Dict[str, float]:
+        if not threshold_override:
+            return DEFAULT_VALID_THRESHOLDS
+
+        override_thresholds = json.loads(threshold_override)
+        merged = override_thresholds.copy()
+        for field, threshold in DEFAULT_VALID_THRESHOLDS.items():
+            if field not in merged:
+                merged[field] = threshold
+        return merged
+
+    def _check_validation_thresholds(
+        self,
+        field_names: List[str],
+        validation_issues: InputDataValidationIssues,
+        rows_processed_count: int,
+    ) -> None:
+        if rows_processed_count == 0:
+            return
+        for field in field_names:
+            actual_ratio = 1.0
+            empty_count = validation_issues.empty_counter[field]
+            not_empty_count = validation_issues.not_empty_counter[field]
+            format_error_count = validation_issues.format_error_counter[field]
+            is_value_field = field in VALUE_FIELDS
+            if is_value_field and not_empty_count == 0:
+                # Skip if the value is empty for all rows
+                continue
+            if is_value_field:
+                actual_ratio = (not_empty_count - format_error_count) / not_empty_count
+            else:
+                total_issues = format_error_count + empty_count
+                actual_ratio = (
+                    rows_processed_count - total_issues
+                ) / rows_processed_count
+
+            actual_ratio = round(actual_ratio, 2)
+            validation_issues.set_field_threshold(field, actual_ratio)
+            if (
+                field in self._valid_thresholds
+                and self._valid_thresholds[field] > 0.0
+                and actual_ratio < self._valid_thresholds[field]
+            ):
+                validation_issues.add_field_under_threshold(field)


### PR DESCRIPTION
Summary:
The data validation threshold config is now used at the end of the data
validator to determine if a file has enough usable data in it according to the
thresholds. This validation threshold config will default when not specified.

The value field threshold is only applied to the number of rows that are not
empty.

Differential Revision: D34984488

