### PR TITLE
rename PCInstanceCalculationException, refine ValidationException in one command runner

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -15,8 +15,16 @@ class OneCommandRunnerBaseException(Exception):
         )
 
 
-# TODO(T114624787): [BE][PCS] rename PLInstanceCalculationException to PCInstanceCalculationException
-class PLInstanceCalculationException(OneCommandRunnerBaseException, RuntimeError):
+class PCStudyValidationException(OneCommandRunnerBaseException, RuntimeError):
+    def __init__(self, cause: str, remediation: str) -> None:
+        super().__init__(
+            msg="PCStudyValidationException",
+            cause=cause,
+            remediation=remediation,
+        )
+
+
+class PCInstanceCalculationException(OneCommandRunnerBaseException, RuntimeError):
     pass
 
 

--- a/fbpcs/pl_coordinator/pc_calc_instance.py
+++ b/fbpcs/pl_coordinator/pc_calc_instance.py
@@ -16,7 +16,7 @@ from fbpcs.pl_coordinator.constants import (
     POLL_INTERVAL,
     OPERATION_REQUEST_TIMEOUT,
 )
-from fbpcs.pl_coordinator.exceptions import PLInstanceCalculationException
+from fbpcs.pl_coordinator.exceptions import PCInstanceCalculationException
 from fbpcs.pl_coordinator.pl_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
@@ -75,7 +75,7 @@ class PrivateComputationCalcInstance:
                     )
                     return
                 sleep(POLL_INTERVAL)
-            raise PLInstanceCalculationException(
+            raise PCInstanceCalculationException(
                 "Timeout",
                 f"Poll {self.role} status timed out after {timeout}s expecting valid status.",
                 "Try running again",
@@ -103,13 +103,13 @@ class PrivateComputationCalcInstance:
                 fail_status,
                 PrivateComputationInstanceStatus.TIMEOUT,
             ]:
-                raise PLInstanceCalculationException(
+                raise PCInstanceCalculationException(
                     f"{self.role} failed with status {self.status}. Expecting status {status}.",
                     "unknown",
                     "Try running again",
                 )
             sleep(POLL_INTERVAL)
-        raise PLInstanceCalculationException(
+        raise PCInstanceCalculationException(
             "Timeout",
             f"Poll {self.role} status timed out after {timeout}s expecting status: {status}.",
             "Try running again",

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -15,7 +15,7 @@ from fbpcs.pl_coordinator.pl_graphapi_utils import (
 )
 from fbpcs.pl_coordinator.pl_instance_runner import (
     PLInstanceRunner,
-    PLInstanceCalculationException,
+    PCInstanceCalculationException,
     IncompatibleStageError,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -280,7 +280,7 @@ class TestPlInstanceRunner(TestCase):
 
                 runner = self._get_runner(type(stage))
                 if not result:
-                    with self.assertRaises(PLInstanceCalculationException):
+                    with self.assertRaises(PCInstanceCalculationException):
                         runner.publisher.wait_stage_start(stage)
                 else:
                     runner.publisher.wait_stage_start(stage)
@@ -312,7 +312,7 @@ class TestPlInstanceRunner(TestCase):
 
                 runner = self._get_runner(type(stage))
                 if not result:
-                    with self.assertRaises(PLInstanceCalculationException):
+                    with self.assertRaises(PCInstanceCalculationException):
                         runner.wait_stage_complete(stage)
                 else:
                     runner.wait_stage_complete(stage)


### PR DESCRIPTION
Summary:
* T114624787 - rename PLInstanceCalculationException to PCInstanceCalculationException
* refine ValidationException in one command runner
** consolidate exception to inhereit OneCommandRunnerBaseException
** adding remediations for better trouble shooting

Differential Revision: D35557550

