### PR TITLE
Annotate stage flows with binary name

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/main.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/main.cpp
@@ -125,7 +125,9 @@ int main(int argc, char* argv[]) {
     XLOG(INFO, cost.getEstimatedCostString());
 
     if (FLAGS_log_cost) {
-      auto run_name = (FLAGS_run_name != "") ? FLAGS_run_name : "temp_run_name";
+      bool run_name_specified = FLAGS_run_name != "";
+      auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
+
       auto party = (FLAGS_party == static_cast<int>(fbpcf::Party::Alice))
           ? "Publisher"
           : "Partner";
@@ -141,13 +143,15 @@ int main(int argc, char* argv[]) {
           "num_files",
           FLAGS_num_files)("file_start_index", FLAGS_file_start_index)("concurrency", FLAGS_concurrency)("use_xor_encryption", FLAGS_use_xor_encryption);
 
-      XLOGF(
-          INFO,
-          "{}",
-          cost.writeToS3(
-              party,
-              run_name,
-              cost.getEstimatedCostDynamic(run_name, party, extra_info)));
+      folly::dynamic costDict =
+          cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+      auto objectName = run_name_specified
+          ? run_name
+          : folly::to<std::string>(
+                FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+      XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
     }
 
     return 0;

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -165,7 +165,8 @@ int main(int argc, char* argv[]) {
       schedulerStatistics.receivedNetwork);
 
   if (FLAGS_log_cost) {
-    auto run_name = (FLAGS_run_name != "") ? FLAGS_run_name : "temp_run_name";
+    bool run_name_specified = FLAGS_run_name != "";
+    auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
     auto party = (FLAGS_party == common::PUBLISHER) ? "Publisher" : "Partner";
 
     folly::dynamic extra_info = common::getCostExtraInfo(
@@ -178,13 +179,15 @@ int main(int argc, char* argv[]) {
         FLAGS_use_xor_encryption,
         schedulerStatistics);
 
-    XLOGF(
-        INFO,
-        "{}",
-        cost.writeToS3(
-            party,
-            run_name,
-            cost.getEstimatedCostDynamic(run_name, party, extra_info)));
+    folly::dynamic costDict =
+        cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+    auto objectName = run_name_specified
+        ? run_name
+        : folly::to<std::string>(
+              FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+    XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
   }
 
   return 0;

--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -7,7 +7,6 @@
 
 #include "fbpcs/performance_tools/CostEstimation.h"
 #include <fbpcf/io/FileManagerUtil.h>
-#include <fbpcs/performance_tools/CostEstimation.h>
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
@@ -190,29 +189,23 @@ void CostEstimation::end() {
 
 std::string CostEstimation::writeToS3(
     std::string party,
-    std::string run_name,
+    std::string objectName,
     folly::dynamic costDynamic) {
   std::string s3FullPath = folly::to<std::string>(
       "https://", s3Bucket_, ".s3.us-west-2.amazonaws.com/", s3Path_, "/");
-  std::string filePath = folly::to<std::string>(
-      s3FullPath,
-      run_name,
-      "_",
-      party,
-      "_",
-      costDynamic["timestamp"].asString(),
-      ".json");
+  std::string filePath =
+      folly::to<std::string>(s3FullPath, objectName, "_", party, ".json");
 
   return _writeToS3(filePath, costDynamic);
 }
 
 std::string CostEstimation::writeToS3(
-    std::string run_name,
+    std::string objectName,
     folly::dynamic costDynamic) {
   std::string s3FullPath = folly::to<std::string>(
       "https://", s3Bucket_, ".s3.us-west-2.amazonaws.com/", s3Path_, "/");
-  std::string filePath = folly::to<std::string>(
-      s3FullPath, run_name, "_", costDynamic["timestamp"].asString(), ".json");
+  std::string filePath =
+      folly::to<std::string>(s3FullPath, objectName, ".json");
 
   return _writeToS3(filePath, costDynamic);
 }
@@ -222,6 +215,7 @@ std::string CostEstimation::_writeToS3(
     folly::dynamic costDynamic) {
   std::string costData = folly::toPrettyJson(costDynamic);
   try {
+    XLOG(INFO) << "Writing cost file to s3: " << filePath;
     fbpcf::io::write(filePath, costData);
   } catch (const std::exception& e) {
     XLOG(WARN) << "Error: Exception writing cost in S3.\n\terror msg: "

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -27,6 +27,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageServiceArgs,
     PrivateComputationStageService,
 )
 
@@ -133,7 +134,10 @@ class PostProcessingStageService(PrivateComputationStageService):
             handler_name
         ] = PostProcessingHandlerStatus.STARTED
         try:
-            await handler.run(self._storage_svc, private_computation_instance)
+            await handler.run(
+                self._storage_svc,
+                private_computation_instance,
+            )
             self._logger.info(f"Completed post processing handler: {handler_name=}")
             post_processing_instance.handler_statuses[
                 handler_name

--- a/fbpcs/private_computation/stage_flows/private_computation_base_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_base_stage_flow.py
@@ -8,7 +8,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Type, TypeVar, TYPE_CHECKING
+from typing import Type, TypeVar, TYPE_CHECKING, Optional
 
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         PrivateComputationStageService,
         PrivateComputationStageServiceArgs,
     )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.stage_flow.stage_flow import StageFlow, StageFlowData
 
 C = TypeVar("C", bound="PrivateComputationBaseStageFlow")
@@ -32,6 +33,8 @@ class PrivateComputationStageFlowData(StageFlowData[PrivateComputationInstanceSt
     is_joint_stage: bool
     timeout: int = 3600
     is_retryable: bool = True
+    does_stage_write_to_s3: bool = False
+    binary_name: Optional[GameNames] = None
 
 
 class PrivateComputationBaseStageFlow(StageFlow):

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.aggregate_shards_stage_service import (
     AggregateShardsStageService,
 )
@@ -75,18 +76,24 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
         PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_COMPLETED,
         PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.DECOUPLED_ATTRIBUTION,
     )
     DECOUPLED_AGGREGATION = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.DECOUPLED_AGGREGATION,
     )
     AGGREGATE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.SHARD_AGGREGATOR,
     )
 
     def get_stage_service(

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -8,6 +8,7 @@ from fbpcs.pid.entity.pid_instance import UnionPIDStage
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.aggregate_shards_stage_service import (
     AggregateShardsStageService,
 )
@@ -115,18 +116,24 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_COMPLETED,
         PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.DECOUPLED_ATTRIBUTION,
     )
     DECOUPLED_AGGREGATION = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.DECOUPLED_AGGREGATION,
     )
     AGGREGATE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.SHARD_AGGREGATOR,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.aggregate_shards_stage_service import (
     AggregateShardsStageService,
 )
@@ -77,18 +78,24 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.PCF2_ATTRIBUTION_COMPLETED,
         PrivateComputationInstanceStatus.PCF2_ATTRIBUTION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.PCF2_ATTRIBUTION,
     )
     PCF2_AGGREGATION = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.PCF2_AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.PCF2_AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.PCF2_AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.PCF2_AGGREGATION,
     )
     AGGREGATE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.SHARD_AGGREGATOR,
     )
 
     def get_stage_service(

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -8,6 +8,7 @@ from fbpcs.pid.entity.pid_instance import UnionPIDStage
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.aggregate_shards_stage_service import (
     AggregateShardsStageService,
 )
@@ -114,18 +115,24 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.PCF2_ATTRIBUTION_COMPLETED,
         PrivateComputationInstanceStatus.PCF2_ATTRIBUTION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.PCF2_ATTRIBUTION,
     )
     PCF2_AGGREGATION = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.PCF2_AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.PCF2_AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.PCF2_AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.PCF2_AGGREGATION,
     )
     AGGREGATE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,
         PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         True,
+        does_stage_write_to_s3=True,
+        binary_name=GameNames.SHARD_AGGREGATOR,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,


### PR DESCRIPTION
Summary:
Each mpc binary which uses the cost library has a hard coded path in s3 which it uses to write the json file. See https://fburl.com/code/bzkqk6kv. In order for the PCS coordination to know which folder to read from, it has to know which binary is run for each stage. Currently there is no easy way to get this from the StageFlow that is stored on the instance. Since the post processing handlers are run at the end we will not be able to get the binary type from the pc_instance.

This diff adds two parameters which indicate the binary uses the cost logging library as well as which GameName it is.

Differential Revision: D35908046

