### PR TITLE
Add a deployment script for workload identity.

### DIFF
--- a/docker/pce_deployment/gcp/Dockerfile.ubuntu
+++ b/docker/pce_deployment/gcp/Dockerfile.ubuntu
@@ -14,6 +14,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ##########################################
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    kubectl \
     python3.8 \
     python3-dev \
     python3-pip \
@@ -56,8 +57,10 @@ RUN curl -SL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terra
 RUN mkdir /terraform_deployment
 COPY fbpcs/infra/pce/gcp_terraform_template /terraform_deployment/terraform_scripts
 COPY fbpcs/infra/publisher/gcp/deploy.sh /terraform_deployment
+COPY fbpcs/infra/publisher/gcp/deploy-workload-identity.sh /terraform_deployment
 COPY fbpcs/infra/publisher/gcp/util.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/deploy.sh
+RUN chmod +x /terraform_deployment/deploy-workload-identity.sh
 RUN chmod +x /terraform_deployment/util.sh
 CMD ["/bin/bash"]
 WORKDIR /terraform_deployment

--- a/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/main.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/main.tf
@@ -1,5 +1,4 @@
 provider "google" {
-  credentials = file(var.credential_path)
   project     = var.project_id
 }
 

--- a/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/variable.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/workload_identity/variable.tf
@@ -2,10 +2,6 @@ variable "project_id" {
   description = "an unique identifier for your GCP project"
 }
 
-variable "credential_path" {
-  description = "credential path of GCP service accounts"
-}
-
 variable "name_postfix" {
   description = "the postfix to append after a resource name"
 }

--- a/fbpcs/infra/publisher/gcp/deploy-workload-identity.sh
+++ b/fbpcs/infra/publisher/gcp/deploy-workload-identity.sh
@@ -9,14 +9,10 @@ set -e
 source ./util.sh
 
 usage() {
-    echo "Usage: deploy.sh <deploy|undeploy>
+    echo "Usage: deploy-workload-identity.sh <deploy|undeploy>
         [ -t, --tag | A unique identifier to identify resources in this deployment]
         [ -r, --region | GCP region, e.g. us-west-2 ]
         [ -a, --account_id | Publisher's GCP project ID]
-        [ -p, --partner_account_id | Partner's GCP project ID]
-        [ -c, --publisher_vpc_cidr | Publisher's VPC CIDR]
-        [ -s, --secondary_subnet_cidr | Publishers secondary subnet CIDR]
-        [ -v, --partner_vpc_cidr | Partner's VPC CIDR]
         [ -b, --bucket | GCS bucket name for storing tfstate]"
     exit 1
 }
@@ -38,10 +34,6 @@ while [ $# -gt 0 ]; do
         -t|--tag) pce_id="$2" ;;
         -r|--region) region="$2" ;;
         -a|--account_id) gcp_project_id="$2" ;;
-        -p|--partner_account_id) partner_gcp_project_id="$2" ;;
-        -c|--publisher_vpc_cidr) vpc_cidr="$2" ;;
-        -s|--secondary_subnet_cidr) subnet_secondary_cidr="$2" ;;
-        -v|--partner_vpc_cidr) partner_vpc_cidr="$2" ;;
         -b|--bucket) gcs_bucket_for_storage="$2" ;;
         *) usage ;;
     esac
@@ -50,14 +42,13 @@ while [ $# -gt 0 ]; do
 done
 
 name_postfix="${pce_id}"
+cluster_name="onedocker-cluster-${name_postfix}"
 
 echo "GCP region is $region."
 echo "The string '$name_postfix' will be appended after the name of the GCP resources."
 echo "Publisher's GCP project ID is $gcp_project_id"
-echo "Publisher's VPC CIDR is $vpc_cidr"
-echo "Partner's GCP project ID is $partner_gcp_project_id"
-echo "Partner's VPC CIDR is $partner_vpc_cidr"
 echo "The GCS bucket for storing the Terraform state file is $gcs_bucket_for_storage"
+echo "The cluster that workload identity will be applied on is $cluster_name"
 
 undeploy_gcp_resources () {
     echo "Start undeploying..."
@@ -68,34 +59,35 @@ undeploy_gcp_resources () {
     echo "All tfstate files exist. Continue..."
 
     echo "########################Delete PCE resources########################"
-    cd /terraform_deployment/terraform_scripts/common/pce
+    cd /terraform_deployment/terraform_scripts/common/workload_identity
     terraform init \
         -backend-config "bucket=$gcs_bucket_for_storage" \
-        -backend-config "prefix=tfstate/pce$name_postfix.tfstate"
+        -backend-config "prefix=tfstate/wi-$name_postfix.tfstate"
     terraform destroy \
         -auto-approve \
         -var "gcp_region=$region" \
         -var "project_id=$gcp_project_id" \
-        -var "name_postfix=$name_postfix"
+        -var "name_postfix=$name_postfix" \
+        -var "cluster_name=$cluster_name"
 }
 
 deploy_gcp_resources () {
     echo "########################Started GCP Infrastructure Deployment########################"
     verify_or_create_bucket "$gcs_bucket_for_storage" "$region"
 
+    gcloud container clusters get-credentials --region "$region" "$cluster_name"
+
     # Deploy PCE Terraform scripts
-    cd /terraform_deployment/terraform_scripts/common/pce
+    cd /terraform_deployment/terraform_scripts/common/workload_identity
     terraform init \
         -backend-config "bucket=$gcs_bucket_for_storage" \
-        -backend-config "prefix=tfstate/pce$name_postfix.tfstate"
+        -backend-config "prefix=tfstate/wi-$name_postfix.tfstate"
     terraform apply \
         -auto-approve \
         -var "gcp_region=$region" \
         -var "project_id=$gcp_project_id" \
         -var "name_postfix=$name_postfix" \
-        -var "subnet_primary_cidr=$vpc_cidr" \
-        -var "subnet_secondary_cidr=$subnet_secondary_cidr" \
-        -var "otherparty_subnet_cidr=$partner_vpc_cidr" \
+        -var "cluster_name=$cluster_name"
 
     # Print the output
     echo "######################## PCE terraform output ########################"


### PR DESCRIPTION
Summary:
## Background
To functionally deploy a MPC game on GCP, they need to be able to connect with GCS to get the ad data. This requires us to be able to authenticate requests from withing the OneDocker contianers that are running the MPC binaries.

## This commit
This commit adds a workload identity deployment script to the PCE-Deployment docker image. This script can be used to add workload identity authentication to a PCE cluster.

Differential Revision: D35846330

