### PR TITLE
Updating the OneCommandRunner to reflect the changes and run as per timestamp and not end and start dates

### DIFF
--- a/fbpcs/pl_coordinator/pl_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pl_graphapi_utils.py
@@ -96,18 +96,13 @@ class PLGraphAPIClient:
     def create_pa_instance(
         self,
         dataset_id: str,
-        start_date: str,
-        end_date: str,
+        timestamp: int,
         attribution_rule: str,
         num_containers: int,
-        result_type: str,
     ) -> requests.Response:
         params = self.params.copy()
         params["attribution_rule"] = attribution_rule
-        params["start_date"] = start_date
-        params["end_date"] = end_date
-        params["num_containers"] = num_containers
-        params["result_type"] = result_type
+        params["timestamp"] = timestamp
         r = requests.post(f"{URL}/{dataset_id}/instance", params=params)
         self._check_err(r, "creating fb pa instance")
         return r

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -7,8 +7,10 @@
 
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Type, Optional, Dict, Any
 
+import dateutil.parser
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     PLGraphAPIClient,
 )
@@ -19,6 +21,9 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     AttributionRule,
     AggregationType,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
@@ -42,6 +47,10 @@ INSTANCES = "instances"
 NUM_SHARDS = "num_shards"
 NUM_CONTAINERS = "num_containers"
 
+# instance fields
+TIMESTAMP = "timestamp"
+ATTRIBUTION_RULE = "attribution_rule"
+STATUS = "status"
 
 """
 The input to this function will be the input path, the dataset_id as well as the following params to choose
@@ -57,64 +66,77 @@ def run_attribution(
     config: Dict[str, Any],
     dataset_id: str,
     input_path: str,
-    start_date: str,
-    end_date: str,
+    timestamp: str,
     attribution_rule: AttributionRule,
     aggregation_type: AggregationType,
     concurrency: int,
     num_files_per_mpc_container: int,
     k_anonymity_threshold: int,
-    result_type: str,
     stage_flow: Type[PrivateComputationBaseStageFlow],
     logger: logging.Logger,
     num_tries: Optional[int] = 2,  # this is number of tries per stage
 ) -> None:
 
-    ## Step 1: Validation. Function arguments and  for private lift run.
+    ## Step 1: Validation. Function arguments and  for private attribution run.
     # obtain the values in the dataset info vector.
     client = PLGraphAPIClient(config["graphapi"]["access_token"], logger)
     datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
     datasets = datasets_info[DATASETS_INFORMATION]
     matched_data = {}
-    attribution_rule_str = attribution_rule.value
+    attribution_rule_str = attribution_rule.name
+    attribution_rule_val = attribution_rule.value
+    instance_id = None
+
+    # Validate if input is datetime or timestamp
+    is_date_format = _iso_date_validator(timestamp)
+    if is_date_format:
+        dt = datetime.fromisoformat(timestamp)
+    else:
+        dt = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+    print(dt)
+    return
+
+    dt = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
     # Verify that input has matching dataset info:
-    # a. appropriate date range
-    # b. attribution rule
-    # c. result type
+    # a. attribution rule
+    # b. timestamp
+    if len(datasets) == 0:
+        raise ValueError("Dataset for given parameters and dataset invalid")
     for data in datasets:
-        unmatched_start_date = data["start_date"] != start_date
-        unmatched_end_date = data["end_date"] != end_date
-        unmatched_attribution_rule = data["attribution_rule"] != attribution_rule_str
-        unmatched_result_type = data["result_type"] != result_type
+        if data["key"] == attribution_rule_str:
+            matched_attr = data["value"]
 
-        if (
-            unmatched_start_date
-            or unmatched_end_date
-            or unmatched_result_type
-            or unmatched_attribution_rule
-        ):
-            continue
-        matched_data = data
-        break
-
+    for m_data in matched_attr:
+        m_time = dateutil.parser.parse(m_data[TIMESTAMP])
+        if m_time == dt:
+            matched_data = m_data
+            break
     if len(matched_data) == 0:
         raise ValueError("No dataset matching to the information provided")
 
     # Step 2: Validate what instances need to be created vs what already exist
     dataset_instance_data = _get_existing_pa_instances(client, dataset_id)
     existing_instances = dataset_instance_data["data"]
-    if len(existing_instances) == 0:
+    for inst in existing_instances:
+        inst_time = dateutil.parser.parse(inst[TIMESTAMP])
+        print(inst[STATUS])
+        if (
+            inst[ATTRIBUTION_RULE] == attribution_rule_val
+            and inst_time == dt
+            and inst[STATUS]
+            != PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED
+        ):
+            instance_id = inst["id"]
+            break
+
+    if instance_id is None:
         instance_id = _create_new_instance(
             dataset_id,
-            start_date,
-            end_date,
-            attribution_rule_str,
-            result_type,
+            int(timestamp),
+            attribution_rule_val,
             client,
             logger,
         )
-    else:
-        instance_id = existing_instances[0]["id"]
 
     instance_data = _get_pa_instance_info(client, instance_id, logger)
     num_pid_containers = instance_data[NUM_CONTAINERS]
@@ -143,21 +165,17 @@ def run_attribution(
 
 def _create_new_instance(
     dataset_id: str,
-    start_date: str,
-    end_date: str,
+    timestamp: int,
     attribution_rule: str,
-    result_type: str,
     client: PLGraphAPIClient,
     logger: logging.Logger,
 ) -> str:
     instance_id = json.loads(
         client.create_pa_instance(
             dataset_id,
-            start_date,
-            end_date,
+            timestamp,
             attribution_rule,
             2,
-            result_type,
         ).text
     )["id"]
     logger.info(
@@ -183,6 +201,16 @@ def _get_pa_instance_info(
     client: PLGraphAPIClient, instance_id: str, logger: logging.Logger
 ) -> Any:
     return json.loads(client.get_instance(instance_id).text)
+
+
+def _iso_date_validator(timestamp: str) -> Any:
+    try:
+        datetime.strptime(timestamp, "%Y-%m-%d")
+        return True
+    except Exception:
+        pass
+    else:
+        return False
 
 
 def _get_attribution_dataset_info(

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -25,7 +25,7 @@ Usage:
     pc-cli print_instance <instance_id> --config=<config_file> [options]
     pc-cli print_log_urls <instance_id> --config=<config_file> [options]
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
-    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --start_date=<start_date> --end_date=<end_date> --attribution_rule=<attribution_rule> --result_type=<result_type> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>[options]
+    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path>  --timestamp=<timestamp> --attribution_rule=<attribution_rule>  --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>[options]
 
 
 Options:
@@ -160,9 +160,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             "--num_mpc_containers": schema.Or(None, schema.Use(int)),
             "--aggregation_type": schema.Or(None, schema.Use(AggregationType)),
             "--attribution_rule": schema.Or(None, schema.Use(AttributionRule)),
-            "--result_type": schema.Or(None, str),
-            "--start_date": schema.Or(None, str),
-            "--end_date": schema.Or(None, str),
+            "--timestamp": schema.Or(None, str),
             "--num_files_per_mpc_container": schema.Or(None, schema.Use(int)),
             "--num_shards": schema.Or(None, schema.Use(int)),
             "--num_shards_list": schema.Or(
@@ -308,14 +306,12 @@ def main(argv: Optional[List[str]] = None) -> None:
             config=config,
             dataset_id=arguments["--dataset_id"],
             input_path=arguments["--input_path"],
-            start_date=arguments["--start_date"],
-            end_date=arguments["--end_date"],
+            timestamp=arguments["--timestamp"],
             attribution_rule=arguments["--attribution_rule"],
             aggregation_type=arguments["--aggregation_type"],
             concurrency=arguments["--concurrency"],
             num_files_per_mpc_container=arguments["--num_files_per_mpc_container"],
             k_anonymity_threshold=arguments["--k_anonymity_threshold"],
-            result_type=arguments["--result_type"],
             logger=logger,
             stage_flow=stage_flow,
             num_tries=2,


### PR DESCRIPTION
Summary:
# In this diff:
1. Updated pc-cli to include timestamp as a new argument and removing start_date, end_date and result_type from the cli options
2. Altering the logic that checks for existing instances as well creation of new instances to reflect GraphAPI changes

# Next Steps:
1. Integrating the OneCommand with the E2E testing
2. Integrating with the release process
3. Setting up the API to the newly created 3rd party permission

Reviewed By: yanglu-fb

Differential Revision: D35053574

