### PR TITLE
Adding support for test repository in PCS for PID games.

### DIFF
--- a/fbpcs/data_processing/pid_preparer/union_pid_preparer_cpp.py
+++ b/fbpcs/data_processing/pid_preparer/union_pid_preparer_cpp.py
@@ -13,7 +13,7 @@ import pathlib
 import subprocess
 import sys
 import tempfile
-from typing import Optional
+from typing import Dict, Optional
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus, ContainerInstance
 from fbpcp.service.onedocker import OneDockerService
@@ -97,6 +97,7 @@ class CppUnionPIDDataPreparerService(UnionPIDDataPreparerService):
         tmp_directory: str = "/tmp/",
         container_timeout: Optional[int] = None,
         wait_for_container: bool = True,
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> ContainerInstance:
         return asyncio.run(
             self.prepare_on_container_async(
@@ -107,6 +108,7 @@ class CppUnionPIDDataPreparerService(UnionPIDDataPreparerService):
                 tmp_directory,
                 container_timeout,
                 wait_for_container,
+                env_vars,
             )
         )
 
@@ -120,6 +122,7 @@ class CppUnionPIDDataPreparerService(UnionPIDDataPreparerService):
         tmp_directory: str = "/tmp/",
         container_timeout: Optional[int] = None,
         wait_for_container: bool = True,
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> ContainerInstance:
         logger = logging.getLogger(__name__)
         timeout = container_timeout or DEFAULT_CONTAINER_TIMEOUT_IN_SEC
@@ -149,6 +152,7 @@ class CppUnionPIDDataPreparerService(UnionPIDDataPreparerService):
                 version=binary_version,
                 cmd_args_list=[cmd_args],
                 timeout=timeout,
+                env_vars=env_vars,
             )
 
             container = (

--- a/fbpcs/onedocker_binary_config.py
+++ b/fbpcs/onedocker_binary_config.py
@@ -16,3 +16,6 @@ from dataclasses_json import dataclass_json
 class OneDockerBinaryConfig:
     tmp_directory: str
     binary_version: str
+    repository_path: str = (
+        "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/"
+    )

--- a/fbpcs/pid/service/pid_service/pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_prepare_stage.py
@@ -75,6 +75,9 @@ class PIDPrepareStage(PIDStage):
         for shard in range(num_shards):
             next_input_path = self.get_sharded_filepath(input_path, shard)
             next_output_path = self.get_sharded_filepath(output_path, shard)
+            env_vars = {
+                "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
+            }
             coro = preparer.prepare_on_container_async(
                 input_path=next_input_path,
                 output_path=next_output_path,
@@ -83,6 +86,7 @@ class PIDPrepareStage(PIDStage):
                 tmp_directory=self.onedocker_binary_config.tmp_directory,
                 wait_for_container=wait_for_containers,
                 container_timeout=container_timeout,
+                env_vars=env_vars,
             )
             coroutines.append(coro)
 

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -262,5 +262,6 @@ class PIDProtocolRunStage(PIDStage):
     def _gen_env_vars(self) -> Dict[str, str]:
         env_vars = {
             "RUST_LOG": "info",
+            "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path,
         }
         return env_vars

--- a/fbpcs/pid/service/pid_service/pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_shard_stage.py
@@ -93,6 +93,9 @@ class PIDShardStage(PIDStage):
                 tmp_directory=self.onedocker_binary_config.tmp_directory,
                 hmac_key=hmac_key,
             )
+            env_vars = {
+                "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
+            }
             binary_name = sharder.get_binary_name(ShardType.HASHED_FOR_PID)
             containers = await sharder.start_containers(
                 cmd_args_list=[args],
@@ -101,6 +104,7 @@ class PIDShardStage(PIDStage):
                 binary_name=binary_name,
                 timeout=container_timeout,
                 wait_for_containers_to_finish=wait_for_containers,
+                env_vars=env_vars,
             )
             container = containers[0]  # there is always just 1 container
         except Exception as e:

--- a/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_dispatcher.py
@@ -32,6 +32,7 @@ class TestPIDDispatcher(unittest.TestCase):
         self.onedocker_binary_config = OneDockerBinaryConfig(
             tmp_directory="/tmp/",
             binary_version="latest",
+            repository_path="test_path/",
         )
 
     @patch("fbpcs.pid.repository.pid_instance.PIDInstanceRepository")

--- a/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_run_protocol_stage.py
@@ -23,6 +23,7 @@ class TestPIDProtocolRunStage(unittest.TestCase):
         self.onedocker_binary_config = OneDockerBinaryConfig(
             tmp_directory="/tmp/",
             binary_version="latest",
+            repository_path="test_path/",
         )
 
     @to_sync

--- a/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/tests/test_pid_shard_stage.py
@@ -79,6 +79,7 @@ class TestPIDShardStage(unittest.TestCase):
             test_onedocker_binary_config = OneDockerBinaryConfig(
                 tmp_directory="/test_tmp_directory/",
                 binary_version="latest",
+                repository_path="test_path/",
             )
             stage = PIDShardStage(
                 stage=UnionPIDStage.PUBLISHER_SHARD,
@@ -187,6 +188,7 @@ class TestPIDShardStage(unittest.TestCase):
                 test_onedocker_binary_config = OneDockerBinaryConfig(
                     tmp_directory="/test_tmp_directory/",
                     binary_version="latest",
+                    repository_path="test_path/",
                 )
                 container = ContainerInstance(
                     instance_id="123",

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -195,6 +195,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
                 server_ips=server_ips,
                 game_args=game_args,
                 container_timeout=self._container_timeout,
+                repository_path=binary_config.repository_path,
             )
         # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
         pc_instance.instances.append(PCSMPCInstance.from_mpc_instance(mpc_instance))

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -116,6 +116,7 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running.")

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -112,6 +112,7 @@ class AggregationStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for decoupled aggregation stage.")

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -110,6 +110,7 @@ class AttributionStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for decoupled attribution.")

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -114,6 +114,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for pcf2.0 based aggregation stage.")

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -111,6 +111,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
         )
 
         logging.info("MPC instance started running for pcf2.0 attribution.")

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -8,7 +8,7 @@
 
 import asyncio
 import logging
-from typing import Optional, List
+from typing import Dict, Optional, List
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.service.onedocker import OneDockerService
@@ -29,6 +29,7 @@ class RunBinaryBaseService:
         binary_name: str,
         timeout: Optional[int] = None,
         wait_for_containers_to_finish: bool = False,
+        env_vars: Optional[Dict[str, str]] = None,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class RunBinaryBaseService:
             version=binary_version,
             cmd_args_list=cmd_args_list,
             timeout=timeout,
+            env_vars=env_vars,
         )
 
         containers = await onedocker_svc.wait_for_pending_containers(

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -262,6 +262,7 @@ async def start_combiner_service(
         padding_size=padding_size,
         log_cost=log_cost,
     )
+    env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
     return await combiner_service.start_containers(
         cmd_args_list=args,
         onedocker_svc=onedocker_svc,
@@ -269,6 +270,7 @@ async def start_combiner_service(
         binary_name=binary_name,
         timeout=None,
         wait_for_containers_to_finish=wait_for_containers,
+        env_vars=env_vars,
     )
 
 
@@ -328,6 +330,7 @@ async def start_sharder_service(
         args_list.append(args_per_shard)
 
     binary_name = sharder.get_binary_name(ShardType.ROUND_ROBIN)
+    env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
     return await sharder.start_containers(
         cmd_args_list=args_list,
         onedocker_svc=onedocker_svc,
@@ -335,6 +338,7 @@ async def start_sharder_service(
         binary_name=binary_name,
         timeout=None,
         wait_for_containers_to_finish=wait_for_containers,
+        env_vars=env_vars,
     )
 
 

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -59,6 +59,7 @@ async def create_and_start_mpc_instance(
     server_ips: Optional[List[str]] = None,
     game_args: Optional[List[Dict[str, Any]]] = None,
     container_timeout: Optional[int] = None,
+    repository_path: Optional[str] = None,
 ) -> MPCInstance:
     """Creates an MPC instance and runs MPC service with it
 
@@ -72,11 +73,11 @@ async def create_and_start_mpc_instance(
         server_ips: ip addresses of the publisher's containers.
         game_args: arguments that are passed to game binaries by onedocker
         container_timeout: optional duration in seconds before cloud containers timeout
+        repository_path: Path from where we can download the required executable.
 
     Returns:
         return: an mpc instance started by mpc service
     """
-
     mpc_svc.create_instance(
         instance_id=instance_id,
         game_name=game_name,
@@ -85,11 +86,16 @@ async def create_and_start_mpc_instance(
         game_args=game_args,
     )
 
+    env_vars = {}
+    if repository_path:
+        env_vars["ONEDOCKER_REPOSITORY_PATH"] = repository_path
+
     return await mpc_svc.start_instance_async(
         instance_id=instance_id,
         server_ips=server_ips,
         timeout=container_timeout or DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
         version=binary_version,
+        env_vars=env_vars,
     )
 
 

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -36,7 +36,9 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = AggregateShardsStageService(

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -39,7 +39,9 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = ComputeMetricsStageService(

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -38,7 +38,9 @@ class TestAggregationStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = AggregationStageService(

--- a/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
@@ -37,7 +37,9 @@ class TestAttributionStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = AttributionStageService(

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -35,7 +35,9 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = IdSpineCombinerStageService(

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -38,7 +38,9 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = PCF2AggregationStageService(

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -37,7 +37,9 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = PCF2AttributionStageService(

--- a/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
@@ -36,7 +36,9 @@ class TestPrepareDataStageService(IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
         self.stage_svc = PrepareDataStageService(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -118,7 +118,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
 
@@ -618,12 +620,14 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             mock_mpc_svc.create_instance.call_args,
         )
 
+        env_vars = {}
         self.assertEqual(
             call(
                 instance_id=instance_id,
                 server_ips=server_ips,
                 timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
                 version=binary_version,
+                env_vars=env_vars,
             ),
             mock_mpc_svc.start_instance_async.call_args,
         )

--- a/fbpcs/private_computation/test/service/test_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_shard_stage_service.py
@@ -34,9 +34,12 @@ class TestShardStageService(IsolatedAsyncioTestCase):
 
         self.onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
-                tmp_directory="/test_tmp_directory/", binary_version="latest"
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
             )
         )
+
         self.stage_svc = ShardStageService(
             self.onedocker_service, self.onedocker_binary_config_map
         )


### PR DESCRIPTION
Summary:
# Context

All the private computation production binaries as stored in a public S3 Repository - one-docker-repository-prod. Due to security concerns as well as not to interfere with with the production code currently run by advertisers, we cannot upload binaries created on unreleased code to this public repo.

This creates a challenge in order to test the binaries with PCS service.
In order to resolve this issue, in this stack I am adding support for running custom binaries through PCS and thus using end to end tests and EP.

For this, I have created a separate private S3 bucket - one-docker-repository-test. We can upload any unreleased code to this buckets as this are private and separate from production route. In this stack of diffs I will be adding support for using one-docker-repository-test through PCS as well as build scripts.

# This Diff
In this diff adding support for one-docker-repository-test in PCS for PID binaries.

# This Stack
1. Add support for one-docker-repository-test in PCS for MPC binaries.
2. Add support for uploading to one-docker-repository-test in build script.
3. Add support for one-docker-repository-test in PCS for PID binaries.
4. Add option to fbpcs_e2e_runner to use test repository.
5. Add path to EP for custom repository.
6.  (Not a diff but) - Publish documentation/post to detail use of the new functionality, as well as guidelines for developers to use test their custom binaries.

Differential Revision: D35137463

