### PR TITLE
Require id_ field for the PUBLISHER pc-role

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -32,6 +32,10 @@ PL_FIELDS: List[str] = [
     VALUE_FIELD,
     EVENT_TIMESTAMP_FIELD,
 ]
+VALUE_FIELDS: List[str] = [
+    VALUE_FIELD,
+    CONVERSION_VALUE_FIELD,
+]
 
 INTEGER_REGEX: Pattern[str] = re.compile(r"^[0-9]+$")
 TIMESTAMP_REGEX: Pattern[str] = re.compile(r"^[0-9]{10}$")
@@ -65,3 +69,13 @@ BINARY_PATHS = [
     "private_attribution/shard-aggregator/latest/shard-aggregator",
     "private_lift/lift/latest/lift",
 ]
+
+DEFAULT_VALID_THRESHOLDS: Dict[str, float] = {
+    ID_FIELD: 0.75,
+    VALUE_FIELD: 0.5,
+    CONVERSION_VALUE_FIELD: 0.5,
+    EVENT_TIMESTAMP_FIELD: 0.9,
+    CONVERSION_TIMESTAMP_FIELD: 0.9,
+    # This field is unused
+    CONVERSION_METADATA_FIELD: 0,
+}

--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -36,6 +36,14 @@ VALUE_FIELDS: List[str] = [
     VALUE_FIELD,
     CONVERSION_VALUE_FIELD,
 ]
+ALL_FIELDS: List[str] = [
+    ID_FIELD,
+    CONVERSION_VALUE_FIELD,
+    CONVERSION_TIMESTAMP_FIELD,
+    CONVERSION_METADATA_FIELD,
+    VALUE_FIELD,
+    EVENT_TIMESTAMP_FIELD,
+]
 
 INTEGER_REGEX: Pattern[str] = re.compile(r"^[0-9]+$")
 TIMESTAMP_REGEX: Pattern[str] = re.compile(r"^[0-9]{10}$")

--- a/fbpcs/pc_pre_validation/enums.py
+++ b/fbpcs/pc_pre_validation/enums.py
@@ -11,3 +11,9 @@ from enum import Enum
 class ValidationResult(Enum):
     SUCCESS = "success"
     FAILED = "failed"
+
+
+# T114991551
+class PCRole(Enum):
+    PUBLISHER = "PUBLISHER"
+    PARTNER = "PARTNER"

--- a/fbpcs/pc_pre_validation/input_data_validation_issues.py
+++ b/fbpcs/pc_pre_validation/input_data_validation_issues.py
@@ -7,7 +7,7 @@
 
 
 from collections import Counter
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from fbpcs.pc_pre_validation.constants import (
     ID_FIELD,
@@ -22,7 +22,10 @@ from fbpcs.pc_pre_validation.constants import (
 class InputDataValidationIssues:
     def __init__(self) -> None:
         self.empty_counter: Counter[str] = Counter()
+        self.not_empty_counter: Counter[str] = Counter()
         self.format_error_counter: Counter[str] = Counter()
+        self.fields_under_threshold: List[str] = []
+        self.field_thresholds: Dict[str, float] = {}
 
     def get_as_dict(self) -> Dict[str, Any]:
         issues = {}
@@ -42,6 +45,9 @@ class InputDataValidationIssues:
     def count_empty_field(self, field: str) -> None:
         self.empty_counter[field] += 1
 
+    def count_not_empty_field(self, field: str) -> None:
+        self.not_empty_counter[field] += 1
+
     def count_format_error_field(self, field: str) -> None:
         self.format_error_counter[field] += 1
 
@@ -55,3 +61,9 @@ class InputDataValidationIssues:
             field_issues["bad_format"] = format_error_count
         if field_issues:
             issues[field] = field_issues
+
+    def add_field_under_threshold(self, field: str) -> None:
+        self.fields_under_threshold.append(field)
+
+    def set_field_threshold(self, field: str, threshold: float) -> None:
+        self.field_thresholds[field] = threshold

--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -19,17 +19,20 @@ Error handling:
 """
 
 import csv
+import json
 import time
-from typing import Sequence, Optional
+from typing import Dict, List, Sequence, Optional
 
 from fbpcp.service.storage_s3 import S3StorageService
 from fbpcs.pc_pre_validation.constants import (
+    DEFAULT_VALID_THRESHOLDS,
     INPUT_DATA_TMP_FILE_PATH,
     INPUT_DATA_VALIDATOR_NAME,
     PA_FIELDS,
     PL_FIELDS,
     VALID_LINE_ENDING_REGEX,
     VALIDATION_REGEXES,
+    VALUE_FIELDS,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.input_data_validation_issues import (
@@ -57,6 +60,9 @@ class InputDataValidator(Validator):
         self._cloud_provider = cloud_provider
         self._storage_service = S3StorageService(region, access_key_id, access_key_data)
         self._name: str = INPUT_DATA_VALIDATOR_NAME
+        self._valid_thresholds: Dict[str, float] = self._get_valid_thresholds(
+            valid_threshold_override
+        )
 
     @property
     def name(self) -> str:
@@ -68,6 +74,7 @@ class InputDataValidator(Validator):
         return f"{INPUT_DATA_TMP_FILE_PATH}/{filename}-{now}"
 
     def __validate__(self) -> ValidationReport:
+        field_names = []
         rows_processed_count = 0
         validation_issues = InputDataValidationIssues()
         try:
@@ -77,7 +84,7 @@ class InputDataValidator(Validator):
                 csv_reader = csv.DictReader(local_file)
                 field_names = csv_reader.fieldnames or []
                 header_row = ",".join(field_names)
-                self._validate_header(field_names)
+                field_names = self._validate_header(field_names)
 
             with open(self._local_file_path, "rb") as local_file:
                 header_line = local_file.readline().decode("utf-8")
@@ -100,6 +107,31 @@ class InputDataValidator(Validator):
                 validation_issues,
             )
 
+        self._check_validation_thresholds(
+            field_names, validation_issues, rows_processed_count
+        )
+
+        if validation_issues.fields_under_threshold:
+            fields_str = ",".join(validation_issues.fields_under_threshold)
+            validation_thresholds_required = {
+                key: value
+                for key, value in self._valid_thresholds.items()
+                if key in validation_issues.field_thresholds
+            }
+            error_message = "\n".join(
+                [
+                    f"Too many row values for '{fields_str}' are unusable:",
+                    f"Required data quality: {validation_thresholds_required}",
+                    f"Actual data quality: {validation_issues.field_thresholds}",
+                ]
+            )
+            return self._format_validation_report(
+                ValidationResult.FAILED,
+                f"File: {self._input_file_path} failed validation. Error: {error_message}",
+                rows_processed_count,
+                validation_issues,
+            )
+
         return self._format_validation_report(
             ValidationResult.SUCCESS,
             f"File: {self._input_file_path} completed validation successfully",
@@ -115,7 +147,7 @@ class InputDataValidator(Validator):
                 f"Failed to download the input file. Please check the file path and its permission.\n\t{e}"
             )
 
-    def _validate_header(self, header_row: Sequence[str]) -> None:
+    def _validate_header(self, header_row: Sequence[str]) -> List[str]:
         if not header_row:
             raise Exception("The header row was empty.")
 
@@ -126,10 +158,14 @@ class InputDataValidator(Validator):
             PL_FIELDS
         )
 
-        if not (match_pa_fields or match_pl_fields):
-            raise Exception(
-                f"Failed to parse the header row. The header row fields must be either: {PL_FIELDS} or: {PA_FIELDS}"
-            )
+        if match_pa_fields:
+            return PA_FIELDS
+        if match_pl_fields:
+            return PL_FIELDS
+
+        raise Exception(
+            f"Failed to parse the header row. The header row fields must be either: {PL_FIELDS} or: {PA_FIELDS}"
+        )
 
     def _validate_line_ending(self, line: str) -> None:
         if not VALID_LINE_ENDING_REGEX.match(line):
@@ -142,7 +178,10 @@ class InputDataValidator(Validator):
     ) -> None:
         if value.strip() == "":
             validation_issues.count_empty_field(field)
-        elif field in VALIDATION_REGEXES and not VALIDATION_REGEXES[field].match(value):
+            return
+
+        validation_issues.count_not_empty_field(field)
+        if field in VALIDATION_REGEXES and not VALIDATION_REGEXES[field].match(value):
             validation_issues.count_format_error_field(field)
 
     def _format_validation_report(
@@ -156,10 +195,13 @@ class InputDataValidator(Validator):
         validation_errors = validation_issues.get_as_dict()
 
         if validation_errors:
+            some_errors_str = (
+                ", with some errors." if result == ValidationResult.SUCCESS else ""
+            )
             return ValidationReport(
                 validation_result=result,
                 validator_name=INPUT_DATA_VALIDATOR_NAME,
-                message=f"{message}, with some errors.",
+                message=f"{message}{some_errors_str}",
                 details={
                     "rows_processed_count": rows_processed_count,
                     "validation_errors": validation_errors,
@@ -174,3 +216,50 @@ class InputDataValidator(Validator):
                     "rows_processed_count": rows_processed_count,
                 },
             )
+
+    def _get_valid_thresholds(
+        self, threshold_override: Optional[str]
+    ) -> Dict[str, float]:
+        if not threshold_override:
+            return DEFAULT_VALID_THRESHOLDS
+
+        override_thresholds = json.loads(threshold_override)
+        merged = override_thresholds.copy()
+        for field, threshold in DEFAULT_VALID_THRESHOLDS.items():
+            if field not in merged:
+                merged[field] = threshold
+        return merged
+
+    def _check_validation_thresholds(
+        self,
+        field_names: List[str],
+        validation_issues: InputDataValidationIssues,
+        rows_processed_count: int,
+    ) -> None:
+        if rows_processed_count == 0:
+            return
+        for field in field_names:
+            actual_ratio = 1.0
+            empty_count = validation_issues.empty_counter[field]
+            not_empty_count = validation_issues.not_empty_counter[field]
+            format_error_count = validation_issues.format_error_counter[field]
+            is_value_field = field in VALUE_FIELDS
+            if is_value_field and not_empty_count == 0:
+                # Skip if the value is empty for all rows
+                continue
+            if is_value_field:
+                actual_ratio = (not_empty_count - format_error_count) / not_empty_count
+            else:
+                total_issues = format_error_count + empty_count
+                actual_ratio = (
+                    rows_processed_count - total_issues
+                ) / rows_processed_count
+
+            actual_ratio = round(actual_ratio, 2)
+            validation_issues.set_field_threshold(field, actual_ratio)
+            if (
+                field in self._valid_thresholds
+                and self._valid_thresholds[field] > 0.0
+                and actual_ratio < self._valid_thresholds[field]
+            ):
+                validation_issues.add_field_under_threshold(field)

--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -34,7 +34,7 @@ from fbpcs.pc_pre_validation.constants import (
     VALIDATION_REGEXES,
     VALUE_FIELDS,
 )
-from fbpcs.pc_pre_validation.enums import ValidationResult
+from fbpcs.pc_pre_validation.enums import PCRole, ValidationResult
 from fbpcs.pc_pre_validation.input_data_validation_issues import (
     InputDataValidationIssues,
 )
@@ -49,6 +49,7 @@ class InputDataValidator(Validator):
         input_file_path: str,
         cloud_provider: CloudProvider,
         region: str,
+        pc_role: PCRole,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         start_timestamp: Optional[str] = None,
@@ -58,6 +59,7 @@ class InputDataValidator(Validator):
         self._input_file_path = input_file_path
         self._local_file_path: str = self._get_local_filepath()
         self._cloud_provider = cloud_provider
+        self._pc_role = pc_role
         self._storage_service = S3StorageService(region, access_key_id, access_key_data)
         self._name: str = INPUT_DATA_VALIDATOR_NAME
         self._valid_thresholds: Dict[str, float] = self._get_valid_thresholds(

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -16,6 +16,7 @@ Usage:
         --input-file-path=<input-file-path>
         --cloud-provider=<cloud-provider>
         --region=<region>
+        --pc-role=<pc-role>
         [--access-key-id=<access-key-id>]
         [--access-key-data=<access-key-data>]
         [--start-timestamp=<start-timestamp>]
@@ -24,11 +25,13 @@ Usage:
 """
 
 
+from typing import List
+from typing import Optional as OptionalType
 from typing import cast
 
 from docopt import docopt
 from fbpcs.pc_pre_validation.binary_file_validator import BinaryFileValidator
-from fbpcs.pc_pre_validation.enums import ValidationResult
+from fbpcs.pc_pre_validation.enums import PCRole, ValidationResult
 from fbpcs.pc_pre_validation.input_data_validator import InputDataValidator
 from fbpcs.pc_pre_validation.validator import Validator
 from fbpcs.pc_pre_validation.validators_runner import run_validators
@@ -38,6 +41,7 @@ from schema import Schema, Optional, Or, Use
 INPUT_FILE_PATH = "--input-file-path"
 CLOUD_PROVIDER = "--cloud-provider"
 REGION = "--region"
+PC_ROLE = "--pc-role"
 ACCESS_KEY_ID = "--access-key-id"
 ACCESS_KEY_DATA = "--access-key-data"
 START_TIMESTAMP = "--start-timestamp"
@@ -45,15 +49,17 @@ END_TIMESTAMP = "--end-timestamp"
 VALID_THRESHOLD_OVERRIDE = "--valid-threshold-override"
 
 
-def main() -> None:
+def main(argv: OptionalType[List[str]] = None) -> None:
     optional_string = Or(None, str)
     cloud_provider_from_string = Use(lambda arg: CloudProvider[arg])
+    pc_role_from_string = Use(lambda arg: PCRole[arg])
 
     s = Schema(
         {
             INPUT_FILE_PATH: str,
             CLOUD_PROVIDER: cloud_provider_from_string,
             REGION: str,
+            PC_ROLE: pc_role_from_string,
             Optional(ACCESS_KEY_ID): optional_string,
             Optional(ACCESS_KEY_DATA): optional_string,
             Optional(START_TIMESTAMP): optional_string,
@@ -61,7 +67,7 @@ def main() -> None:
             Optional(VALID_THRESHOLD_OVERRIDE): optional_string,
         }
     )
-    arguments = s.validate(docopt(__doc__))
+    arguments = s.validate(docopt(__doc__, argv))
     assert arguments
     print("Parsed pc_pre_validation_cli arguments")
 
@@ -72,6 +78,7 @@ def main() -> None:
                 arguments[INPUT_FILE_PATH],
                 arguments[CLOUD_PROVIDER],
                 arguments[REGION],
+                arguments[PC_ROLE],
                 arguments[ACCESS_KEY_ID],
                 arguments[ACCESS_KEY_DATA],
             ),

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -75,12 +75,15 @@ def main(argv: OptionalType[List[str]] = None) -> None:
         cast(
             Validator,
             InputDataValidator(
-                arguments[INPUT_FILE_PATH],
-                arguments[CLOUD_PROVIDER],
-                arguments[REGION],
-                arguments[PC_ROLE],
-                arguments[ACCESS_KEY_ID],
-                arguments[ACCESS_KEY_DATA],
+                input_file_path=arguments[INPUT_FILE_PATH],
+                cloud_provider=arguments[CLOUD_PROVIDER],
+                region=arguments[REGION],
+                pc_role=arguments[PC_ROLE],
+                start_timestamp=arguments[START_TIMESTAMP],
+                end_timestamp=arguments[END_TIMESTAMP],
+                valid_threshold_override=arguments[VALID_THRESHOLD_OVERRIDE],
+                access_key_id=arguments[ACCESS_KEY_ID],
+                access_key_data=arguments[ACCESS_KEY_DATA],
             ),
         ),
         cast(

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -27,6 +27,7 @@ from fbpcs.private_computation.entity.cloud_provider import CloudProvider
 
 # Name the file randomly in order to avoid failures when the tests run concurrently
 TEST_FILENAME = f"test-input-data-validation-{random.randint(0, 1000000)}.csv"
+TEST_CLOUD_PROVIDER: CloudProvider = CloudProvider.AWS
 TEST_INPUT_FILE_PATH = f"s3://test-bucket/{TEST_FILENAME}"
 TEST_REGION = "us-west-2"
 TEST_PC_ROLE: PCRole = PCRole.PARTNER
@@ -64,38 +65,35 @@ class TestInputDataValidator(TestCase):
     def test_initializing_the_validation_runner_fields(
         self, mock_storage_service: Mock
     ) -> None:
-        cloud_provider = CloudProvider.AWS
-        pc_role = PCRole.PUBLISHER
         access_key_id = "id1"
         access_key_data = "data2"
-        region = "us-east-2"
         constructed_storage_service = MagicMock()
         mock_storage_service.__init__(return_value=constructed_storage_service)
 
         validator = InputDataValidator(
             TEST_INPUT_FILE_PATH,
-            cloud_provider,
-            region,
-            pc_role,
+            TEST_CLOUD_PROVIDER,
+            TEST_REGION,
+            TEST_PC_ROLE,
             access_key_id,
             access_key_data,
         )
 
-        mock_storage_service.assert_called_with(region, access_key_id, access_key_data)
+        mock_storage_service.assert_called_with(
+            TEST_REGION, access_key_id, access_key_data
+        )
         self.assertEqual(validator._storage_service, constructed_storage_service)
         self.assertEqual(validator._input_file_path, TEST_INPUT_FILE_PATH)
-        self.assertEqual(validator._cloud_provider, cloud_provider)
-        self.assertEqual(validator._pc_role, pc_role)
+        self.assertEqual(validator._cloud_provider, TEST_CLOUD_PROVIDER)
+        self.assertEqual(validator._pc_role, TEST_PC_ROLE)
 
     @patch("fbpcs.pc_pre_validation.input_data_validator.S3StorageService")
     def test_run_validations_copy_failure(self, storage_service_mock: Mock) -> None:
         exception_message = "failed to copy"
-        input_file_path = "s3://test-bucket/data.csv"
-        cloud_provider = CloudProvider.AWS
         expected_report = ValidationReport(
             validation_result=ValidationResult.FAILED,
             validator_name=INPUT_DATA_VALIDATOR_NAME,
-            message=f"File: {input_file_path} failed validation. Error: Failed to download the input file. Please check the file path and its permission.\n\t{exception_message}",
+            message=f"File: {TEST_INPUT_FILE_PATH} failed validation. Error: Failed to download the input file. Please check the file path and its permission.\n\t{exception_message}",
             details={
                 "rows_processed_count": 0,
             },
@@ -104,7 +102,7 @@ class TestInputDataValidator(TestCase):
         storage_service_mock.copy.side_effect = Exception(exception_message)
 
         validator = InputDataValidator(
-            input_file_path, cloud_provider, "us-west-2", TEST_PC_ROLE
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_PC_ROLE
         )
         report = validator.validate()
 
@@ -116,7 +114,6 @@ class TestInputDataValidator(TestCase):
         self, time_mock: Mock, _storage_service_mock: Mock
     ) -> None:
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,value,event_timestamp\n",
             b"abcd/1234+WXYZ=,100,1645157987\n",
@@ -134,7 +131,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_PC_ROLE
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_PC_ROLE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -146,7 +143,6 @@ class TestInputDataValidator(TestCase):
     ) -> None:
         exception_message = f"Failed to parse the header row. The header row fields must be either: {PL_FIELDS} or: {PA_FIELDS}"
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"bad,header,row\n",
             b"1,2,3\n",
@@ -163,7 +159,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_PC_ROLE
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_PC_ROLE
         )
         report = validator.validate()
 
@@ -175,7 +171,6 @@ class TestInputDataValidator(TestCase):
         self, time_mock: Mock, _storage_service_mock: Mock
     ) -> None:
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         expected_report = ValidationReport(
             validation_result=ValidationResult.FAILED,
             validator_name=INPUT_DATA_VALIDATOR_NAME,
@@ -186,7 +181,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_PC_ROLE
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_PC_ROLE
         )
         report = validator.validate()
 
@@ -199,7 +194,6 @@ class TestInputDataValidator(TestCase):
     ) -> None:
         exception_message = "Detected an unexpected line ending. The only supported line ending is '\\n'"
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,value,event_timestamp\n",
             b"abcd/1234+WXYZ=,100,1645157987\r\n",
@@ -216,7 +210,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_PC_ROLE
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_PC_ROLE
         )
         report = validator.validate()
 
@@ -228,7 +222,6 @@ class TestInputDataValidator(TestCase):
         self, time_mock: Mock, _storage_service_mock: Mock
     ) -> None:
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,value,event_timestamp\n",
             b",100,1645157987\n",
@@ -261,7 +254,7 @@ class TestInputDataValidator(TestCase):
 
         validator = InputDataValidator(
             TEST_INPUT_FILE_PATH,
-            cloud_provider,
+            TEST_CLOUD_PROVIDER,
             TEST_REGION,
             TEST_PC_ROLE,
             valid_threshold_override=SKIP_THRESHOLD_VALIDATION_STR,
@@ -276,7 +269,6 @@ class TestInputDataValidator(TestCase):
         self, time_mock: Mock, _storage_service_mock: Mock
     ) -> None:
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,conversion_value,conversion_timestamp,conversion_metadata\n",
             b"abcd/1234+WXYZ=,100,1645157987,\n",
@@ -309,7 +301,7 @@ class TestInputDataValidator(TestCase):
 
         validator = InputDataValidator(
             TEST_INPUT_FILE_PATH,
-            cloud_provider,
+            TEST_CLOUD_PROVIDER,
             TEST_REGION,
             TEST_PC_ROLE,
             valid_threshold_override=SKIP_THRESHOLD_VALIDATION_STR,
@@ -324,7 +316,6 @@ class TestInputDataValidator(TestCase):
         self, time_mock: Mock, _storage_service_mock: Mock
     ) -> None:
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,value,event_timestamp\n",
             b"ab...,100,1645157987\n",
@@ -357,7 +348,7 @@ class TestInputDataValidator(TestCase):
 
         validator = InputDataValidator(
             TEST_INPUT_FILE_PATH,
-            cloud_provider,
+            TEST_CLOUD_PROVIDER,
             TEST_REGION,
             TEST_PC_ROLE,
             valid_threshold_override=SKIP_THRESHOLD_VALIDATION_STR,
@@ -372,7 +363,6 @@ class TestInputDataValidator(TestCase):
         self, time_mock: Mock, _storage_service_mock: Mock
     ) -> None:
         time_mock.time.return_value = TEST_TIMESTAMP
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,conversion_value,conversion_timestamp,conversion_metadata\n",
             b"abcd/1234+WXYZ=,$100,1645157987,\n",
@@ -405,7 +395,7 @@ class TestInputDataValidator(TestCase):
 
         validator = InputDataValidator(
             TEST_INPUT_FILE_PATH,
-            cloud_provider,
+            TEST_CLOUD_PROVIDER,
             TEST_REGION,
             TEST_PC_ROLE,
             valid_threshold_override=SKIP_THRESHOLD_VALIDATION_STR,
@@ -434,7 +424,6 @@ class TestInputDataValidator(TestCase):
                 f"Actual data quality: {expected_actual_thresholds}",
             ]
         )
-        cloud_provider = CloudProvider.AWS
         lines = [
             b"id_,value,event_timestamp\n",
             b"...,100,\n",
@@ -473,7 +462,7 @@ class TestInputDataValidator(TestCase):
 
         validator = InputDataValidator(
             TEST_INPUT_FILE_PATH,
-            cloud_provider,
+            TEST_CLOUD_PROVIDER,
             TEST_REGION,
             TEST_PC_ROLE,
             valid_threshold_override=TEST_THRESHOLD_OVERRIDES_STR,

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -46,15 +46,77 @@ class TestPCPreValidationCLI(TestCase):
         validation_cli.main(argv)
 
         input_data_validator_mock.assert_called_with(
-            expected_input_file_path,
-            expected_cloud_provider,
-            expected_region,
-            expected_pc_role,
-            None,
-            None,
+            input_file_path=expected_input_file_path,
+            cloud_provider=expected_cloud_provider,
+            region=expected_region,
+            pc_role=expected_pc_role,
+            start_timestamp=None,
+            end_timestamp=None,
+            valid_threshold_override=None,
+            access_key_id=None,
+            access_key_data=None,
         )
         binary_file_validator_mock.assert_called_with(
             region=expected_region, access_key_id=None, access_key_data=None
+        )
+        run_validators_mock.assert_called_with(
+            [input_data_validator_mock(), binary_file_validator_mock()]
+        )
+
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.print")
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.InputDataValidator")
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.BinaryFileValidator")
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.run_validators")
+    def test_parsing_all_args(
+        self,
+        run_validators_mock: Mock,
+        binary_file_validator_mock: Mock,
+        input_data_validator_mock: Mock,
+        _print_mock: Mock,
+    ) -> None:
+        aggregated_result = ValidationResult.SUCCESS
+        aggregated_report = "Aggregated report..."
+        run_validators_mock.side_effect = [[aggregated_result, aggregated_report]]
+        expected_input_file_path = "https://test/input-file-path0"
+        cloud_provider_str = "AWS"
+        expected_cloud_provider = CloudProvider.AWS
+        expected_region = "region1"
+        expected_pc_role = PCRole.PARTNER
+        pc_role_str = "PARTNER"
+        expected_start_timestamp = "1600000000"
+        expected_end_timestamp = "1640000000"
+        expected_valid_threshold_override = '{"id_":0.6,"timestamp":0.7,"value":0.2}'
+        expected_access_key_id = "access_key_id2"
+        expected_access_key_data = "access_key_data3"
+        argv = [
+            f"--input-file-path={expected_input_file_path}",
+            f"--cloud-provider={cloud_provider_str}",
+            f"--region={expected_region}",
+            f"--pc-role={pc_role_str}",
+            f"--start-timestamp={expected_start_timestamp}",
+            f"--end-timestamp={expected_end_timestamp}",
+            f"--valid-threshold-override={expected_valid_threshold_override}",
+            f"--access-key-id={expected_access_key_id}",
+            f"--access-key-data={expected_access_key_data}",
+        ]
+
+        validation_cli.main(argv)
+
+        input_data_validator_mock.assert_called_with(
+            input_file_path=expected_input_file_path,
+            cloud_provider=expected_cloud_provider,
+            region=expected_region,
+            pc_role=expected_pc_role,
+            start_timestamp=expected_start_timestamp,
+            end_timestamp=expected_end_timestamp,
+            valid_threshold_override=expected_valid_threshold_override,
+            access_key_id=expected_access_key_id,
+            access_key_data=expected_access_key_data,
+        )
+        binary_file_validator_mock.assert_called_with(
+            region=expected_region,
+            access_key_id=expected_access_key_id,
+            access_key_data=expected_access_key_data,
         )
         run_validators_mock.assert_called_with(
             [input_data_validator_mock(), binary_file_validator_mock()]

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from fbpcs.pc_pre_validation import (
+    pc_pre_validation_cli as validation_cli,
+)
+from fbpcs.pc_pre_validation.enums import PCRole, ValidationResult
+from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+
+
+class TestPCPreValidationCLI(TestCase):
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.print")
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.InputDataValidator")
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.BinaryFileValidator")
+    @patch("fbpcs.pc_pre_validation.pc_pre_validation_cli.run_validators")
+    def test_parsing_required_args(
+        self,
+        run_validators_mock: Mock,
+        binary_file_validator_mock: Mock,
+        input_data_validator_mock: Mock,
+        _print_mock: Mock,
+    ) -> None:
+        aggregated_result = ValidationResult.SUCCESS
+        aggregated_report = "Aggregated report..."
+        run_validators_mock.side_effect = [[aggregated_result, aggregated_report]]
+        expected_input_file_path = "https://test/input-file-path0"
+        cloud_provider_str = "AWS"
+        expected_cloud_provider = CloudProvider.AWS
+        expected_region = "region1"
+        expected_pc_role = PCRole.PARTNER
+        pc_role_str = "PARTNER"
+        argv = [
+            f"--input-file-path={expected_input_file_path}",
+            f"--cloud-provider={cloud_provider_str}",
+            f"--region={expected_region}",
+            f"--pc-role={pc_role_str}",
+        ]
+
+        validation_cli.main(argv)
+
+        input_data_validator_mock.assert_called_with(
+            expected_input_file_path,
+            expected_cloud_provider,
+            expected_region,
+            expected_pc_role,
+            None,
+            None,
+        )
+        binary_file_validator_mock.assert_called_with(
+            region=expected_region, access_key_id=None, access_key_data=None
+        )
+        run_validators_mock.assert_called_with(
+            [input_data_validator_mock(), binary_file_validator_mock()]
+        )


### PR DESCRIPTION
Summary:
When the role is PUBLISHER, the input data validator will require at least the
id_ to be specified. If other known fields are in the CSV header, those fields
will also be validated.

Also sort the output string field in order to avoid non-deterministic test
failures.

Differential Revision: D35039963

