### PR TITLE
Use thread pool to upload files to S3

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.h
+++ b/fbpcs/data_processing/sharding/GenericSharder.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <exception>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -28,6 +29,8 @@ void stripQuotes(std::string& s);
  */
 void dos2Unix(std::string& s);
 } // namespace detail
+
+constexpr int THREAD_POOL_SIZE = 20;
 
 /**
  * A class which can shard data from one file into many sub-files.
@@ -159,5 +162,15 @@ class GenericSharder {
   std::vector<std::string> outputPaths_;
   int32_t logEveryN_;
   std::unordered_map<std::size_t, int> rowsInShard;
+
+  void copySingleFileToDestination(
+      std::string outputDst,
+      std::string tmpFileSrc,
+      std::vector<std::exception_ptr>& errorStorage,
+      int i);
+
+  void copySingleFileToDestinationImpl(
+      std::string outputDst,
+      std::string tmpFileSrc);
 };
 } // namespace data_processing::sharder


### PR DESCRIPTION
Summary:
Right now files are uploaded serially, which adds a lot of walltime when dealing with a lot of shards. Plus, as we get ready to deal with scale, this is not a good solution.

Ideally, in the future, we would improve this in one or more ways
1) Use multipart upload instead of putting the entire object. This would allow us to upload the file in chunks and in parallel
2) Don't even write to disk, directly write to S3 using the new buffered writer functionality (D34944603). It is TBD whether this will be better than option 1
3) Switch to using async uploads instead of blocking uploads. This is probably the best option, since the SDK would handle the parallelization. But definitely worth investigating if we can achieve the best performance with this.

Reviewed By: jrodal98

Differential Revision: D35651355

