### PR TITLE
modify PID PREPARE to be able to handle multiple columns

### DIFF
--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
@@ -8,6 +8,7 @@
 #include "UnionPIDDataPreparer.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
@@ -33,11 +34,7 @@
 
 namespace measurement::pid {
 
-// The `split` function internally uses RE2 which relies on consuming patterns.
-// This pattern indicates it will get all the non commas in a capture group.
-// The ,? at the end means there may not be a comma in the line at all.
-static const std::string kCommaSplitRegex = "([^,]+),?";
-static const std::string kIdColumnName = "id_";
+static const std::string kIdColumnPrefix = "id_";
 
 template <typename T>
 static std::string vectorToString(const std::vector<T>& vec) {
@@ -53,6 +50,20 @@ static std::string vectorToString(const std::vector<T>& vec) {
   }
   buf << "]";
   return buf.str();
+}
+
+static std::vector<std::string> splitByCharDelimiter(
+    std::string& str,
+    const char& delim) {
+  // Preprocessing step: Remove spaces if any
+  str.erase(std::remove(str.begin(), str.end(), ' '), str.end());
+  std::vector<std::string> tokens;
+  std::stringstream ss(str);
+  std::string token;
+  while (std::getline(ss, token, delim)) {
+    tokens.push_back(token);
+  }
+  return tokens;
 }
 
 std::vector<std::string> UnionPIDDataPreparer::split(
@@ -88,20 +99,35 @@ UnionPIDDataPreparerResults UnionPIDDataPreparer::prepare() const {
   std::string line;
 
   getline(inStream, line);
-  auto header = split(line, kCommaSplitRegex);
-  auto idIter = std::find(header.begin(), header.end(), kIdColumnName);
-  if (idIter == header.end()) {
+  auto header = splitByCharDelimiter(line, ',');
+  // auto header = split(line, kCommaSplitRegex);
+  auto idIter = header.begin();
+  std::vector<std::int64_t> idColumnIndices;
+  std::int64_t idColumnCount = 0;
+
+  // find indices of columns with its column name start with kIdColumnPrefix
+  while (
+      (idIter = std::find_if(idIter, header.end(), [&](std::string const& c) {
+         return c.rfind(kIdColumnPrefix) == 0;
+       })) != header.end()) {
+    idColumnIndices.push_back(std::distance(header.begin(), idIter));
+    idIter++;
+    if (++idColumnCount == maxColumnCnt_) {
+      break;
+    }
+  }
+  if (0 == idColumnCount) {
     // note: it's not *essential* to clean up tmpfile here, but it will
     // pollute our test directory otherwise, which is just somewhat annoying.
     std::remove(tmpFilename.c_str());
-    XLOG(FATAL) << kIdColumnName << " column missing from input header\n"
+    XLOG(FATAL) << kIdColumnPrefix << " column missing from input header\n"
                 << "Header: " << vectorToString(header);
   }
 
-  auto idColumnIdx = std::distance(header.begin(), idIter);
   std::unordered_set<std::string> seenIds;
   while (getline(inStream, line)) {
-    auto cols = split(line, kCommaSplitRegex);
+    auto cols = splitByCharDelimiter(line, ',');
+    // auto cols = split(line, kCommaSplitRegex);
     auto rowSize = cols.size();
     auto headerSize = header.size();
 
@@ -117,10 +143,25 @@ UnionPIDDataPreparerResults UnionPIDDataPreparer::prepare() const {
                   << "Row   : " << vectorToString(cols);
     }
 
-    auto id = cols.at(idColumnIdx);
-    if (seenIds.find(id) == seenIds.end()) {
-      *tmpFile << id << '\n';
-      seenIds.insert(id);
+    std::vector<std::string> ids;
+    for (std::int64_t idColumnIdx : idColumnIndices) {
+      ids.push_back(cols.at(idColumnIdx));
+    }
+    // join all the ids with delimiter ","
+    std::string concatIds = std::accumulate(
+        ids.begin(),
+        ids.end(),
+        std::string(),
+        [&](std::string x, std::string y) {
+          return x.empty() ? y : x + std::string(",") + y;
+        });
+
+    // we simply concatenate id columns to see if the same concatenated ids
+    // appeared before. therefore, if the order of ids is different, we would
+    // not catch duplicates.
+    if (seenIds.find(concatIds) == seenIds.end()) {
+      *tmpFile << concatIds << '\n';
+      seenIds.insert(concatIds);
     } else {
       ++res.duplicateIdCount;
     }

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
@@ -24,11 +24,13 @@ class UnionPIDDataPreparer {
       const std::string& inputPath,
       const std::string& outputPath,
       const std::filesystem::path& tmpDirectory,
+      int64_t maxColumnCnt = 1,
       int64_t logEveryN = 1'000)
       : inputPath_{inputPath},
         outputPath_{outputPath},
         tmpDirectory_{tmpDirectory},
-        logEveryN_{logEveryN} {}
+        logEveryN_{logEveryN},
+        maxColumnCnt_{maxColumnCnt} {}
 
   UnionPIDDataPreparerResults prepare() const;
 
@@ -41,6 +43,7 @@ class UnionPIDDataPreparer {
   std::string outputPath_;
   std::filesystem::path tmpDirectory_;
   int64_t logEveryN_;
+  int64_t maxColumnCnt_;
 };
 
 } // namespace measurement::pid

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
@@ -133,4 +133,20 @@ TEST(UnionPIDDataPreparerTest, RowCountTest) {
   validateRowCounts(rowCountExpected, outpath);
 }
 
+TEST(UnionPIDDataPreparerTest, ColumnCountTest) {
+  std::vector<std::string> lines = {
+      "id_,id_1,id_2,aaa,bbb",
+      "123,456,789,abc,def",
+      "111,,,aaa,bbb",
+      "999,888,,aaa,bbb"};
+  std::string expected{"123,456\n111,\n999,888\n"};
+  std::filesystem::path inpath{tmpnam(nullptr)};
+  std::filesystem::path outpath{tmpnam(nullptr)};
+  writeLinesToFile(inpath, lines);
+
+  UnionPIDDataPreparer preparer{inpath, outpath, "/tmp/", 2};
+  preparer.prepare();
+  validateFileContents(expected, outpath);
+}
+
 } // namespace measurement::pid

--- a/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
@@ -22,6 +22,7 @@ DEFINE_string(
     tmp_directory,
     "/tmp/",
     "Directory where temporary files should be saved before final write");
+DEFINE_int32(max_column_cnt, 1, "Number of columns to write");
 DEFINE_int32(log_every_n, 1'000'000, "How frequently to log updates");
 
 int main(int argc, char** argv) {
@@ -31,7 +32,11 @@ int main(int argc, char** argv) {
 
   std::filesystem::path tmpDirectory{FLAGS_tmp_directory};
   measurement::pid::UnionPIDDataPreparer preparer{
-      FLAGS_input_path, FLAGS_output_path, tmpDirectory, FLAGS_log_every_n};
+      FLAGS_input_path,
+      FLAGS_output_path,
+      tmpDirectory,
+      FLAGS_max_column_cnt,
+      FLAGS_log_every_n};
 
   preparer.prepare();
   return 0;


### PR DESCRIPTION
Summary:
In this diff, we are modifying PID data processing binary, `UnionPIDDataPreparer.` We modified followings.

- added new CLI arg `max_column_cnt` in union_pid_data_preparer
- modified `UnionPIDDataPreparer` to be able to generate multiple id columns that starts with `kIdColumnPrefix = "id_"`
- drop if there is identical combinations of ids with the same order
- added new test called `ColumnCountTest` in `UnionPIDDataPreparerTest` to test if it can take care of multiple columns and if `max_column_cnt` is functioning correctly
- added new split function `splitByCharDelimiter` to be able to allow empty string

The last one would remove regex based splitting. Consultation needed to understand what removal of the regex function would possibly cause.

Differential Revision: D35028654

