### PR TITLE
Using target_id and action_type in attribution rule

### DIFF
--- a/fbpcs/emp_games/common/Constants.h
+++ b/fbpcs/emp_games/common/Constants.h
@@ -30,6 +30,7 @@ inline const std::string LAST_CLICK_28D = "last_click_28d";
 inline const std::string LAST_TOUCH_28D = "last_touch_28d";
 inline const std::string LAST_CLICK_2_7D = "last_click_2_7d";
 inline const std::string LAST_TOUCH_2_7D = "last_touch_2_7d";
+inline const std::string LAST_CLICK_1D_TARGETID = "last_click_1d_targetid";
 
 /*
   ADDITIONAL INPUT COLUMNS

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h
@@ -27,7 +27,7 @@ AttributionInputMetrics<usingBatch, inputEncryption>::parseTouchpoints(
   std::vector<uint64_t> timestamps;
   std::vector<bool> isClicks;
   std::vector<uint64_t> targetId;
-  std::vector<uint16_t> actionType;
+  std::vector<uint64_t> actionType;
   bool targetIdPresent = false;
   bool actionTypePresent = false;
 
@@ -53,7 +53,7 @@ AttributionInputMetrics<usingBatch, inputEncryption>::parseTouchpoints(
       targetId = common::getInnerArray<uint64_t>(value);
     } else if (column == "action_type") {
       actionTypePresent = true;
-      actionType = common::getInnerArray<uint16_t>(value);
+      actionType = common::getInnerArray<uint64_t>(value);
     }
   }
 
@@ -126,7 +126,7 @@ AttributionInputMetrics<usingBatch, inputEncryption>::parseConversions(
     const std::vector<std::string>& parts) {
   std::vector<uint64_t> convTimestamps;
   std::vector<uint64_t> targetId;
-  std::vector<uint16_t> actionType;
+  std::vector<uint64_t> actionType;
   bool targetIdPresent = false;
   bool actionTypePresent = false;
 
@@ -141,7 +141,7 @@ AttributionInputMetrics<usingBatch, inputEncryption>::parseConversions(
       targetId = common::getInnerArray<uint64_t>(value);
     } else if (column == "action_type") {
       actionTypePresent = true;
-      actionType = common::getInnerArray<uint16_t>(value);
+      actionType = common::getInnerArray<uint64_t>(value);
     }
   }
 
@@ -206,8 +206,8 @@ AttributionInputMetrics<usingBatch, inputEncryption>::
         FLAGS_max_num_touchpoints, std::vector<uint64_t>{});
     std::vector<std::vector<uint64_t>> targetIds(
         FLAGS_max_num_touchpoints, std::vector<uint64_t>{});
-    std::vector<std::vector<uint16_t>> actionTypes(
-        FLAGS_max_num_touchpoints, std::vector<uint16_t>{});
+    std::vector<std::vector<uint64_t>> actionTypes(
+        FLAGS_max_num_touchpoints, std::vector<uint64_t>{});
 
     // The touchpoints are parsed row by row, whereas the batches are across
     // rows.
@@ -258,8 +258,8 @@ AttributionInputMetrics<usingBatch, inputEncryption>::
         FLAGS_max_num_conversions, std::vector<uint64_t>{});
     std::vector<std::vector<uint64_t>> targetIds(
         FLAGS_max_num_touchpoints, std::vector<uint64_t>{});
-    std::vector<std::vector<uint16_t>> actionTypes(
-        FLAGS_max_num_touchpoints, std::vector<uint16_t>{});
+    std::vector<std::vector<uint64_t>> actionTypes(
+        FLAGS_max_num_touchpoints, std::vector<uint64_t>{});
 
     // The conversions are parsed row by row, whereas the batches are across
     // rows.

--- a/fbpcs/emp_games/pcf2_attribution/Constants.h
+++ b/fbpcs/emp_games/pcf2_attribution/Constants.h
@@ -13,6 +13,8 @@ namespace pcf2_attribution {
 
 const int kMaxConcurrency = 16;
 const size_t timeStampWidth = 32;
+const size_t targetIdWidth = 32;
+const size_t actionTypeWidth = 16;
 
 template <int schedulerId, bool usingBatch = true>
 using PubBit =
@@ -28,6 +30,20 @@ template <int schedulerId, bool usingBatch = true>
 using SecTimestamp = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<timeStampWidth, usingBatch>;
 
+template <int schedulerId, bool usingBatch = true>
+using PubTargetId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<targetIdWidth, usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecTargetId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<targetIdWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubActionType = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<actionTypeWidth, usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecActionType = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<actionTypeWidth, usingBatch>;
+
 template <typename T, bool useVector>
 using ConditionalVector =
     typename std::conditional<useVector, std::vector<T>, T>::type;
@@ -37,5 +53,11 @@ using SecBitT = ConditionalVector<SecBit<schedulerId, usingBatch>, !usingBatch>;
 template <int schedulerId, bool usingBatch = true>
 using SecTimestampT =
     ConditionalVector<SecTimestamp<schedulerId, usingBatch>, !usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecTargetIdT =
+    ConditionalVector<SecTargetId<schedulerId, usingBatch>, !usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecActionTypeT =
+    ConditionalVector<SecActionType<schedulerId, usingBatch>, !usingBatch>;
 
 } // namespace pcf2_attribution


### PR DESCRIPTION
Summary:
**What?**
- We need to ensure attributions happen at <user, target_id, action_type> level instead of current <user> level. This diff is using `target_id` and `action_type` in core PA attribution logic.

**Next?**
- Next we will add correctness tests for the new input columns.

Differential Revision: D36123455

