### PR TITLE
Validate input_data files for the pre_validate command 2/2

### DIFF
--- a/fbpcs/private_computation/service/input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/service/input_data_validation_stage_service.py
@@ -23,6 +23,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.pre_validation_util import get_cmd_args
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
@@ -88,15 +89,7 @@ class InputDataValidationStageService(PrivateComputationStageService):
         region = self._pc_validator_config.region
         binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
         binary_config = self._onedocker_binary_config_map[binary_name]
-        cmd_args = " ".join(
-            [
-                f"--input-file-path={pc_instance.input_path}",
-                "--cloud-provider=AWS",
-                f"--region={region}",
-                # pc_pre_validation assumes all other binaries runs on the same version tag as its own
-                f"--binary-version={binary_config.binary_version}",
-            ]
-        )
+        cmd_args = get_cmd_args(pc_instance.input_path, region, binary_config)
 
         env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
         container_instances = await RunBinaryBaseService().start_containers(

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -6,26 +6,109 @@
 
 # pyre-strict
 
+import asyncio
 import logging
 from typing import Any, Dict, List
 
+from fbpcp.entity.container_instance import ContainerInstanceStatus
+from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.service.input_data_validation_stage_service import (
+    PRE_VALIDATION_CHECKS_TIMEOUT,
+)
+from fbpcs.private_computation.service.pre_validation_util import get_cmd_args
+from fbpcs.private_computation.service.private_computation import (
+    PrivateComputationService,
+)
+from fbpcs.private_computation.service.run_binary_base_service import (
+    RunBinaryBaseService,
+)
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
 )
 
 
-def pre_validate(
-    config: Dict[str, Any],
-    input_paths: List[str],
-    logger: logging.Logger,
-) -> None:
-    pc_service = _build_private_computation_service(
-        config["private_computation"],
-        config["mpc"],
-        config["pid"],
-        config.get("post_processing_handlers", {}),
-        config.get("pid_post_processing_handlers", {}),
-    )
-    paths_string = "\n".join(input_paths)
-    logger.info(f"Starting pre_validate on input_paths: {paths_string}")
-    assert pc_service
+class PreValidateService:
+    @staticmethod
+    async def run_pre_validate_async(
+        pc_service: PrivateComputationService,
+        input_paths: List[str],
+        logger: logging.Logger,
+    ) -> None:
+        region = pc_service.pc_validator_config.region
+        onedocker_svc = pc_service.onedocker_svc
+        binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
+        binary_config = pc_service.onedocker_binary_config_map[binary_name]
+        env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
+
+        cmd_args = [
+            get_cmd_args(input_path, region, binary_config)
+            for input_path in input_paths
+        ]
+
+        container_instances = await RunBinaryBaseService().start_containers(
+            cmd_args,
+            onedocker_svc,
+            binary_config.binary_version,
+            binary_name,
+            timeout=PRE_VALIDATION_CHECKS_TIMEOUT,
+            env_vars=env_vars,
+        )
+        logger.info("Started container instances")
+
+        completed_containers = await RunBinaryBaseService().wait_for_containers_async(
+            onedocker_svc,
+            container_instances,
+        )
+
+        error_messages = []
+        cluster = onedocker_svc.container_svc.get_cluster()
+
+        for container in completed_containers:
+            if container.status != ContainerInstanceStatus.COMPLETED:
+                task_id = container.instance_id.split("/")[-1]
+                failed_task_link = f"https://{region}.console.aws.amazon.com/ecs/home?region={region}#/clusters/{cluster}/tasks/{task_id}/details"
+
+                error_message = (
+                    f"[PreValidate] - failed because of some failed validations. Please check the logs in ECS for task id '{task_id}' to see the validation issues:\n"
+                    + f"Failed task link: {failed_task_link}"
+                )
+                error_messages.append(error_message)
+
+        if error_messages:
+            num_failed = len(error_messages)
+            num_success = len(completed_containers) - num_failed
+            failed = f"Number of containers that failed validation: {num_failed}\n"
+            succeeded = f"Number of containers that passed validation: {num_success}\n"
+            error_messages_string = "\n".join(error_messages)
+
+            error_message = (
+                f"ERROR - {failed}{succeeded}Errors: {error_messages_string}"
+            )
+            logger.error(error_message)
+            raise Exception(error_message)
+
+        logger.info(
+            "SUCCESS - All validation containers returned success.\n"
+            + f"Container count: {len(completed_containers)}\n"
+            + f"Input paths: {input_paths}"
+        )
+
+    @staticmethod
+    def pre_validate(
+        config: Dict[str, Any],
+        input_paths: List[str],
+        logger: logging.Logger,
+    ) -> None:
+        pc_service = _build_private_computation_service(
+            config["private_computation"],
+            config["mpc"],
+            config["pid"],
+            config.get("post_processing_handlers", {}),
+            config.get("pid_post_processing_handlers", {}),
+        )
+        paths_string = "\n".join(input_paths)
+
+        logger.info(f"Starting pre_validate on input_paths: {paths_string}")
+        asyncio.run(
+            PreValidateService.run_pre_validate_async(pc_service, input_paths, logger)
+        )

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from typing import Any, Dict, List
+
+from fbpcs.private_computation_cli.private_computation_service_wrapper import (
+    _build_private_computation_service,
+)
+
+
+def pre_validate(
+    config: Dict[str, Any],
+    input_paths: List[str],
+    logger: logging.Logger,
+) -> None:
+    pc_service = _build_private_computation_service(
+        config["private_computation"],
+        config["mpc"],
+        config["pid"],
+        config.get("post_processing_handlers", {}),
+        config.get("pid_post_processing_handlers", {}),
+    )
+    paths_string = "\n".join(input_paths)
+    logger.info(f"Starting pre_validate on input_paths: {paths_string}")
+    assert pc_service

--- a/fbpcs/private_computation/service/pre_validation_util.py
+++ b/fbpcs/private_computation/service/pre_validation_util.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+
+
+def get_cmd_args(
+    input_path: str, region: str, binary_config: OneDockerBinaryConfig
+) -> str:
+    return " ".join(
+        [
+            f"--input-file-path={input_path}",
+            "--cloud-provider=AWS",
+            f"--region={region}",
+            # pc_pre_validation assumes all other binaries runs on the same version tag as its own
+            f"--binary-version={binary_config.binary_version}",
+        ]
+    )

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -21,6 +21,7 @@ Usage:
     pc-cli run_instance <instance_id> --config=<config_file> --input_path=<input_path> --num_shards=<num_shards> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli run_instances <instance_ids> --config=<config_file> --input_paths=<input_paths> --num_shards_list=<num_shards_list> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
+    pc-cli pre_validate <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
     pc-cli print_log_urls <instance_id> --config=<config_file> [options]
@@ -53,6 +54,7 @@ from fbpcs.private_computation.pc_attribution_runner import (
     get_attribution_dataset_info,
     run_attribution,
 )
+from fbpcs.private_computation.service.pre_validate_service import pre_validate
 from fbpcs.private_computation.service.utils import transform_file_path
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
@@ -124,6 +126,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             "run_instance": bool,
             "run_instances": bool,
             "run_study": bool,
+            "pre_validate": bool,
             "run_attribution": bool,
             "cancel_current_stage": bool,
             "print_instance": bool,
@@ -341,6 +344,12 @@ def main(argv: Optional[List[str]] = None) -> None:
             get_attribution_dataset_info(
                 config=config, dataset_id=arguments["--dataset_id"], logger=logger
             )
+        )
+    elif arguments["pre_validate"]:
+        pre_validate(
+            config=config,
+            input_paths=arguments["--input_paths"],
+            logger=logger,
         )
 
 

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -54,7 +54,7 @@ from fbpcs.private_computation.pc_attribution_runner import (
     get_attribution_dataset_info,
     run_attribution,
 )
-from fbpcs.private_computation.service.pre_validate_service import pre_validate
+from fbpcs.private_computation.service.pre_validate_service import PreValidateService
 from fbpcs.private_computation.service.utils import transform_file_path
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
@@ -346,7 +346,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             )
         )
     elif arguments["pre_validate"]:
-        pre_validate(
+        PreValidateService.pre_validate(
             config=config,
             input_paths=arguments["--input_paths"],
             logger=logger,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -228,7 +228,6 @@ def get_instance(
     instance = pc_service.get_instance(instance_id)
     if instance.current_stage.is_started_status(instance.status):
         instance = pc_service.update_instance(instance_id)
-
     return instance
 
 

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -12,6 +12,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from fbpcs.private_computation_cli import private_computation_cli as pc_cli
+from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
 
 
 class TestPrivateComputationCli(TestCase):
@@ -289,6 +290,27 @@ class TestPrivateComputationCli(TestCase):
         )
         pc_cli.main(argv)
         run_study_mock.assert_called_once()
+
+    @patch("fbpcs.private_computation_cli.private_computation_cli.pre_validate")
+    @patch("fbpcs.private_computation_cli.private_computation_cli.logging.getLogger")
+    def test_pre_validate(self, getLoggerMock, pre_validate_mock) -> None:
+        getLoggerMock.return_value = getLoggerMock
+        expected_config = ConfigYamlDict.from_file(self.temp_filename)
+        argv = [
+            "pre_validate",
+            "12345",
+            f"--config={self.temp_filename}",
+            "--objective_ids=12,34,56,78,90",
+            f"--input_paths={','.join(self.temp_files_paths)}",
+        ]
+
+        pc_cli.main(argv)
+
+        pre_validate_mock.assert_called_once_with(
+            config=expected_config,
+            input_paths=self.temp_files_paths,
+            logger=getLoggerMock,
+        )
 
     @patch("fbpcs.private_computation_cli.private_computation_cli.cancel_current_stage")
     def test_cancel_current_stage(self, cancel_stage_mock) -> None:

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -291,9 +291,9 @@ class TestPrivateComputationCli(TestCase):
         pc_cli.main(argv)
         run_study_mock.assert_called_once()
 
-    @patch("fbpcs.private_computation_cli.private_computation_cli.pre_validate")
+    @patch("fbpcs.private_computation_cli.private_computation_cli.PreValidateService")
     @patch("fbpcs.private_computation_cli.private_computation_cli.logging.getLogger")
-    def test_pre_validate(self, getLoggerMock, pre_validate_mock) -> None:
+    def test_pre_validate(self, getLoggerMock, pre_validate_service_mock) -> None:
         getLoggerMock.return_value = getLoggerMock
         expected_config = ConfigYamlDict.from_file(self.temp_filename)
         argv = [
@@ -306,7 +306,7 @@ class TestPrivateComputationCli(TestCase):
 
         pc_cli.main(argv)
 
-        pre_validate_mock.assert_called_once_with(
+        pre_validate_service_mock.pre_validate.assert_called_once_with(
             config=expected_config,
             input_paths=self.temp_files_paths,
             logger=getLoggerMock,


### PR DESCRIPTION
Summary:
The pre_validate command can be used to quickly validate multiple input_data
files in parallel. It runs the equivalent of the pc_pre_validation stage
(currently named input_data_validation_stage_service) which also includes the
binary validation check.

It is useful for debugging pc_pre_validation errors that can occur when running
the run_study command by replacing the 'run_study' command argument with
'pre_validate'.

Differential Revision: D36191150

