### PR TITLE
call stop_instance for PID Instances when cancel stage

### DIFF
--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -176,6 +176,9 @@ class PIDService:
                 )
 
         instance.status = PIDInstanceStatus.CANCELED
+        if instance.current_stage in instance.stages_status:
+            instance.stages_status[instance.current_stage] = PIDStageStatus.FAILED
+
         self.instance_repository.update(instance)
         self.logger.info(f"PID instance {instance_id} has been successfully canceled.")
         return instance

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -17,6 +17,7 @@ from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
@@ -434,6 +435,8 @@ class PrivateComputationService:
         last_instance = private_computation_instance.instances[-1]
         if isinstance(last_instance, MPCInstance):
             self.mpc_svc.stop_instance(instance_id=last_instance.instance_id)
+        elif isinstance(last_instance, PIDInstance):
+            self.pid_svc.stop_instance(instance_id=last_instance.instance_id)
         else:
             self.logger.warning(
                 f"Canceling the current stage of instance {instance_id} is not supported yet."


### PR DESCRIPTION
Summary:
## Why
We want to call PID service stop containers when stage is retiring(cancel), we need to kill existing containers before retrying
There was a bug when PID stage (ID matching more precise) retries, the partner side containers didn't terminate before retry.
which causes the capacity issue and the stage won't be completed as the old containers have been peered to the publisher's side.
this is the #2 mid-term solution in T116997514
more context: https://fb.workplace.com/groups/331044242148818/posts/463212832265291/?comment_id=463312582255316
## What
1. call `pid_svc.stop_instance` when stage is canceling during retry.
2. make pid stage as Failed after stop_instance api called
3. adding UTs

## Next
turn on retry on ID_Match stage back which we disabled in D35622568 (https://github.com/facebookresearch/fbpcs/commit/df95e194bb2db0639bcc66c36b9dd6b2eb1c6eec)

Differential Revision: D36135286

