### PR TITLE
Migrate PID sharder to use new BufferedReader

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.h
+++ b/fbpcs/data_processing/sharding/GenericSharder.h
@@ -31,6 +31,7 @@ void dos2Unix(std::string& s);
 } // namespace detail
 
 constexpr int THREAD_POOL_SIZE = 20;
+constexpr size_t BUFFER_SIZE = 1073741824; // 2^30
 
 /**
  * A class which can shard data from one file into many sub-files.

--- a/fbpcs/data_processing/sharding/shard.cpp
+++ b/fbpcs/data_processing/sharding/shard.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gflags/gflags.h>
+#include <signal.h>
 
 #include <fbpcf/aws/AwsSdk.h>
 #include <folly/init/Init.h>
@@ -36,6 +37,8 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
 
   data_processing::sharder::runShard(
       FLAGS_input_filename,

--- a/fbpcs/data_processing/sharding/shard_pid.cpp
+++ b/fbpcs/data_processing/sharding/shard_pid.cpp
@@ -9,6 +9,7 @@
 
 #include <fbpcf/aws/AwsSdk.h>
 #include <folly/init/Init.h>
+#include <signal.h>
 
 #include "fbpcs/data_processing/sharding/Sharding.h"
 
@@ -40,6 +41,8 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
 
   data_processing::sharder::runShardPid(
       FLAGS_input_filename,


### PR DESCRIPTION
Summary:
This diff makes the change in production to use the new Buffered Reader. Google doc for context is linked below (internal only).

See test plan for full details of how this was tested.

There is one workaround about `SIGPIPE` that is explained with an in-line comment.

Differential Revision: D35729872

