### PR TITLE
fix broken cloudwatch URL logging

### DIFF
--- a/fbpcs/experimental/cloud_logs/log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/log_retriever.py
@@ -80,7 +80,13 @@ class LogRetriever:
         Raises:
             IndexError: if container_name is not well-formed
         """
-        container_name = cluster_name.replace("-cluster", "-container")
+        container_name = cluster_name.replace("-cluster", "-container").replace(
+            # This log group doesn't exist in the experiment platform aws account.
+            # Replace it with a 32 digit string to trick subsequent string replacement
+            # into thinking it was deployed with PCE Service. Improvise. Adapt. Overcome
+            "mpc-aem-exp-platform-publisher",
+            "0" * 32,
+        )
         container_name_parts = container_name.split("-")
 
         # If the name does not have a 32 bit random string inside, return directly

--- a/fbpcs/experimental/cloud_logs/test/test_log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/test/test_log_retriever.py
@@ -42,3 +42,21 @@ class TestLogRetriever(unittest.TestCase):
         expected = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-shared-us-west-2/log-events/ecs$252Fonedocker-container-shared-us-west-2$252F3a5e4213036b4456a6c16695b938b361"
         actual = retriever.get_log_url(container_id)
         self.assertEqual(expected, actual)
+
+    def test_get_log_url_exp_platform(self) -> None:
+        retriever = LogRetriever(CloudProvider.AWS)
+        for container_id, expected_url in (
+            # partner
+            (
+                "arn:aws:ecs:us-west-2:119557546360:task/onedocker-cluster-mpc-aem-exp-platform-partner/dc4fdf05e7684165b639b4e1831872c8",
+                "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-mpc-aem-exp-platform-partner/log-events/ecs$252Fonedocker-container-mpc-aem-exp-platform-partner$252Fdc4fdf05e7684165b639b4e1831872c8",
+            ),
+            # publisher
+            (
+                "arn:aws:ecs:us-west-2:119557546360:task/onedocker-cluster-mpc-aem-exp-platform-publisher/aeb6151d016046dab698b988e04018d4",
+                "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-shared-us-west-2/log-events/ecs$252Fonedocker-container-shared-us-west-2$252Faeb6151d016046dab698b988e04018d4",
+            ),
+        ):
+            with self.subTest(container_id=container_id, expected_url=expected_url):
+                actual = retriever.get_log_url(container_id)
+                self.assertEqual(expected_url, actual)


### PR DESCRIPTION
Summary:
## What

* Fix broken cloudwatch URL logging for the MPC-AEM AWS account

## Why

* I am a man of the people
* Bug reports:
  * https://fb.workplace.com/groups/347899107359347/permalink/351833476965910/
  * https://fb.workplace.com/groups/347899107359347/permalink/365610878921503/

Differential Revision: D36123407

