### PR TITLE
service wrapper get PCSTier

### DIFF
--- a/fbpcs/private_computation/entity/pcs_tier.py
+++ b/fbpcs/private_computation/entity/pcs_tier.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+
+class PCSTier(Enum):
+    UNKNOWN = "unknown"
+    RC = "rc"
+    CANARY = "canary"
+    PROD = "latest"
+
+    @staticmethod
+    def from_str(tier_str: str) -> "PCSTier":
+        """maps str (possibly smc tier of deployed PCS thrift servers) to a PCSTier."""
+
+        if tier_str in (
+            "rc",
+            "private_measurement.private_computation_service_rc",
+        ):
+            return PCSTier.RC
+        elif tier_str in (
+            "canary",
+            "private_measurement.private_computation_service_canary",
+        ):
+            return PCSTier.CANARY
+        elif tier_str in (
+            "latest",
+            "private_measurement.private_computation_service",
+        ):
+            return PCSTier.PROD
+        else:
+            return PCSTier.UNKNOWN

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -27,6 +27,7 @@ from fbpcs.post_processing_handler.post_processing_handler import PostProcessing
 from fbpcs.private_computation.entity.pc_validator_config import (
     PCValidatorConfig,
 )
+from fbpcs.private_computation.entity.pcs_tier import PCSTier
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -324,6 +325,24 @@ def print_log_urls(
 
     for stage, log_url in log_urls.items():
         print(f"[{stage}]: {log_url}")
+
+
+def get_tier(config: Dict[str, Any]) -> PCSTier:
+    """Grab binary version from config.yml dict and convert to PCSTier
+
+    Arguments:
+        config: config.yml dict representation (assumed to be full representation)
+
+    Returns:
+        The PCSTier associated with the binary version
+    """
+
+    onedocker_binary_config_map = _build_onedocker_binary_cfg_map(
+        config["private_computation"]["dependency"]["OneDockerBinaryConfig"]
+    )
+    binary_config = onedocker_binary_config_map["default"]
+    tier_str = binary_config.binary_version
+    return PCSTier.from_str(tier_str)
 
 
 def _build_container_service(config: Dict[str, Any]) -> PCSContainerService:


### PR DESCRIPTION
Summary:
## What is this diff stack

* auto canary selection context: https://fb.workplace.com/groups/126488202795965/permalink/310554107722706/
* Adding validation at the beginning of the computation that the tier specified by the advertiser (canary, prod, etc) is correct / the same as Meta
* run_fbpcs.sh will auto retry with the correct tier if the advertiser specifies the wrong one

## What is this diff

* Add logic to extract a PCS tier from a config.yml file

## Why

* We will call this in a subsequent diff when comparing publisher tier to partner tier

Reviewed By: joe1234wu

Differential Revision: D35514440

