### PR TITLE
Update all the StageFlows combiner to be aligned with PID config stored in PIDService

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -110,6 +110,7 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
             return IdSpineCombinerStageService(
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                pid_svc=args.pid_svc,
             )
         elif self is self.RESHARD:
             return ShardStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -109,6 +109,7 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
             return IdSpineCombinerStageService(
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                pid_svc=args.pid_svc,
             )
         elif self is self.RESHARD:
             return ShardStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
@@ -112,6 +112,7 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
             return IdSpineCombinerStageService(
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                pid_svc=args.pid_svc,
             )
         elif self is self.RESHARD:
             return ShardStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -183,6 +183,7 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
             return IdSpineCombinerStageService(
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                pid_svc=args.pid_svc,
             )
         elif self is self.RESHARD:
             return ShardStageService(


### PR DESCRIPTION
Summary:
In the stacked diff D35603603 (https://github.com/facebookresearch/fbpcs/commit/f8601f0c32f87b2c6c7286fb4e1928dd46fa070d), we onboarded single-node multi-key PID. It requires PIDService to be passed to IdSpineCombinerStageService. It would create a discrepancy between the earlier PID stages and IdSpineCombinerStageService stage.

In this diff, we are passing pid_svc as argument to all the IdSpineCombinerStageService caller.

Reviewed By: joe1234wu

Differential Revision: D35730966

