### PR TITLE
Add a new GCP PCE deployment docker image.

### DIFF
--- a/docker/pce_deployment/gcp/Dockerfile.ubuntu
+++ b/docker/pce_deployment/gcp/Dockerfile.ubuntu
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+ARG os_release="latest"
+
+FROM ubuntu:${os_release}
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+##########################################
+# Install packages
+##########################################
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    python3.8 \
+    python3-pip \
+    sudo \
+    apt-transport-https \
+    ca-certificates \
+    gnupg \
+    unzip
+
+##########################################
+# Install gcloud SDK
+##########################################
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.gpg \
+    && apt-get update -y && apt-get install google-cloud-sdk -y
+
+##########################################
+# Install Terraform
+##########################################
+ENV TERRAFORM_VERSION 0.14.9
+
+# Download Terraform, verify checksum, and unzip
+WORKDIR /usr/local/bin
+RUN curl -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip --output terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+  curl -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS --output terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
+  grep terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform_${TERRAFORM_VERSION}_SHA256SUMS | sha256sum -c - && \
+  unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+  rm terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
+  rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+##########################################
+# Copy Terraform scripts
+##########################################
+RUN mkdir /terraform_deployment
+COPY fbpcs/infra/pce/gcp_terraform_template /terraform_deployment/terraform_scripts
+CMD ["/bin/bash"]
+WORKDIR /terraform_deployment
+
+##########################################
+# Set onedocker env variables
+##########################################
+ENV PATH="/terraform_deployment:${PATH}"
+ENV ONEDOCKER_REPOSITORY_PATH="LOCAL"
+ENV ONEDOCKER_EXE_PATH="/terraform_deployment/"


### PR DESCRIPTION
Summary:
Context:
In order to deploy PCEs in GCP, we need a Docker image that includes the Google Cloud SDK. After talking this through with taoyong-ty and zhuang-93, we decided that a new image was the best route for right now. It may be merged with the AWS later down the road.

This Diff:
This diff creates a new docker file that will be used to create a pce deployment image for GCP. It also updates the existing build docker script to support a new flag that tells it to build the gcp image rather than the aws image.

Differential Revision: D35114991

