### PR TITLE
update onedocker publish test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -224,6 +224,28 @@ jobs:
           ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
         working-directory: ./fbpcs/tests/github/
 
+      - name: Attribution - PID shard
+        run: |
+          ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} pid_shard
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Check Status
+        timeout-minutes: 5
+        run: |
+          ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Attribution - PID prepare
+        run: |
+          ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} pid_prepare
+        working-directory: ./fbpcs/tests/github/
+
+      - name: Check Status
+        timeout-minutes: 5
+        run: |
+          ./check_status.sh ${{ env.PA_CONTAINER_NAME }} attribution
+        working-directory: ./fbpcs/tests/github/
+
       - name: Attribution - Id Match
         run: |
           ./attribution_run_stages.sh ${{ env.PA_CONTAINER_NAME }} run_next

--- a/fbpcs/tests/github/attribution_run_stages.sh
+++ b/fbpcs/tests/github/attribution_run_stages.sh
@@ -48,7 +48,7 @@ case "$stage" in
             --aggregation_type="$ATTRIBUTION_TYPE"
             ;;
     # Stages without passing IP addresses
-    id_spine_combiner | reshard | pid_metric_export | data_validation )
+    id_spine_combiner | reshard | pid_shard | pid_prepare | pid_metric_export | data_validation )
         echo "Attribution Publisher $stage starts"
         $docker_command run_next "$ATTRIBUTION_PUBLISHER_NAME" \
             --config="$DOCKER_CLOUD_CONFIG_FILE"


### PR DESCRIPTION
Summary:
## What

* update docker-publish test to call new attribution stages, as introduced here: D35485230 (https://github.com/facebookresearch/fbpcs/commit/6835b2dcda5628c27c3741a7be4d2206efb75632)

## Why

* so that the test works

Differential Revision: D35591223

