### PR TITLE
don't update instance unless the status is STARTED

### DIFF
--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -114,9 +114,11 @@ class PostProcessingStageService(PrivateComputationStageService):
         # if any of the handlers failed, then the status of the post processing instance would have
         # been set to failed. If none of them failed, then that means all of the handlers completed, so
         # we can set the status to completed.
-        if post_processing_instance.status != PostProcessingInstanceStatus.FAILED:
+        if post_processing_instance.status is not PostProcessingInstanceStatus.FAILED:
             post_processing_instance.status = PostProcessingInstanceStatus.COMPLETED
-            pc_instance.status = pc_instance.current_stage.completed_status
+            pc_instance.update_status(
+                pc_instance.current_stage.completed_status, self._logger
+            )
         return pc_instance
 
     async def _run_post_processing_handler(


### PR DESCRIPTION
Summary:
## What

* Change PCS update_instance behavior:
    * if the status is started, update instance
    * otherwise, do not update the instance

* Updated the post_processing_handler status update logic to use the update_status method

## Why

* You only need to update the instance when it is in a STARTED state, since an instance in COMPLETED or FAILED should not change
* Helping prevent issues as seen here: https://fburl.com/yrrozywg
* the update_status method also sets the `end_ts`, which will ensure that we accurately report the runtime of a private computation run

Reviewed By: joe1234wu

Differential Revision: D35087157

