### PR TITLE
increase instance SLA

### DIFF
--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -32,6 +32,6 @@ RETRY_INTERVAL = 60
 MIN_NUM_INSTANCES = 1
 MAX_NUM_INSTANCES = 5
 PROCESS_WAIT = 1  # interval between starting processes.
-INSTANCE_SLA = 14400  # 2 hr instance sla, 2 tries per stage, total 4 hrs.
+INSTANCE_SLA = 57600  # 8 hr instance sla, 2 tries per stage, total 16 hrs.
 
 FBPCS_GRAPH_API_TOKEN = "FBPCS_GRAPH_API_TOKEN"


### PR DESCRIPTION
Summary:
## What

* Increase INSTANCE_SLA by 4x

## Why

* Currently we assume an SLA of 2 hours. In reality, our SLA is 8 hours
* I suspect this is the cause of the recurrent COMPUTATION_COMPLETED failure, as was seen recently: https://fb.workplace.com/groups/331044242148818/posts/463212832265291/?comment_id=463947832191791

## impacc

a COMPUTATION_COMPLETED error has been experienced 4 times in the last 90 days. I'm inclined to believe this diff will prevent it from happening again (though I cannot be sure).

{F721898269}

Reviewed By: leegross

Differential Revision: D35622265

