### PR TITLE
skip binary_file_validation if `ONEDOCKER_REPOSITORY_PATH` is set.

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -78,3 +78,5 @@ BINARY_PATHS = [
     "private_attribution/shard-aggregator/latest/shard-aggregator",
     "private_lift/lift/latest/lift",
 ]
+
+ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"


### PR DESCRIPTION
Summary:
fbpcs-github-cicd e2e tests are failing at the binary-file-validation step, due to missing S3 permission.

fbpcs-github-cicd uses `ghcr.io/facebookresearch/fbpcs/rc/onedocker:rc`, which has all binaries baked in a local path, so s3 permissions are not needed at the first place. For now, we will skip the binary-file-validation.

Follow up items:
1. Add a way to detect the tag(e.g., latest, canary) used in pc cli, and choose the binary locations to check based on the tags.
2. Check local binary: if ONEDOCKER_REPOSITORY_PATH == LOCAL, check binary at ONEDOCKER_EXE_PATH/binary-name.

Differential Revision: D35208409

