### PR TITLE
Calculate match in Attributor

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "folly/logging/xlog.h"
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class Attributor {
+ public:
+  Attributor(int myRole, InputProcessor<schedulerId> inputProcessor)
+      : myRole_{myRole},
+        inputProcessor_{inputProcessor},
+        numRows_{inputProcessor.getNumRows()} {
+    calculateEvents();
+  }
+
+  const std::vector<SecBit<schedulerId>> getEvents() const {
+    return events_;
+  }
+
+ private:
+  // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
+  void calculateEvents();
+
+  int32_t myRole_;
+  InputProcessor<schedulerId> inputProcessor_;
+  int64_t numRows_;
+
+  std::vector<SecBit<schedulerId>> events_;
+};
+
+} // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -21,21 +21,36 @@ class Attributor {
         inputProcessor_{inputProcessor},
         numRows_{inputProcessor.getNumRows()} {
     calculateEvents();
+    calculateNumConvSquaredAndConverters();
   }
 
   const std::vector<SecBit<schedulerId>> getEvents() const {
     return events_;
   }
 
+  const SecBit<schedulerId> getConverters() const {
+    return converters_;
+  }
+
+  const SecNumConvSquared<schedulerId> getNumConvSquared() const {
+    return numConvSquared_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
+
+  // Test/Control numConvSquared: number of valid events squared
+  // Test/Control converters: any valid event
+  void calculateNumConvSquaredAndConverters();
 
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   int64_t numRows_;
 
   std::vector<SecBit<schedulerId>> events_;
+  SecBit<schedulerId> converters_;
+  SecNumConvSquared<schedulerId> numConvSquared_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -22,6 +22,7 @@ class Attributor {
         numRows_{inputProcessor.getNumRows()} {
     calculateEvents();
     calculateNumConvSquaredAndConverters();
+    calculateMatch();
   }
 
   const std::vector<SecBit<schedulerId>> getEvents() const {
@@ -36,6 +37,10 @@ class Attributor {
     return numConvSquared_;
   }
 
+  const SecBit<schedulerId> getMatch() const {
+    return match_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
@@ -44,6 +49,10 @@ class Attributor {
   // Test/Control converters: any valid event
   void calculateNumConvSquaredAndConverters();
 
+  // Test/control match: valid opportunity timestamp & any valid purchase
+  // timestamp
+  void calculateMatch();
+
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   int64_t numRows_;
@@ -51,6 +60,7 @@ class Attributor {
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;
   SecNumConvSquared<schedulerId> numConvSquared_;
+  SecBit<schedulerId> match_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -78,4 +78,13 @@ void Attributor<schedulerId>::calculateNumConvSquaredAndConverters() {
   converters_ = eventArray.at(firstIndex);
 }
 
+template <int schedulerId>
+void Attributor<schedulerId>::calculateMatch() {
+  XLOG(INFO) << "Calculate match";
+  // a valid test/control match is when a person with an opportunity made
+  // ANY nonzero conversion.
+  match_ = inputProcessor_.getAnyValidPurchaseTimestamp() &
+      inputProcessor_.getIsValidOpportunityTimestamp();
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace private_lift {
+
+template <int schedulerId>
+void Attributor<schedulerId>::calculateEvents() {
+  XLOG(INFO) << "Calculate events";
+  for (auto& thresholdTs : inputProcessor_.getThresholdTimestamps()) {
+    // Events occur when there is a valid purchase, i.e. the opportunity
+    // timestamp is less than the threshold timestamp
+    events_.push_back(std::move(
+        inputProcessor_.getIsValidOpportunityTimestamp() &
+        (thresholdTs > inputProcessor_.getOpportunityTimestamps())));
+  }
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -21,4 +21,61 @@ void Attributor<schedulerId>::calculateEvents() {
   }
 }
 
+template <int schedulerId>
+void Attributor<schedulerId>::calculateNumConvSquaredAndConverters() {
+  XLOG(INFO) << "Calculate numConvSquared & converters";
+  // We find the first valid event using a binary tree approach. The number of
+  // conversions is the remaining number of elements in the array.
+  // We first construct new arrays to store the intermediate results
+  std::vector<SecNumConvSquared<schedulerId>> numConvSquaredArray;
+  for (size_t i = 0; i < events_.size(); ++i) {
+    auto numConv = events_.size() - i;
+    auto convSquared = static_cast<uint32_t>(numConv * numConv);
+    SecNumConvSquared<schedulerId> numConvSquared(
+        std::vector(numRows_, convSquared), common::PUBLISHER);
+    numConvSquaredArray.push_back(numConvSquared);
+  }
+  // The numConvSquared is zero if there are no valid events
+  SecNumConvSquared<schedulerId> zero{
+      std::vector<uint32_t>(numRows_, 0), common::PUBLISHER};
+  numConvSquaredArray.push_back(zero);
+
+  std::vector<SecBit<schedulerId>> eventArray = events_;
+  SecBit<schedulerId> zeroBit{
+      std::vector<bool>(numRows_, false), common::PUBLISHER};
+  eventArray.push_back(zeroBit);
+
+  int stepSize = 1; // we process the array elements in pairs with indices
+                    // differing by stepSize
+  int firstIndex = 0; // first index at this level
+  while (firstIndex < eventArray.size() / 2) {
+    for (size_t i = firstIndex; i < eventArray.size(); i += 2 * stepSize) {
+      if (i + stepSize < eventArray.size()) {
+        // If there is a valid event at i, we set the numConvSquared to be
+        // numConvSquared[i], else we set it to be numConvSquared[i + stepSize]
+        numConvSquaredArray[i + stepSize] =
+            numConvSquaredArray.at(i + stepSize)
+                .mux(eventArray.at(i), numConvSquaredArray.at(i));
+        // Update the events for the next level
+        eventArray[i + stepSize] =
+            eventArray.at(i + stepSize) | eventArray.at(i);
+      } else {
+        // Odd number of elements at this level, compute the mux with the
+        // previous pair
+        auto previousIndex = i - stepSize;
+        numConvSquaredArray[previousIndex] = numConvSquaredArray.at(i).mux(
+            eventArray.at(previousIndex),
+            numConvSquaredArray.at(previousIndex));
+        eventArray[previousIndex] =
+            eventArray.at(previousIndex) | eventArray.at(i);
+      }
+    }
+    firstIndex += stepSize;
+    stepSize = stepSize << 1;
+  }
+  numConvSquared_ = numConvSquaredArray.at(firstIndex);
+  // A converter occurs when a row contains any valid event
+  converters_ = eventArray.at(firstIndex);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -11,6 +11,7 @@
 
 namespace private_lift {
 
+const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;
 const size_t timeStampWidth = 32;
@@ -46,5 +47,13 @@ using PubTimestamp = typename fbpcf::frontend::MpcGame<
 template <int schedulerId, bool usingBatch = true>
 using SecTimestamp = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<timeStampWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubNumConvSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<numConvSquaredWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecNumConvSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<numConvSquaredWidth, usingBatch>;
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -143,4 +143,18 @@ TEST_F(AttributorTest, testNumConvSquared) {
   EXPECT_EQ(numConvSquared0, expectNumConvSquared);
 }
 
+TEST_F(AttributorTest, testMatch) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getMatch().openToParty(0).getValue();
+  });
+  auto future1 = std::async(
+      [&] { return partnerAttributor_->getMatch().openToParty(0).getValue(); });
+  auto match0 = future0.get();
+  auto match1 = future1.get();
+  std::vector<bool> expectMatch = {0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1,
+                                   1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0,
+                                   0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1};
+  EXPECT_EQ(match0, expectMatch);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -113,4 +113,34 @@ TEST_F(AttributorTest, testEvents) {
   EXPECT_EQ(events0, expectEvents);
 }
 
+TEST_F(AttributorTest, testConverters) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getConverters().openToParty(0).getValue();
+  });
+  auto future1 = std::async([&] {
+    return partnerAttributor_->getConverters().openToParty(0).getValue();
+  });
+  auto converters0 = future0.get();
+  auto converters1 = future1.get();
+  std::vector<bool> expectConverters = {0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+                                        0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0,
+                                        0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1};
+  EXPECT_EQ(converters0, expectConverters);
+}
+
+TEST_F(AttributorTest, testNumConvSquared) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getNumConvSquared().openToParty(0).getValue();
+  });
+  auto future1 = std::async([&] {
+    return partnerAttributor_->getNumConvSquared().openToParty(0).getValue();
+  });
+  auto numConvSquared0 = future0.get();
+  auto numConvSquared1 = future1.get();
+  std::vector<uint64_t> expectNumConvSquared = {
+      0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 4, 4, 0, 1,
+      1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 1, 0, 0, 1, 1};
+  EXPECT_EQ(numConvSquared0, expectNumConvSquared);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcs/emp_games/common/TestUtil.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
+namespace private_lift {
+const bool unsafe = true;
+
+template <int schedulerId>
+Attributor<schedulerId> createAttributorWithScheduler(
+    int myRole,
+    InputData inputData,
+    int numConversionsPerUser,
+    std::reference_wrapper<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myRole, factory);
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+  auto inputProcessor =
+      InputProcessor<schedulerId>(myRole, inputData, numConversionsPerUser);
+  return Attributor<schedulerId>(myRole, inputProcessor);
+}
+
+class AttributorTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<Attributor<0>> publisherAttributor_;
+  std::unique_ptr<Attributor<1>> partnerAttributor_;
+
+  void SetUp() override {
+    std::string baseDir =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__);
+    std::string publisherInputFilename =
+        baseDir + "../sample_input/publisher_unittest3.csv";
+    std::string partnerInputFilename =
+        baseDir + "../sample_input/partner_2_convs_unittest.csv";
+    int numConversionsPerUser = 2;
+    int epoch = 1546300800;
+    auto publisherInputData = InputData(
+        publisherInputFilename,
+        InputData::LiftMPCType::Standard,
+        InputData::LiftGranularityType::Conversion,
+        epoch,
+        numConversionsPerUser);
+    auto partnerInputData = InputData(
+        partnerInputFilename,
+        InputData::LiftMPCType::Standard,
+        InputData::LiftGranularityType::Conversion,
+        epoch,
+        numConversionsPerUser);
+
+    auto schedulerCreator =
+        fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>;
+    auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+    auto future0 = std::async(
+        createAttributorWithScheduler<0>,
+        0,
+        publisherInputData,
+        numConversionsPerUser,
+        std::reference_wrapper<
+            fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+            *factories[0]),
+        schedulerCreator);
+
+    auto future1 = std::async(
+        createAttributorWithScheduler<1>,
+        1,
+        partnerInputData,
+        numConversionsPerUser,
+        std::reference_wrapper<
+            fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+            *factories[1]),
+        schedulerCreator);
+
+    publisherAttributor_ = std::make_unique<Attributor<0>>(future0.get());
+    partnerAttributor_ = std::make_unique<Attributor<1>>(future1.get());
+  }
+};
+
+template <int schedulerId>
+std::vector<std::vector<bool>> revealEvents(
+    std::unique_ptr<Attributor<schedulerId>> attributor) {
+  std::vector<std::vector<bool>> output;
+  for (const auto& events : attributor->getEvents()) {
+    output.push_back(events.openToParty(0).getValue());
+  }
+  return output;
+}
+
+TEST_F(AttributorTest, testEvents) {
+  auto future0 = std::async(revealEvents<0>, std::move(publisherAttributor_));
+  auto future1 = std::async(revealEvents<1>, std::move(partnerAttributor_));
+  auto events0 = future0.get();
+  auto events1 = future1.get();
+  std::vector<std::vector<bool>> expectEvents = {
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1,
+       1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1}};
+  EXPECT_EQ(events0, expectEvents);
+}
+
+} // namespace private_lift


### PR DESCRIPTION
Summary:
We add a method to calculate the match in the Attributor. A match occurs when a row has a valid opportunity timestamp and any valid purchase timestamp. These are already pre-computed in plaintext in D35791490 (https://github.com/facebookresearch/fbpcs/commit/1398ae59fd59b45ddb8fb7cde8b7e8720a39fd9c), so the only logic here is to take the AND of these two bits.

For more details about the correctness tests, refer to https://docs.google.com/spreadsheets/d/1xsIl33YDU_y7lSVD5gsiGV-ubl2x9TDYiTVRyR4dS74/edit?usp=sharing

Reviewed By: RuiyuZhu

Differential Revision: D35794563

