### PR TITLE
Privately share values in InputProcessor

### DIFF
--- a/fbpcs/emp_games/common/Util.h
+++ b/fbpcs/emp_games/common/Util.h
@@ -142,6 +142,54 @@ O privatelyShareArrayWithPaddingFrom(
 }
 
 /**
+ * Convert input arrays of dimension numRows by numCols to its transpose, of
+ * dimension numCols by numRows. If the input has a different size, resize the
+ * output accordingly and fill up additional entries with paddingValue.
+ **/
+template <typename T>
+std::vector<std::vector<T>> transposeArraysWithPadding(
+    const std::vector<std::vector<T>>& inputArrays,
+    size_t numRows,
+    size_t numCols,
+    T paddingValue) {
+  std::vector<std::vector<T>> outputArrays;
+  for (size_t i = 0; i < numCols; ++i) {
+    std::vector<T> outputArray;
+    for (size_t j = 0; j < numRows; ++j) {
+      if (inputArrays.size() > j && inputArrays.at(j).size() > i) {
+        outputArray.push_back(inputArrays.at(j).at(i));
+      } else {
+        outputArray.push_back(paddingValue);
+      }
+    }
+    outputArrays.push_back(std::move(outputArray));
+  }
+  return outputArrays;
+}
+
+/**
+ * Privately share tranposed array of arrays of type T from sender, with batch
+ * output type O. The input arrays have dimension numRows by numCols, and are
+ * first tranposed before sharing. If the input has a different size, resize the
+ * transposed arrays accordingly and fill up additional entries with
+ * paddingValue.
+ */
+template <int sender, typename T, typename O>
+std::vector<O> privatelyShareTransposedArraysWithPaddingFrom(
+    const std::vector<std::vector<T>>& inputArrays,
+    size_t numRows,
+    size_t numCols,
+    T paddingValue) {
+  auto transposedInputArrays = transposeArraysWithPadding<T>(
+      inputArrays, numRows, numCols, paddingValue);
+  std::vector<O> output;
+  for (auto& transposedInputArray : transposedInputArrays) {
+    output.push_back(O{transposedInputArray, sender});
+  }
+  return output;
+}
+
+/**
  * Convert a vector to a string, used for debug logging.
  */
 template <typename T>

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -11,6 +11,9 @@
 
 namespace private_lift {
 
+const size_t valueWidth = 32;
+const size_t valueSquaredWidth = 64;
+
 template <int schedulerId, bool usingBatch = true>
 using PubBit =
     typename fbpcf::frontend::MpcGame<schedulerId>::template PubBit<usingBatch>;
@@ -18,5 +21,21 @@ using PubBit =
 template <int schedulerId, bool usingBatch = true>
 using SecBit =
     typename fbpcf::frontend::MpcGame<schedulerId>::template SecBit<usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubValue = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubSignedInt<valueWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecValue = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecSignedInt<valueWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubValueSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubSignedInt<valueSquaredWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecValueSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecSignedInt<valueSquaredWidth, usingBatch>;
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,7 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    privatelySharePurchaseValuesStep();
     privatelyShareTestReachStep();
   }
 
@@ -34,6 +35,15 @@ class InputProcessor {
 
   int64_t getNumRows() const {
     return numRows_;
+  }
+
+  const std::vector<SecValue<schedulerId>> getPurchaseValues() const {
+    return purchaseValues_;
+  }
+
+  const std::vector<SecValueSquared<schedulerId>> getPurchaseValueSquared()
+      const {
+    return purchaseValueSquared_;
   }
 
   const SecBit<schedulerId> getTestReach() const {
@@ -44,6 +54,9 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Privately share purchase values and purchase values squared
+  void privatelySharePurchaseValuesStep();
+
   // Privately share test reach (nonzero impressions)
   void privatelyShareTestReachStep();
 
@@ -52,6 +65,8 @@ class InputProcessor {
   int64_t numRows_;
   int32_t numConversionsPerUser_;
 
+  std::vector<SecValue<schedulerId>> purchaseValues_;
+  std::vector<SecValueSquared<schedulerId>> purchaseValueSquared_;
   SecBit<schedulerId> testReach_;
 };
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -29,6 +29,29 @@ void InputProcessor<schedulerId>::validateNumRowsStep() {
 }
 
 template <int schedulerId>
+void InputProcessor<schedulerId>::privatelySharePurchaseValuesStep() {
+  XLOG(INFO) << "Share purchase values";
+  // Since the input values are processed row by row, while we will be doing
+  // batch computations with the values across the rows, we have to first
+  // transpose the input arrays before sharing them in MPC.
+  purchaseValues_ = common::privatelyShareTransposedArraysWithPaddingFrom<
+      common::PARTNER,
+      int64_t,
+      SecValue<schedulerId>>(
+      inputData_.getPurchaseValueArrays(), numRows_, numConversionsPerUser_, 0);
+
+  XLOG(INFO) << "Share purchase values squared";
+  purchaseValueSquared_ = common::privatelyShareTransposedArraysWithPaddingFrom<
+      common::PARTNER,
+      int64_t,
+      SecValueSquared<schedulerId>>(
+      inputData_.getPurchaseValueSquaredArrays(),
+      numRows_,
+      numConversionsPerUser_,
+      0);
+}
+
+template <int schedulerId>
 void InputProcessor<schedulerId>::privatelyShareTestReachStep() {
   XLOG(INFO) << "Share reach";
   std::vector<bool> testReach;


### PR DESCRIPTION
Summary:
We add methods to privately share the purchase values and the values squared in the InputProcessor. Since the input values are processed row by row, while we will be doing batch computations with the values across the rows, we have to first transpose the input arrays before sharing them in MPC.

For more details about the correctness tests, refer to https://docs.google.com/spreadsheets/d/1xsIl33YDU_y7lSVD5gsiGV-ubl2x9TDYiTVRyR4dS74/edit#gid=0

Reviewed By: RuiyuZhu

Differential Revision: D35791405

