### PR TITLE
set binary version

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -140,7 +140,9 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
             return InputDataValidationStageService(
-                args.pc_validator_config, args.onedocker_svc
+                args.pc_validator_config,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
             )
         elif self is self.ID_MATCH:
             return IdMatchStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -139,7 +139,9 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
             return InputDataValidationStageService(
-                args.pc_validator_config, args.onedocker_svc
+                args.pc_validator_config,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
             )
         elif self is self.ID_MATCH:
             return IdMatchStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -141,7 +141,9 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
             return DummyStageService()
         elif self is self.INPUT_DATA_VALIDATION:
             return InputDataValidationStageService(
-                args.pc_validator_config, args.onedocker_svc
+                args.pc_validator_config,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
             )
         elif self is self.PID_SHARD:
             return PIDStageService(


### PR DESCRIPTION
Summary:
## What

* set binary version in input_data_validation stage
* use RunBinaryBaseService instead of calling one docker service directly

## Why

As ajinkya-ghonge pointed out, we aren't setting the binary version for the input data validation stage, which is going to cause a lot of issues during build and release.

Differential Revision: D35271378

