### PR TITLE
Privately share cohorts in InputProcessor

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -23,6 +23,7 @@ class Attributor {
     calculateEvents();
     calculateNumConvSquaredAndConverters();
     calculateMatch();
+    calculateReachedConversions();
   }
 
   const std::vector<SecBit<schedulerId>> getEvents() const {
@@ -41,6 +42,10 @@ class Attributor {
     return match_;
   }
 
+  const std::vector<SecBit<schedulerId>> getReachedConversions() const {
+    return reachedConversions_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
@@ -53,6 +58,9 @@ class Attributor {
   // timestamp
   void calculateMatch();
 
+  // Test reached conversions: valid event & reach (number of impressions > 0)
+  void calculateReachedConversions();
+
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   int64_t numRows_;
@@ -61,6 +69,7 @@ class Attributor {
   SecBit<schedulerId> converters_;
   SecNumConvSquared<schedulerId> numConvSquared_;
   SecBit<schedulerId> match_;
+  std::vector<SecBit<schedulerId>> reachedConversions_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -21,7 +21,7 @@ class Attributor {
         inputProcessor_{inputProcessor},
         numRows_{inputProcessor.getNumRows()} {
     calculateEvents();
-    calculateNumConvSquaredAndConverters();
+    calculateNumConvSquaredAndValueSquaredAndConverters();
     calculateMatch();
     calculateReachedConversions();
     calculateValues();
@@ -55,13 +55,18 @@ class Attributor {
     return reachedValues_;
   }
 
+  const SecValueSquared<schedulerId> getValueSquared() const {
+    return valueSquared_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
 
   // Test/Control numConvSquared: number of valid events squared
   // Test/Control converters: any valid event
-  void calculateNumConvSquaredAndConverters();
+  // Test/Control value squared: sum(valid event ? purchaseValue : 0)^2
+  void calculateNumConvSquaredAndValueSquaredAndConverters();
 
   // Test/control match: valid opportunity timestamp & any valid purchase
   // timestamp
@@ -85,6 +90,7 @@ class Attributor {
   std::vector<SecBit<schedulerId>> reachedConversions_;
   std::vector<SecValue<schedulerId>> values_;
   std::vector<SecValue<schedulerId>> reachedValues_;
+  SecValueSquared<schedulerId> valueSquared_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -24,6 +24,7 @@ class Attributor {
     calculateNumConvSquaredAndConverters();
     calculateMatch();
     calculateReachedConversions();
+    calculateValues();
   }
 
   const std::vector<SecBit<schedulerId>> getEvents() const {
@@ -46,6 +47,14 @@ class Attributor {
     return reachedConversions_;
   }
 
+  const std::vector<SecValue<schedulerId>> getValues() const {
+    return values_;
+  }
+
+  const std::vector<SecValue<schedulerId>> getReachedValues() const {
+    return reachedValues_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
@@ -61,6 +70,10 @@ class Attributor {
   // Test reached conversions: valid event & reach (number of impressions > 0)
   void calculateReachedConversions();
 
+  // Test/control value: valid event ? purchaseValue : 0
+  // Test reached value: isReached ? purchaseValue : 0
+  void calculateValues();
+
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   int64_t numRows_;
@@ -70,6 +83,8 @@ class Attributor {
   SecNumConvSquared<schedulerId> numConvSquared_;
   SecBit<schedulerId> match_;
   std::vector<SecBit<schedulerId>> reachedConversions_;
+  std::vector<SecValue<schedulerId>> values_;
+  std::vector<SecValue<schedulerId>> reachedValues_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "folly/logging/xlog.h"
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class Attributor {
+ public:
+  Attributor(int myRole, InputProcessor<schedulerId> inputProcessor)
+      : myRole_{myRole},
+        inputProcessor_{inputProcessor},
+        numRows_{inputProcessor.getNumRows()} {
+    calculateEvents();
+  }
+
+  const std::vector<SecBit<schedulerId>> getEvents() const {
+    return events_;
+  }
+
+ private:
+  // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
+  void calculateEvents();
+
+  int32_t myRole_;
+  InputProcessor<schedulerId> inputProcessor_;
+  int64_t numRows_;
+
+  std::vector<SecBit<schedulerId>> events_;
+};
+
+} // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -21,21 +21,36 @@ class Attributor {
         inputProcessor_{inputProcessor},
         numRows_{inputProcessor.getNumRows()} {
     calculateEvents();
+    calculateNumConvSquaredAndConverters();
   }
 
   const std::vector<SecBit<schedulerId>> getEvents() const {
     return events_;
   }
 
+  const SecBit<schedulerId> getConverters() const {
+    return converters_;
+  }
+
+  const SecNumConvSquared<schedulerId> getNumConvSquared() const {
+    return numConvSquared_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
+
+  // Test/Control numConvSquared: number of valid events squared
+  // Test/Control converters: any valid event
+  void calculateNumConvSquaredAndConverters();
 
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   int64_t numRows_;
 
   std::vector<SecBit<schedulerId>> events_;
+  SecBit<schedulerId> converters_;
+  SecNumConvSquared<schedulerId> numConvSquared_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -22,6 +22,7 @@ class Attributor {
         numRows_{inputProcessor.getNumRows()} {
     calculateEvents();
     calculateNumConvSquaredAndConverters();
+    calculateMatch();
   }
 
   const std::vector<SecBit<schedulerId>> getEvents() const {
@@ -36,6 +37,10 @@ class Attributor {
     return numConvSquared_;
   }
 
+  const SecBit<schedulerId> getMatch() const {
+    return match_;
+  }
+
  private:
   // Test/Control events: validPurchase (oppTs < purchaseTs + 10)
   void calculateEvents();
@@ -44,6 +49,10 @@ class Attributor {
   // Test/Control converters: any valid event
   void calculateNumConvSquaredAndConverters();
 
+  // Test/control match: valid opportunity timestamp & any valid purchase
+  // timestamp
+  void calculateMatch();
+
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   int64_t numRows_;
@@ -51,6 +60,7 @@ class Attributor {
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;
   SecNumConvSquared<schedulerId> numConvSquared_;
+  SecBit<schedulerId> match_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -87,4 +87,15 @@ void Attributor<schedulerId>::calculateMatch() {
       inputProcessor_.getIsValidOpportunityTimestamp();
 }
 
+template <int schedulerId>
+void Attributor<schedulerId>::calculateReachedConversions() {
+  XLOG(INFO) << "Calculate reached conversions";
+  for (const auto& event : events_) {
+    // A reached conversion is when there is a reach (number of impressions > 0)
+    // and a valid event, and this is only calculated for the test population
+    reachedConversions_.push_back(
+        std::move(event & inputProcessor_.getTestReach()));
+  }
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -78,4 +78,13 @@ void Attributor<schedulerId>::calculateNumConvSquaredAndConverters() {
   converters_ = eventArray.at(firstIndex);
 }
 
+template <int schedulerId>
+void Attributor<schedulerId>::calculateMatch() {
+  XLOG(INFO) << "Calculate match";
+  // a valid test/control match is when a person with an opportunity made
+  // ANY nonzero conversion.
+  match_ = inputProcessor_.getAnyValidPurchaseTimestamp() &
+      inputProcessor_.getIsValidOpportunityTimestamp();
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace private_lift {
+
+template <int schedulerId>
+void Attributor<schedulerId>::calculateEvents() {
+  XLOG(INFO) << "Calculate events";
+  for (auto& thresholdTs : inputProcessor_.getThresholdTimestamps()) {
+    // Events occur when there is a valid purchase, i.e. the opportunity
+    // timestamp is less than the threshold timestamp
+    events_.push_back(std::move(
+        inputProcessor_.getIsValidOpportunityTimestamp() &
+        (thresholdTs > inputProcessor_.getOpportunityTimestamps())));
+  }
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -21,4 +21,61 @@ void Attributor<schedulerId>::calculateEvents() {
   }
 }
 
+template <int schedulerId>
+void Attributor<schedulerId>::calculateNumConvSquaredAndConverters() {
+  XLOG(INFO) << "Calculate numConvSquared & converters";
+  // We find the first valid event using a binary tree approach. The number of
+  // conversions is the remaining number of elements in the array.
+  // We first construct new arrays to store the intermediate results
+  std::vector<SecNumConvSquared<schedulerId>> numConvSquaredArray;
+  for (size_t i = 0; i < events_.size(); ++i) {
+    auto numConv = events_.size() - i;
+    auto convSquared = static_cast<uint32_t>(numConv * numConv);
+    SecNumConvSquared<schedulerId> numConvSquared(
+        std::vector(numRows_, convSquared), common::PUBLISHER);
+    numConvSquaredArray.push_back(numConvSquared);
+  }
+  // The numConvSquared is zero if there are no valid events
+  SecNumConvSquared<schedulerId> zero{
+      std::vector<uint32_t>(numRows_, 0), common::PUBLISHER};
+  numConvSquaredArray.push_back(zero);
+
+  std::vector<SecBit<schedulerId>> eventArray = events_;
+  SecBit<schedulerId> zeroBit{
+      std::vector<bool>(numRows_, false), common::PUBLISHER};
+  eventArray.push_back(zeroBit);
+
+  int stepSize = 1; // we process the array elements in pairs with indices
+                    // differing by stepSize
+  int firstIndex = 0; // first index at this level
+  while (firstIndex < eventArray.size() / 2) {
+    for (size_t i = firstIndex; i < eventArray.size(); i += 2 * stepSize) {
+      if (i + stepSize < eventArray.size()) {
+        // If there is a valid event at i, we set the numConvSquared to be
+        // numConvSquared[i], else we set it to be numConvSquared[i + stepSize]
+        numConvSquaredArray[i + stepSize] =
+            numConvSquaredArray.at(i + stepSize)
+                .mux(eventArray.at(i), numConvSquaredArray.at(i));
+        // Update the events for the next level
+        eventArray[i + stepSize] =
+            eventArray.at(i + stepSize) | eventArray.at(i);
+      } else {
+        // Odd number of elements at this level, compute the mux with the
+        // previous pair
+        auto previousIndex = i - stepSize;
+        numConvSquaredArray[previousIndex] = numConvSquaredArray.at(i).mux(
+            eventArray.at(previousIndex),
+            numConvSquaredArray.at(previousIndex));
+        eventArray[previousIndex] =
+            eventArray.at(previousIndex) | eventArray.at(i);
+      }
+    }
+    firstIndex += stepSize;
+    stepSize = stepSize << 1;
+  }
+  numConvSquared_ = numConvSquaredArray.at(firstIndex);
+  // A converter occurs when a row contains any valid event
+  converters_ = eventArray.at(firstIndex);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -98,4 +98,28 @@ void Attributor<schedulerId>::calculateReachedConversions() {
   }
 }
 
+template <int schedulerId>
+void Attributor<schedulerId>::calculateValues() {
+  XLOG(INFO) << "Calculate values";
+  if (events_.size() != inputProcessor_.getPurchaseValues().size()) {
+    XLOG(FATAL)
+        << "Numbers of event bits and/or purchase values are inconsistent.";
+  }
+  auto zero = PubValue<schedulerId>(std::vector<int64_t>(numRows_, 0));
+  for (size_t i = 0; i < events_.size(); ++i) {
+    // The value is the purchase value if there is a valid event, otherwise it
+    // is zero
+    values_.push_back(std::move(
+        zero.mux(events_.at(i), inputProcessor_.getPurchaseValues().at(i))));
+  }
+
+  XLOG(INFO) << "Calculate reached values";
+  // A reached value is the value when there is a reach, otherwise it is zero.
+  // This is only calculated for the test population.
+  for (const auto& value : values_) {
+    reachedValues_.push_back(
+        std::move(zero.mux(inputProcessor_.getTestReach(), value)));
+  }
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -11,6 +11,7 @@
 
 namespace private_lift {
 
+const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;
 const size_t timeStampWidth = 32;
@@ -46,5 +47,13 @@ using PubTimestamp = typename fbpcf::frontend::MpcGame<
 template <int schedulerId, bool usingBatch = true>
 using SecTimestamp = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<timeStampWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubNumConvSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<numConvSquaredWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecNumConvSquared = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<numConvSquaredWidth, usingBatch>;
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -11,6 +11,7 @@
 
 namespace private_lift {
 
+const size_t groupWidth = 6; // at most 32 cohorts
 const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;
@@ -23,6 +24,14 @@ using PubBit =
 template <int schedulerId, bool usingBatch = true>
 using SecBit =
     typename fbpcf::frontend::MpcGame<schedulerId>::template SecBit<usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubGroup = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<groupWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using SecGroup = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<groupWidth, usingBatch>;
 
 template <int schedulerId, bool usingBatch = true>
 using PubValue = typename fbpcf::frontend::MpcGame<

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -204,7 +204,7 @@ void InputData::addFromCSV(
       // Work-in-progress: we currently support cohort_id *or* feature columns
       groupIds_.push_back(parsed);
       // We use parsed + 1 because cohorts are zero-indexed
-      numGroups_ = std::max(numGroups_, parsed + 1);
+      numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
     } else if (column == "event_timestamp") {
       // When event_timestamp column presents (in standard Converter Lift
       // input), parse it as arrays of size 1.

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -42,11 +42,11 @@ class InputData {
   // values are just 0/1
   std::vector<int64_t> bitmaskFor(int64_t groupId) const;
 
-  const std::vector<int64_t>& getTestPopulation() const {
+  const std::vector<bool>& getTestPopulation() const {
     return testPopulation_;
   }
 
-  const std::vector<int64_t>& getControlPopulation() const {
+  const std::vector<bool>& getControlPopulation() const {
     return controlPopulation_;
   }
 
@@ -96,7 +96,7 @@ class InputData {
     return purchaseValueSquaredArrays_;
   }
 
-  const std::vector<int64_t>& getGroupIds() const {
+  const std::vector<uint32_t>& getGroupIds() const {
     return groupIds_;
   }
 
@@ -170,8 +170,8 @@ class InputData {
   LiftMPCType liftMpcType_;
   LiftGranularityType liftGranularityType_;
   int64_t epoch_;
-  std::vector<int64_t> testPopulation_;
-  std::vector<int64_t> controlPopulation_;
+  std::vector<bool> testPopulation_;
+  std::vector<bool> controlPopulation_;
   std::vector<uint32_t> opportunityTimestamps_;
   std::vector<int64_t> numImpressions_;
   std::vector<int64_t> numClicks_;
@@ -179,7 +179,7 @@ class InputData {
   std::vector<uint32_t> purchaseTimestamps_;
   std::vector<int64_t> purchaseValues_;
   std::vector<int64_t> purchaseValuesSquared_;
-  std::vector<int64_t> groupIds_;
+  std::vector<uint32_t> groupIds_;
   std::vector<std::vector<uint32_t>> opportunityTimestampArrays_;
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;
@@ -190,7 +190,7 @@ class InputData {
   std::map<std::vector<std::string>, int64_t> featuresToGroupId_;
   int64_t totalValue_ = 0;
   int64_t totalValueSquared_ = 0;
-  int64_t numGroups_ = 0;
+  uint32_t numGroups_ = 0;
   int32_t numConversionsPerUser_;
 
   bool firstLineParsedAlready_ = false;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,8 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    privatelySharePopulationStep();
+    privatelyShareCohortsStep();
     privatelyShareTimestampsStep();
     privatelySharePurchaseValuesStep();
     privatelyShareTestReachStep();
@@ -36,6 +38,14 @@ class InputProcessor {
 
   int64_t getNumRows() const {
     return numRows_;
+  }
+
+  uint32_t getNumPartnerCohorts() const {
+    return numPartnerCohorts_;
+  }
+
+  const std::vector<std::vector<bool>> getCohortIndexShares() const {
+    return cohortIndexShares_;
   }
 
   const SecTimestamp<schedulerId> getOpportunityTimestamps() const {
@@ -75,6 +85,12 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Privately share popoulation
+  void privatelySharePopulationStep();
+
+  // Privately share number of cohorts and index shares of cohort group ids.
+  void privatelyShareCohortsStep();
+
   // Privately share timestamps
   void privatelyShareTimestampsStep();
 
@@ -88,6 +104,7 @@ class InputProcessor {
   InputData inputData_;
   int64_t numRows_;
   int32_t numConversionsPerUser_;
+  uint32_t numPartnerCohorts_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;
@@ -97,6 +114,10 @@ class InputProcessor {
   std::vector<SecValue<schedulerId>> purchaseValues_;
   std::vector<SecValueSquared<schedulerId>> purchaseValueSquared_;
   SecBit<schedulerId> testReach_;
+
+  SecBit<schedulerId> controlPopulation_;
+  SecGroup<schedulerId> cohortGroupIds_;
+  std::vector<std::vector<bool>> cohortIndexShares_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -143,4 +143,18 @@ TEST_F(AttributorTest, testNumConvSquared) {
   EXPECT_EQ(numConvSquared0, expectNumConvSquared);
 }
 
+TEST_F(AttributorTest, testMatch) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getMatch().openToParty(0).getValue();
+  });
+  auto future1 = std::async(
+      [&] { return partnerAttributor_->getMatch().openToParty(0).getValue(); });
+  auto match0 = future0.get();
+  auto match1 = future1.get();
+  std::vector<bool> expectMatch = {0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1,
+                                   1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0,
+                                   0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1};
+  EXPECT_EQ(match0, expectMatch);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -230,4 +230,19 @@ TEST_F(AttributorTest, testReachedValues) {
   EXPECT_EQ(values0, expectReachedValues);
 }
 
+TEST_F(AttributorTest, testValueSquared) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getValueSquared().openToParty(0).getValue();
+  });
+  auto future1 = std::async([&] {
+    return partnerAttributor_->getValueSquared().openToParty(0).getValue();
+  });
+  auto values0 = future0.get();
+  auto values1 = future1.get();
+  std::vector<int64_t> expectValueSquared = {
+      0,   0, 0, 0, 0, 0, 0, 400, 400, 0,    0,   0,   0, 900, 900,  0,   400,
+      400, 0, 0, 0, 0, 0, 0, 0,   0,   2500, 900, 400, 0, 0,   2500, 2500};
+  EXPECT_EQ(values0, expectValueSquared);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -113,4 +113,34 @@ TEST_F(AttributorTest, testEvents) {
   EXPECT_EQ(events0, expectEvents);
 }
 
+TEST_F(AttributorTest, testConverters) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getConverters().openToParty(0).getValue();
+  });
+  auto future1 = std::async([&] {
+    return partnerAttributor_->getConverters().openToParty(0).getValue();
+  });
+  auto converters0 = future0.get();
+  auto converters1 = future1.get();
+  std::vector<bool> expectConverters = {0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+                                        0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0,
+                                        0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1};
+  EXPECT_EQ(converters0, expectConverters);
+}
+
+TEST_F(AttributorTest, testNumConvSquared) {
+  auto future0 = std::async([&] {
+    return publisherAttributor_->getNumConvSquared().openToParty(0).getValue();
+  });
+  auto future1 = std::async([&] {
+    return partnerAttributor_->getNumConvSquared().openToParty(0).getValue();
+  });
+  auto numConvSquared0 = future0.get();
+  auto numConvSquared1 = future1.get();
+  std::vector<uint64_t> expectNumConvSquared = {
+      0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 4, 4, 0, 1,
+      1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 1, 0, 0, 1, 1};
+  EXPECT_EQ(numConvSquared0, expectNumConvSquared);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcs/emp_games/common/TestUtil.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
+namespace private_lift {
+const bool unsafe = true;
+
+template <int schedulerId>
+Attributor<schedulerId> createAttributorWithScheduler(
+    int myRole,
+    InputData inputData,
+    int numConversionsPerUser,
+    std::reference_wrapper<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myRole, factory);
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+  auto inputProcessor =
+      InputProcessor<schedulerId>(myRole, inputData, numConversionsPerUser);
+  return Attributor<schedulerId>(myRole, inputProcessor);
+}
+
+class AttributorTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<Attributor<0>> publisherAttributor_;
+  std::unique_ptr<Attributor<1>> partnerAttributor_;
+
+  void SetUp() override {
+    std::string baseDir =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__);
+    std::string publisherInputFilename =
+        baseDir + "../sample_input/publisher_unittest3.csv";
+    std::string partnerInputFilename =
+        baseDir + "../sample_input/partner_2_convs_unittest.csv";
+    int numConversionsPerUser = 2;
+    int epoch = 1546300800;
+    auto publisherInputData = InputData(
+        publisherInputFilename,
+        InputData::LiftMPCType::Standard,
+        InputData::LiftGranularityType::Conversion,
+        epoch,
+        numConversionsPerUser);
+    auto partnerInputData = InputData(
+        partnerInputFilename,
+        InputData::LiftMPCType::Standard,
+        InputData::LiftGranularityType::Conversion,
+        epoch,
+        numConversionsPerUser);
+
+    auto schedulerCreator =
+        fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>;
+    auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+    auto future0 = std::async(
+        createAttributorWithScheduler<0>,
+        0,
+        publisherInputData,
+        numConversionsPerUser,
+        std::reference_wrapper<
+            fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+            *factories[0]),
+        schedulerCreator);
+
+    auto future1 = std::async(
+        createAttributorWithScheduler<1>,
+        1,
+        partnerInputData,
+        numConversionsPerUser,
+        std::reference_wrapper<
+            fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+            *factories[1]),
+        schedulerCreator);
+
+    publisherAttributor_ = std::make_unique<Attributor<0>>(future0.get());
+    partnerAttributor_ = std::make_unique<Attributor<1>>(future1.get());
+  }
+};
+
+template <int schedulerId>
+std::vector<std::vector<bool>> revealEvents(
+    std::unique_ptr<Attributor<schedulerId>> attributor) {
+  std::vector<std::vector<bool>> output;
+  for (const auto& events : attributor->getEvents()) {
+    output.push_back(events.openToParty(0).getValue());
+  }
+  return output;
+}
+
+TEST_F(AttributorTest, testEvents) {
+  auto future0 = std::async(revealEvents<0>, std::move(publisherAttributor_));
+  auto future1 = std::async(revealEvents<1>, std::move(partnerAttributor_));
+  auto events0 = future0.get();
+  auto events1 = future1.get();
+  std::vector<std::vector<bool>> expectEvents = {
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1,
+       1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1}};
+  EXPECT_EQ(events0, expectEvents);
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -157,4 +157,29 @@ TEST_F(AttributorTest, testMatch) {
   EXPECT_EQ(match0, expectMatch);
 }
 
+template <int schedulerId>
+std::vector<std::vector<bool>> revealReachedConversions(
+    std::unique_ptr<Attributor<schedulerId>> attributor) {
+  std::vector<std::vector<bool>> output;
+  for (const auto& reachedConversions : attributor->getReachedConversions()) {
+    output.push_back(std::move(reachedConversions.openToParty(0).getValue()));
+  }
+  return output;
+}
+
+TEST_F(AttributorTest, testReachedConversions) {
+  auto future0 =
+      std::async(revealReachedConversions<0>, std::move(publisherAttributor_));
+  auto future1 =
+      std::async(revealReachedConversions<1>, std::move(partnerAttributor_));
+  auto reachedConversions0 = future0.get();
+  auto reachedConversions1 = future1.get();
+  std::vector<std::vector<bool>> expectReachedConversions = {
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0}};
+  EXPECT_EQ(reachedConversions0, expectReachedConversions);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
@@ -43,10 +43,10 @@ TEST_F(InputDataTest, TestInputDataPublisher) {
       InputData::LiftGranularityType::Conversion,
       1546300800,
       4};
-  std::vector<int64_t> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
-                                               0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
-  std::vector<int64_t> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                                  0, 0, 1, 0, 0, 1, 1, 0, 1, 1};
+  std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
+                                            0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
+  std::vector<bool> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                               0, 0, 1, 0, 0, 1, 1, 0, 1, 1};
   // opportunity_timestamp - epoch
   std::vector<uint32_t> expectOpportunityTimestamps = {
       53699630, 53699601, 0,        0,        0,        53699661, 53699252,
@@ -67,10 +67,10 @@ TEST_F(InputDataTest, TestInputDataPublisherOppColLast) {
       InputData::LiftGranularityType::Conversion,
       1546300800,
       4};
-  std::vector<int64_t> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
-                                               0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
-  std::vector<int64_t> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
-                                                  0, 0, 1, 0, 0, 1, 1, 0, 1, 1};
+  std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
+                                            0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
+  std::vector<bool> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
+                                               0, 0, 1, 0, 0, 1, 1, 0, 1, 1};
   // opportunity_timestamp - epoch
   std::vector<uint32_t> expectOpportunityTimestamps = {
       53699630, 53699601, 0,        0,        0,        53699661, 53699252,
@@ -119,8 +119,8 @@ TEST_F(InputDataTest, TestInputDataPartner) {
       {0, 0, 0, 0},  {0, 0, 0, 0},   {0, 47, 57, 51}, {63, 69, 21, 24},
       {0, 0, 0, 0},  {0, 0, 0, 0},   {0, 0, 0, 0},    {0, 0, 0, 0},
   };
-  std::vector<int64_t> expectCohortIds = {0, 1, 0, 0, 2, 0, 0, 0, 0, 0,
-                                          0, 0, 0, 0, 1, 2, 0, 0, 0, 0};
+  std::vector<uint32_t> expectCohortIds = {0, 1, 0, 0, 2, 0, 0, 0, 0, 0,
+                                           0, 0, 0, 0, 1, 2, 0, 0, 0, 0};
   auto resPurchaseTimestampArrays = inputData.getPurchaseTimestampArrays();
   auto resPurchaseValueArrays = inputData.getPurchaseValueArrays();
   EXPECT_EQ(expectGetPurchaseTimestampArrays, resPurchaseTimestampArrays);

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -93,6 +93,25 @@ TEST_F(InputProcessorTest, testNumRows) {
   EXPECT_EQ(partnerInputProcessor_.getNumRows(), 33);
 }
 
+TEST_F(InputProcessorTest, testNumPartnerCohorts) {
+  EXPECT_EQ(publisherInputProcessor_.getNumPartnerCohorts(), 3);
+  EXPECT_EQ(partnerInputProcessor_.getNumPartnerCohorts(), 3);
+}
+
+TEST_F(InputProcessorTest, testCohortIndexShares) {
+  auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
+  auto partnerShares = partnerInputProcessor_.getCohortIndexShares();
+  // 0 1 3 0 0 4 1 1 3 1 1 3 0 1 4 0 0 3 0 0 3 0 0 3 0 0 2 2 0 0 2 2 5
+  std::vector<std::vector<bool>> expectCohortIndexShares = {
+      {0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0,
+       1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+      {0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0,
+       1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0},
+      {0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
+  EXPECT_EQ(publisherShares, expectCohortIndexShares);
+}
+
 TEST_F(InputProcessorTest, testOpportunityTimestamps) {
   auto future0 = std::async([&] {
     return publisherInputProcessor_.getOpportunityTimestamps()


### PR DESCRIPTION
Summary:
We add a method to privately share the cohort group ids for both the test/control population in the InputProcessor, where the group ids are converted to index shares used for ORAM aggregation.

To compute the aggregation for both the test/control population and cohorts, we create new group ids that encode whether each row corresponds to a test/control and the cohort group id. For the test population, we use the original group id, and for the control population we add the number of cohorts to the original group id.

Note also that for the test/control population, we have to differentiate between non-opportunities, test and control. In the PL logic, we can ignore all non-opportunities, hence instead of treating them as a separate group, we treat them as part of the test group, and parse them as invalid inputs in the InputProcessor. Thus it suffices here to only share the control population, and the remaining rows are treated as the test population.

For more details about these optimizations, refer to https://docs.google.com/document/d/1frSxg9-74rtTemqmxewVA0QZAbUplsLAriBHZD-KEms/edit?usp=sharing

For more details about the correctness tests, refer to https://docs.google.com/spreadsheets/d/1xsIl33YDU_y7lSVD5gsiGV-ubl2x9TDYiTVRyR4dS74/edit?usp=sharing

Reviewed By: RuiyuZhu

Differential Revision: D35907556

