### PR TITLE
Migrate the GCP PCE terraform scripts to the fbpcs/infra folder.

### DIFF
--- a/fbpcs/infra/pce/gcp_terraform_template/common/pce/compute.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/pce/compute.tf
@@ -1,0 +1,11 @@
+resource "google_container_cluster" "main" {
+  name             = "onedocker-cluster-${var.name_postfix}"
+  location         = var.gcp_region
+  network          = google_compute_network.main.id
+  subnetwork       = google_compute_subnetwork.subnet.id
+  enable_autopilot = true
+
+  ip_allocation_policy {
+    cluster_secondary_range_name = "pods"
+  }
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/pce/main.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/pce/main.tf
@@ -1,0 +1,9 @@
+provider "google" {
+  credentials = file(var.credential_path)
+  project     = var.project_id
+}
+
+terraform {
+  backend "gcs" {
+  }
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/pce/networking.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/pce/networking.tf
@@ -1,0 +1,34 @@
+resource "google_compute_network" "main" {
+  name                    = "onedocker-vpc-${var.gcp_region}-${var.name_postfix}"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "onedocker-subnet-${var.gcp_region}-${var.name_postfix}"
+  ip_cidr_range = var.subnet_primary_cidr
+  region        = var.gcp_region
+  network       = google_compute_network.main.id
+
+  secondary_ip_range = [
+    {
+      range_name    = "pods"
+      ip_cidr_range = var.subnet_secondary_cidr
+    }
+  ]
+}
+
+# GCP has two implied rules for all networks with lowest priority, one is let any instance send traffic to any destination
+# and the other one is to block any incoming connections.
+# Reference: https://cloud.google.com/vpc/docs/firewalls#default_firewall_rules
+resource "google_compute_firewall" "ingress_rules" {
+  name          = "onedocker-vpc-firewall-ingress-${var.gcp_region}-${var.name_postfix}"
+  network       = google_compute_network.main.id
+  description   = "Creates firewall ingress rule for VPCs"
+  source_ranges = [var.otherparty_subnet_cidr]
+  direction     = "INGRESS"
+  allow {
+    protocol = "tcp"
+    ports    = ["5000-15500"]
+  }
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/pce/output.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/pce/output.tf
@@ -1,0 +1,28 @@
+output "vpc_name" {
+  value       = google_compute_network.main.name
+  description = "The name of the provisioned VPC"
+}
+
+output "vpc_id" {
+  value       = google_compute_network.main.id
+  description = "The id of the provisioned VPC"
+}
+
+output "subnet_primary_cidr" {
+  value       = google_compute_subnetwork.subnet.ip_cidr_range
+  description = "The CIDR block of the provisioned subnet for compute engine"
+}
+
+output "subnet_secondary_cidr" {
+  value       = google_compute_subnetwork.subnet.secondary_ip_range[0].ip_cidr_range
+  description = "The CIDR block of the provisioned subnet for kubernetes engine"
+}
+
+output "subnet_id" {
+  value       = google_compute_subnetwork.subnet.id
+  description = "The id of the subnet associated with the vpc"
+}
+
+output "cluster_name" {
+  value = google_container_cluster.main.name
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/pce/variable.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/pce/variable.tf
@@ -1,0 +1,31 @@
+variable "gcp_region" {
+  description = "region of the gcp resources"
+  default     = "us-west2"
+}
+
+variable "project_id" {
+  description = "an unique identifier for your GCP project"
+}
+
+variable "credential_path" {
+  description = "credential path of GCP service accounts"
+}
+
+variable "name_postfix" {
+  description = "the postfix to append after a resource name"
+}
+
+variable "subnet_primary_cidr" {
+  description = "the primary CIDR block of a subnet"
+  default     = "10.10.0.0/20"
+}
+
+variable "subnet_secondary_cidr" {
+  description = "the secondary CIDR block of a subnet"
+  default     = "10.0.0.0/20"
+}
+
+variable "otherparty_subnet_cidr" {
+  description = "Other party's subnet's secondary CIDR block, it should not overlap with existing subnets' 2nd CIDR"
+  default     = "10.1.0.0/20"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/main.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/main.tf
@@ -1,0 +1,14 @@
+provider "google" {
+  credentials = file(var.credential_path)
+  project     = var.project_id
+}
+
+terraform {
+  backend "gcs" {
+  }
+}
+
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "gke_${var.project_id}_${var.gcp_region}_${var.cluster_name}"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/output.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/output.tf
@@ -1,0 +1,14 @@
+output "gke_service_account" {
+  value       = google_service_account.gke_sa.email
+  description = "The google service account used in GKE"
+}
+
+output "k8s_namespace" {
+  value       = kubernetes_namespace.k8s_ns.metadata[0].name
+  description = "kubernetes namespace"
+}
+
+output "k8s_service_account" {
+  value       = kubernetes_service_account.k8s_sa.metadata[0].name
+  description = "The name of provisioned kubernetes service account"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/variable.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/variable.tf
@@ -1,0 +1,19 @@
+variable "project_id" {
+  description = "an unique identifier for your GCP project"
+}
+
+variable "credential_path" {
+  description = "credential path of GCP service accounts"
+}
+
+variable "name_postfix" {
+  description = "the postfix to append after a resource name"
+}
+
+variable "gcp_region" {
+  description = "the region of the k8s cluster"
+}
+
+variable "cluster_name" {
+  description = "The cluster in the kubernetes context"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/wi.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/wi.tf
@@ -1,0 +1,39 @@
+locals {
+  gke_sa = "onedocker-${var.name_postfix}"
+  k8s_ns = kubernetes_namespace.k8s_ns.metadata[0].name
+  k8s_sa = kubernetes_service_account.k8s_sa.metadata[0].name
+}
+
+resource "google_project_iam_member" "project" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.gke_sa.email}"
+}
+
+resource "google_service_account" "gke_sa" {
+  account_id   = local.gke_sa
+  display_name = local.gke_sa
+  project      = var.project_id
+}
+
+resource "kubernetes_namespace" "k8s_ns" {
+  metadata {
+    name = "onedocker"
+  }
+}
+
+resource "kubernetes_service_account" "k8s_sa" {
+  metadata {
+    name      = "onedocker-k8s-sa"
+    namespace = local.k8s_ns
+    annotations = {
+      "iam.gke.io/gcp-service-account" : google_service_account.gke_sa.email
+    }
+  }
+}
+
+resource "google_service_account_iam_member" "workload_identity_binding" {
+  service_account_id = google_service_account.gke_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${local.k8s_ns}/${local.k8s_sa}]"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/main.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/main.tf
@@ -1,0 +1,9 @@
+provider "google" {
+  credentials = file(var.credential_path)
+  project     = var.project_id
+}
+
+terraform {
+  backend "gcs" {
+  }
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/output.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/output.tf
@@ -1,0 +1,4 @@
+output "vpc_peering_id" {
+  value       = google_compute_network_peering.vpc_peering.id
+  description = "The id of the VPC peering connection"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/variable.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/variable.tf
@@ -1,0 +1,19 @@
+variable "project_id" {
+  description = "an unique identifier for your GCP project"
+}
+
+variable "credential_path" {
+  description = "credential path of GCP service accounts"
+}
+
+variable "name_postfix" {
+  description = "the postfix to append after a resource name"
+}
+
+variable "vpc_id" {
+  description = "The ip of provisioned vpc"
+}
+
+variable "otherparty_vpc_id" {
+  description = "Other party's vpc id"
+}

--- a/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/vpc_peering.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/partner/vpc_peering/vpc_peering.tf
@@ -1,0 +1,5 @@
+resource "google_compute_network_peering" "vpc_peering" {
+  name         = "onedocker-vpc-peering-${var.name_postfix}"
+  network      = var.vpc_id
+  peer_network = var.otherparty_vpc_id
+}


### PR DESCRIPTION
Summary: This commit moves the GCP PCE terraform scripts to the fbpcs/infra folder so that it can be included in the

Differential Revision: D35082150

