### PR TITLE
Sum value squared in Aggregator

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -56,6 +56,8 @@ class Aggregator {
         testCohortIndexShares_{inputProcessor.getTestCohortIndexShares()} {
     initOram();
     sumEvents();
+    sumConverters();
+    sumMatch();
   }
 
   const OutputMetricsData getMetrics() const {
@@ -71,6 +73,10 @@ class Aggregator {
   void initOram();
 
   void sumEvents();
+
+  void sumConverters();
+
+  void sumMatch();
 
   // Run ORAM aggregation on input. The template parameter useVector indicates
   // whether the input consists of a vector of inputs or a single input.

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -59,6 +59,7 @@ class Aggregator {
     sumConverters();
     sumNumConvSquared();
     sumMatch();
+    sumValues();
   }
 
   const OutputMetricsData getMetrics() const {
@@ -80,6 +81,8 @@ class Aggregator {
   void sumNumConvSquared();
 
   void sumMatch();
+
+  void sumValues();
 
   // Run ORAM aggregation on input. The template parameter useVector indicates
   // whether the input consists of a vector of inputs or a single input.
@@ -118,6 +121,9 @@ class Aggregator {
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<false, valueWidth>>>
       cohortUnsignedWriteOnlyOramFactory_;
+  std::unique_ptr<
+      fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<true, valueWidth>>>
+      cohortSignedWriteOnlyOramFactory_;
 
   std::vector<std::vector<bool>> cohortIndexShares_;
   std::vector<std::vector<bool>> testCohortIndexShares_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -57,6 +57,7 @@ class Aggregator {
     initOram();
     sumEvents();
     sumConverters();
+    sumNumConvSquared();
     sumMatch();
   }
 
@@ -75,6 +76,8 @@ class Aggregator {
   void sumEvents();
 
   void sumConverters();
+
+  void sumNumConvSquared();
 
   void sumMatch();
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "folly/logging/xlog.h"
+
+#include "fbpcf/mpc_std_lib/oram/IWriteOnlyOramFactory.h"
+#include "fbpcf/mpc_std_lib/oram/LinearOramFactory.h"
+#include "fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h"
+#include "fbpcs/emp_games/lift/common/GroupedLiftMetrics.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/OutputMetricsData.h"
+
+namespace private_lift {
+
+template <bool isSigned, int8_t width>
+using Intp = typename fbpcf::mpc_std_lib::util::Intp<isSigned, width>;
+
+template <int schedulerId>
+class Aggregator {
+ public:
+  Aggregator(
+      int myRole,
+      InputProcessor<schedulerId> inputProcessor,
+      std::unique_ptr<Attributor<schedulerId>> attributor,
+      int32_t numConversionsPerUser,
+      std::shared_ptr<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+          communicationAgentFactory)
+      : myRole_{myRole},
+        inputProcessor_{inputProcessor},
+        attributor_{std::move(attributor)},
+        numRows_{inputProcessor.getNumRows()},
+        numPartnerCohorts_{inputProcessor.getNumPartnerCohorts()},
+        numConversionsPerUser_{numConversionsPerUser},
+        communicationAgentFactory_{communicationAgentFactory},
+        cohortIndexShares_{inputProcessor.getCohortIndexShares()},
+        testCohortIndexShares_{inputProcessor.getTestCohortIndexShares()} {
+    initOram();
+  }
+
+  const OutputMetricsData getMetrics() const {
+    return metrics_;
+  }
+
+  const std::unordered_map<int64_t, OutputMetricsData> getCohortMetrics()
+      const {
+    return cohortMetrics_;
+  }
+
+ private:
+  void initOram();
+
+  int32_t myRole_;
+  InputProcessor<schedulerId> inputProcessor_;
+  std::unique_ptr<Attributor<schedulerId>> attributor_;
+  int64_t numRows_;
+  uint32_t numPartnerCohorts_;
+  int32_t numConversionsPerUser_;
+  uint32_t numCohortGroups_;
+  uint32_t numTestCohortGroups_;
+  OutputMetricsData metrics_;
+
+  std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+      communicationAgentFactory_;
+  std::unique_ptr<
+      fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<false, valueWidth>>>
+      cohortUnsignedWriteOnlyOramFactory_;
+
+  std::vector<std::vector<bool>> cohortIndexShares_;
+  std::vector<std::vector<bool>> testCohortIndexShares_;
+  std::unordered_map<int64_t, OutputMetricsData> cohortMetrics_;
+};
+} // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -60,6 +60,7 @@ class Aggregator {
     sumNumConvSquared();
     sumMatch();
     sumValues();
+    sumValueSquared();
   }
 
   const OutputMetricsData getMetrics() const {
@@ -83,6 +84,8 @@ class Aggregator {
   void sumMatch();
 
   void sumValues();
+
+  void sumValueSquared();
 
   // Run ORAM aggregation on input. The template parameter useVector indicates
   // whether the input consists of a vector of inputs or a single input.
@@ -124,6 +127,9 @@ class Aggregator {
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<true, valueWidth>>>
       cohortSignedWriteOnlyOramFactory_;
+  std::unique_ptr<fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<
+      Intp<false, valueSquaredWidth>>>
+      valueSquaredWriteOnlyOramFactory_;
 
   std::vector<std::vector<bool>> cohortIndexShares_;
   std::vector<std::vector<bool>> testCohortIndexShares_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
@@ -31,4 +31,98 @@ void Aggregator<schedulerId>::initOram() {
   }
 }
 
+template <int schedulerId>
+void Aggregator<schedulerId>::sumEvents() {
+  XLOG(INFO) << "Aggregate events";
+  // Aggregate across test/control and cohorts
+  std::vector<std::vector<std::vector<bool>>> valueSharesArray;
+  for (auto events : attributor_->getEvents()) {
+    std::vector<std::vector<bool>> valueShares(
+        valueWidth, std::vector<bool>(numRows_, 0));
+    valueShares[0] = events.extractBit().getValue();
+    valueSharesArray.push_back(std::move(valueShares));
+  }
+  auto oram = cohortUnsignedWriteOnlyOramFactory_->create(numCohortGroups_);
+  auto aggregationOutput = aggregate<false, valueWidth, true>(
+      cohortIndexShares_, valueSharesArray, numCohortGroups_, std::move(oram));
+
+  // Extract metrics
+  auto cohortOutput = revealCohortOutput(aggregationOutput);
+  metrics_.testEvents = std::get<0>(cohortOutput).at(0);
+  metrics_.controlEvents = std::get<0>(cohortOutput).at(1);
+  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+    cohortMetrics_[i].testEvents = std::get<1>(cohortOutput).at(i);
+    cohortMetrics_[i].controlEvents = std::get<2>(cohortOutput).at(i);
+  }
+}
+
+template <int schedulerId>
+template <bool isSigned, int8_t width, bool useVector>
+std::vector<SecInt<schedulerId, isSigned, width>>
+Aggregator<schedulerId>::aggregate(
+    const std::vector<std::vector<bool>>& indexShares,
+    ConditionalVector<std::vector<std::vector<bool>>, useVector>& valueShares,
+    size_t oramSize,
+    std::unique_ptr<
+        fbpcf::mpc_std_lib::oram::IWriteOnlyOram<Intp<isSigned, width>>> oram)
+    const {
+  // aggregate using ORAM
+  if constexpr (useVector) {
+    for (size_t i = 0; i < valueShares.size(); ++i) {
+      oram->obliviousAddBatch(indexShares, valueShares.at(i));
+    }
+  } else {
+    oram->obliviousAddBatch(indexShares, valueShares);
+  }
+  std::vector<SecInt<schedulerId, isSigned, width>> output;
+  for (size_t i = 0; i < oramSize; ++i) {
+    NativeIntp<isSigned, width> additiveSum(oram->secretRead(i));
+    // Convert additive shares to secret shares by inputting them into MPC
+    // and adding them, then extracting the secret shares.
+    auto publisherSum =
+        SecInt<schedulerId, isSigned, width>(additiveSum, common::PUBLISHER);
+    auto partnerSum =
+        SecInt<schedulerId, isSigned, width>(additiveSum, common::PARTNER);
+    output.push_back(publisherSum + partnerSum);
+  }
+  return output;
+}
+
+template <int schedulerId>
+template <bool isSigned, int8_t width>
+std::tuple<
+    std::vector<NativeIntp<isSigned, width>>,
+    std::vector<NativeIntp<isSigned, width>>,
+    std::vector<NativeIntp<isSigned, width>>>
+Aggregator<schedulerId>::revealCohortOutput(
+    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput) const {
+  std::vector<NativeIntp<isSigned, width>> testCohortOutput;
+  std::vector<NativeIntp<isSigned, width>> controlCohortOutput;
+  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+    // Extract cohort metrics
+    testCohortOutput.push_back(
+        aggregationOutput.at(i).extractIntShare().getValue());
+    controlCohortOutput.push_back(aggregationOutput.at(i + numPartnerCohorts_)
+                                      .extractIntShare()
+                                      .getValue());
+  }
+
+  // Initialize test/control metrics for the case where there are no partner
+  // cohorts
+  auto test = aggregationOutput.at(0);
+  auto control =
+      aggregationOutput.at(std::max(uint32_t(1), numPartnerCohorts_));
+  for (size_t i = 1; i < numPartnerCohorts_; ++i) {
+    // Compute test/control metrics by summing up cohort metrics for each
+    // population
+    test = test + aggregationOutput.at(i);
+    control = control + aggregationOutput.at(i + numPartnerCohorts_);
+  }
+  std::vector<NativeIntp<isSigned, width>> testControlOutput;
+  testControlOutput.push_back(test.extractIntShare().getValue());
+  testControlOutput.push_back(control.extractIntShare().getValue());
+  return std::make_tuple(
+      testControlOutput, testCohortOutput, controlCohortOutput);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
@@ -78,6 +78,26 @@ void Aggregator<schedulerId>::sumConverters() {
 }
 
 template <int schedulerId>
+void Aggregator<schedulerId>::sumNumConvSquared() {
+  XLOG(INFO) << "Aggregate numConvSquared";
+  // Aggregate across test/control and cohorts
+  auto valueShares =
+      attributor_->getNumConvSquared().extractIntShare().getBooleanShares();
+  auto oram = cohortUnsignedWriteOnlyOramFactory_->create(numCohortGroups_);
+  auto aggregationOutput = aggregate<false, valueWidth, false>(
+      cohortIndexShares_, valueShares, numCohortGroups_, std::move(oram));
+
+  // Extract metrics
+  auto cohortOutput = revealCohortOutput(aggregationOutput);
+  metrics_.testNumConvSquared = std::get<0>(cohortOutput).at(0);
+  metrics_.controlNumConvSquared = std::get<0>(cohortOutput).at(1);
+  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+    cohortMetrics_[i].testNumConvSquared = std::get<1>(cohortOutput).at(i);
+    cohortMetrics_[i].controlNumConvSquared = std::get<2>(cohortOutput).at(i);
+  }
+}
+
+template <int schedulerId>
 void Aggregator<schedulerId>::sumMatch() {
   XLOG(INFO) << "Aggregate matchCount";
   // Aggregate across test/control and cohorts

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/common/Util.h"
+namespace private_lift {
+
+template <int schedulerId>
+void Aggregator<schedulerId>::initOram() {
+  // Initialize ORAM
+  bool isPublisher = (myRole_ == common::PUBLISHER);
+  numCohortGroups_ = std::max(2 * numPartnerCohorts_, uint32_t(2));
+
+  if (numCohortGroups_ > 4) {
+    // If the ORAM size is larger than 4, linear ORAM is less efficient
+    // theoretically
+    cohortUnsignedWriteOnlyOramFactory_ =
+        fbpcf::mpc_std_lib::oram::getSecureWriteOnlyOramFactory<
+            Intp<false, valueWidth>,
+            groupWidth,
+            schedulerId>(isPublisher, 0, 1, *communicationAgentFactory_);
+  } else {
+    cohortUnsignedWriteOnlyOramFactory_ = fbpcf::mpc_std_lib::oram::
+        getSecureLinearOramFactory<Intp<false, valueWidth>, schedulerId>(
+            isPublisher, 0, 1, *communicationAgentFactory_);
+  }
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcf/test/TestHelper.h"
+
+#include "fbpcs/emp_games/common/TestUtil.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
+namespace private_lift {
+const bool unsafe = true;
+
+template <int schedulerId>
+Aggregator<schedulerId> createAggregatorWithScheduler(
+    int myRole,
+    InputData inputData,
+    int numConversionsPerUser,
+    std::shared_ptr<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myRole, *factory);
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+  auto inputProcessor =
+      InputProcessor<schedulerId>(myRole, inputData, numConversionsPerUser);
+  auto attributor =
+      std::make_unique<Attributor<schedulerId>>(myRole, inputProcessor);
+  return Aggregator<schedulerId>(
+      myRole,
+      inputProcessor,
+      std::move(attributor),
+      numConversionsPerUser,
+      factory);
+}
+
+class AggregatorTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<Aggregator<0>> publisherAggregator_;
+  std::unique_ptr<Aggregator<1>> partnerAggregator_;
+
+  void SetUp() override {
+    std::string baseDir =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__);
+    std::string publisherInputFilename =
+        baseDir + "../sample_input/publisher_unittest3.csv";
+    std::string partnerInputFilename =
+        baseDir + "../sample_input/partner_2_convs_unittest.csv";
+    int numConversionsPerUser = 2;
+    int epoch = 1546300800;
+    auto publisherInputData = InputData(
+        publisherInputFilename,
+        InputData::LiftMPCType::Standard,
+        InputData::LiftGranularityType::Conversion,
+        epoch,
+        numConversionsPerUser);
+    auto partnerInputData = InputData(
+        partnerInputFilename,
+        InputData::LiftMPCType::Standard,
+        InputData::LiftGranularityType::Conversion,
+        epoch,
+        numConversionsPerUser);
+
+    auto schedulerCreator =
+        fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>;
+    auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+    auto future0 = std::async(
+        createAggregatorWithScheduler<0>,
+        0,
+        publisherInputData,
+        numConversionsPerUser,
+        std::move(factories[0]),
+        schedulerCreator);
+
+    auto future1 = std::async(
+        createAggregatorWithScheduler<1>,
+        1,
+        partnerInputData,
+        numConversionsPerUser,
+        std::move(factories[1]),
+        schedulerCreator);
+
+    publisherAggregator_ = std::make_unique<Aggregator<0>>(future0.get());
+    partnerAggregator_ = std::make_unique<Aggregator<1>>(future1.get());
+  }
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -94,4 +94,18 @@ class AggregatorTest : public ::testing::Test {
   }
 };
 
+TEST_F(AggregatorTest, testEvents) {
+  auto test = publisherAggregator_->getMetrics().testEvents;
+  auto control = publisherAggregator_->getMetrics().controlEvents;
+  EXPECT_EQ(test, 9);
+  EXPECT_EQ(control, 5);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].testEvents, 2);
+  EXPECT_EQ(cohort[1].testEvents, 3);
+  EXPECT_EQ(cohort[2].testEvents, 4);
+  EXPECT_EQ(cohort[0].controlEvents, 2);
+  EXPECT_EQ(cohort[1].controlEvents, 2);
+  EXPECT_EQ(cohort[2].controlEvents, 1);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -150,4 +150,18 @@ TEST_F(AggregatorTest, testMatchCount) {
   EXPECT_EQ(cohort[2].controlMatchCount, 1);
 }
 
+TEST_F(AggregatorTest, testValues) {
+  auto test = publisherAggregator_->getMetrics().testValue;
+  auto control = publisherAggregator_->getMetrics().controlValue;
+  EXPECT_EQ(test, 120);
+  EXPECT_EQ(control, 20);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].testValue, 40);
+  EXPECT_EQ(cohort[1].testValue, 50);
+  EXPECT_EQ(cohort[2].testValue, 30);
+  EXPECT_EQ(cohort[0].controlValue, 40);
+  EXPECT_EQ(cohort[1].controlValue, 30);
+  EXPECT_EQ(cohort[2].controlValue, -50);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -108,4 +108,32 @@ TEST_F(AggregatorTest, testEvents) {
   EXPECT_EQ(cohort[2].controlEvents, 1);
 }
 
+TEST_F(AggregatorTest, testConverters) {
+  auto test = publisherAggregator_->getMetrics().testConverters;
+  auto control = publisherAggregator_->getMetrics().controlConverters;
+  EXPECT_EQ(test, 7);
+  EXPECT_EQ(control, 4);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].testConverters, 2);
+  EXPECT_EQ(cohort[1].testConverters, 2);
+  EXPECT_EQ(cohort[2].testConverters, 3);
+  EXPECT_EQ(cohort[0].controlConverters, 2);
+  EXPECT_EQ(cohort[1].controlConverters, 1);
+  EXPECT_EQ(cohort[2].controlConverters, 1);
+}
+
+TEST_F(AggregatorTest, testMatchCount) {
+  auto test = publisherAggregator_->getMetrics().testMatchCount;
+  auto control = publisherAggregator_->getMetrics().controlMatchCount;
+  EXPECT_EQ(test, 12);
+  EXPECT_EQ(control, 7);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].testMatchCount, 6);
+  EXPECT_EQ(cohort[1].testMatchCount, 3);
+  EXPECT_EQ(cohort[2].testMatchCount, 3);
+  EXPECT_EQ(cohort[0].controlMatchCount, 4);
+  EXPECT_EQ(cohort[1].controlMatchCount, 2);
+  EXPECT_EQ(cohort[2].controlMatchCount, 1);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -122,6 +122,20 @@ TEST_F(AggregatorTest, testConverters) {
   EXPECT_EQ(cohort[2].controlConverters, 1);
 }
 
+TEST_F(AggregatorTest, testNumConvSquared) {
+  auto test = publisherAggregator_->getMetrics().testNumConvSquared;
+  EXPECT_EQ(test, 13);
+  auto control = publisherAggregator_->getMetrics().controlNumConvSquared;
+  EXPECT_EQ(control, 7);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].testNumConvSquared, 2);
+  EXPECT_EQ(cohort[1].testNumConvSquared, 5);
+  EXPECT_EQ(cohort[2].testNumConvSquared, 6);
+  EXPECT_EQ(cohort[0].controlNumConvSquared, 2);
+  EXPECT_EQ(cohort[1].controlNumConvSquared, 4);
+  EXPECT_EQ(cohort[2].controlNumConvSquared, 1);
+}
+
 TEST_F(AggregatorTest, testMatchCount) {
   auto test = publisherAggregator_->getMetrics().testMatchCount;
   auto control = publisherAggregator_->getMetrics().controlMatchCount;

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -164,4 +164,18 @@ TEST_F(AggregatorTest, testValues) {
   EXPECT_EQ(cohort[2].controlValue, -50);
 }
 
+TEST_F(AggregatorTest, testValueSquared) {
+  auto test = publisherAggregator_->getMetrics().testValueSquared;
+  auto control = publisherAggregator_->getMetrics().controlValueSquared;
+  EXPECT_EQ(test, 8000);
+  EXPECT_EQ(control, 4200);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].testValueSquared, 800);
+  EXPECT_EQ(cohort[1].testValueSquared, 1300);
+  EXPECT_EQ(cohort[2].testValueSquared, 5900);
+  EXPECT_EQ(cohort[0].controlValueSquared, 800);
+  EXPECT_EQ(cohort[1].controlValueSquared, 900);
+  EXPECT_EQ(cohort[2].controlValueSquared, 2500);
+}
+
 } // namespace private_lift


### PR DESCRIPTION
Summary:
We add methods to sum the value squared in the Aggregator, across the test/control populations and the cohorts. We use 64 bits for the value squared, hence we create a new `WriteOnlyOramFactory` to construct the ORAM.

For more details about the correctness tests, refer to https://docs.google.com/spreadsheets/d/1xsIl33YDU_y7lSVD5gsiGV-ubl2x9TDYiTVRyR4dS74/edit?usp=sharing

Reviewed By: RuiyuZhu

Differential Revision: D35910667

