### PR TITLE
Add stop_instance in PID service

### DIFF
--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -50,6 +50,7 @@ class PIDInstanceStatus(Enum):
     STARTED = "STARTED"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
+    CANCELED = "CANCELED"
 
 
 @dataclass


### PR DESCRIPTION
Summary:
## Why
We want stop containers when PID service is retring, we need to kill existing containers before retry
There was a bug when PID stage (ID matching more precise) retris, the parnert side containers didn't terminate before retry.
which cause capacity issue and stage won't be completed as the old containers been peered to publisher's side.
this is the #2 mid-term solution in T116997514

more context: https://fb.workplace.com/groups/331044242148818/posts/463212832265291/?comment_id=463312582255316

## What
1. added stop_instance in pid service to kll all exsiting containers stored in a PID instance
2. aded unit test for this api
3. Will have another Diff for adopting this api when PCS retris on PID stages

Reviewed By: yuyashiraki

Differential Revision: D35789428

