### PR TITLE
support input_path override for partner side

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -223,6 +223,19 @@ class PrivateComputationService:
     def get_instance(self, instance_id: str) -> PrivateComputationInstance:
         return self.instance_repository.read(instance_id=instance_id)
 
+    def update_input_path(
+        self, instance_id: str, input_path: str
+    ) -> PrivateComputationInstance:
+        """
+        override input path only allow partner side
+        """
+        pc_instance = self.get_instance(instance_id)
+        if pc_instance.role is PrivateComputationRole.PARTNER:
+            pc_instance.input_path = input_path
+            self.instance_repository.update(pc_instance)
+
+        return pc_instance
+
     # TODO T88759390: make an async version of this function
     def update_instance(self, instance_id: str) -> PrivateComputationInstance:
         private_computation_instance = self.instance_repository.read(instance_id)

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -192,6 +192,22 @@ def run_stage(
     logger.info(instance)
 
 
+def update_input_path(
+    config: Dict[str, Any], instance_id: str, input_path: str, logger: logging.Logger
+) -> PrivateComputationInstance:
+    """
+    Update input path by given instance_id, currently only support partner instance override.
+    """
+    pc_service = _build_private_computation_service(
+        config["private_computation"],
+        config["mpc"],
+        config["pid"],
+        config.get("post_processing_handlers", {}),
+        config.get("pid_post_processing_handlers", {}),
+    )
+    return pc_service.update_input_path(instance_id, input_path)
+
+
 def get_instance(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> PrivateComputationInstance:
@@ -212,6 +228,7 @@ def get_instance(
     instance = pc_service.get_instance(instance_id)
     if instance.current_stage.is_started_status(instance.status):
         instance = pc_service.update_instance(instance_id)
+
     return instance
 
 


### PR DESCRIPTION
Summary:
[PCS] support input_path override for partner side
action item for PCS H1 2022 roadmap https://docs.google.com/spreadsheets/d/1kD_SsE5tLcSkPnfiQp_fKOhA1LEQPivrtOY1M7cjy_g/edit?usp=sharing

add auto-instance overrid input path from partner side

Reviewed By: marksliva, gitfish77

Differential Revision: D35727367

