### PR TITLE
Increasing timeout in PL reshard and next stages.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -160,7 +160,7 @@ jobs:
         working-directory: ./fbpcs/tests/github/
 
       - name: Check Status
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
         working-directory: ./fbpcs/tests/github/
@@ -171,7 +171,7 @@ jobs:
         working-directory: ./fbpcs/tests/github/
 
       - name: Check Status
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
         working-directory: ./fbpcs/tests/github/
@@ -182,7 +182,7 @@ jobs:
         working-directory: ./fbpcs/tests/github/
 
       - name: Check Status
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           ./check_status.sh ${{ env.PL_CONTAINER_NAME }} lift
         working-directory: ./fbpcs/tests/github/


### PR DESCRIPTION
Summary:
# Context
As stated in UBN - T118159117, B&R is currently blocked as github actions are timing out on PL Reshard stage. This is happening due to a recent change done in D35852672 (https://github.com/facebookresearch/fbpcs/commit/42b25ec6bff70a7fc7d8cfe2785ac0a6704d40f3), where we have increased the number of mpc shards by 5 times for PL.
This increase in number of files in addition to the time taken to write each file to S3 (approx. 4 seconds) is causing the flow to time out. verified from AWS logs, that the stage does pass.

# Changes in diff
Increase time out in PL reshard and next stages to unblock B&R. Will land this once analysis is posted on UBN, documenting the reason and justification for this increase.

Differential Revision: D35951713

