### PR TITLE
Add symlink for pcf2 into /home/pcs/onedocker/package

### DIFF
--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -88,7 +88,7 @@ USER pcs
 # Link all the binaries into /home/pcs/onedocker/package
 RUN mkdir -p /home/pcs/onedocker/package
 WORKDIR /usr/local/bin
-RUN for b in $(ls attribution* lift* pid* shard* private-id* decoupled*); do ln -s $(pwd)/$b /home/pcs/onedocker/package/$b; done
+RUN for b in $(ls attribution* lift* pid* shard* private-id* decoupled* pcf2*); do ln -s $(pwd)/$b /home/pcs/onedocker/package/$b; done
 
 # Link binaries name to match with onedocker binaries name
 RUN ln -s decoupled_attribution_calculator /home/pcs/onedocker/package/decoupled_attribution


### PR DESCRIPTION
Summary:
PCF2 e2e workflow is failing because this symlink doesn't exist

https://pxl.cl/213Fv

{F713208622}

Differential Revision: D35025637

