### PR TITLE
Sum reached conversions and reached values in Aggregator

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -59,7 +59,9 @@ class Aggregator {
     sumConverters();
     sumNumConvSquared();
     sumMatch();
+    sumReachedConversions();
     sumValues();
+    sumReachedValues();
     sumValueSquared();
   }
 
@@ -83,7 +85,11 @@ class Aggregator {
 
   void sumMatch();
 
+  void sumReachedConversions();
+
   void sumValues();
+
+  void sumReachedValues();
 
   void sumValueSquared();
 
@@ -109,6 +115,15 @@ class Aggregator {
   revealCohortOutput(std::vector<SecInt<schedulerId, isSigned, width>>
                          aggregationOutput) const;
 
+  // Reveal cohort output from aggregation output as a tuple consisting of the
+  // test metrics and the test cohort metrics.
+  template <bool isSigned, int8_t width>
+  std::tuple<
+      NativeIntp<isSigned, width>,
+      std::vector<NativeIntp<isSigned, width>>>
+  revealTestCohortOutput(std::vector<SecInt<schedulerId, isSigned, width>>
+                             aggregationOutput) const;
+
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   std::unique_ptr<Attributor<schedulerId>> attributor_;
@@ -127,6 +142,12 @@ class Aggregator {
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<true, valueWidth>>>
       cohortSignedWriteOnlyOramFactory_;
+  std::unique_ptr<
+      fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<false, valueWidth>>>
+      testCohortUnsignedWriteOnlyOramFactory_;
+  std::unique_ptr<
+      fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<true, valueWidth>>>
+      testCohortSignedWriteOnlyOramFactory_;
   std::unique_ptr<fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<
       Intp<false, valueSquaredWidth>>>
       valueSquaredWriteOnlyOramFactory_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -150,6 +150,16 @@ TEST_F(AggregatorTest, testMatchCount) {
   EXPECT_EQ(cohort[2].controlMatchCount, 1);
 }
 
+TEST_F(AggregatorTest, testReachedConversions) {
+  auto reachedConversions =
+      publisherAggregator_->getMetrics().reachedConversions;
+  EXPECT_EQ(reachedConversions, 4);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].reachedConversions, 1);
+  EXPECT_EQ(cohort[1].reachedConversions, 0);
+  EXPECT_EQ(cohort[2].reachedConversions, 3);
+}
+
 TEST_F(AggregatorTest, testValues) {
   auto test = publisherAggregator_->getMetrics().testValue;
   auto control = publisherAggregator_->getMetrics().controlValue;
@@ -162,6 +172,15 @@ TEST_F(AggregatorTest, testValues) {
   EXPECT_EQ(cohort[0].controlValue, 40);
   EXPECT_EQ(cohort[1].controlValue, 30);
   EXPECT_EQ(cohort[2].controlValue, -50);
+}
+
+TEST_F(AggregatorTest, testReachedValues) {
+  auto test = publisherAggregator_->getMetrics().reachedValue;
+  EXPECT_EQ(test, 100);
+  auto cohort = publisherAggregator_->getCohortMetrics();
+  EXPECT_EQ(cohort[0].reachedValue, 20);
+  EXPECT_EQ(cohort[1].reachedValue, 0);
+  EXPECT_EQ(cohort[2].reachedValue, 80);
 }
 
 TEST_F(AggregatorTest, testValueSquared) {


### PR DESCRIPTION
Summary:
We add methods to aggregate the reached conversions and reached values in the Aggregator. These are only computed for the test population, hence we use the test cohort index shares. We also use a different method to reveal the output since we only have to extract the metrics for the test population.

For more details about the correctness tests, refer to https://docs.google.com/spreadsheets/d/1xsIl33YDU_y7lSVD5gsiGV-ubl2x9TDYiTVRyR4dS74/edit?usp=sharing

Reviewed By: RuiyuZhu

Differential Revision: D35910749

