### PR TITLE
Fix a bug in the build-docker script.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -29,8 +29,8 @@ EOF
 FBPCF_DEPENDENCY="emp_games data_processing onedocker"
 AVAILABLE_PACKAGES="emp_games data_processing pce_deployment onedocker"
 PACKAGE=$1
-if [[ ! " $AVAILABLE_PACKAGES " =~ $PACKAGE ]]; then
-   usage
+if [[ ! " $AVAILABLE_PACKAGES " =~ $PACKAGE || -z "$PACKAGE" ]]; then
+  usage
 fi
 shift
 


### PR DESCRIPTION
Summary: There was a bug in the build docker script that would cause it to silently fail when no package was passed in. This fix prints the `usage` string when no package is passed.

Differential Revision: D35114537

