### PR TITLE
Add deployment scripts to the GCP PCE Deployment dockerfile

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -97,5 +97,6 @@ for P in $PACKAGE; do
     --build-arg os_release="${OS_RELEASE}" \
     --build-arg fbpcf_image="${FBPCF_IMAGE}" \
     --compress \
+    --platform linux/amd64 \
     -t "${IMAGE_PREFIX}${DOCKER_PACKAGE}:${TAG}" -f "docker/${P}/Dockerfile${DOCKER_EXTENSION}" .
 done

--- a/docker/pce_deployment/gcp/Dockerfile.ubuntu
+++ b/docker/pce_deployment/gcp/Dockerfile.ubuntu
@@ -55,6 +55,10 @@ RUN curl -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terra
 ##########################################
 RUN mkdir /terraform_deployment
 COPY fbpcs/infra/pce/gcp_terraform_template /terraform_deployment/terraform_scripts
+COPY fbpcs/infra/publisher/gcp/deploy.sh /terraform_deployment
+COPY fbpcs/infra/publisher/gcp/util.sh /terraform_deployment
+RUN chmod +x /terraform_deployment/deploy.sh
+RUN chmod +x /terraform_deployment/util.sh
 CMD ["/bin/bash"]
 WORKDIR /terraform_deployment
 

--- a/fbpcs/infra/publisher/gcp/deploy.sh
+++ b/fbpcs/infra/publisher/gcp/deploy.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+# shellcheck disable=SC1091
+source ./util.sh
+
+usage() {
+    echo "Usage: deploy.sh <deploy|undeploy>
+        [ -t, --tag | A unique identifier to identify resources in this deployment]
+        [ -r, --region | GCP region, e.g. us-west-2 ]
+        [ -a, --account_id | Publisher's GCP project ID]
+        [ -p, --partner_account_id | Partner's GCP project ID]
+        [ -c, --publisher_vpc_cidr | Publisher's VPC CIDR]
+        [ -s, --secondary_subnet_cidr | Publishers secondary subnet CIDR]
+        [ -v, --partner_vpc_cidr | Partner's VPC CIDR]
+        [ -b, --bucket | GCS bucket name for storing tfstate]"
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+undeploy=false
+case "$1" in
+    deploy) ;;
+    undeploy) undeploy=true ;;
+    *) usage ;;
+esac
+shift
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -t|--tag) pce_id="$2" ;;
+        -r|--region) region="$2" ;;
+        -a|--account_id) gcp_project_id="$2" ;;
+        -p|--partner_account_id) partner_gcp_project_id="$2" ;;
+        -c|--publisher_vpc_cidr) vpc_cidr="$2" ;;
+        -s|--secondary_subnet_cidr) subnet_secondary_cidr="$2" ;;
+        -v|--partner_vpc_cidr) partner_vpc_cidr="$2" ;;
+        -b|--bucket) gcs_bucket_for_storage="$2" ;;
+        *) usage ;;
+    esac
+    shift
+    shift
+done
+
+name_postfix="-${pce_id}"
+
+echo "GCP region is $region."
+echo "The string '$name_postfix' will be appended after the name of the GCP resources."
+echo "Publisher's GCP project ID is $gcp_project_id"
+echo "Publisher's VPC CIDR is $vpc_cidr"
+echo "Partner's GCP project ID is $partner_gcp_project_id"
+echo "Partner's VPC CIDR is $partner_vpc_cidr"
+echo "The GCS bucket for storing the Terraform state file is $gcs_bucket_for_storage"
+
+undeploy_gcp_resources () {
+    echo "Start undeploying..."
+    echo "########################Check tfstate files########################"
+    if ! verify_object_existence "$gcs_bucket_for_storage" "tfstate/pce$name_postfix.tfstate"; then
+        exit 1
+    fi
+    echo "All tfstate files exist. Continue..."
+
+    echo "########################Delete PCE resources########################"
+    cd /terraform_deployment/terraform_scripts/common/pce
+    terraform init \
+        -backend-config "bucket=$gcs_bucket_for_storage" \
+        -backend-config "prefix=tfstate/pce$name_postfix.tfstate"
+    terraform destroy \
+        -auto-approve \
+        -var "gcp_region=$region" \
+        -var "project_id=$gcp_project_id" \
+        -var "name_postfix=$name_postfix"
+}
+
+deploy_gcp_resources () {
+    echo "########################Started GCP Infrastructure Deployment########################"
+    verify_or_create_bucket "$gcs_bucket_for_storage" "$region"
+
+    # Deploy PCE Terraform scripts
+    cd /terraform_deployment/terraform_scripts/common/pce
+    terraform init \
+        -backend-config "bucket=$gcs_bucket_for_storage" \
+        -backend-config "prefix=tfstate/pce$name_postfix.tfstate"
+    terraform apply \
+        -auto-approve \
+        -var "gcp_region=$region" \
+        -var "project_id=$gcp_project_id" \
+        -var "name_postfix=$name_postfix" \
+        -var "subnet_primary_cidr=$vpc_cidr" \
+        -var "subnet_secondary_cidr=$subnet_secondary_cidr" \
+        -var "otherparty_subnet_cidr=$partner_vpc_cidr" \
+
+    # Print the output
+    echo "######################## PCE terraform output ########################"
+    terraform output
+
+    echo "########################Finished GCP Infrastructure Deployment########################"
+}
+
+##########################################
+# Main
+##########################################
+
+if "$undeploy"
+then
+    echo "Undeploying the GCP resources..."
+    undeploy_gcp_resources
+else
+    deploy_gcp_resources
+fi
+exit 0

--- a/fbpcs/infra/publisher/gcp/util.sh
+++ b/fbpcs/infra/publisher/gcp/util.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+##########################################
+# Helper functions
+##########################################
+
+verify_object_existence() {
+    local bucket_name=$1
+    local key_name=$2
+
+    missing=$("gsutil ls gs://${bucket_name}/${key_name} |& grep -c CommandException")
+
+    if [ "${missing}" == 1 ]; then
+        echo "The file $key_name does not exist. Exiting..."
+        false
+    else
+        echo "The file $key_name exists."
+        true
+    fi
+}
+
+check_bucket_exists() {
+    local bucket_name=$1
+
+    missing=$(gsutil ls gs://"${bucket_name}" |& grep -c BucketNotFound)
+
+    if [ "${missing}" == 1 ]; then
+        false
+    else
+        true
+    fi
+}
+
+create_gcs_bucket() {
+    local bucket_name=$1
+    local region=$2
+    gsutil mb -l "$region" "gs://$bucket_name"
+}
+
+verify_gcs_bucket_access () {
+    local bucket_name=$1
+
+    no_access=$(gsutil ls gs://"${bucket_name}" |& grep -c AccessDeniedException)
+
+    if [ "${no_access}" == 1 ]; then
+        false
+    else
+        true
+    fi
+}
+
+verify_or_create_bucket() {
+    local bucket_name=$1
+    local region=$2
+    echo "########################Create storage buckets if they don't exist ########################"
+
+    if ! check_bucket_exists "$bucket_name";
+    then
+        echo "The bucket $bucket_name doesn't exist. Creating..."
+        create_gcs_bucket "$bucket_name" "$region"
+        echo "The bucket $bucket_name is created."
+        true
+    elif ! verify_gcs_bucket_access "$bucket_name"
+    then
+        echo "You don't have access to the bucket $bucket_name. Please choose another name."
+        false
+    else
+        echo "The bucket $bucket_name exists and you have access to it."
+        true
+    fi
+}


### PR DESCRIPTION
Summary:
# Background
To deploy PCEs from the PCE service UI and CLI, we need to be able to communicate to a service within the cloud (GCP in this case) that can run the terraform scripts required to deploy a new PCE.
# This commit
This commit updates the docker image that is used to deploy PCEs to include the deployment script that is required to creat a new PCE. It also updates the docker build command to pin the built image to the linux/amd64 architecture. This became and issue in my testing as the images I built on my local machine (Mac with ARM64) wouldn't run on the nodes in the GCP clusters.

Differential Revision: D35499707

