### PR TITLE
default enable the use-row-number in PID for both Partner and Publisher side.

### DIFF
--- a/fbpcs/data_processing/lift_id_combiner/test/LiftIdSpineFileCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/test/LiftIdSpineFileCombinerTest.cpp
@@ -174,21 +174,45 @@ TEST_F(LiftIdSpineFileCombinerTest, ParseFailure) {
 // As this is publisher data the opp_flag flag needs to be created in the
 // program itself
 TEST_F(LiftIdSpineFileCombinerTest, ValidSpinePublisher) {
+  // FLAGS_sort_strategy is "sort" by default
+  // So testing keep_original will require over write it.
+  FLAGS_sort_strategy = "keep_original";
   std::vector<std::string> dataInput = {
       "id_,opportunity_timestamp,test_flag",
       "123,100,1",
       "456,150,0",
       "789,200,0"};
   std::vector<std::string> spineInput = {
-      "AAAA,123", "BBBB,", "CCCC,456", "DDDD,789", "EEEE,", "FFFF,"};
+      "FFFF,", "EEEE,", "DDDD,789", "CCCC,456", "BBBB,", "AAAA,123"};
   std::vector<std::string> expectedOutput = {
       "id_,opportunity_timestamp,opportunity,test_flag",
-      "AAAA,100,1,1",
-      "BBBB,0,0,0",
-      "CCCC,150,1,0",
-      "DDDD,200,1,0",
+      "FFFF,0,0,0",
       "EEEE,0,0,0",
-      "FFFF,0,0,0"};
+      "DDDD,200,1,0",
+      "CCCC,150,1,0",
+      "BBBB,0,0,0",
+      "AAAA,100,1,1"};
+  runTest(dataInput, spineInput, expectedOutput);
+}
+
+TEST_F(LiftIdSpineFileCombinerTest, ValidSortedSpinePublisher) {
+  std::vector<std::string> dataInput = {
+      "id_,opportunity_timestamp,test_flag",
+      "aaa,100,1",
+      "bbb,150,0",
+      "ccc,200,0"};
+  std::vector<std::string> spineInput = {
+      "1,aaa", "2,", "3,bbb", "10,ccc", "100,", "123,"};
+  // We tread id_ column as a string
+  // so the sort will based on lexicographical order.
+  std::vector<std::string> expectedOutput = {
+      "id_,opportunity_timestamp,opportunity,test_flag",
+      "1,100,1,1",
+      "10,200,1,0",
+      "100,0,0,0",
+      "123,0,0,0",
+      "2,0,0,0",
+      "3,150,1,0"};
   runTest(dataInput, spineInput, expectedOutput);
 }
 
@@ -203,12 +227,14 @@ TEST_F(LiftIdSpineFileCombinerTest, ValidSpinePartner) {
       "222,375,300",
       "333,400,400"};
   std::vector<std::string> spineInput = {
-      "AAAA,123", "BBBB,111", "CCCC,", "DDDD,", "EEEE,222", "FFFF,333"};
+      "1,123", "2,", "10,111", "DDDD,", "EEEE,222", "FFFF,333"};
+  // We tread id_ column as a string
+  // so the sort will based on lexicographical order.
   std::vector<std::string> expectedOutput = {
       "id_,event_timestamps,values",
-      "AAAA,[0,0,0,125],[0,0,0,100]",
-      "BBBB,[0,0,0,200],[0,0,0,200]",
-      "CCCC,[0,0,0,0],[0,0,0,0]",
+      "1,[0,0,0,125],[0,0,0,100]",
+      "10,[0,0,0,200],[0,0,0,200]",
+      "2,[0,0,0,0],[0,0,0,0]",
       "DDDD,[0,0,0,0],[0,0,0,0]",
       "EEEE,[0,0,0,375],[0,0,0,300]",
       "FFFF,[0,0,0,400],[0,0,0,400]"};

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -154,7 +154,7 @@ class PrivateComputationInstance(InstanceBase):
 
     # this is used by Private ID protocol to indicate whether we should
     # enable 'use-row-numbers' argument.
-    pid_use_row_numbers: bool = False
+    pid_use_row_numbers: bool = True
 
     creation_ts: int = 0
     end_ts: int = 0

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -134,7 +134,7 @@ class PrivateComputationService:
         stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
         result_visibility: ResultVisibility = ResultVisibility.PUBLIC,
         tier: Optional[str] = None,
-        pid_use_row_numbers: bool = False,
+        pid_use_row_numbers: bool = True,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 


### PR DESCRIPTION
Summary:
## Why
- We are replacing the Private ID to row ID in the output of PID matching stage
- Previously we only add the support for Partner side. But in reality, we need to enable row-id for both partner and publisher side. Otherwise, the order of data processing output data is not the same, which leads to entire Private Lift produce incorrect output.

## What changes
- In this diff we set use-row-number to True by default. This will replace **all** private ID into row ID for **all** Private Computation.

Reviewed By: rajprateek, anthonyzhang25

Differential Revision: D35119323

