### PR TITLE
improve binary-validator to check non-default S3 repo path

### DIFF
--- a/fbpcs/pc_pre_validation/binary_path.py
+++ b/fbpcs/pc_pre_validation/binary_path.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import abc
+from dataclasses import dataclass
+from typing import Optional
+
+
+class BinaryPath(abc.ABC):
+    def __str__(self) -> str:
+        return self._stringify()
+
+    @abc.abstractmethod
+    def _stringify(self) -> str:
+        pass
+
+
+@dataclass
+class BinaryInfo:
+    package: str
+    binary: Optional[str] = None
+
+
+class S3BinaryPath(BinaryPath):
+    def __init__(
+        self,
+        repo_path: str,
+        binary_info: BinaryInfo,
+        version: str,
+    ) -> None:
+        self.repo_path: str = repo_path
+        self.package: str = binary_info.package
+        self.binary: str = binary_info.binary or binary_info.package.rsplit("/")[-1]
+        self.version = version
+
+    def _stringify(self) -> str:
+        return f"{self.repo_path}{self.package}/{self.version}/{self.binary}"

--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -9,6 +9,8 @@
 import re
 from typing import Dict, List, Pattern
 
+from fbpcs.pc_pre_validation.binary_path import BinaryInfo
+
 INPUT_DATA_VALIDATOR_NAME = "Input Data Validator"
 BINARY_FILE_VALIDATOR_NAME = "Binary File Validator"
 
@@ -61,22 +63,23 @@ VALIDATION_REGEXES: Dict[str, Pattern[str]] = {
 
 VALID_LINE_ENDING_REGEX: Pattern[str] = re.compile(r".*(\S|\S\n)$")
 
-BINARY_REPOSITORY = "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com"
-BINARY_PATHS = [
-    "data_processing/attribution_id_combiner/latest/attribution_id_combiner",
-    "data_processing/lift_id_combiner/latest/lift_id_combiner",
-    "data_processing/pid_preparer/latest/pid_preparer",
-    "data_processing/sharder_hashed_for_pid/latest/sharder_hashed_for_pid",
-    "pid/private-id-client/latest/cross-psi-client",
-    "pid/private-id-client/latest/cross-psi-xor-client",
-    "pid/private-id-client/latest/private-id-client",
-    "pid/private-id-server/latest/cross-psi-server",
-    "pid/private-id-server/latest/cross-psi-xor-server",
-    "pid/private-id-server/latest/private-id-server",
-    "private_attribution/compute/latest/compute",
-    "private_attribution/decoupled_aggregation/latest/decoupled_aggregation",
-    "private_attribution/shard-aggregator/latest/shard-aggregator",
-    "private_lift/lift/latest/lift",
+DEFAULT_BINARY_REPOSITORY = (
+    "https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/"
+)
+DEFAULT_BINARY_VERSION = "latest"
+BINARY_INFOS: List[BinaryInfo] = [
+    BinaryInfo("data_processing/attribution_id_combiner"),
+    BinaryInfo("data_processing/lift_id_combiner"),
+    BinaryInfo("data_processing/pid_preparer"),
+    BinaryInfo("data_processing/sharder"),
+    BinaryInfo("data_processing/sharder_hashed_for_pid"),
+    BinaryInfo("pcf2_aggregation", "pcf2_aggregation"),
+    BinaryInfo("pcf2_attribution", "pcf2_attribution"),
+    BinaryInfo("pid/private-id-client"),
+    BinaryInfo("pid/private-id-server"),
+    BinaryInfo("private_attribution/decoupled_aggregation"),
+    BinaryInfo("private_attribution/decoupled_attribution"),
+    BinaryInfo("private_attribution/shard-aggregator"),
+    BinaryInfo("private_lift/lift"),
 ]
-
 ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"

--- a/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
@@ -6,17 +6,26 @@
 # pyre-strict
 import os
 from unittest import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import patch, call, Mock
 
 from fbpcp.error.pcp import PcpError
 from fbpcs.pc_pre_validation.binary_file_validator import BinaryFileValidator
-from fbpcs.pc_pre_validation.constants import BINARY_FILE_VALIDATOR_NAME
+from fbpcs.pc_pre_validation.binary_path import BinaryInfo
+from fbpcs.pc_pre_validation.constants import (
+    BINARY_FILE_VALIDATOR_NAME,
+    DEFAULT_BINARY_REPOSITORY,
+    DEFAULT_BINARY_VERSION,
+    ONEDOCKER_REPOSITORY_PATH,
+)
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.validation_report import ValidationReport
 
 TEST_REGION = "us-west-2"
-TEST_BINARY_REPO = "https://test.s3.us-west-2.amazonaws.com"
-TEST_BINARY_PATHS = ["path/to/binary/1", "path/to_binary_2", "path/to_binary_3"]
+TEST_BINARY_INFOS = [
+    BinaryInfo("package/1"),
+    BinaryInfo("package/2"),
+    BinaryInfo("package/3", "binary"),
+]
 
 
 class TestBinaryFileValidator(TestCase):
@@ -25,19 +34,24 @@ class TestBinaryFileValidator(TestCase):
         expected_report = ValidationReport(
             validation_result=ValidationResult.SUCCESS,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="Completed binary accessibility validation successfuly",
+            message=f"Completed binary accessibility validation successfully (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {DEFAULT_BINARY_VERSION}).",
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.file_exists.return_value = True
 
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(
-            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
+        )
+        storage_service_mock.file_exists.assert_has_calls(
+            [
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/1/latest/1"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/2/latest/2"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/3/latest/binary"),
+            ]
         )
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
@@ -45,22 +59,20 @@ class TestBinaryFileValidator(TestCase):
         expected_report = ValidationReport(
             validation_result=ValidationResult.FAILED,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+            message=f"You don't have permission to access some private computation software (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {DEFAULT_BINARY_VERSION}). Please contact your representative at Meta",
             details={
-                f"{TEST_BINARY_REPO}/{TEST_BINARY_PATHS[0]}": "binary does not exist"
+                f"{DEFAULT_BINARY_REPOSITORY}package/1/latest/1": "binary does not exist"
             },
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.file_exists.side_effect = [False, True, True]
 
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(
-            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
         )
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
@@ -70,9 +82,9 @@ class TestBinaryFileValidator(TestCase):
         expected_report = ValidationReport(
             validation_result=ValidationResult.FAILED,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="You don't have permission to access some private computation softwares. Please contact your representative at Meta",
+            message=f"You don't have permission to access some private computation software (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {DEFAULT_BINARY_VERSION}). Please contact your representative at Meta",
             details={
-                f"{TEST_BINARY_REPO}/{TEST_BINARY_PATHS[2]}": "An error occurred (403) when calling the HeadObject operation: Forbidden"
+                f"{DEFAULT_BINARY_REPOSITORY}package/3/latest/binary": "An error occurred (403) when calling the HeadObject operation: Forbidden"
             },
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
@@ -85,14 +97,12 @@ class TestBinaryFileValidator(TestCase):
                 )
             ),
         ]
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(
-            storage_service_mock.file_exists.call_count, len(TEST_BINARY_PATHS)
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
         )
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
@@ -106,31 +116,94 @@ class TestBinaryFileValidator(TestCase):
         storage_service_mock.file_exists.side_effect = PcpError(
             Exception("An internal error occurred (500)")
         )
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(storage_service_mock.file_exists.call_count, 1)
 
     @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
-    @patch.dict(os.environ, {"ONEDOCKER_REPOSITORY_PATH": "LOCAL"}, clear=True)
-    def test_run_validations_skip_validation_if_repo_envvar_is_set(
+    @patch.dict(os.environ, {ONEDOCKER_REPOSITORY_PATH: "LOCAL"}, clear=True)
+    def test_run_validations_if_repo_envvar_is_local(
         self, storage_service_mock: Mock
     ) -> None:
         expected_report = ValidationReport(
             validation_result=ValidationResult.SUCCESS,
             validator_name=BINARY_FILE_VALIDATOR_NAME,
-            message="Completed binary accessibility validation successfuly",
+            message="Completed binary accessibility validation successfully (Repo path: LOCAL, software_version: latest).",
         )
         storage_service_mock.__init__(return_value=storage_service_mock)
         storage_service_mock.file_exists.return_value = True
 
-        validator = BinaryFileValidator(
-            TEST_REGION, TEST_BINARY_REPO, TEST_BINARY_PATHS
-        )
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
         report = validator.validate()
 
         self.assertEqual(report, expected_report)
         self.assertEqual(storage_service_mock.file_exists.call_count, 0)
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    @patch.dict(
+        os.environ, {ONEDOCKER_REPOSITORY_PATH: "https://test-repo.com/"}, clear=True
+    )
+    def test_run_validations_non_default_repo(self, storage_service_mock: Mock) -> None:
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message=f"Completed binary accessibility validation successfully (Repo path: https://test-repo.com/, software_version: {DEFAULT_BINARY_VERSION}).",
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.return_value = True
+
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
+        )
+        storage_service_mock.file_exists.assert_has_calls(
+            [
+                call("https://test-repo.com/package/1/latest/1"),
+                call("https://test-repo.com/package/2/latest/2"),
+                call("https://test-repo.com/package/3/latest/binary"),
+            ]
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_run_validations_non_default_version_tag(
+        self, storage_service_mock: Mock
+    ) -> None:
+        binary_version = "canary"
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.SUCCESS,
+            validator_name=BINARY_FILE_VALIDATOR_NAME,
+            message=f"Completed binary accessibility validation successfully (Repo path: {DEFAULT_BINARY_REPOSITORY}, software_version: {binary_version}).",
+        )
+        storage_service_mock.__init__(return_value=storage_service_mock)
+        storage_service_mock.file_exists.return_value = True
+
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS, binary_version)
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+        self.assertEqual(
+            storage_service_mock.file_exists.call_count, len(TEST_BINARY_INFOS)
+        )
+        storage_service_mock.file_exists.assert_has_calls(
+            [
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/1/canary/1"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/2/canary/2"),
+                call(f"{DEFAULT_BINARY_REPOSITORY}package/3/canary/binary"),
+            ]
+        )
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    def test_get_binary_repo_default(self, storage_service_mock: Mock) -> None:
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        self.assertEqual(DEFAULT_BINARY_REPOSITORY, validator._get_repo_path())
+
+    @patch("fbpcs.pc_pre_validation.binary_file_validator.S3StorageService")
+    @patch.dict(os.environ, {ONEDOCKER_REPOSITORY_PATH: "non-default"}, clear=True)
+    def test_get_binary_repo_non_default(self, storage_service_mock: Mock) -> None:
+        validator = BinaryFileValidator(TEST_REGION, TEST_BINARY_INFOS)
+        self.assertEqual("non-default", validator._get_repo_path())

--- a/fbpcs/pc_pre_validation/tests/binary_path_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_path_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import TestCase
+
+from fbpcs.pc_pre_validation.binary_path import BinaryInfo, S3BinaryPath
+
+TEST_REPO = "https://test-bucket.us-west-2.amazonaws.com/"
+
+
+class TestBinaryPath(TestCase):
+    def test_s3_package_path(self) -> None:
+        test_cases = [
+            {
+                "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
+                "version": "latest",
+                "expected": f"{TEST_REPO}data_processing/attribution_id_combiner/latest/attribution_id_combiner",
+            },
+            {
+                "binary_info": BinaryInfo("pid/private-id-client", "cross-psi-client"),
+                "version": "latest",
+                "expected": f"{TEST_REPO}pid/private-id-client/latest/cross-psi-client",
+            },
+            {
+                "binary_info": BinaryInfo("data_processing/attribution_id_combiner"),
+                "version": "canary",
+                "expected": f"{TEST_REPO}data_processing/attribution_id_combiner/canary/attribution_id_combiner",
+            },
+        ]
+
+        for case in test_cases:
+            # pyre-ignore
+            s3_path = S3BinaryPath(TEST_REPO, case["binary_info"], case["version"])
+            self.assertEquals(case["expected"], str(s3_path))


### PR DESCRIPTION
Summary:
1. improve binary-validator to check non-default S3 repo path.
2. split the __validator__ method into smaller methods.
3. add unit tests for the new methods

Differential Revision: D35299688

