### PR TITLE
add business id to pce config

### DIFF
--- a/fbpcs/private_computation/entity/pce_config.py
+++ b/fbpcs/private_computation/entity/pce_config.py
@@ -25,6 +25,7 @@ class PCEConfig:
     cloud_provider: CloudProvider = CloudProvider.AWS
     # TODO T118605748 The cloud_account_id should not be optional in PCEConfig. Make it required after a full release cycle
     cloud_account_id: Optional[str] = None
+    partner_id: Optional[str] = None
 
     def __str__(self) -> str:
         # pyre-ignore


### PR DESCRIPTION
Summary:
## What

* See title
* If it's a PCE Service config, simple add the business ID that was used to fetch the config
* If it's a legacy config, attach the business ID that was used to *attempt* to fetch the config from PCE Service

## Why

* For tracking advertiser onboarding
* Having the business ID here will let us normalize the advertiser names that show up throughout the various PC dashboards (cc madisonwelch)

Differential Revision: D36182984

