### PR TITLE
Adding Github e2e test to adopt new stages changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -143,9 +143,20 @@ jobs:
           ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
         working-directory: ./fbpcs/tests/github/
 
-      - name: Lift - Prepare Compute Input
+      - name: Lift - Prepare Compute Input - Id Spine combine
         run: |
-          ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} prepare_compute_input
+          ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} id_spine_combiner
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Check Status
+        timeout-minutes: 5
+        run: |
+          ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Lift - Prepare Compute Input - ReSharding
+        run: |
+          ./lift_run_stages.sh ${{ env.PL_CONTAINER_NAME }} reshard
         working-directory: ./fbpcs/tests/github/
 
       - name: Check Status
@@ -235,9 +246,20 @@ jobs:
           ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
         working-directory: ./fbpcs/tests/github/
 
-      - name: Attribution - Prepare Compute Input
+      - name: Attribution - Prepare Compute Input - Id Spine combine
         run: |
-          ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} prepare_compute_input
+          ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} id_spine_combiner
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Check Status
+        timeout-minutes: 5
+        run: |
+          ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Attribution - Prepare Compute Input - ReSharding
+        run: |
+          ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} reshard
         working-directory: ./fbpcs/tests/github/
 
       - name: Check Status

--- a/fbpcs/tests/github/attribution_run_stages.sh
+++ b/fbpcs/tests/github/attribution_run_stages.sh
@@ -4,7 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Usage:Run attribution different stages: create_instance, id_match, prepare_compute_input, compute_attribution, aggregate_shards
+# Usage:Run attribution different stages: create_instance, id_match, id_spine_combiner, reshard, compute_attribution, aggregate_shards
+# Note: Each run_next call will get the next stage from stage flow order
+# the latest stage flow order please refer to : fbcode/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
 
 set -e
 
@@ -46,7 +48,7 @@ case "$stage" in
             --aggregation_type="$ATTRIBUTION_TYPE"
             ;;
     # Stages without passing IP addresses
-    prepare_compute_input | pid_metric_export | data_validation )
+    id_spine_combiner | reshard | pid_metric_export | data_validation )
         echo "Attribution Publisher $stage starts"
         $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"

--- a/fbpcs/tests/github/lift_run_stages.sh
+++ b/fbpcs/tests/github/lift_run_stages.sh
@@ -4,7 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Usage: Run Lift different stages: create_instance, id_match, prepare_compute_input, compute_metrics, aggregate_shards
+# Usage: Run Lift different stages: create_instance, id_match, id_spine_combiner, reshard, compute_metrics, aggregate_shards
+# Note: Each run_next call will get the next stage from stage flow order
+# the latest stage flow order please refer to : fbcode/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
 
 set -e
 
@@ -40,7 +42,7 @@ case "$stage" in
             --concurrency="$LIFT_CONCURRENCY"
             ;;
     # stages donot need IP exchange
-    prepare_compute_input | pid_shard | pid_prepare | pid_metric_export | data_validation )
+    id_spine_combiner | reshard | pid_shard | pid_prepare | pid_metric_export | data_validation )
         echo "Lift Publisher $stage starts"
         $docker_command run_next "$LIFT_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"


### PR DESCRIPTION
Summary:
Adding Github e2e test to adopt new stages changes
## why
we had another Diff D35189656 (https://github.com/facebookresearch/fbpcs/commit/0df30e189506c743abe61d4d0471c70dd96554f7) series removed prepare_data stage from lift/attribution games, this Diff is to update github action e2e test to align with latest flow in OneDocer image build action.

Differential Revision: D35297683

