### PR TITLE
Adding start and end date to post processing handler.

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -140,6 +140,11 @@ class PrivateComputationInstance(InstanceBase):
     concurrency: int = 1  # used only by MPC compute metrics stage. TODO T102588568: rename to compute_metrics_concurrency
     k_anonymity_threshold: int = 0
 
+    # start and end date of the partner side dataset in current computation run
+    # this fields are specific to private attribution
+    computation_dataset_start_date: Optional[str] = None
+    computation_dataset_end_date: Optional[str] = None
+
     # this field is deprecated
     fail_fast: bool = False
 


### PR DESCRIPTION
Summary:
# PA Reporting
As part of end to end flow of Private Attribution, we need to show the final aggregated results through Ads Insight API (and eventually through Ads Manager UI).
Advertisers should be able to query results for their Ad Id based on custom date ranges as well as Ad Id levels. Furthermore, advertisers should be able to retrieve results for any level of Ad IDs (L0 - L4 - Assuming L0 level Ad Ids were used in computation run).
To achieve, we will be following a short term and a long term approach.
Short term, we will add the functionality on top of our existing ENT + LASER framework to allow Advertisers to query aggregated results for an Ad Object Id with various date and level based queries.
In the Long term (not part of this stack), we will move to MSIS + SABER configuration to provide the same functionality and also ensure long term scalability.

# This Diff
In this diff, adding the dataset start and end date to private computation instance as well as to Post processing handler stage.

This dataset dates, represent the start and end date of the partner dataset. In most of the cases (except some initial pilot use cases), this dates would be same (daily recurrent runs)

# This Stack
1. Add start and end date to computation instance and post processing tier.
2. Add L0 - L4 functionality to dataswarm pipeline.
3. Add support for custom date queries to UMAPI layer.
4. Add validations and error messages to be shown on UMAPI layer.
5. Extend end to end tests for PA to check the laser tier (for short term).
6. Extend EP to test for laser tier.

Differential Revision: D35215775

