### PR TITLE
Add post processing handler to transfer cost estimation files from s3 to hive

### DIFF
--- a/fbpcs/private_computation/entity/post_processing_data.py
+++ b/fbpcs/private_computation/entity/post_processing_data.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from dataclasses import dataclass
+from dataclasses import field, dataclass
+from typing import Set
 
 from dataclasses_json import dataclass_json
 
@@ -23,6 +24,7 @@ class PostProcessingData:
 
     # TODO : Add breakdown key to PostProcessingData.
     dataset_timestamp: int = 0
+    s3_cost_export_output_paths: Set[str] = field(default_factory=set)
 
     def __str__(self) -> str:
         # pyre-ignore

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -55,6 +55,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument({"name": "threshold", "required": True}),
             OneDockerArgument({"name": "first_shard_index", "required": False}),
             OneDockerArgument({"name": "log_cost", "required": False}),
+            OneDockerArgument({"name": "run_name", "required": False}),
         ],
     },
     GameNames.DECOUPLED_ATTRIBUTION.value: {
@@ -70,6 +71,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument({"name": "use_xor_encryption", "required": True}),
             OneDockerArgument({"name": "use_postfix", "required": True}),
             OneDockerArgument({"name": "log_cost", "required": False}),
+            OneDockerArgument({"name": "run_name", "required": False}),
         ],
     },
     GameNames.DECOUPLED_AGGREGATION.value: {
@@ -88,6 +90,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument({"name": "use_xor_encryption", "required": True}),
             OneDockerArgument({"name": "use_postfix", "required": True}),
             OneDockerArgument({"name": "log_cost", "required": False}),
+            OneDockerArgument({"name": "run_name", "required": False}),
         ],
     },
     GameNames.PCF2_ATTRIBUTION.value: {
@@ -103,6 +106,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument({"name": "use_xor_encryption", "required": True}),
             OneDockerArgument({"name": "use_postfix", "required": True}),
             OneDockerArgument({"name": "log_cost", "required": False}),
+            OneDockerArgument({"name": "run_name", "required": False}),
         ],
     },
     GameNames.PCF2_AGGREGATION.value: {
@@ -121,6 +125,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument({"name": "use_xor_encryption", "required": True}),
             OneDockerArgument({"name": "use_postfix", "required": True}),
             OneDockerArgument({"name": "log_cost", "required": False}),
+            OneDockerArgument({"name": "run_name", "required": False}),
         ],
     },
 }

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -107,6 +107,16 @@ class AggregateShardsStageService(PrivateComputationStageService):
         else:
             input_stage_path = pc_instance.compute_stage_output_base_path
 
+        if self._log_cost_to_s3:
+            run_name = pc_instance.instance_id
+
+            if pc_instance.post_processing_data:
+                pc_instance.post_processing_data.s3_cost_export_output_paths.add(
+                    f"sa-logs/{run_name}_{pc_instance.role.value.title()}.json",
+                )
+        else:
+            run_name = ""
+
         if self._is_validating:
             # num_containers_real_data is the number of containers processing real data
             # synthetic data is processed by a dedicated extra container, and this container is always the last container,
@@ -130,7 +140,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
                     "output_path": pc_instance.shard_aggregate_stage_output_path,
                     "first_shard_index": 0,
                     "threshold": pc_instance.k_anonymity_threshold,
-                    "run_name": pc_instance.instance_id if self._log_cost_to_s3 else "",
+                    "run_name": run_name,
                     "log_cost": self._log_cost_to_s3,
                 },
                 {
@@ -141,7 +151,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
                     + "_synthetic_data_shards",
                     "first_shard_index": synthetic_data_shard_start_index,
                     "threshold": pc_instance.k_anonymity_threshold,
-                    "run_name": pc_instance.instance_id if self._log_cost_to_s3 else "",
+                    "run_name": run_name,
                     "log_cost": self._log_cost_to_s3,
                 },
             ]
@@ -173,7 +183,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
                     "num_shards": num_shards,
                     "output_path": pc_instance.shard_aggregate_stage_output_path,
                     "threshold": pc_instance.k_anonymity_threshold,
-                    "run_name": pc_instance.instance_id if self._log_cost_to_s3 else "",
+                    "run_name": run_name,
                     "log_cost": self._log_cost_to_s3,
                 },
             ]

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -149,6 +149,16 @@ class AggregationStageService(PrivateComputationStageService):
         attribution_rule = checked_cast(
             AttributionRule, private_computation_instance.attribution_rule
         )
+
+        if self._log_cost_to_s3:
+            run_name = private_computation_instance.instance_id
+            if private_computation_instance.post_processing_data:
+                private_computation_instance.post_processing_data.s3_cost_export_output_paths.add(
+                    f"agg-logs/{run_name}_{private_computation_instance.role.value.title()}.json",
+                )
+        else:
+            run_name = ""
+
         common_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.decoupled_aggregation_stage_output_base_path,
@@ -159,9 +169,7 @@ class AggregationStageService(PrivateComputationStageService):
             "input_base_path_secret_share": private_computation_instance.decoupled_attribution_stage_output_base_path,
             "use_xor_encryption": True,
             "use_postfix": True,
-            "run_name": private_computation_instance.instance_id
-            if self._log_cost_to_s3
-            else "",
+            "run_name": run_name,
             "max_num_touchpoints": private_computation_instance.padding_size,
             "max_num_conversions": private_computation_instance.padding_size,
             "log_cost": self._log_cost_to_s3,

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -153,15 +153,24 @@ class AttributionStageService(PrivateComputationStageService):
         attribution_rule = checked_cast(
             AttributionRule, private_computation_instance.attribution_rule
         )
+
+        if self._log_cost_to_s3:
+            run_name = (
+                private_computation_instance.instance_id + "_decoupled_attribution"
+            )
+            if private_computation_instance.post_processing_data:
+                private_computation_instance.post_processing_data.s3_cost_export_output_paths.add(
+                    f"att-logs/{run_name}_{private_computation_instance.role.value.title()}.json",
+                )
+        else:
+            run_name = ""
+
         common_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.decoupled_attribution_stage_output_base_path,
             "num_files": private_computation_instance.num_files_per_mpc_container,
             "concurrency": private_computation_instance.concurrency,
-            "run_name": private_computation_instance.instance_id
-            + "_decoupled_attribution"
-            if self._log_cost_to_s3
-            else "",
+            "run_name": run_name,
             "max_num_touchpoints": private_computation_instance.padding_size,
             "max_num_conversions": private_computation_instance.padding_size,
             "log_cost": self._log_cost_to_s3,

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -151,6 +151,16 @@ class PCF2AggregationStageService(PrivateComputationStageService):
         attribution_rule = checked_cast(
             AttributionRule, private_computation_instance.attribution_rule
         )
+
+        if self._log_cost_to_s3:
+            run_name = private_computation_instance.instance_id
+            if private_computation_instance.post_processing_data:
+                private_computation_instance.post_processing_data.s3_cost_export_output_paths.add(
+                    f"agg-logs/{run_name}_{private_computation_instance.role.value.title()}.json",
+                )
+        else:
+            run_name = ""
+
         common_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.pcf2_aggregation_stage_output_base_path,
@@ -161,9 +171,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "input_base_path_secret_share": private_computation_instance.pcf2_attribution_stage_output_base_path,
             "use_xor_encryption": True,
             "use_postfix": True,
-            "run_name": private_computation_instance.instance_id
-            if self._log_cost_to_s3
-            else "",
+            "run_name": run_name,
             "max_num_touchpoints": private_computation_instance.padding_size,
             "max_num_conversions": private_computation_instance.padding_size,
             "log_cost": self._log_cost_to_s3,

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -154,16 +154,25 @@ class PCF2AttributionStageService(PrivateComputationStageService):
         attribution_rule = checked_cast(
             AttributionRule, private_computation_instance.attribution_rule
         )
+        if self._log_cost_to_s3:
+            run_name = (
+                private_computation_instance.instance_id
+                + "_"
+                + GameNames.PCF2_ATTRIBUTION.value
+            )
+            if private_computation_instance.post_processing_data:
+                private_computation_instance.post_processing_data.s3_cost_export_output_paths.add(
+                    f"att-logs/{run_name}_{private_computation_instance.role.value.title()}.json"
+                )
+        else:
+            run_name = ""
+
         common_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.pcf2_attribution_stage_output_base_path,
             "num_files": private_computation_instance.num_files_per_mpc_container,
             "concurrency": private_computation_instance.concurrency,
-            "run_name": private_computation_instance.instance_id
-            + "_"
-            + GameNames.PCF2_ATTRIBUTION.value
-            if self._log_cost_to_s3
-            else "",
+            "run_name": run_name,
             "max_num_touchpoints": private_computation_instance.padding_size,
             "max_num_conversions": private_computation_instance.padding_size,
             "log_cost": self._log_cost_to_s3,


### PR DESCRIPTION
Summary:
In order to read the s3 files written by the cost estimation library and to write them to hive, we need to add a stage to PCS that runs after the binaries have finished. This handler will be run on FB infra and have access to the AWS accounts through the Storage Service.

In this diff we set up a new post processing handler which iterates through the stages in the stage flow and checks for each stage whether it needs to read the file from s3.

I've moved the run names which are passed into the binaries into a shared attribute on the pc_instance to keep them synced when the file is read.

Differential Revision: D36140878

