### PR TITLE
Introduce tier entity

### DIFF
--- a/fbpcs/private_computation/entity/pcs_tier.py
+++ b/fbpcs/private_computation/entity/pcs_tier.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+
+class PCSTier(Enum):
+    UNKNOWN = "unknown"
+    RC = "rc"
+    CANARY = "canary"
+    PROD = "latest"
+
+    @staticmethod
+    def from_str(tier_str: str) -> "PCSTier":
+        """maps str (possibly smc tier of deployed PCS thrift servers) to a PCSTier."""
+
+        if tier_str in (
+            "rc",
+            "private_measurement.private_computation_service_rc",
+        ):
+            return PCSTier.RC
+        elif tier_str in (
+            "canary",
+            "private_measurement.private_computation_service_canary",
+        ):
+            return PCSTier.CANARY
+        elif tier_str in (
+            "latest",
+            "private_measurement.private_computation_service",
+        ):
+            return PCSTier.PROD
+        else:
+            return PCSTier.UNKNOWN


### PR DESCRIPTION
Summary:
## What is this diff stack

* auto canary selection context: https://fb.workplace.com/groups/126488202795965/permalink/310554107722706/
* Adding validation at the beginning of the computation that the tier specified by the advertiser (canary, prod, etc) is correct / the same as Meta
* run_fbpcs.sh will auto retry with the correct tier if the advertiser specifies the wrong one

## What is this diff

* Add a PCSTier enum enumerating the tiers supported in production
* from_str method for converting from strings associated with a tier to the tier

## Why

* Having an enum representation of different tiers will come in handy later on in the stack when we compare publisher to partner tier

Reviewed By: leegross

Differential Revision: D35455523

