### PR TITLE
Making stage flow in run_attribution configurable with default value of PCF2

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -58,8 +58,8 @@ from fbpcs.private_computation.service.utils import get_log_urls
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
+from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
+    PrivateComputationPCF2StageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
@@ -190,7 +190,7 @@ class PrivateComputationService:
             ),
             _stage_flow_cls_name=unwrap_or_default(
                 optional=stage_flow_cls,
-                default=PrivateComputationDecoupledStageFlow
+                default=PrivateComputationPCF2StageFlow
                 if game_type is PrivateComputationGameType.ATTRIBUTION
                 else PrivateComputationStageFlow,
             ).get_cls_name(),

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -60,11 +60,11 @@ from fbpcs.private_computation.service.utils import (
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
-)
 from fbpcs.private_computation.stage_flows.private_computation_mr_stage_flow import (
     PrivateComputationMRStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
+    PrivateComputationPCF2StageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
@@ -77,10 +77,10 @@ def _get_valid_stages_data() -> List[Tuple[PrivateComputationBaseStageFlow]]:
         (PrivateComputationStageFlow.COMPUTE,),
         (PrivateComputationStageFlow.AGGREGATE,),
         (PrivateComputationStageFlow.POST_PROCESSING_HANDLERS,),
-        (PrivateComputationDecoupledStageFlow.ID_MATCH,),
-        (PrivateComputationDecoupledStageFlow.DECOUPLED_ATTRIBUTION,),
-        (PrivateComputationDecoupledStageFlow.DECOUPLED_AGGREGATION,),
-        (PrivateComputationDecoupledStageFlow.AGGREGATE,),
+        (PrivateComputationPCF2StageFlow.ID_MATCH,),
+        (PrivateComputationPCF2StageFlow.PCF2_ATTRIBUTION,),
+        (PrivateComputationPCF2StageFlow.PCF2_AGGREGATION,),
+        (PrivateComputationPCF2StageFlow.AGGREGATE,),
     ]
 
 

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -25,7 +25,7 @@ Usage:
     pc-cli print_instance <instance_id> --config=<config_file> [options]
     pc-cli print_log_urls <instance_id> --config=<config_file> [options]
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
-    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path>  --timestamp=<timestamp> --attribution_rule=<attribution_rule>  --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [options]
+    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [options]
 
 
 Options:
@@ -57,8 +57,8 @@ from fbpcs.private_computation.service.utils import transform_file_path
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
+from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
+    PrivateComputationPCF2StageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
@@ -301,7 +301,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             dry_run=arguments["--dry_run"],
         )
     elif arguments["run_attribution"]:
-        stage_flow = PrivateComputationDecoupledStageFlow
+        stage_flow = PrivateComputationPCF2StageFlow
         run_attribution(
             config=config,
             dataset_id=arguments["--dataset_id"],

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -110,6 +110,23 @@ class TestPrivateComputationCli(TestCase):
             pc_cli.main(argv)
             create_mock.assert_called_once()
 
+    @patch("fbpcs.private_computation_cli.private_computation_cli.run_attribution")
+    def test_run_attribution(self, create_mock) -> None:
+        argv = [
+            "run_attribution",
+            "--dataset_id=43423422232",
+            "--attribution_rule=last_click_1d",
+            f"--input_path={self.temp_files_paths[0]}",
+            "--aggregation_type=measurement",
+            "--concurrency=4",
+            "--num_files_per_mpc_container=4",
+            f"--config={self.temp_filename}",
+            "--timestamp=1646870400",
+            "--k_anonymity_threshold=0",
+        ]
+        pc_cli.main(argv)
+        create_mock.assert_called_once()
+
     @patch("fbpcs.private_computation_cli.private_computation_cli.validate")
     def test_validate(self, validate_mock) -> None:
         argv = [


### PR DESCRIPTION
Summary:
As we are rolling out PCF2 to canary, making this change to make it the default flow in PA.

In this diff, making stage flow configurable with a default value of PCF2 in run_attribution.

Differential Revision: D36180109

