### PR TITLE
Privately share timestamps in InputProcessor

### DIFF
--- a/fbpcs/emp_games/common/Util.h
+++ b/fbpcs/emp_games/common/Util.h
@@ -142,6 +142,54 @@ O privatelyShareArrayWithPaddingFrom(
 }
 
 /**
+ * Convert input arrays of dimension numRows by numCols to its transpose, of
+ * dimension numCols by numRows. If the input has a different size, resize the
+ * output accordingly and fill up additional entries with paddingValue.
+ **/
+template <typename T>
+std::vector<std::vector<T>> transposeArraysWithPadding(
+    const std::vector<std::vector<T>>& inputArrays,
+    size_t numRows,
+    size_t numCols,
+    T paddingValue) {
+  std::vector<std::vector<T>> outputArrays;
+  for (size_t i = 0; i < numCols; ++i) {
+    std::vector<T> outputArray;
+    for (size_t j = 0; j < numRows; ++j) {
+      if (inputArrays.size() > j && inputArrays.at(j).size() > i) {
+        outputArray.push_back(inputArrays.at(j).at(i));
+      } else {
+        outputArray.push_back(paddingValue);
+      }
+    }
+    outputArrays.push_back(std::move(outputArray));
+  }
+  return outputArrays;
+}
+
+/**
+ * Privately share tranposed array of arrays of type T from sender, with batch
+ * output type O. The input arrays have dimension numRows by numCols, and are
+ * first tranposed before sharing. If the input has a different size, resize the
+ * transposed arrays accordingly and fill up additional entries with
+ * paddingValue.
+ */
+template <int sender, typename T, typename O>
+std::vector<O> privatelyShareTransposedArraysWithPaddingFrom(
+    const std::vector<std::vector<T>>& inputArrays,
+    size_t numRows,
+    size_t numCols,
+    T paddingValue) {
+  auto transposedInputArrays = transposeArraysWithPadding<T>(
+      inputArrays, numRows, numCols, paddingValue);
+  std::vector<O> output;
+  for (auto& transposedInputArray : transposedInputArrays) {
+    output.push_back(O{transposedInputArray, sender});
+  }
+  return output;
+}
+
+/**
  * Convert a vector to a string, used for debug logging.
  */
 template <typename T>

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -11,6 +11,9 @@
 
 namespace private_lift {
 
+const size_t valueWidth = 32;
+const size_t valueSquaredWidth = 64;
+
 template <int schedulerId, bool usingBatch = true>
 using PubBit =
     typename fbpcf::frontend::MpcGame<schedulerId>::template PubBit<usingBatch>;
@@ -18,5 +21,21 @@ using PubBit =
 template <int schedulerId, bool usingBatch = true>
 using SecBit =
     typename fbpcf::frontend::MpcGame<schedulerId>::template SecBit<usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubValue = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubSignedInt<valueWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecValue = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecSignedInt<valueWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubValueSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubSignedInt<valueSquaredWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecValueSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecSignedInt<valueSquaredWidth, usingBatch>;
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -13,6 +13,7 @@ namespace private_lift {
 
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;
+const size_t timeStampWidth = 32;
 
 template <int schedulerId, bool usingBatch = true>
 using PubBit =
@@ -37,5 +38,13 @@ using PubValueSquared = typename fbpcf::frontend::MpcGame<
 template <int schedulerId, bool usingBatch = true>
 using SecValueSquared = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecSignedInt<valueSquaredWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubTimestamp = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<timeStampWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecTimestamp = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<timeStampWidth, usingBatch>;
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -45,7 +45,7 @@ InputData::InputData(
 
 void InputData::setTimestamps(
     std::string& str,
-    std::vector<std::vector<int64_t>>& timestampArrays) {
+    std::vector<std::vector<uint32_t>>& timestampArrays) {
   timestampArrays.emplace_back();
   // Strip the brackets [] before splitting into individual timestamp values
   auto innerString = str.substr(1, str.size() - 1);
@@ -66,7 +66,7 @@ void InputData::setTimestamps(
       LOG(FATAL) << "Timestamp " << parsed << " is before epoch " << epoch_
                  << ", which is unexpected.";
     }
-    timestampArrays.back().push_back(parsed - epoch_);
+    timestampArrays.back().push_back(parsed < epoch_ ? 0 : parsed - epoch_);
   }
 }
 
@@ -193,7 +193,7 @@ void InputData::addFromCSV(
         LOG(FATAL) << "Timestamp " << parsed << " is before epoch " << epoch_
                    << ", which is unexpected.";
       }
-      opportunityTimestamps_.push_back(parsed - epoch_);
+      opportunityTimestamps_.push_back(parsed < epoch_ ? 0 : parsed - epoch_);
     } else if (column == "num_impressions") {
       numImpressions_.push_back(parsed);
     } else if (column == "num_clicks") {
@@ -212,7 +212,7 @@ void InputData::addFromCSV(
         value = "[" + value + "]";
         setTimestamps(value, purchaseTimestampArrays_);
       } else {
-        purchaseTimestamps_.push_back(parsed - epoch_);
+        purchaseTimestamps_.push_back(parsed < epoch_ ? 0 : parsed - epoch_);
       }
     } else if (column == "event_timestamps") {
       setTimestamps(value, purchaseTimestampArrays_);

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -50,7 +50,7 @@ class InputData {
     return controlPopulation_;
   }
 
-  const std::vector<int64_t>& getOpportunityTimestamps() const {
+  const std::vector<uint32_t>& getOpportunityTimestamps() const {
     return opportunityTimestamps_;
   }
 
@@ -66,16 +66,16 @@ class InputData {
     return totalSpend_;
   }
 
-  const std::vector<std::vector<int64_t>>& getOpportunityTimestampArrays()
+  const std::vector<std::vector<uint32_t>>& getOpportunityTimestampArrays()
       const {
     return opportunityTimestampArrays_;
   }
 
-  const std::vector<int64_t>& getPurchaseTimestamps() const {
+  const std::vector<uint32_t>& getPurchaseTimestamps() const {
     return purchaseTimestamps_;
   }
 
-  const std::vector<std::vector<int64_t>>& getPurchaseTimestampArrays() const {
+  const std::vector<std::vector<uint32_t>>& getPurchaseTimestampArrays() const {
     return purchaseTimestampArrays_;
   }
 
@@ -147,7 +147,7 @@ class InputData {
    */
   void setTimestamps(
       std::string& str,
-      std::vector<std::vector<int64_t>>& timestampArrays);
+      std::vector<std::vector<uint32_t>>& timestampArrays);
 
   /*
    * Append values from str to valueArrays and add to totalValue.
@@ -172,16 +172,16 @@ class InputData {
   int64_t epoch_;
   std::vector<int64_t> testPopulation_;
   std::vector<int64_t> controlPopulation_;
-  std::vector<int64_t> opportunityTimestamps_;
+  std::vector<uint32_t> opportunityTimestamps_;
   std::vector<int64_t> numImpressions_;
   std::vector<int64_t> numClicks_;
   std::vector<int64_t> totalSpend_;
-  std::vector<int64_t> purchaseTimestamps_;
+  std::vector<uint32_t> purchaseTimestamps_;
   std::vector<int64_t> purchaseValues_;
   std::vector<int64_t> purchaseValuesSquared_;
   std::vector<int64_t> groupIds_;
-  std::vector<std::vector<int64_t>> opportunityTimestampArrays_;
-  std::vector<std::vector<int64_t>> purchaseTimestampArrays_;
+  std::vector<std::vector<uint32_t>> opportunityTimestampArrays_;
+  std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;
   std::vector<std::vector<int64_t>> purchaseValueSquaredArrays_;
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,7 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    privatelySharePurchaseValuesStep();
     privatelyShareTestReachStep();
   }
 
@@ -34,6 +35,15 @@ class InputProcessor {
 
   int64_t getNumRows() const {
     return numRows_;
+  }
+
+  const std::vector<SecValue<schedulerId>> getPurchaseValues() const {
+    return purchaseValues_;
+  }
+
+  const std::vector<SecValueSquared<schedulerId>> getPurchaseValueSquared()
+      const {
+    return purchaseValueSquared_;
   }
 
   const SecBit<schedulerId> getTestReach() const {
@@ -44,6 +54,9 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Privately share purchase values and purchase values squared
+  void privatelySharePurchaseValuesStep();
+
   // Privately share test reach (nonzero impressions)
   void privatelyShareTestReachStep();
 
@@ -52,6 +65,8 @@ class InputProcessor {
   int64_t numRows_;
   int32_t numConversionsPerUser_;
 
+  std::vector<SecValue<schedulerId>> purchaseValues_;
+  std::vector<SecValueSquared<schedulerId>> purchaseValueSquared_;
   SecBit<schedulerId> testReach_;
 };
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,7 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    privatelyShareTimestampsStep();
     privatelySharePurchaseValuesStep();
     privatelyShareTestReachStep();
   }
@@ -35,6 +36,26 @@ class InputProcessor {
 
   int64_t getNumRows() const {
     return numRows_;
+  }
+
+  const SecTimestamp<schedulerId> getOpportunityTimestamps() const {
+    return opportunityTimestamps_;
+  }
+
+  const SecBit<schedulerId> getIsValidOpportunityTimestamp() const {
+    return isValidOpportunityTimestamp_;
+  }
+
+  const std::vector<SecTimestamp<schedulerId>> getPurchaseTimestamps() const {
+    return purchaseTimestamps_;
+  }
+
+  const std::vector<SecTimestamp<schedulerId>> getThresholdTimestamps() const {
+    return thresholdTimestamps_;
+  }
+
+  const SecBit<schedulerId> getAnyValidPurchaseTimestamp() const {
+    return anyValidPurchaseTimestamp_;
   }
 
   const std::vector<SecValue<schedulerId>> getPurchaseValues() const {
@@ -54,6 +75,9 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Privately share timestamps
+  void privatelyShareTimestampsStep();
+
   // Privately share purchase values and purchase values squared
   void privatelySharePurchaseValuesStep();
 
@@ -65,6 +89,11 @@ class InputProcessor {
   int64_t numRows_;
   int32_t numConversionsPerUser_;
 
+  SecTimestamp<schedulerId> opportunityTimestamps_;
+  SecBit<schedulerId> isValidOpportunityTimestamp_;
+  std::vector<SecTimestamp<schedulerId>> purchaseTimestamps_;
+  std::vector<SecTimestamp<schedulerId>> thresholdTimestamps_;
+  SecBit<schedulerId> anyValidPurchaseTimestamp_;
   std::vector<SecValue<schedulerId>> purchaseValues_;
   std::vector<SecValueSquared<schedulerId>> purchaseValueSquared_;
   SecBit<schedulerId> testReach_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -29,6 +29,29 @@ void InputProcessor<schedulerId>::validateNumRowsStep() {
 }
 
 template <int schedulerId>
+void InputProcessor<schedulerId>::privatelySharePurchaseValuesStep() {
+  XLOG(INFO) << "Share purchase values";
+  // Since the input values are processed row by row, while we will be doing
+  // batch computations with the values across the rows, we have to first
+  // transpose the input arrays before sharing them in MPC.
+  purchaseValues_ = common::privatelyShareTransposedArraysWithPaddingFrom<
+      common::PARTNER,
+      int64_t,
+      SecValue<schedulerId>>(
+      inputData_.getPurchaseValueArrays(), numRows_, numConversionsPerUser_, 0);
+
+  XLOG(INFO) << "Share purchase values squared";
+  purchaseValueSquared_ = common::privatelyShareTransposedArraysWithPaddingFrom<
+      common::PARTNER,
+      int64_t,
+      SecValueSquared<schedulerId>>(
+      inputData_.getPurchaseValueSquaredArrays(),
+      numRows_,
+      numConversionsPerUser_,
+      0);
+}
+
+template <int schedulerId>
 void InputProcessor<schedulerId>::privatelyShareTestReachStep() {
   XLOG(INFO) << "Share reach";
   std::vector<bool> testReach;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -29,6 +29,80 @@ void InputProcessor<schedulerId>::validateNumRowsStep() {
 }
 
 template <int schedulerId>
+void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
+  // TODO: We're using 32 bits for timestamps along with an offset setting the
+  // epoch to 2019-01-01. This will break in the year 2087.
+  XLOG(INFO) << "Share opportunity timestamps";
+  opportunityTimestamps_ = common::privatelyShareArrayWithPaddingFrom<
+      common::PUBLISHER,
+      uint32_t,
+      SecTimestamp<schedulerId>>(
+      inputData_.getOpportunityTimestamps(), numRows_, 0);
+
+  XLOG(INFO) << "Share if opportunity timestamps are valid";
+  std::vector<bool> isValidOpportunityTimestamp;
+  for (size_t i = 0; i < inputData_.getOpportunityTimestamps().size(); ++i) {
+    // Nonzero opportunity timestamp and is opportunity (test or control)
+    isValidOpportunityTimestamp.push_back(
+        (inputData_.getOpportunityTimestamps().at(i) > 0) &
+        (inputData_.getControlPopulation().at(i) |
+         inputData_.getTestPopulation().at(i)));
+  }
+  isValidOpportunityTimestamp_ = common::privatelyShareArrayWithPaddingFrom<
+      common::PUBLISHER,
+      bool,
+      SecBit<schedulerId>>(isValidOpportunityTimestamp, numRows_, 0);
+
+  XLOG(INFO) << "Share purchase timestamps";
+  purchaseTimestamps_ = common::privatelyShareTransposedArraysWithPaddingFrom<
+      common::PARTNER,
+      uint32_t,
+      SecTimestamp<schedulerId>>(
+      inputData_.getPurchaseTimestampArrays(),
+      numRows_,
+      numConversionsPerUser_,
+      0);
+
+  XLOG(INFO) << "Share if any purchase timestamp is valid";
+  std::vector<bool> anyValidPurchaseTimestamp;
+  for (auto& purchaseTimestampArray : inputData_.getPurchaseTimestampArrays()) {
+    bool anyValidPurchaseTs = false;
+    for (auto purchaseTs : purchaseTimestampArray) {
+      // compute whether each row contains at least one valid (positive)
+      // purchase timestamp
+      anyValidPurchaseTs = anyValidPurchaseTs | (purchaseTs > 0);
+    }
+    anyValidPurchaseTimestamp.push_back(anyValidPurchaseTs);
+  }
+  anyValidPurchaseTimestamp_ = common::privatelyShareArrayWithPaddingFrom<
+      common::PARTNER,
+      bool,
+      SecBit<schedulerId>>(anyValidPurchaseTimestamp, numRows_, 0);
+
+  XLOG(INFO) << "Share threshold timestamps";
+  // Threshold timestamps are valid (positive) purchase timestamp with added
+  // attribution window
+  const int window = 10;
+  std::vector<std::vector<uint32_t>> thresholdTimestampArrays;
+  for (const auto& purchaseTimestampArray :
+       inputData_.getPurchaseTimestampArrays()) {
+    std::vector<uint32_t> thresholdTimestampArray;
+    for (auto purchaseTimestamp : purchaseTimestampArray) {
+      auto thresholdTimestamp =
+          purchaseTimestamp > 0 ? purchaseTimestamp + window : 0;
+      thresholdTimestampArray.push_back(thresholdTimestamp);
+    }
+    thresholdTimestampArrays.push_back(std::move(thresholdTimestampArray));
+  }
+  // Secretly share threshold timestamps
+  thresholdTimestamps_ = common::privatelyShareTransposedArraysWithPaddingFrom<
+      common::PARTNER,
+      uint32_t,
+      SecTimestamp<schedulerId>>(
+      thresholdTimestampArrays, numRows_, numConversionsPerUser_, 0);
+}
+
+template <int schedulerId>
 void InputProcessor<schedulerId>::privatelySharePurchaseValuesStep() {
   XLOG(INFO) << "Share purchase values";
   // Since the input values are processed row by row, while we will be doing

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
@@ -48,11 +48,10 @@ TEST_F(InputDataTest, TestInputDataPublisher) {
   std::vector<int64_t> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
                                                   0, 0, 1, 0, 0, 1, 1, 0, 1, 1};
   // opportunity_timestamp - epoch
-  std::vector<int64_t> expectOpportunityTimestamps = {
-      53699630,    53699601,    -1546300800, -1546300800, -1546300800,
-      53699661,    53699252,    53700031,    53699730,    53700172,
-      -1546300800, -1546300800, 53699306,    53700140,    53699240,
-      53699397,    53699415,    53700127,    53699760,    53699598};
+  std::vector<uint32_t> expectOpportunityTimestamps = {
+      53699630, 53699601, 0,        0,        0,        53699661, 53699252,
+      53700031, 53699730, 53700172, 0,        0,        53699306, 53700140,
+      53699240, 53699397, 53699415, 53700127, 53699760, 53699598};
   auto resTestPopulation = inputData.getTestPopulation();
   auto resControlPopulation = inputData.getControlPopulation();
   auto resOpportunityTimestamps = inputData.getOpportunityTimestamps();
@@ -73,11 +72,10 @@ TEST_F(InputDataTest, TestInputDataPublisherOppColLast) {
   std::vector<int64_t> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
                                                   0, 0, 1, 0, 0, 1, 1, 0, 1, 1};
   // opportunity_timestamp - epoch
-  std::vector<int64_t> expectOpportunityTimestamps = {
-      53699630,    53699601,    -1546300800, -1546300800, -1546300800,
-      53699661,    53699252,    53700031,    53699730,    53700172,
-      -1546300800, -1546300800, 53699306,    53700140,    53699240,
-      53699397,    53699415,    53700127,    53699760,    53699598};
+  std::vector<uint32_t> expectOpportunityTimestamps = {
+      53699630, 53699601, 0,        0,        0,        53699661, 53699252,
+      53700031, 53699730, 53700172, 0,        0,        53699306, 53700140,
+      53699240, 53699397, 53699415, 53700127, 53699760, 53699598};
   auto resTestPopulation = inputData.getTestPopulation();
   auto resControlPopulation = inputData.getControlPopulation();
   auto resOpportunityTimestamps = inputData.getOpportunityTimestamps();
@@ -93,27 +91,27 @@ TEST_F(InputDataTest, TestInputDataPartner) {
       InputData::LiftGranularityType::Conversion,
       1546300800, /* epoch */
       4 /* num_conversions_per_user */};
-  std::vector<std::vector<int64_t>> expectGetPurchaseTimestampArrays = {
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, 53699530, 53699794},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, 53699428},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, 53699222, 53699836, 53699923},
+  std::vector<std::vector<uint32_t>> expectGetPurchaseTimestampArrays = {
+      {0, 0, 0, 0},
+      {0, 0, 53699530, 53699794},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 53699428},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 53699222, 53699836, 53699923},
       {53699839, 53699868, 53700039, 53700058},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800},
-      {-1546300800, -1546300800, -1546300800, -1546300800}};
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0},
+      {0, 0, 0, 0}};
   std::vector<std::vector<int64_t>> expectPurchaseValueArrays = {
       {0, 0, 0, 0},  {0, 0, 71, 71}, {0, 0, 0, 0},    {0, 0, 0, 0},
       {0, 0, 0, 25}, {0, 0, 0, 0},   {0, 0, 0, 0},    {0, 0, 0, 0},
@@ -139,7 +137,7 @@ TEST_F(InputDataTest, TestInputDataPartnerConverterLift) {
       InputData::LiftGranularityType::Converter,
       0, /* epoch */
       1 /* num_conversions_per_user */};
-  std::vector<std::vector<int64_t>> expectGetPurchaseTimestamps = {
+  std::vector<std::vector<uint32_t>> expectGetPurchaseTimestamps = {
       {0},          {1600000594}, {0}, {0}, {1600000228}, {0}, {0},
       {0},          {0},          {0}, {0}, {0},          {0}, {0},
       {1600000723}, {1600000858}, {0}, {0}, {0},          {0}};


### PR DESCRIPTION
Summary:
We add a method to privately share input timestamps in the InputProcessor. This methods share the opportunity timestamps from the publisher and the purchase timestamps from the partner.

In addition to sharing these timestamps, we also pre-compute and share other information needed about the timestamps:
- `isValidOpportunityTimestamp` indicates whether an opportunity timestamp is positive and corresponds to an opportunity (test/control).
- `thresholdTimestamps` are the purchase timestamps with an added attribution window (10), which are needed to calculate the main attribution logic (opportunity timestamp < threshold timestamp).
- `anyValidPurchaseTimestamp` indicate whether each row contains at least one positive purchase timestamp. This is needed to compute the match.

For more details about the correctness test cases, refer to https://docs.google.com/spreadsheets/d/1xsIl33YDU_y7lSVD5gsiGV-ubl2x9TDYiTVRyR4dS74/edit#gid=0

Reviewed By: RuiyuZhu

Differential Revision: D35791490

