### PR TITLE
convert date input as pacfic time

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -5,3 +5,4 @@ networkx>=2.6.3
 requests>=2.26.0
 schema==0.7.0 # fbpcp requires this version, so we must as well
 termcolor==1.1.0
+pytz>=2022.1

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Type, Optional, Dict, Any
 
 import dateutil.parser
+import pytz
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     PLGraphAPIClient,
 )
@@ -87,12 +88,11 @@ def run_attribution(
     attribution_rule_str = attribution_rule.name
     attribution_rule_val = attribution_rule.value
     instance_id = None
-
+    pacific_timezone = pytz.timezone("US/Pacific")
     # Validate if input is datetime or timestamp
     is_date_format = _iso_date_validator(timestamp)
     if is_date_format:
-        mod_dt = timestamp + " 00:00:00+00:00"
-        dt = datetime.fromisoformat(mod_dt)
+        dt = pacific_timezone.localize(datetime.strptime(timestamp, "%Y-%m-%d"))
     else:
         dt = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
 


### PR DESCRIPTION
Summary:
Previously we tried to align partner/publisher side using UTC date.  It turns out all internal tables/systems are partitioned by Pacific Time. To make data preparation and result analyzing easier, the daily recurring run should be based upon Pacific Time.

This diff parses the date from parameter as if it is a Pacific Time. In the runbook, we should also be more explicit about the timezone.

Reviewed By: ashiquemfb

Differential Revision: D36123232

