### PR TITLE
Making PCF2 as the default flow for attribution.

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -58,8 +58,8 @@ from fbpcs.private_computation.service.utils import get_log_urls
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
+from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
+    PrivateComputationPCF2StageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
@@ -190,7 +190,7 @@ class PrivateComputationService:
             ),
             _stage_flow_cls_name=unwrap_or_default(
                 optional=stage_flow_cls,
-                default=PrivateComputationDecoupledStageFlow
+                default=PrivateComputationPCF2StageFlow
                 if game_type is PrivateComputationGameType.ATTRIBUTION
                 else PrivateComputationStageFlow,
             ).get_cls_name(),

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -60,11 +60,11 @@ from fbpcs.private_computation.service.utils import (
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
-from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
-    PrivateComputationDecoupledStageFlow,
-)
 from fbpcs.private_computation.stage_flows.private_computation_mr_stage_flow import (
     PrivateComputationMRStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
+    PrivateComputationPCF2StageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
@@ -77,10 +77,10 @@ def _get_valid_stages_data() -> List[Tuple[PrivateComputationBaseStageFlow]]:
         (PrivateComputationStageFlow.COMPUTE,),
         (PrivateComputationStageFlow.AGGREGATE,),
         (PrivateComputationStageFlow.POST_PROCESSING_HANDLERS,),
-        (PrivateComputationDecoupledStageFlow.ID_MATCH,),
-        (PrivateComputationDecoupledStageFlow.DECOUPLED_ATTRIBUTION,),
-        (PrivateComputationDecoupledStageFlow.DECOUPLED_AGGREGATION,),
-        (PrivateComputationDecoupledStageFlow.AGGREGATE,),
+        (PrivateComputationPCF2StageFlow.ID_MATCH,),
+        (PrivateComputationPCF2StageFlow.PCF2_ATTRIBUTION,),
+        (PrivateComputationPCF2StageFlow.PCF2_AGGREGATION,),
+        (PrivateComputationPCF2StageFlow.AGGREGATE,),
     ]
 
 


### PR DESCRIPTION
Summary:
As we are rolling out PCF2 to canary, making this change to make it the default flow in PA.

In this diff, changing default flow for Private computation.
In next dif, will make the stage flow configurable in oneCommandRunner with a default value of PCF2.

Differential Revision: D36177821

