### PR TITLE
Remove timestamp from s3 path

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/main.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/main.cpp
@@ -125,7 +125,9 @@ int main(int argc, char* argv[]) {
     XLOG(INFO, cost.getEstimatedCostString());
 
     if (FLAGS_log_cost) {
-      auto run_name = (FLAGS_run_name != "") ? FLAGS_run_name : "temp_run_name";
+      bool run_name_specified = FLAGS_run_name != "";
+      auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
+
       auto party = (FLAGS_party == static_cast<int>(fbpcf::Party::Alice))
           ? "Publisher"
           : "Partner";
@@ -141,13 +143,15 @@ int main(int argc, char* argv[]) {
           "num_files",
           FLAGS_num_files)("file_start_index", FLAGS_file_start_index)("concurrency", FLAGS_concurrency)("use_xor_encryption", FLAGS_use_xor_encryption);
 
-      XLOGF(
-          INFO,
-          "{}",
-          cost.writeToS3(
-              party,
-              run_name,
-              cost.getEstimatedCostDynamic(run_name, party, extra_info)));
+      folly::dynamic costDict =
+          cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+      auto objectName = run_name_specified
+          ? run_name
+          : folly::to<std::string>(
+                FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+      XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
     }
 
     return 0;

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -165,7 +165,8 @@ int main(int argc, char* argv[]) {
       schedulerStatistics.receivedNetwork);
 
   if (FLAGS_log_cost) {
-    auto run_name = (FLAGS_run_name != "") ? FLAGS_run_name : "temp_run_name";
+    bool run_name_specified = FLAGS_run_name != "";
+    auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
     auto party = (FLAGS_party == common::PUBLISHER) ? "Publisher" : "Partner";
 
     folly::dynamic extra_info = common::getCostExtraInfo(
@@ -178,13 +179,15 @@ int main(int argc, char* argv[]) {
         FLAGS_use_xor_encryption,
         schedulerStatistics);
 
-    XLOGF(
-        INFO,
-        "{}",
-        cost.writeToS3(
-            party,
-            run_name,
-            cost.getEstimatedCostDynamic(run_name, party, extra_info)));
+    folly::dynamic costDict =
+        cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+    auto objectName = run_name_specified
+        ? run_name
+        : folly::to<std::string>(
+              FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+    XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
   }
 
   return 0;

--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -7,7 +7,6 @@
 
 #include "fbpcs/performance_tools/CostEstimation.h"
 #include <fbpcf/io/FileManagerUtil.h>
-#include <fbpcs/performance_tools/CostEstimation.h>
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
@@ -190,29 +189,23 @@ void CostEstimation::end() {
 
 std::string CostEstimation::writeToS3(
     std::string party,
-    std::string run_name,
+    std::string objectName,
     folly::dynamic costDynamic) {
   std::string s3FullPath = folly::to<std::string>(
       "https://", s3Bucket_, ".s3.us-west-2.amazonaws.com/", s3Path_, "/");
-  std::string filePath = folly::to<std::string>(
-      s3FullPath,
-      run_name,
-      "_",
-      party,
-      "_",
-      costDynamic["timestamp"].asString(),
-      ".json");
+  std::string filePath =
+      folly::to<std::string>(s3FullPath, objectName, "_", party, ".json");
 
   return _writeToS3(filePath, costDynamic);
 }
 
 std::string CostEstimation::writeToS3(
-    std::string run_name,
+    std::string objectName,
     folly::dynamic costDynamic) {
   std::string s3FullPath = folly::to<std::string>(
       "https://", s3Bucket_, ".s3.us-west-2.amazonaws.com/", s3Path_, "/");
-  std::string filePath = folly::to<std::string>(
-      s3FullPath, run_name, "_", costDynamic["timestamp"].asString(), ".json");
+  std::string filePath =
+      folly::to<std::string>(s3FullPath, objectName, ".json");
 
   return _writeToS3(filePath, costDynamic);
 }
@@ -222,6 +215,7 @@ std::string CostEstimation::_writeToS3(
     folly::dynamic costDynamic) {
   std::string costData = folly::toPrettyJson(costDynamic);
   try {
+    XLOG(INFO) << "Writing cost file to s3: " << filePath;
     fbpcf::io::write(filePath, costData);
   } catch (const std::exception& e) {
     XLOG(WARN) << "Error: Exception writing cost in S3.\n\terror msg: "


### PR DESCRIPTION
Summary: In order to read the cost file from PCS code, we need to remove the extra timestamp. The start time of the binary is non-deterministic so we should just use the run name in the file path.

Differential Revision: D35908383

