### PR TITLE
add _get_exe_folder() method for local binaries support

### DIFF
--- a/fbpcs/pc_pre_validation/binary_file_validator.py
+++ b/fbpcs/pc_pre_validation/binary_file_validator.py
@@ -13,9 +13,11 @@ from fbpcs.pc_pre_validation.binary_path import BinaryInfo, S3BinaryPath
 from fbpcs.pc_pre_validation.constants import (
     DEFAULT_BINARY_REPOSITORY,
     DEFAULT_BINARY_VERSION,
+    DEFAULT_EXE_FOLDER,
     BINARY_INFOS,
     BINARY_FILE_VALIDATOR_NAME,
     ONEDOCKER_REPOSITORY_PATH,
+    ONEDOCKER_EXE_PATH,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.validation_report import ValidationReport
@@ -36,6 +38,7 @@ class BinaryFileValidator(Validator):
         self._binary_infos = binary_infos
         self._binary_version: str = binary_version or DEFAULT_BINARY_VERSION
         self._repo_path: str = self._get_repo_path()
+        self._exe_folder: str = self._get_exe_folder()
 
     @property
     def name(self) -> str:
@@ -59,6 +62,15 @@ class BinaryFileValidator(Validator):
         """
         repo_path = os.getenv(ONEDOCKER_REPOSITORY_PATH)
         return repo_path or DEFAULT_BINARY_REPOSITORY
+
+    def _get_exe_folder(self) -> str:
+        """Get the folder of local binaries
+
+        Returns:
+            Return ONEDOCKER_EXE_PATH variable if set, return DEFAULT_EXE_FOLDER otherwise.
+        """
+        exe_folder = os.getenv(ONEDOCKER_EXE_PATH)
+        return exe_folder or DEFAULT_EXE_FOLDER
 
     def _validate_local_binaries(self) -> Dict[str, str]:
         """Validate the existence of local binaries

--- a/fbpcs/pc_pre_validation/binary_path.py
+++ b/fbpcs/pc_pre_validation/binary_path.py
@@ -38,3 +38,16 @@ class S3BinaryPath(BinaryPath):
 
     def _stringify(self) -> str:
         return f"{self.repo_path}{self.package}/{self.version}/{self.binary}"
+
+
+class LocalBinaryPath(BinaryPath):
+    def __init__(
+        self,
+        exe_folder: str,
+        binary_info: BinaryInfo,
+    ) -> None:
+        self.exe_folder: str = exe_folder
+        self.binary: str = binary_info.binary or binary_info.package.rsplit("/")[-1]
+
+    def _stringify(self) -> str:
+        return f"{self.exe_folder}{self.binary}"

--- a/fbpcs/pc_pre_validation/binary_path.py
+++ b/fbpcs/pc_pre_validation/binary_path.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import abc
+from dataclasses import dataclass
+from typing import Optional
+
+
+class BinaryPath(abc.ABC):
+    def __str__(self) -> str:
+        return self._stringify()
+
+    @abc.abstractmethod
+    def _stringify(self) -> str:
+        pass
+
+
+@dataclass
+class BinaryInfo:
+    package: str
+    binary: Optional[str] = None
+
+
+class S3BinaryPath(BinaryPath):
+    def __init__(
+        self,
+        repo_path: str,
+        binary_info: BinaryInfo,
+        version: str,
+    ) -> None:
+        self.repo_path: str = repo_path
+        self.package: str = binary_info.package
+        self.binary: str = binary_info.binary or binary_info.package.rsplit("/")[-1]
+        self.version = version
+
+    def _stringify(self) -> str:
+        return f"{self.repo_path}{self.package}/{self.version}/{self.binary}"

--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -9,6 +9,8 @@
 import re
 from typing import Dict, List, Pattern
 
+from fbpcs.pc_pre_validation.binary_path import BinaryInfo
+
 INPUT_DATA_VALIDATOR_NAME = "Input Data Validator"
 BINARY_FILE_VALIDATOR_NAME = "Binary File Validator"
 
@@ -61,22 +63,23 @@ VALIDATION_REGEXES: Dict[str, Pattern[str]] = {
 
 VALID_LINE_ENDING_REGEX: Pattern[str] = re.compile(r".*(\S|\S\n)$")
 
-BINARY_REPOSITORY = "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com"
-BINARY_PATHS = [
-    "data_processing/attribution_id_combiner/latest/attribution_id_combiner",
-    "data_processing/lift_id_combiner/latest/lift_id_combiner",
-    "data_processing/pid_preparer/latest/pid_preparer",
-    "data_processing/sharder_hashed_for_pid/latest/sharder_hashed_for_pid",
-    "pid/private-id-client/latest/cross-psi-client",
-    "pid/private-id-client/latest/cross-psi-xor-client",
-    "pid/private-id-client/latest/private-id-client",
-    "pid/private-id-server/latest/cross-psi-server",
-    "pid/private-id-server/latest/cross-psi-xor-server",
-    "pid/private-id-server/latest/private-id-server",
-    "private_attribution/compute/latest/compute",
-    "private_attribution/decoupled_aggregation/latest/decoupled_aggregation",
-    "private_attribution/shard-aggregator/latest/shard-aggregator",
-    "private_lift/lift/latest/lift",
+DEFAULT_BINARY_REPOSITORY = (
+    "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/"
+)
+DEFAULT_BINARY_VERSION = "latest"
+BINARY_INFOS: List[BinaryInfo] = [
+    BinaryInfo("data_processing/attribution_id_combiner"),
+    BinaryInfo("data_processing/lift_id_combiner"),
+    BinaryInfo("data_processing/pid_preparer"),
+    BinaryInfo("data_processing/sharder"),
+    BinaryInfo("data_processing/sharder_hashed_for_pid"),
+    BinaryInfo("pcf2_aggregation", "pcf2_aggregation"),
+    BinaryInfo("pcf2_attribution", "pcf2_attribution"),
+    BinaryInfo("pid/private-id-client"),
+    BinaryInfo("pid/private-id-server"),
+    BinaryInfo("private_attribution/decoupled_aggregation"),
+    BinaryInfo("private_attribution/decoupled_attribution"),
+    BinaryInfo("private_attribution/shard-aggregator"),
+    BinaryInfo("private_lift/lift"),
 ]
-
 ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"

--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -67,6 +67,7 @@ DEFAULT_BINARY_REPOSITORY = (
     "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/"
 )
 DEFAULT_BINARY_VERSION = "latest"
+DEFAULT_EXE_FOLDER = "/root/onedocker/package/"
 BINARY_INFOS: List[BinaryInfo] = [
     BinaryInfo("data_processing/attribution_id_combiner"),
     BinaryInfo("data_processing/lift_id_combiner"),
@@ -83,3 +84,4 @@ BINARY_INFOS: List[BinaryInfo] = [
     BinaryInfo("private_lift/lift"),
 ]
 ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"
+ONEDOCKER_EXE_PATH = "ONEDOCKER_EXE_PATH"

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -20,6 +20,7 @@ Usage:
         [--access-key-data=<access-key-data>]
         [--start-timestamp=<start-timestamp>]
         [--end-timestamp=<end-timestamp>]
+        [--binary-version=<binary-version>]
 """
 
 
@@ -43,6 +44,7 @@ ACCESS_KEY_ID = "--access-key-id"
 ACCESS_KEY_DATA = "--access-key-data"
 START_TIMESTAMP = "--start-timestamp"
 END_TIMESTAMP = "--end-timestamp"
+BINARY_VERSION = "--binary-version"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -58,6 +60,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(ACCESS_KEY_DATA): optional_string,
             Optional(START_TIMESTAMP): optional_string,
             Optional(END_TIMESTAMP): optional_string,
+            Optional(BINARY_VERSION): optional_string,
         }
     )
     arguments = s.validate(docopt(__doc__, argv))
@@ -83,6 +86,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 region=arguments[REGION],
                 access_key_id=arguments[ACCESS_KEY_ID],
                 access_key_data=arguments[ACCESS_KEY_DATA],
+                binary_version=arguments[BINARY_VERSION],
             ),
         ),
     ]

--- a/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
@@ -15,7 +15,9 @@ from fbpcs.pc_pre_validation.constants import (
     BINARY_FILE_VALIDATOR_NAME,
     DEFAULT_BINARY_REPOSITORY,
     DEFAULT_BINARY_VERSION,
+    DEFAULT_EXE_FOLDER,
     ONEDOCKER_REPOSITORY_PATH,
+    ONEDOCKER_EXE_PATH,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.validation_report import ValidationReport
@@ -207,3 +209,14 @@ class TestBinaryFileValidator(TestCase):
     def test_get_binary_repo_non_default(self, storage_service_mock: Mock) -> None:
         validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         self.assertEqual("non-default", validator._get_repo_path())
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_get_exe_folder_default(self, storage_service_mock: Mock) -> None:
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        self.assertEqual(DEFAULT_EXE_FOLDER, validator._get_exe_folder())
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    @patch.dict(os.environ, {ONEDOCKER_EXE_PATH: "/non-default/folder/"}, clear=True)
+    def test_get_exe_folder_non_default(self, storage_service_mock: Mock) -> None:
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        self.assertEqual("/non-default/folder/", validator._get_exe_folder())

--- a/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
@@ -6,17 +6,26 @@
 # pyre-strict
 import os
 from unittest import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import patch, call, Mock
 
 from fbpcp.error.pcp import PcpError
 from fbpcs.pc_pre_validation.binary_file_validator import BinaryFileValidator
-from fbpcs.pc_pre_validation.constants import BINARY_FILE_VALIDATOR_NAME
+from fbpcs.pc_pre_validation.binary_path import BinaryInfo
+from fbpcs.pc_pre_validation.constants import (
+    BINARY_FILE_VALIDATOR_NAME,
+    DEFAULT_BINARY_REPOSITORY,
+    DEFAULT_BINARY_VERSION,
+    ONEDOCKER_REPOSITORY_PATH,
+)
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.validation_report import ValidationReport
 
 TEST_REGION = "us-west-2"
-TEST_BINARY_REPO = "https://test.s3.us-west-2.amazonaws.com"
-TEST_BINARY_PATHS = ["path/to/binary/1", "path/to_binary_2", "path/to_binary_3"]
+TEST_BINARY_INFOS = [
+    BinaryInfo("package/1"),
+    BinaryInfo("package/2"),
+    BinaryInfo("package/3", "binary"),
+]
 
 
 class TestBinaryFileValidator(TestCase):
@@ -25,19 +34,24 @@ class TestBinaryFileValidator(TestCase):
         expected_report = ValidationReport(
             validation_result=ValidationResult.SUCCESS,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="Completed binary accessibility validation successfuly",
+            message=f"Completed binary accessibility validation successfully (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {DEFAULT_BINARY_VERSION}).",
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.file_exists.return_value = True
 
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(
-            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
+        )
+        storage_service_mock.file_exists.assert_has_calls(
+            [
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/1/latest/1"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/2/latest/2"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/3/latest/binary"),
+            ]
         )
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
@@ -45,22 +59,20 @@ class TestBinaryFileValidator(TestCase):
         expected_report = ValidationReport(
             validation_result=ValidationResult.FAILED,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+            message=f"You don't have permission to access some private computation software (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {DEFAULT_BINARY_VERSION}). Please contact your representative at Meta",
             details={
-                f"{TEST_BINARY_REPO}/{TEST_BINARY_PATHS[0]}": "binary does not exist"
+                f"{DEFAULT_BINARY_REPOSITORY}package/1/latest/1": "binary does not exist"
             },
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.file_exists.side_effect = [False, True, True]
 
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(
-            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
         )
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
@@ -70,9 +82,9 @@ class TestBinaryFileValidator(TestCase):
         expected_report = ValidationReport(
             validation_result=ValidationResult.FAILED,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+            message=f"You don't have permission to access some private computation software (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {DEFAULT_BINARY_VERSION}). Please contact your representative at Meta",
             details={
-                f"{TEST_BINARY_REPO}/{TEST_BINARY_PATHS[2]}": "An error occurred (403) when calling the HeadObject operation: Forbidden"
+                f"{DEFAULT_BINARY_REPOSITORY}package/3/latest/binary": "An error occurred (403) when calling the HeadObject operation: Forbidden"
             },
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
@@ -85,14 +97,12 @@ class TestBinaryFileValidator(TestCase):
                 )
             ),
         ]
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(
-            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
         )
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
@@ -106,31 +116,94 @@ class TestBinaryFileValidator(TestCase):
         storage_service_mock.file_exists.side_effect = PcpError(
             Exception("An internal error occurred (500)")
         )
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(storage_service_mock.file_exists.call_count, 1)
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
-    @patch.dict(os.environ, {"ONEDOCKER_REPOSITORY_PATH": "LOCAL"}, clear=True)
-    def test_run_validations_skip_validation_if_repo_envvar_is_set(
+    @patch.dict(os.environ, {ONEDOCKER_REPOSITORY_PATH: "LOCAL"}, clear=True)
+    def test_run_validations_if_repo_envvar_is_local(
         self, storage_service_mock: Mock
     ) -> None:
         expected_report = ValidationReport(
             validation_result=ValidationResult.SUCCESS,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="Completed binary accessibility validation successfuly",
+            message="Completed binary accessibility validation successfully (Repo path: LOCAL, software_version: latest).",
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.file_exists.return_value = True
 
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(storage_service_mock.file_exists.call_count, 0)
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    @patch.dict(
+        os.environ, {ONEDOCKER_REPOSITORY_PATH: "https://test-repo.com/"}, clear=True
+    )
+    def test_run_validations_non_default_repo(self, storage_service_mock: Mock) -> None:
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message=f"Completed binary accessibility validation successfully (Repo path: https://test-repo.com/, software_version: {DEFAULT_BINARY_VERSION}).",
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.return_value = True
+
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
+        )
+        storage_service_mock.file_exists.assert_has_calls(
+            [
+                call("https://test-repo.com/package/1/latest/1"),
+                call("https://test-repo.com/package/2/latest/2"),
+                call("https://test-repo.com/package/3/latest/binary"),
+            ]
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_run_validations_non_default_version_tag(
+        self, storage_service_mock: Mock
+    ) -> None:
+        binary_version = "canary"
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message=f"Completed binary accessibility validation successfully (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {binary_version}).",
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.return_value = True
+
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS, binary_version)
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
+        )
+        storage_service_mock.file_exists.assert_has_calls(
+            [
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/1/canary/1"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/2/canary/2"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/3/canary/binary"),
+            ]
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_get_binary_repo_default(self, storage_service_mock: Mock) -> None:
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        self.assertEqual(DEFAULT_BINARY_REPOSITORY, validator._get_repo_path())
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    @patch.dict(os.environ, {ONEDOCKER_REPOSITORY_PATH: "non-default"}, clear=True)
+    def test_get_binary_repo_non_default(self, storage_service_mock: Mock) -> None:
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        self.assertEqual("non-default", validator._get_repo_path())

--- a/fbpcs/pc_pre_validation/tests/binary_path_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_path_test.py
@@ -5,9 +5,14 @@
 
 from unittest import TestCase
 
-from fbpcs.pc_pre_validation.binary_path import BinaryInfo, S3BinaryPath
+from fbpcs.pc_pre_validation.binary_path import (
+    LocalBinaryPath,
+    BinaryInfo,
+    S3BinaryPath,
+)
 
 TEST_REPO = "https://test-bucket.us-west-2.amazonaws.com/"
+TEST_EXEC_FOLDER = "/root/test-path/"
 
 
 class TestBinaryPath(TestCase):
@@ -19,9 +24,9 @@ class TestBinaryPath(TestCase):
                 "expected": f"{TEST_REPO}data_processing/attribution_id_combiner/latest/attribution_id_combiner",
             },
             {
-                "binary_info": BinaryInfo("pid/private-id-client", "cross-psi-client"),
+                "binary_info": BinaryInfo("pcf2_aggregation", "pcf2_aggregation"),
                 "version": "latest",
-                "expected": f"{TEST_REPO}pid/private-id-client/latest/cross-psi-client",
+                "expected": f"{TEST_REPO}pcf2_aggregation/latest/pcf2_aggregation",
             },
             {
                 "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
@@ -34,3 +39,24 @@ class TestBinaryPath(TestCase):
             # pyre-ignore
             s3_path = S3BinaryPath(TEST_REPO, case["binary_info"], case["version"])
             self.assertEquals(case["expected"], str(s3_path))
+
+    def test_local_package_path(self) -> None:
+        test_cases = [
+            {
+                "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
+                "expected": f"{TEST_EXEC_FOLDER}attribution_id_combiner",
+            },
+            {
+                "binary_info": BinaryInfo("pcf2_aggregation", "pcf2_aggregation"),
+                "expected": f"{TEST_EXEC_FOLDER}pcf2_aggregation",
+            },
+            {
+                "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
+                "expected": f"{TEST_EXEC_FOLDER}attribution_id_combiner",
+            },
+        ]
+
+        for case in test_cases:
+            # pyre-ignore
+            local_path = LocalBinaryPath(TEST_EXEC_FOLDER, case["binary_info"])
+            self.assertEquals(case["expected"], str(local_path))

--- a/fbpcs/pc_pre_validation/tests/binary_path_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_path_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import TestCase
+
+from fbpcs.pc_pre_validation.binary_path import BinaryInfo, S3BinaryPath
+
+TEST_REPO = "https://test-bucket.us-west-2.amazonaws.com/"
+
+
+class TestBinaryPath(TestCase):
+    def test_s3_package_path(self) -> None:
+        test_cases = [
+            {
+                "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
+                "version": "latest",
+                "expected": f"{TEST_REPO}data_processing/attribution_id_combiner/latest/attribution_id_combiner",
+            },
+            {
+                "binary_info": BinaryInfo("pid/private-id-client", "cross-psi-client"),
+                "version": "latest",
+                "expected": f"{TEST_REPO}pid/private-id-client/latest/cross-psi-client",
+            },
+            {
+                "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
+                "version": "canary",
+                "expected": f"{TEST_REPO}data_processing/attribution_id_combiner/canary/attribution_id_combiner",
+            },
+        ]
+
+        for case in test_cases:
+            # pyre-ignore
+            s3_path = S3BinaryPath(TEST_REPO, case["binary_info"], case["version"])
+            self.assertEquals(case["expected"], str(s3_path))

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -52,7 +52,10 @@ class TestPCPreValidationCLI(TestCase):
             access_key_data=None,
         )
         binary_file_validator_mock.assert_called_with(
-            region=expected_region, access_key_id=None, access_key_data=None
+            region=expected_region,
+            access_key_id=None,
+            access_key_data=None,
+            binary_version=None,
         )
         run_validators_mock.assert_called_with(
             [input_data_validator_mock(), binary_file_validator_mock()]
@@ -80,6 +83,7 @@ class TestPCPreValidationCLI(TestCase):
         expected_end_timestamp = "1640000000"
         expected_access_key_id = "access_key_id2"
         expected_access_key_data = "access_key_data3"
+        expected_binary_version = "binary_version"
         argv = [
             f"--input-file-path={expected_input_file_path}",
             f"--cloud-provider={cloud_provider_str}",
@@ -88,6 +92,7 @@ class TestPCPreValidationCLI(TestCase):
             f"--end-timestamp={expected_end_timestamp}",
             f"--access-key-id={expected_access_key_id}",
             f"--access-key-data={expected_access_key_data}",
+            f"--binary-version={expected_binary_version}",
         ]
 
         validation_cli.main(argv)
@@ -105,6 +110,7 @@ class TestPCPreValidationCLI(TestCase):
             region=expected_region,
             access_key_id=expected_access_key_id,
             access_key_data=expected_access_key_data,
+            binary_version=expected_binary_version,
         )
         run_validators_mock.assert_called_with(
             [input_data_validator_mock(), binary_file_validator_mock()]

--- a/fbpcs/private_computation/service/input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/service/input_data_validation_stage_service.py
@@ -86,16 +86,18 @@ class InputDataValidationStageService(PrivateComputationStageService):
         self, pc_instance: PrivateComputationInstance
     ) -> None:
         region = self._pc_validator_config.region
+        binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
+        binary_config = self._onedocker_binary_config_map[binary_name]
+
         cmd_args = " ".join(
             [
                 f"--input-file-path={pc_instance.input_path}",
                 "--cloud-provider=AWS",
                 f"--region={region}",
+                # pc_pre_validation assumes all other binaries runs on the same version tag as its own
+                f"--binary-version={binary_config.binary_version}",
             ]
         )
-
-        binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
-        binary_config = self._onedocker_binary_config_map[binary_name]
 
         container_instances = await RunBinaryBaseService().start_containers(
             [cmd_args],

--- a/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
@@ -74,6 +74,7 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
                 f"--input-file-path={self._pc_instance.input_path}",
                 "--cloud-provider=AWS",
                 f"--region={region}",
+                "--binary-version=latest",
             ]
         )
         pc_validator_config = PCValidatorConfig(


### PR DESCRIPTION
Summary: This is an API needed for validating local binaries.

Differential Revision: D35326956

