### PR TITLE
Unblock PID binaries' release

### DIFF
--- a/promote_scripts/promote_binaries.sh
+++ b/promote_scripts/promote_binaries.sh
@@ -17,14 +17,6 @@ if [ $# -ne 2 ]; then
     exit
 fi
 
-# Remove when PID is ready to be released again
-# Confirm PID binaries will be skipped
-read -rp "Please acknowledge that you are aware PID binaries are skipped by typing 'yes': " yesno
-case $yesno in
-  yes ) ;;
-  * ) printf "'yes' not confirmed, exiting...\n"; exit;;
-esac
-
 # list of the binaries
 binary_names=(
     'private_lift/lift'
@@ -34,9 +26,8 @@ binary_names=(
     'pcf2_attribution'
     'pcf2_aggregation'
     'private_attribution/shard-aggregator'
-    # Uncomment when PID is ready to be released again
-    # 'pid/private-id-client'
-    # 'pid/private-id-server'
+    'pid/private-id-client'
+    'pid/private-id-server'
     # 'pid/private-id-multi-key-client'
     # 'pid/private-id-multi-key-server'
     'data_processing/sharder'


### PR DESCRIPTION
Summary: Per https://fburl.com/kkud7dde, we are unblocking PID binary release as the PR for fixes has landed (see https://fburl.com/musplg06). This diff does an undo of the changes from D33433302.

Differential Revision: D35034258

