### PR TITLE
Create PCSContainerInstance and PCSContainerService

### DIFF
--- a/fbpcs/common/entity/pcs_container_instance.py
+++ b/fbpcs/common/entity/pcs_container_instance.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import Optional
+
+from dataclasses_json import dataclass_json
+from fbpcp.entity.container_instance import ContainerInstance
+
+
+@dataclass_json
+@dataclass
+class PCSContainerInstance(ContainerInstance):
+    log_url: Optional[str] = None
+
+    @classmethod
+    def from_container_instance(
+        cls, container_instance: ContainerInstance, log_url: Optional[str] = None
+    ) -> "PCSContainerInstance":
+        return cls(
+            container_instance.instance_id,
+            container_instance.ip_address,
+            container_instance.status,
+            log_url,
+        )

--- a/fbpcs/common/entity/pcs_mpc_instance.py
+++ b/fbpcs/common/entity/pcs_mpc_instance.py
@@ -6,7 +6,8 @@
 
 # pyre-strict
 
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
 
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.entity.mpc_instance import (
@@ -15,9 +16,20 @@ from fbpcp.entity.mpc_instance import (
     MPCInstanceStatus,
 )
 from fbpcs.common.entity.instance_base import InstanceBase
+from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
 
 
+@dataclass
 class PCSMPCInstance(MPCInstance, InstanceBase):
+    instance_id: str
+    game_name: str
+    mpc_party: MPCParty
+    num_workers: int
+    server_ips: Optional[List[str]]
+    containers: List[Union[PCSContainerInstance, ContainerInstance]]
+    status: MPCInstanceStatus
+    game_args: Optional[List[Dict[str, Any]]]
+
     @classmethod
     def create_instance(
         cls,
@@ -26,7 +38,9 @@ class PCSMPCInstance(MPCInstance, InstanceBase):
         mpc_party: MPCParty,
         num_workers: int,
         server_ips: Optional[List[str]] = None,
-        containers: Optional[List[ContainerInstance]] = None,
+        containers: Optional[
+            List[Union[PCSContainerInstance, ContainerInstance]]
+        ] = None,
         status: MPCInstanceStatus = MPCInstanceStatus.UNKNOWN,
         game_args: Optional[List[Dict[str, Any]]] = None,
     ) -> "PCSMPCInstance":

--- a/fbpcs/common/entity/stage_state_instance.py
+++ b/fbpcs/common/entity/stage_state_instance.py
@@ -9,13 +9,14 @@
 import time
 from dataclasses import field, dataclass
 from enum import Enum
-from typing import Optional, List
+from typing import Optional, List, Union
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.instance_base import InstanceBase
+from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
 
 
 class StageStateInstanceStatus(Enum):
@@ -31,7 +32,9 @@ class StageStateInstance(InstanceBase):
     instance_id: str
     stage_name: str
     status: StageStateInstanceStatus = StageStateInstanceStatus.CREATED
-    containers: List[ContainerInstance] = field(default_factory=list)
+    containers: List[Union[PCSContainerInstance, ContainerInstance]] = field(
+        default_factory=list
+    )
     creation_ts: int = field(default_factory=lambda: int(time.time()))
     end_ts: Optional[int] = None
 

--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional, Dict, List
+
+from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.error.pcp import PcpError
+from fbpcp.service.container import ContainerService
+from fbpcp.service.container_aws import AWSContainerService
+from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
+from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
+
+
+class PCSContainerService(ContainerService):
+    def __init__(self, inner_container_service: ContainerService) -> None:
+        self.inner_container_service: ContainerService = inner_container_service
+        self.log_retriever: Optional[LogRetriever] = None
+        if isinstance(self.inner_container_service, AWSContainerService):
+            self.log_retriever = LogRetriever(CloudProvider.AWS)
+
+    def get_region(
+        self,
+    ) -> str:
+        return self.inner_container_service.get_region()
+
+    def get_cluster(
+        self,
+    ) -> str:
+        return self.inner_container_service.get_cluster()
+
+    def create_instance(
+        self,
+        container_definition: str,
+        cmd: str,
+        env_vars: Optional[Dict[str, str]] = None,
+    ) -> ContainerInstance:
+        instance = self.inner_container_service.create_instance(
+            container_definition, cmd, env_vars
+        )
+        log_url = None
+        if self.log_retriever:
+            log_url = self.log_retriever.get_log_url(instance.instance_id)
+
+        return PCSContainerInstance.from_container_instance(instance, log_url)
+
+    def create_instances(
+        self,
+        container_definition: str,
+        cmds: List[str],
+        env_vars: Optional[Dict[str, str]] = None,
+    ) -> List[ContainerInstance]:
+        return [
+            self.create_instance(container_definition, cmd, env_vars) for cmd in cmds
+        ]
+
+    def get_instance(self, instance_id: str) -> Optional[ContainerInstance]:
+        instance = self.inner_container_service.get_instance(instance_id)
+        if instance is not None:
+            log_url = None
+            if self.log_retriever:
+                log_url = self.log_retriever.get_log_url(instance_id)
+            return PCSContainerInstance.from_container_instance(instance, log_url)
+
+    def get_instances(
+        self, instance_ids: List[str]
+    ) -> List[Optional[ContainerInstance]]:
+        return [self.get_instance(instance_id) for instance_id in instance_ids]
+
+    def cancel_instance(self, instance_id: str) -> None:
+        return self.inner_container_service.cancel_instance(instance_id)
+
+    def cancel_instances(self, instance_ids: List[str]) -> List[Optional[PcpError]]:
+        return self.inner_container_service.cancel_instances(instance_ids)
+
+    def get_current_instances_count(self) -> int:
+        return self.inner_container_service.get_current_instances_count()

--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -8,10 +8,11 @@
 
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcs.common.entity.instance_base import InstanceBase
+from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
 from fbpcs.pid.entity.pid_stages import UnionPIDStage
 
 
@@ -63,9 +64,9 @@ class PIDInstance(InstanceBase):
     data_path: Optional[str] = None
     spine_path: Optional[str] = None
     hmac_key: Optional[str] = None
-    stages_containers: Dict[UnionPIDStage, List[ContainerInstance]] = field(
-        default_factory=dict
-    )
+    stages_containers: Dict[
+        UnionPIDStage, List[Union[PCSContainerInstance, ContainerInstance]]
+    ] = field(default_factory=dict)
     stages_status: Dict[UnionPIDStage, PIDStageStatus] = field(default_factory=dict)
     status: PIDInstanceStatus = PIDInstanceStatus.UNKNOWN
     current_stage: Optional[UnionPIDStage] = None

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -17,6 +17,7 @@ from fbpcp.service.mpc import MPCService
 from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
+from fbpcs.common.service.pcs_container_service import PCSContainerService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_service_config import OneDockerServiceConfig
 from fbpcs.pid.entity.pid_instance import PIDInstance
@@ -325,8 +326,8 @@ def print_log_urls(
         print(f"[{stage}]: {log_url}")
 
 
-def _build_container_service(config: Dict[str, Any]) -> ContainerService:
-    return reflect.get_instance(config, ContainerService)
+def _build_container_service(config: Dict[str, Any]) -> PCSContainerService:
+    return PCSContainerService(reflect.get_instance(config, ContainerService))
 
 
 def _build_storage_service(config: Dict[str, Any]) -> StorageService:


### PR DESCRIPTION
Summary:
1. Create a subclass of ContainerInstance called PCSContainerInstance that also stores the log_url field.
2. Replace ContainerInstance with PCSContainerInstance in dataclass.
3. Create a subclass of ContainerService called PCSContainerService
4. Implement every method for PCSContainerService as required by ContainerService interface

Refer to T114737917 and T114737946 for more details.

Reviewed By: jrodal98

Differential Revision: D35067691

