### PR TITLE
fix the regression when undeploying

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -161,6 +161,8 @@ undeploy_aws_resources() {
         check_s3_object_exist "$s3_bucket_for_storage" "tfstate/glue_etl$tag_postfix.tfstate" "$aws_account_id"
         echo "Semi automated data_pipeline tfstate file exists. Continue..."
         cd /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
+        # lambda_trigger.py needs to be copied here in case a deploy was not previously run in the container
+        cp template/lambda_trigger.py .
         terraform init -reconfigure \
         -backend-config "bucket=$s3_bucket_for_storage" \
         -backend-config "region=$region" \


### PR DESCRIPTION
Summary:
The fix in D36152298 (https://github.com/facebookresearch/fbpcs/commit/fdaf40e9eeea7ae81f7fea49636d2cdd51e332e5) introduced a new problem where an existing semi-automated
deployment can't be fully undeployed unless a deploy command has been
previously run in the container before. Fix the fix by copying the
lambda_trigger.py file for the undeploy case also, so that the undeployment can
succeed.

Differential Revision: D36181959

