### PR TITLE
gte operator

### DIFF
--- a/fbpcs/kodiak/src/mpc_metric_dtype.rs
+++ b/fbpcs/kodiak/src/mpc_metric_dtype.rs
@@ -107,6 +107,7 @@ impl MPCMetricDType {
 
     impl_comparision_method!(lt, <);
     impl_comparision_method!(lte, <=);
+    impl_comparision_method!(gt, >);
 }
 
 #[cfg(test)]
@@ -221,6 +222,62 @@ mod tests {
             MPCMetricDType::Vec(vec![
                 MPCMetricDType::MPCBool(true),
                 MPCMetricDType::MPCBool(false)
+            ])
+        );
+    }
+
+    #[test]
+    fn gt() {
+        assert_eq!(
+            MPCMetricDType::MPCInt32(1).gt(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt64(1).gt(&MPCMetricDType::MPCInt64(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt32(1).gt(&MPCMetricDType::MPCUInt32(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt64(1).gt(&MPCMetricDType::MPCUInt64(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(1),
+                MPCMetricDType::MPCInt32(2)
+            ])
+            .gt(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(true)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])
+            .gt(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(false)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt32(2).gt(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(true)
             ])
         );
     }

--- a/fbpcs/kodiak/src/mpc_metric_dtype.rs
+++ b/fbpcs/kodiak/src/mpc_metric_dtype.rs
@@ -107,8 +107,6 @@ impl MPCMetricDType {
 
     impl_comparision_method!(lt, <);
     impl_comparision_method!(lte, <=);
-    impl_comparision_method!(gt, <);
-    impl_comparision_method!(gte, <=);
 }
 
 #[cfg(test)]
@@ -166,6 +164,62 @@ mod tests {
             ])),
             MPCMetricDType::Vec(vec![
                 MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(false)
+            ])
+        );
+    }
+
+    #[test]
+    fn lte() {
+        assert_eq!(
+            MPCMetricDType::MPCInt32(1).lte(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt64(1).lte(&MPCMetricDType::MPCInt64(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt32(1).lte(&MPCMetricDType::MPCUInt32(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt64(1).lte(&MPCMetricDType::MPCUInt64(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(1),
+                MPCMetricDType::MPCInt32(2)
+            ])
+            .lte(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(true),
+                MPCMetricDType::MPCBool(false)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])
+            .lte(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(true),
+                MPCMetricDType::MPCBool(true)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt32(2).lte(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(true),
                 MPCMetricDType::MPCBool(false)
             ])
         );

--- a/fbpcs/kodiak/src/mpc_metric_dtype.rs
+++ b/fbpcs/kodiak/src/mpc_metric_dtype.rs
@@ -108,6 +108,7 @@ impl MPCMetricDType {
     impl_comparision_method!(lt, <);
     impl_comparision_method!(lte, <=);
     impl_comparision_method!(gt, >);
+    impl_comparision_method!(gte, >=);
 }
 
 #[cfg(test)]
@@ -277,6 +278,62 @@ mod tests {
             ])),
             MPCMetricDType::Vec(vec![
                 MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(true)
+            ])
+        );
+    }
+
+    #[test]
+    fn gte() {
+        assert_eq!(
+            MPCMetricDType::MPCInt32(1).gte(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt64(1).gte(&MPCMetricDType::MPCInt64(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt32(1).gte(&MPCMetricDType::MPCUInt32(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt64(1).gte(&MPCMetricDType::MPCUInt64(2)),
+            MPCMetricDType::MPCBool(false)
+        );
+
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(1),
+                MPCMetricDType::MPCInt32(2)
+            ])
+            .gte(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(true)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])
+            .gte(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(true),
+                MPCMetricDType::MPCBool(false)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt32(2).gte(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(true),
                 MPCMetricDType::MPCBool(true)
             ])
         );

--- a/fbpcs/kodiak/src/mpc_metric_dtype.rs
+++ b/fbpcs/kodiak/src/mpc_metric_dtype.rs
@@ -104,11 +104,72 @@ impl MPCMetricDType {
     {
         T::try_from(self)
     }
+
+    impl_comparision_method!(lt, <);
+    impl_comparision_method!(lte, <=);
+    impl_comparision_method!(gt, <);
+    impl_comparision_method!(gte, <=);
 }
 
 #[cfg(test)]
 mod tests {
     use crate::mpc_metric_dtype::MPCMetricDType;
+
+    #[test]
+    fn lt() {
+        assert_eq!(
+            MPCMetricDType::MPCInt32(1).lt(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt64(1).lt(&MPCMetricDType::MPCInt64(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt32(1).lt(&MPCMetricDType::MPCUInt32(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+        assert_eq!(
+            MPCMetricDType::MPCUInt64(1).lt(&MPCMetricDType::MPCUInt64(2)),
+            MPCMetricDType::MPCBool(true)
+        );
+
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(1),
+                MPCMetricDType::MPCInt32(2)
+            ])
+            .lt(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(true),
+                MPCMetricDType::MPCBool(false)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])
+            .lt(&MPCMetricDType::MPCInt32(2)),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(true)
+            ])
+        );
+        assert_eq!(
+            MPCMetricDType::MPCInt32(2).lt(&MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCInt32(2),
+                MPCMetricDType::MPCInt32(1)
+            ])),
+            MPCMetricDType::Vec(vec![
+                MPCMetricDType::MPCBool(false),
+                MPCMetricDType::MPCBool(false)
+            ])
+        );
+    }
 
     #[test]
     fn add() {


### PR DESCRIPTION
Summary:
## What

* see title

## Why

* because we want to compare things

## After this diff stack

I will create an mpc! macro for streamlining comparison calling, e.g.

mpc!(a + b)
mpc!(a < b)

instead of
a + b
a.lt(b)

I will also create assignment operators (+= and friends) and bitwise operators (or, and, etc)

Reviewed By: gorel

Differential Revision: D35066360

