### PR TITLE
Modify PID sharder to be able to use non-empty id_ column

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.h
+++ b/fbpcs/data_processing/sharding/GenericSharder.h
@@ -151,7 +151,8 @@ class GenericSharder {
    */
   virtual void shardLine(
       std::string line,
-      const std::vector<std::unique_ptr<std::ofstream>>& outFiles);
+      const std::vector<std::unique_ptr<std::ofstream>>& outFiles,
+      const std::vector<int32_t>& idColumnIndices);
 
  private:
   std::string inputPath_;

--- a/fbpcs/data_processing/sharding/HashBasedSharder.cpp
+++ b/fbpcs/data_processing/sharding/HashBasedSharder.cpp
@@ -21,6 +21,7 @@
 #include <folly/logging/xlog.h>
 
 #include "fbpcs/data_processing/hash_slinging_salter/HashSlingingSalter.hpp"
+#include "folly/String.h"
 
 namespace data_processing::sharder {
 namespace detail {
@@ -53,25 +54,41 @@ std::size_t HashBasedSharder::getShardFor(
 
 void HashBasedSharder::shardLine(
     std::string line,
-    const std::vector<std::unique_ptr<std::ofstream>>& outFiles) {
-  auto commaPos = line.find_first_of(",");
-  auto id = line.substr(0, commaPos);
+    const std::vector<std::unique_ptr<std::ofstream>>& outFiles,
+    const std::vector<int32_t>& idColumnIndices) {
+  std::vector<std::string> cols;
+  folly::split(",", line, cols);
+
+  std::string id = "";
+  for (auto idColumnIdx : idColumnIndices) {
+    if (idColumnIdx >= cols.size()) {
+      XLOG_EVERY_MS(INFO, 5000)
+          << "Discrepancy with header:" << line << " does not have "
+          << idColumnIdx << "th column.\n";
+      return;
+    }
+    auto& col = cols.at(idColumnIdx);
+    if (!col.empty()) {
+      if (!hmacKey_.empty()) {
+        // If hmacBase64Key is empty, the hashing already happened upstream.
+        // This means we can reinterpret the id as a base64-encoded string.
+        // Otherwise, hash all the id columns.
+        col = private_lift::hash_slinging_salter::base64SaltedHashFromBase64Key(
+            col, hmacKey_);
+      }
+      if (id.empty()) {
+        id = col;
+      }
+    }
+  }
+  if (id.empty()) {
+    XLOG_EVERY_MS(INFO, 5000) << "All the id values are empty in this row";
+    return;
+  }
   auto numShards = outFiles.size();
   std::size_t shard;
-  if (hmacKey_.empty()) {
-    // Assumption: the string is *already* an HMAC hashed value
-    // If hmacBase64Key is empty, the hashing already happened upstream.
-    // This means we can reinterpret the id as a base64-encoded string.
-    shard = getShardFor(id, numShards);
-    *outFiles.at(shard) << line << "\n";
-  } else {
-    auto base64SaltedId =
-        private_lift::hash_slinging_salter::base64SaltedHashFromBase64Key(
-            id, hmacKey_);
-    shard = getShardFor(base64SaltedId, numShards);
-
-    *outFiles.at(shard) << base64SaltedId << line.substr(commaPos) << "\n";
-  }
+  shard = getShardFor(id, numShards);
+  *outFiles.at(shard) << folly::join(",", cols) << "\n";
   logRowsToShard(shard);
 }
 } // namespace data_processing::sharder

--- a/fbpcs/data_processing/sharding/HashBasedSharder.h
+++ b/fbpcs/data_processing/sharding/HashBasedSharder.h
@@ -102,7 +102,8 @@ class HashBasedSharder final : public GenericSharder {
    */
   void shardLine(
       std::string line,
-      const std::vector<std::unique_ptr<std::ofstream>>& outFiles) final;
+      const std::vector<std::unique_ptr<std::ofstream>>& outFiles,
+      const std::vector<int32_t>& idColumnIndices) final;
 
  private:
   std::string hmacKey_;

--- a/fbpcs/data_processing/sharding/test/GenericSharderTest.cpp
+++ b/fbpcs/data_processing/sharding/test/GenericSharderTest.cpp
@@ -32,7 +32,8 @@ class GenericSharderTest final : public GenericSharder {
 
   void shardLine(
       std::string line,
-      const std::vector<std::unique_ptr<std::ofstream>>& /* unused */) final {
+      const std::vector<std::unique_ptr<std::ofstream>>& /* unused */,
+      const std::vector<int32_t>& /* unused */) final {
     linesCalledWith_.push_back(line);
   }
 

--- a/fbpcs/data_processing/sharding/test/HashBasedSharderTest.cpp
+++ b/fbpcs/data_processing/sharding/test/HashBasedSharderTest.cpp
@@ -75,7 +75,8 @@ TEST(HashBasedSharderTest, TestShardLineNoHmacKey) {
   streams.push_back(std::make_unique<std::ofstream>(outputPaths.at(1)));
 
   HashBasedSharder sharder{"unused", outputPaths, 123, ""};
-  sharder.shardLine(line, streams);
+  std::vector<int32_t> idColumnIndices{0};
+  sharder.shardLine(line, streams, idColumnIndices);
 
   // We can just reset the underlying unique_ptr to flush the writes to disk
   streams.at(0).reset();
@@ -104,7 +105,8 @@ TEST(HashBasedSharderTest, TestShardLineWithHmacKey) {
 
   std::string hmacKey = "abcd1234";
   HashBasedSharder sharder{"unused", outputPaths, 123, hmacKey};
-  sharder.shardLine(line, streams);
+  std::vector<int32_t> idColumnIndices{0};
+  sharder.shardLine(line, streams, idColumnIndices);
 
   // We can just reset the underlying unique_ptr to flush the writes to disk
   streams.at(0).reset();
@@ -114,6 +116,37 @@ TEST(HashBasedSharderTest, TestShardLineWithHmacKey) {
   std::vector<std::string> expected0{};
   std::vector<std::string> expected1{
       "9BX9ClsYtFj3L8N023K3mJnw1vemIGqenY5vfAY0/cg=,1,2,3"};
+
+  data_processing::test_utils::expectFileRowsEqual(
+      outputPaths.at(0), expected0);
+  data_processing::test_utils::expectFileRowsEqual(
+      outputPaths.at(1), expected1);
+}
+
+TEST(HashBasedSharderTest, TestShardMultiKeyLineWithHmacKey) {
+  std::string line = "abcd,defg,1,2,3";
+  std::vector<std::unique_ptr<std::ofstream>> streams;
+  auto randStart = folly::Random::secureRand64();
+  std::vector<std::string> outputPaths{
+      "/tmp/HashBasedSharderTestShardOutput" + std::to_string(randStart),
+      "/tmp/HashBasedSharderTestShardOutput" + std::to_string(randStart + 1),
+  };
+  streams.push_back(std::make_unique<std::ofstream>(outputPaths.at(0)));
+  streams.push_back(std::make_unique<std::ofstream>(outputPaths.at(1)));
+
+  std::string hmacKey = "abcd1234";
+  HashBasedSharder sharder{"unused", outputPaths, 123, hmacKey};
+  std::vector<int32_t> idColumnIndices{0, 1};
+  sharder.shardLine(line, streams, idColumnIndices);
+
+  // We can just reset the underlying unique_ptr to flush the writes to disk
+  streams.at(0).reset();
+  streams.at(1).reset();
+
+  // We didn't write headers, so we expect to *just* have the written line
+  std::vector<std::string> expected0{};
+  std::vector<std::string> expected1{
+      "9BX9ClsYtFj3L8N023K3mJnw1vemIGqenY5vfAY0/cg=,bSRNJ92+ML97JRfp1lEvqssXNCX+lI2T/HQtHRTkBk4=,1,2,3"};
 
   data_processing::test_utils::expectFileRowsEqual(
       outputPaths.at(0), expected0);
@@ -198,4 +231,45 @@ TEST(HashBasedSharderTest, TestShardWithHmacKey) {
   data_processing::test_utils::expectFileRowsEqual(
       outputPaths.at(1), expected1);
 }
+
+TEST(HashBasedSharderTest, TestShardMultiKeyWithHmacKey) {
+  std::vector<std::string> rows{
+      "id_email,id_phone,a,b,c",
+      "abcd,,1,2,3",
+      "abcd,hijk,4,5,6",
+      ",defg,7,8,9",
+      ",,0,0,0",
+  };
+  std::string hmacKey = "abcd1234";
+
+  std::string inputPath = "/tmp/HashBasedSharderTestShardInput" +
+      std::to_string(folly::Random::secureRand64());
+  data_processing::test_utils::writeVecToFile(rows, inputPath);
+  // TODO: Would be great to mock out inputstream/outputstream stuff
+  auto randStart = folly::Random::secureRand64();
+  std::vector<std::string> outputPaths{
+      "/tmp/HashBasedSharderTestShardOutput" + std::to_string(randStart),
+      "/tmp/HashBasedSharderTestShardOutput" + std::to_string(randStart + 1),
+  };
+  HashBasedSharder sharder{inputPath, outputPaths, 123, hmacKey};
+  sharder.shard();
+
+  // HMAC was applied offline, which is how we got these expected lines
+  // HMAC_SHA256(CAST(id AS VARBINARY), FROM_BASE64(hmacKey)) in Presto is a
+  // good way to generate more of these given our I/O specification.
+  std::vector<std::string> expected0{
+      "id_email,id_phone,a,b,c",
+      ",bSRNJ92+ML97JRfp1lEvqssXNCX+lI2T/HQtHRTkBk4=,7,8,9", // ,defg line
+  };
+  std::vector<std::string> expected1{
+      "id_email,id_phone,a,b,c",
+      "9BX9ClsYtFj3L8N023K3mJnw1vemIGqenY5vfAY0/cg=,,1,2,3", // abcd, line
+      "9BX9ClsYtFj3L8N023K3mJnw1vemIGqenY5vfAY0/cg=,ZGCVov/c63+N2Swslf6pY6pWsNzS1IkXKVi+lmAD6yU=,4,5,6", // abcd,hijk line
+  };
+  data_processing::test_utils::expectFileRowsEqual(
+      outputPaths.at(0), expected0);
+  data_processing::test_utils::expectFileRowsEqual(
+      outputPaths.at(1), expected1);
+}
+
 } // namespace data_processing::sharder


### PR DESCRIPTION
Summary:
In this diff,
- modify `GenericSharder.cpp` and `HashBasedSharder.cpp` to use first non-empty prefix `id_` column instead of left most column
- modified `HashBasedSharder.cpp` to encrypt all the prefix `id_` columns instead of only left most column

Note: This diff is mainly for backward compatibility. We are only using first non-empty id column because we don't yet support sharding using multiple key.

Differential Revision: D35607216

