### PR TITLE
Pass PID protocol to PID RUN

### DIFF
--- a/fbpcs/data_processing/service/id_spine_combiner.py
+++ b/fbpcs/data_processing/service/id_spine_combiner.py
@@ -26,6 +26,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
         output_path: str,
         num_shards: int,
         tmp_directory: str,
+        max_id_column_cnt: int = 1,
         sort_strategy: str = DEFAULT_SORT_STRATEGY,
         # TODO T106159008: padding_size and run_name are only temporarily optional
         # because Lift does not use them. It should and will be required to use them.
@@ -48,6 +49,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
                 data_path=next_data_path,
                 output_path=next_output_path,
                 tmp_directory=tmp_directory,
+                max_id_column_cnt=max_id_column_cnt,
                 padding_size=padding_size,
                 run_name=run_name,
                 sort_strategy=sort_strategy,

--- a/fbpcs/pid/service/pid_service/pid_execution_map.py
+++ b/fbpcs/pid/service/pid_service/pid_execution_map.py
@@ -40,6 +40,31 @@ UnionPIDAdvertiserFlow = PIDFlow(
     },
 )
 
+MultiKeyPIDPublisherFlow = PIDFlow(
+    name="multikey_pid_publisher",
+    base_flow="multikey_pid",
+    extra_args={},
+    flow={
+        UnionPIDStage.PUBLISHER_SHARD: [
+            UnionPIDStage.PUBLISHER_PREPARE,
+        ],
+        UnionPIDStage.PUBLISHER_PREPARE: [UnionPIDStage.PUBLISHER_RUN_PID],
+        UnionPIDStage.PUBLISHER_RUN_PID: [],
+    },
+)
+
+MultiKeyPIDAdvertiserFlow = PIDFlow(
+    name="multikey_pid_advertiser",
+    base_flow="multikey_pid",
+    extra_args={},
+    flow={
+        UnionPIDStage.ADV_SHARD: [
+            UnionPIDStage.ADV_PREPARE,
+        ],
+        UnionPIDStage.ADV_PREPARE: [UnionPIDStage.ADV_RUN_PID],
+        UnionPIDStage.ADV_RUN_PID: [],
+    },
+)
 
 # For now the only options supported are the union pid with publisher and partner roles
 PIDDispatcherFlowMap: Dict[PIDExecutionFlowLookupKey, PIDFlow] = {
@@ -49,6 +74,12 @@ PIDDispatcherFlowMap: Dict[PIDExecutionFlowLookupKey, PIDFlow] = {
     PIDExecutionFlowLookupKey(
         PIDRole.PARTNER, PIDProtocol.UNION_PID
     ): UnionPIDAdvertiserFlow,
+    PIDExecutionFlowLookupKey(
+        PIDRole.PUBLISHER, PIDProtocol.MULTIKEY_PID
+    ): MultiKeyPIDPublisherFlow,
+    PIDExecutionFlowLookupKey(
+        PIDRole.PARTNER, PIDProtocol.MULTIKEY_PID
+    ): MultiKeyPIDAdvertiserFlow,
 }
 
 

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -12,11 +12,12 @@ from fbpcp.service.storage import StorageService
 from fbpcp.util.typing import checked_cast
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
-from fbpcs.pid.entity.pid_instance import PIDStageStatus
+from fbpcs.pid.entity.pid_instance import PIDProtocol, PIDStageStatus
 from fbpcs.pid.entity.pid_stages import UnionPIDStage
 from fbpcs.pid.repository.pid_instance import PIDInstanceRepository
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
+from fbpcs.private_computation.service.constants import DEFAULT_PID_PROTOCOL
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
@@ -35,6 +36,7 @@ class PIDProtocolRunStage(PIDStage):
         storage_svc: StorageService,
         onedocker_svc: OneDockerService,
         onedocker_binary_config: OneDockerBinaryConfig,
+        protocol: PIDProtocol = DEFAULT_PID_PROTOCOL,
         server_ips: Optional[List[str]] = None,
     ) -> None:
         super().__init__(
@@ -43,6 +45,7 @@ class PIDProtocolRunStage(PIDStage):
             storage_svc=storage_svc,
             onedocker_svc=onedocker_svc,
             onedocker_binary_config=onedocker_binary_config,
+            protocol=protocol,
             is_joint_stage=True,
         )
 
@@ -86,14 +89,19 @@ class PIDProtocolRunStage(PIDStage):
             # Run publisher commands in container
             self.logger.info("Publisher spinning up containers")
             try:
+                binary = OneDockerBinaryNames.PID_SERVER.value
+                if self.protocol == PIDProtocol.MULTIKEY_PID:
+                    binary = OneDockerBinaryNames.PID_MULTI_KEY_SERVER.value
                 pending_containers = self.onedocker_svc.start_containers(
-                    package_name=OneDockerBinaryNames.PID_SERVER.value,
+                    package_name=binary,
                     version=self.onedocker_binary_config.binary_version,
                     cmd_args_list=self._gen_command_args_list(
                         input_path=input_paths[0],
                         output_path=output_paths[0],
                         num_shards=num_shards,
-                        use_row_numbers=stage_input.pid_use_row_numbers,
+                        use_row_numbers=stage_input.pid_use_row_numbers
+                        and (self.protocol != PIDProtocol.MULTIKEY_PID),
+                        is_multikey=(self.protocol == PIDProtocol.MULTIKEY_PID),
                     ),
                     env_vars=self._gen_env_vars(),
                     timeout=timeout,
@@ -147,15 +155,20 @@ class PIDProtocolRunStage(PIDStage):
             # Run partner commands in container
             self.logger.info("Partner spinning up containers")
             try:
+                binary = OneDockerBinaryNames.PID_CLIENT.value
+                if self.protocol == PIDProtocol.MULTIKEY_PID:
+                    binary = OneDockerBinaryNames.PID_MULTI_KEY_CLIENT.value
                 pending_containers = self.onedocker_svc.start_containers(
-                    package_name=OneDockerBinaryNames.PID_CLIENT.value,
+                    package_name=binary,
                     version=self.onedocker_binary_config.binary_version,
                     cmd_args_list=self._gen_command_args_list(
                         input_path=input_paths[0],
                         output_path=output_paths[0],
                         num_shards=num_shards,
                         server_hostnames=hostnames,
-                        use_row_numbers=stage_input.pid_use_row_numbers,
+                        use_row_numbers=stage_input.pid_use_row_numbers
+                        and (self.protocol != PIDProtocol.MULTIKEY_PID),
+                        is_multikey=(self.protocol == PIDProtocol.MULTIKEY_PID),
                     ),
                     env_vars=self._gen_env_vars(),
                     timeout=timeout,
@@ -200,6 +213,7 @@ class PIDProtocolRunStage(PIDStage):
         use_row_numbers: bool,
         server_hostnames: Optional[List[str]] = None,
         port: int = 15200,
+        is_multikey: bool = False,
     ) -> List[str]:
         # partner
         if server_hostnames:
@@ -223,7 +237,9 @@ class PIDProtocolRunStage(PIDStage):
                 self._gen_command_args(
                     input_path=self.get_sharded_filepath(input_path, i),
                     output_path=self.get_sharded_filepath(output_path, i),
-                    metric_path=self.get_metrics_filepath(output_path, i),
+                    metric_path=self.get_metrics_filepath(output_path, i)
+                    if not is_multikey
+                    else None,
                     port=port,
                     server_hostname=None,
                     use_row_numbers=use_row_numbers,

--- a/fbpcs/pid/service/pid_service/pid_stage_mapper.py
+++ b/fbpcs/pid/service/pid_service/pid_stage_mapper.py
@@ -70,7 +70,12 @@ class PIDStageMapper:
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
-                onedocker_binary_config_map[OneDockerBinaryNames.PID_SERVER.value],
+                onedocker_binary_config_map[
+                    OneDockerBinaryNames.PID_MULTI_KEY_SERVER.value
+                    if protocol == PIDProtocol.MULTIKEY_PID
+                    else OneDockerBinaryNames.PID_SERVER.value
+                ],
+                protocol,
                 server_ips,
             )
         elif stage is UnionPIDStage.ADV_SHARD:
@@ -101,7 +106,12 @@ class PIDStageMapper:
                 instance_repository,
                 storage_svc,
                 onedocker_svc,
-                onedocker_binary_config_map[OneDockerBinaryNames.PID_CLIENT.value],
+                onedocker_binary_config_map[
+                    OneDockerBinaryNames.PID_MULTI_KEY_CLIENT.value
+                    if protocol == PIDProtocol.MULTIKEY_PID
+                    else OneDockerBinaryNames.PID_CLIENT.value
+                ],
+                protocol,
                 server_ips,
             )
         else:

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -43,10 +43,12 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
         onedocker_svc: OneDockerService,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
+        max_id_column_count: int = 1,
     ) -> None:
         self._onedocker_svc = onedocker_svc
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._log_cost_to_s3 = log_cost_to_s3
+        self._max_id_column_count = max_id_column_count
         self._logger: logging.Logger = logging.getLogger(__name__)
 
     async def run_async(
@@ -77,6 +79,7 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
             self._onedocker_binary_config_map,
             combine_output_path,
             log_cost_to_s3=self._log_cost_to_s3,
+            max_id_column_count=self._max_id_column_count,
         )
         self._logger.info("Finished running CombinerService")
 

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -214,6 +214,7 @@ async def start_combiner_service(
     combine_output_path: str,
     log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
     wait_for_containers: bool = False,
+    max_id_column_count: int = 1,
 ) -> List[ContainerInstance]:
     """Run combiner service and return those container instances
 
@@ -258,6 +259,7 @@ async def start_combiner_service(
         if private_computation_instance.is_validating
         else private_computation_instance.num_pid_containers,
         tmp_directory=binary_config.tmp_directory,
+        max_id_column_cnt=max_id_column_count,
         run_name=run_name,
         padding_size=padding_size,
         log_cost=log_cost,

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from fbpcs.pid.entity.pid_instance import UnionPIDStage
+from fbpcs.pid.service.pid_service.utils import get_max_id_column_cnt
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -184,6 +185,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
             return IdSpineCombinerStageService(
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                max_id_column_count=get_max_id_column_cnt(args.pid_svc.protocol),
             )
         elif self is self.RESHARD:
             return ShardStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -32,6 +32,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageServiceArgs,
 )
 from fbpcs.private_computation.service.shard_stage_service import ShardStageService
+from fbpcs.pid.service.pid_service.utils import get_max_id_column_cnt
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -172,6 +173,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
             return IdSpineCombinerStageService(
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                max_id_column_count=get_max_id_column_cnt(args.pid_svc.protocol),
             )
         elif self is self.RESHARD:
             return ShardStageService(


### PR DESCRIPTION
Summary:
In this diff,
- added new PID flows that maps to multikey client/server
- added MULTIKEY to PIDProtocolT in thrift and mapped to it in thrift.py
- in PIDProtocolRunStage, switch binary and args to pass based on pid protocol specified

Differential Revision: D35603482

