### PR TITLE
run_fbpcs.sh auto retry incorrect tier

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -6,10 +6,36 @@
 
 # pyre-strict
 
+import functools
+import logging
+import sys
 from enum import Enum
 
 from fbpcs.pl_coordinator.constants import FBPCS_GRAPH_API_TOKEN
 from fbpcs.private_computation.entity.pcs_tier import PCSTier
+
+# decorators are a serious pain to add typing for, so I'm not going to bother...
+# pyre-ignore
+def sys_exit_after(func):
+    """
+    Catch exceptions and exit with the proper exit codes
+    """
+
+    @functools.wraps(func)
+    # pyre-ignore
+    def wrapped(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except OneCommandRunnerBaseException as e:
+            logging.exception(e)
+            sys.exit(e.exit_code.value)
+        except Exception as e:
+            logging.exception(e)
+            sys.exit(OneCommandRunnerExitCode.ERROR.value)
+        else:
+            sys.exit(OneCommandRunnerExitCode.SUCCESS.value)
+
+    return wrapped
 
 
 class OneCommandRunnerExitCode(Enum):

--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -5,14 +5,56 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+
+from enum import Enum
+
 from fbpcs.pl_coordinator.constants import FBPCS_GRAPH_API_TOKEN
+from fbpcs.private_computation.entity.pcs_tier import PCSTier
+
+
+class OneCommandRunnerExitCode(Enum):
+    """Custom exit codes for one command runner
+
+    Unix exit codes 1-2, 126-165, and 255 have special meaning, so they should be
+    avoided in this enum.
+
+    We will use exit codes 64-113 to conform to C/C++ standard. If we need more than
+    50 exit codes, try not to clash with the unix standard reserved exit codes.
+
+    Resource: https://tldp.org/LDP/abs/html/exitcodes.html
+    """
+
+    # Success, in compliance with unix exit code standards
+    SUCCESS = 0
+    # Catchall for general errors, in compliance with unix exit code standards
+    ERROR = 1
+    INCORRECT_TIER = 64
+    # various incorrect tier exit codes will be used by callers to initiate auto retry
+    # when the tier passed to PCS is incorrect
+    INCORRECT_TIER_EXPECTED_RC = 65
+    INCORRECT_TIER_EXPECTED_CANARY = 66
+    INCORRECT_TIER_EXPECTED_LATEST = 67
 
 
 class OneCommandRunnerBaseException(Exception):
-    def __init__(self, msg: str, cause: str, remediation: str) -> None:
+    def __init__(
+        self,
+        msg: str,
+        cause: str,
+        remediation: str,
+        exit_code: OneCommandRunnerExitCode = OneCommandRunnerExitCode.ERROR,
+    ) -> None:
         super().__init__(
-            "\n".join((msg, f"Cause: {cause}", f"Remediation: {remediation}"))
+            "\n".join(
+                (
+                    msg,
+                    f"Cause: {cause}",
+                    f"Remediation: {remediation}",
+                    f"Exit code: {exit_code} ({exit_code.value})",
+                )
+            )
         )
+        self.exit_code: OneCommandRunnerExitCode = exit_code
 
 
 class PCStudyValidationException(OneCommandRunnerBaseException, RuntimeError):
@@ -50,3 +92,33 @@ class IncompatibleStageError(OneCommandRunnerBaseException, RuntimeError):
             cause="Possible causes include race time error during instance updating, unexpected instance deletion, or differing stageflows",
             remediation="Wait 24 hours for the instance to expire or contact your representative at Meta.",
         )
+
+
+class IncorrectVersionError(OneCommandRunnerBaseException, ValueError):
+    @classmethod
+    def make_error(
+        cls, instance_id: str, expected_tier: PCSTier, actual_tier: PCSTier
+    ) -> "IncorrectVersionError":
+        return cls(
+            msg=f"Expected version for instance {instance_id} is {expected_tier.value}"
+            f" but the computation was attempted with {actual_tier.value}.",
+            cause="The binary_version parameter in your config.yml is incorrect",
+            remediation="If using run_fbpcs.sh, the script will auto retry."
+            " If you see this message but the computation continued anyway, you"
+            " can ignore it. If the computation did not auto retry, you can"
+            f" manually pass -- --version={expected_tier.value} to end of the command."
+            " If you are not using run_fbpcs.sh, you should update the binary_version"
+            f" field in your config.yml to be binary_version: {expected_tier.value}",
+            exit_code=cls._determine_exit_code(expected_tier),
+        )
+
+    @classmethod
+    def _determine_exit_code(cls, expected_tier: PCSTier) -> OneCommandRunnerExitCode:
+        if expected_tier is PCSTier.RC:
+            return OneCommandRunnerExitCode.INCORRECT_TIER_EXPECTED_RC
+        elif expected_tier is PCSTier.CANARY:
+            return OneCommandRunnerExitCode.INCORRECT_TIER_EXPECTED_CANARY
+        elif expected_tier is PCSTier.PROD:
+            return OneCommandRunnerExitCode.INCORRECT_TIER_EXPECTED_LATEST
+        else:
+            return OneCommandRunnerExitCode.INCORRECT_TIER

--- a/fbpcs/private_computation/entity/pcs_tier.py
+++ b/fbpcs/private_computation/entity/pcs_tier.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import Enum
+
+
+class PCSTier(Enum):
+    UNKNOWN = "unknown"
+    RC = "rc"
+    CANARY = "canary"
+    PROD = "latest"
+
+    @staticmethod
+    def from_str(tier_str: str) -> "PCSTier":
+        """maps str (possibly smc tier of deployed PCS thrift servers) to a PCSTier."""
+
+        if tier_str in (
+            "rc",
+            "private_measurement.private_computation_service_rc",
+        ):
+            return PCSTier.RC
+        elif tier_str in (
+            "canary",
+            "private_measurement.private_computation_service_canary",
+        ):
+            return PCSTier.CANARY
+        elif tier_str in (
+            "latest",
+            "private_measurement.private_computation_service",
+        ):
+            return PCSTier.PROD
+        else:
+            return PCSTier.UNKNOWN

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -27,6 +27,7 @@ from fbpcs.post_processing_handler.post_processing_handler import PostProcessing
 from fbpcs.private_computation.entity.pc_validator_config import (
     PCValidatorConfig,
 )
+from fbpcs.private_computation.entity.pcs_tier import PCSTier
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -324,6 +325,24 @@ def print_log_urls(
 
     for stage, log_url in log_urls.items():
         print(f"[{stage}]: {log_url}")
+
+
+def get_tier(config: Dict[str, Any]) -> PCSTier:
+    """Grab binary version from config.yml dict and convert to PCSTier
+
+    Arguments:
+        config: config.yml dict representation (assumed to be full representation)
+
+    Returns:
+        The PCSTier associated with the binary version
+    """
+
+    onedocker_binary_config_map = _build_onedocker_binary_cfg_map(
+        config["private_computation"]["dependency"]["OneDockerBinaryConfig"]
+    )
+    binary_config = onedocker_binary_config_map["default"]
+    tier_str = binary_config.binary_version
+    return PCSTier.from_str(tier_str)
 
 
 def _build_container_service(config: Dict[str, Any]) -> PCSContainerService:


### PR DESCRIPTION
Summary:
## What is this diff stack

* auto canary selection context: https://fb.workplace.com/groups/126488202795965/permalink/310554107722706/
* Adding validation at the beginning of the computation that the tier specified by the advertiser (canary, prod, etc) is correct / the same as Meta
* run_fbpcs.sh will auto retry with the correct tier if the advertiser specifies the wrong one

## What is this diff

* auto retry in run_fbpcs.sh when the tier is incorrect

## Why

* So that advertisers don't need to specify their version (and so that we can correct them if they use the wrong version)

Reviewed By: joe1234wu

Differential Revision: D35569371

