### PR TITLE
Adding dataset timestamp to private computation instance.

### DIFF
--- a/fbpcs/private_computation/entity/post_processing_data.py
+++ b/fbpcs/private_computation/entity/post_processing_data.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class PostProcessingData:
+    """Stores metadata of post processing tier of private computation
+
+    Public attributes:
+        dataset_timestamp: timestamp of the input dataset for private computation. For daily recurring private run,
+                           timestamp would be start of the day for which dataset is selected. This timestamp is
+                           currently used only in Private Attribution and is retrieved by partner while selecting dataset.
+    """
+
+    # TODO : Add breakdown key to PostProcessingData.
+    dataset_timestamp: int = 0
+
+    def __str__(self) -> str:
+        # pyre-ignore
+        return self.to_json()

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -38,6 +38,7 @@ from fbpcs.post_processing_handler.post_processing_instance import (
 )
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
 from fbpcs.private_computation.entity.pce_config import PCEConfig
+from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -103,6 +104,7 @@ class PrivateComputationInstance(InstanceBase):
                         at the same time maintaining privacy. It is currently only used when game_type=attribution
                         because the lift id spine combiner uses a hard-coded value of 25.
                         TODO T104391012: pass padding size to lift id spine combiner.
+        post_processing_data: fields to be sent to the post processing tier.
 
     Private attributes:
         _stage_flow_cls_name: the name of a PrivateComputationBaseStageFlow subclass (cls.__name__)
@@ -155,6 +157,8 @@ class PrivateComputationInstance(InstanceBase):
     # this is used by Private ID protocol to indicate whether we should
     # enable 'use-row-numbers' argument.
     pid_use_row_numbers: bool = True
+
+    post_processing_data: Optional[PostProcessingData] = None
 
     creation_ts: int = 0
     end_ts: int = 0

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -8,6 +8,7 @@ import logging
 import time
 import unittest
 from collections import defaultdict
+from datetime import timedelta, timezone, datetime
 from typing import List, Optional, Tuple
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
@@ -201,6 +202,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(PrivateComputationInstanceStatus.CREATED, args.status)
                 self.assertEqual(1, args.creation_ts)
                 self.assertEqual(expected_k_anon, args.k_anonymity_threshold)
+
+                yesterday_date = datetime.now(tz=timezone.utc) - timedelta(days=1)
+                yesterday_timestamp = datetime.timestamp(yesterday_date)
+                self.assertEqual(
+                    int(yesterday_timestamp),
+                    args.post_processing_data.dataset_timestamp,
+                )
 
     @mock.patch("time.time", new=mock.MagicMock(side_effect=range(1, 100)))
     def test_update_instance(self) -> None:


### PR DESCRIPTION
Summary:
# PA Reporting
As part of end to end flow of Private Attribution, we need to show the final aggregated results through Ads Insight API (and eventually through Ads Manager UI).
Advertisers should be able to query results for their Ad Id based on custom date ranges as well as Ad Id levels. Furthermore, advertisers should be able to retrieve results for any level of Ad IDs (L0 - L4 - Assuming L0 level Ad Ids were used in computation run).
To achieve, we will be following a short term and a long term approach.
Short term, we will add the functionality on top of our existing ENT + LASER framework to allow Advertisers to query aggregated results for an Ad Object Id with various date and level based queries.
In the Long term (not part of this stack), we will move to MSIS + SABER configuration to provide the same functionality and also ensure long term scalability.

# This Diff
In this diff, Adding dataset timestamp to private computation instance.

# This Stack
1. Add dataset timestamp to private computation instance.
2. Add dataset timestamp to partner side computation instance.
3. Add dataset timestamp to private computation thrift.
4. Add dataset timestamp to a call from www layer to thrift.
5. Add dataset timestamp to post processing layer.

Differential Revision: D35758993

