### PR TITLE
Adding support for test repository in PCS.

### DIFF
--- a/fbpcs/onedocker_binary_config.py
+++ b/fbpcs/onedocker_binary_config.py
@@ -16,3 +16,6 @@ from dataclasses_json import dataclass_json
 class OneDockerBinaryConfig:
     tmp_directory: str
     binary_version: str
+    repository_path: str = (
+        "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/"
+    )

--- a/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
@@ -32,6 +32,7 @@ class TestPIDDispatcher(unittest.TestCase):
         self.onedocker_binary_config = OneDockerBinaryConfig(
             tmp_directory="/tmp/",
             binary_version="latest",
+            repository_path="test_path/",
         )
 
     @patch("fbpcs.pid.repository.pid_instance.PIDInstanceRepository")

--- a/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
@@ -23,6 +23,7 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         self.onedocker_binary_config = OneDockerBinaryConfig(
             tmp_directory="/tmp/",
             binary_version="latest",
+            repository_path="test_path/",
         )
 
     @to_sync

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -79,6 +79,7 @@ class TestPIDShardStage(unittest.TestCase):
             test_onedocker_binary_config = OneDockerBinaryConfig(
                 tmp_directory="/test_tmp_directory/",
                 binary_version="latest",
+                repository_path="test_path/",
             )
             stage = PIDShardStage(
                 stage=UnionPIDStage.PUBLISHER_SHARD,
@@ -187,6 +188,7 @@ class TestPIDShardStage(unittest.TestCase):
                 test_onedocker_binary_config = OneDockerBinaryConfig(
                     tmp_directory="/test_tmp_directory/",
                     binary_version="latest",
+                    repository_path="test_path/",
                 )
                 container = ContainerInstance(
                     instance_id="123",

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -195,6 +195,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
                 server_ips=server_ips,
                 game_args=game_args,
                 container_timeout=self._container_timeout,
+                repository_path=binary_config.repository_path,
             )
         # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
         pc_instance.instances.append(PCSMPCInstance.from_mpc_instance(mpc_instance))

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -116,6 +116,7 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running.")

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -112,6 +112,7 @@ class AggregationStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for decoupled aggregation stage.")

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -110,6 +110,7 @@ class AttributionStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for decoupled attribution.")

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -114,6 +114,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for pcf2.0 based aggregation stage.")

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -111,6 +111,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for pcf2.0 attribution.")

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -59,6 +59,7 @@ async def create_and_start_mpc_instance(
     server_ips: Optional[List[str]] = None,
     game_args: Optional[List[Dict[str, Any]]] = None,
     container_timeout: Optional[int] = None,
+    repository_path: Optional[str] = None,
 ) -> MPCInstance:
     """Creates an MPC instance and runs MPC service with it
 
@@ -72,11 +73,11 @@ async def create_and_start_mpc_instance(
         server_ips: ip addresses of the publisher's containers.
         game_args: arguments that are passed to game binaries by onedocker
         container_timeout: optional duration in seconds before cloud containers timeout
+        repository_path: Path from where we can download the required executable.
 
     Returns:
         return: an mpc instance started by mpc service
     """
-
     mpc_svc.create_instance(
         instance_id=instance_id,
         game_name=game_name,
@@ -85,11 +86,16 @@ async def create_and_start_mpc_instance(
         game_args=game_args,
     )
 
+    env_vars = {}
+    if repository_path:
+        env_vars["ONEDOCKER_REPOSITORY_PATH"] = repository_path
+
     return await mpc_svc.start_instance_async(
         instance_id=instance_id,
         server_ips=server_ips,
         timeout=container_timeout or DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
         version=binary_version,
+        env_vars=env_vars,
     )
 
 

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -36,7 +36,9 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = AggregateShardsStageService(

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -39,7 +39,9 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = ComputeMetricsStageService(

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -38,7 +38,9 @@ class TestAggregationStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = AggregationStageService(

--- a/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
@@ -37,7 +37,9 @@ class TestAttributionStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = AttributionStageService(

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -35,7 +35,9 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = IdSpineCombinerStageService(

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -38,7 +38,9 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = PCF2AggregationStageService(

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -37,7 +37,9 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = PCF2AttributionStageService(

--- a/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
@@ -36,7 +36,9 @@ class TestPrepareDataStageService(IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = PrepareDataStageService(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -118,7 +118,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
 
@@ -618,12 +620,14 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             mock_mpc_svc.create_instance.call_args,
         )
 
+        env_vars = {}
         self.assertEqual(
             call(
                 instance_id=instance_id,
                 server_ips=server_ips,
                 timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
                 version=binary_version,
+                env_vars=env_vars,
             ),
             mock_mpc_svc.start_instance_async.call_args,
         )

--- a/fbpcs/private_computation/test/service/test_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_shard_stage_service.py
@@ -34,9 +34,12 @@ class TestShardStageService(IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
+
         self.stage_svc = ShardStageService(
             self.onedocker_service, self.onedocker_binary_config_map
         )


### PR DESCRIPTION
Summary:
# Context

All the private computation production binaries as stored in a public S3 Repository - one-docker-repository-prod. Due to security concerns as well as not to interfere with with the production code currently run by advertisers, we cannot upload binaries created on unreleased code to this public repo.

This creates a challenge in order to test the binaries with PCS service.
In order to resolve this issue, in this stack I am adding support for running custom binaries through PCS and thus using end to end tests and EP.

For this, I have created a separate private S3 bucket - one-docker-repository-test. We can upload any unreleased code to this buckets as this are private and separate from production route. In this stack of diffs I will be adding support for using one-docker-repository-test through PCS as well as build scripts.

# This Diff
In this diff adding support for one-docker-repository-test in PCS for MPC binaries.

# This Stack
1. Add support for one-docker-repository-test in PCS for MPC binaries.
2. Add support for uploading to one-docker-repository-test in build script.
3. Add support for one-docker-repository-test in PCS for PID binaries.
4. Add option to fbpcs_e2e_runner to use test repository.
5. Add path to EP for custom repository.
6.  (Not a diff but) - Publish documentation/post to detail use of the new functionality, as well as guidelines for developers to use test their custom binaries.

Differential Revision: D35096344

