### PR TITLE
Change the behavior of BitString

### DIFF
--- a/fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h
+++ b/fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cmath>
+#include <stdexcept>
 #include "fbpcs/data_processing/unified_data_process/adapter/Adapter.h"
 
 namespace unified_data_process::adapter {
@@ -70,6 +71,7 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
       }
     }
   }
+
   SecString share0(
       typename SecString::ExtractedString(std::move(share0Plaintext)));
   SecString share1(
@@ -80,9 +82,9 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
                             : std::move(myShare0).getValue();
 
   std::vector<int64_t> rst(intersectionSize, 0);
-  for (size_t i = 0; i < indexWidth; i++) {
-    for (size_t j = 0; j < intersectionSize; j++) {
-      rst[j] += (myShare.at(i).at(j)) << i;
+  for (size_t i = 0; i < intersectionSize; i++) {
+    for (size_t j = 0; j < indexWidth; j++) {
+      rst[i] += (myShare.at(i).at(j)) << j;
     }
   }
   return rst;


### PR DESCRIPTION
Summary:
As title.
Current BitString type have some inconsistent behavior.

For example, when initialized by a batch of `std::vector<bool>`, it is expecting {the vector of first bits in all vecs, the vector of second bits in all vecs...} instead of "the first vector, the second vector". This doesn't agree with other batched types.

This diff changes this behavior to align with other batch types.

Reviewed By: elliottlawrence

Differential Revision: D35122217

