### PR TITLE
Add container_definition validation in OneDocker Service

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -79,3 +79,8 @@ class PCSContainerService(ContainerService):
 
     def get_current_instances_count(self) -> int:
         return self.inner_container_service.get_current_instances_count()
+
+    def validate_container_definition(self, container_definition: str) -> None:
+        return self.inner_container_service.validate_container_definition(
+            container_definition
+        )


### PR DESCRIPTION
Summary: We want to check if user uses the wrong format of container_definition in OneDocker. The correct format for container_definition should be *<task definition name>:<revision>#<container name>*. This diff adds such validation and provide some informative logs to users.

Reviewed By: zhuang-93

Differential Revision: D35237834

