### PR TITLE
Updating fbpcs and identity code with update Bit OR method

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/Aggregator_impl.h
+++ b/fbpcs/emp_games/pcf2_aggregation/Aggregator_impl.h
@@ -136,7 +136,7 @@ class MeasurementAggregator : public Aggregator<schedulerId> {
         auto isAttributed = !hasAttributedTouchpoint &
             attributionResults.at(atIndex).isAttributed;
 
-        hasAttributedTouchpoint = hasAttributedTouchpoint || isAttributed;
+        hasAttributedTouchpoint = hasAttributedTouchpoint | isAttributed;
 
         attributedAdId =
             attributedAdId.mux(isAttributed, privateTpmArray.at(tpIndex).adId);

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -258,7 +258,7 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
 
       auto isAttributed = isTouchpointAttributable & !hasAttributedTouchpoint;
 
-      hasAttributedTouchpoint = isAttributed || hasAttributedTouchpoint;
+      hasAttributedTouchpoint = isAttributed | hasAttributedTouchpoint;
 
       if constexpr (usingBatch) {
         OMNISCIENT_ONLY_XLOGF(

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
@@ -231,7 +231,7 @@ inline const AttributionRule<schedulerId, usingBatch, inputEncryption>
           auto touchWithinOneDay = conv.ts <= thresholds.at(0);
           auto clickWithinTwentyEightDays = conv.ts <= thresholds.at(1);
 
-          return validConv & (touchWithinOneDay || clickWithinTwentyEightDays);
+          return validConv & (touchWithinOneDay | clickWithinTwentyEightDays);
         },
         /* computeThresholdsPlaintext */
         [](const Touchpoint<usingBatch>& tp)
@@ -428,7 +428,7 @@ inline const AttributionRule<schedulerId, usingBatch, inputEncryption>
           auto touchWithinOneDay = conv.ts <= thresholds.at(2);
 
           return validConv &
-              ((clickAfterOneDay & clickWithinSevenDays) || touchWithinOneDay);
+              ((clickAfterOneDay & clickWithinSevenDays) | touchWithinOneDay);
         },
         /* computeThresholdsPlaintext */
         [](const Touchpoint<usingBatch>& tp)

--- a/fbpcs/kodiak/src/ffi.cpp
+++ b/fbpcs/kodiak/src/ffi.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<CppMPCBool> mpc_bool_and(
 std::unique_ptr<CppMPCBool> mpc_bool_or(
     const CppMPCBool& a,
     const CppMPCBool& b) {
-  return std::make_unique<CppMPCBool>(a || b);
+  return std::make_unique<CppMPCBool>(a | b);
 }
 std::unique_ptr<CppMPCBool> mpc_bool_xor(
     const CppMPCBool& a,


### PR DESCRIPTION
Summary:
A method was incorrectly implemented, in the name, with logic operator || instead of the bit operator |. This diff corrects that.
It's related to https://www.internalfb.com/diff/D35271995

Reviewed By: RuiyuZhu

Differential Revision: D35329189

