### PR TITLE
Integration of skip-vpc peering from PCE validator

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -27,6 +27,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -182,7 +186,7 @@ public class DeployController {
   }
 
   @GetMapping(path = "/v1/deployment/logs")
-  public byte[] downloadDeploymentLogs() {
+  public ResponseEntity downloadDeploymentLogs() {
     logger.info("Received logs request");
     ByteArrayOutputStream bo = new ByteArrayOutputStream();
     try {
@@ -198,7 +202,10 @@ public class DeployController {
     }
 
     logger.info("Logs request finalized");
-    return bo.toByteArray();
+    MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+    headers.add("Content-Type", "application/octet-stream");
+    headers.add("Content-Disposition", "attachment; filename=\"zipFile.zip\"");
+    return new ResponseEntity(bo.toByteArray(), headers, HttpStatus.OK);
   }
 
   private void compressIfExists(String fullFilePath, String zipName, ZipOutputStream zout) {

--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -106,19 +106,19 @@ log_streaming_data() {
 validateDeploymentResources () {
     local region=$1
     local pce_id=$2
-    local successMessage="Your PCE environments are set up correctly."
     echo "##### validating through PCE validator starts"
-    local pceValidatorOutput=$(python3 -m pce.validator --region="$region" --key-id="$AWS_ACCESS_KEY_ID" --key-data="$AWS_SECRET_ACCESS_KEY" --pce-id="$pce_id" 2>&1)
+    local pceValidatorOutput=$(python3 -m pce.validator --region="$region" --key-id="$AWS_ACCESS_KEY_ID" --key-data="$AWS_SECRET_ACCESS_KEY" --pce-id="$pce_id" --skip-step="vpc_peering" 2>&1)
+    local pceValidatorExitCode=$?
     echo "$pceValidatorOutput"
-    if echo "$pceValidatorOutput" | grep -q "$successMessage"
+    echo "$pceValidatorExitCode"
+
+    if [ $pceValidatorExitCode -ne 0 ]
     then
-        echo "PCE validation successful";
-        log_streaming_data "PCE validation successful"
-    else
         echo "PCE validator found some issue..please analyze further to debug the issue"
-        log_streaming_data "validator found some issue..please analyze logs further to debug the issue"
-        # TODO, once T111250475 is implemneted grep based on exit code
-        # exit 1
+        log_streaming_data "validator might have found some issue..please analyze the logs further to debug the issue"
+    else
+        log_streaming_data "PCE validation successful"
+        log_streaming_data "Action: Please contact META representative to accept the VPC peering request using META's AWS account"
     fi
     echo "##### validating through PCE validator end"
 }


### PR DESCRIPTION
Summary:
After recent release of PCE validator skip flag, this diff is to enable the skip-vpc peering integration.

With this, user will now not see previous error message, and that they can now see an action saying "contact meta to accept vpc peering".

The validation will fail as usual if there is any other error than vpc peeering.

Differential Revision: D35850149

