### PR TITLE
ignore empty path when splitting input_paths to tansform path check

### DIFF
--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -490,7 +490,10 @@ def transform_file_path(file_path: str, aws_region: Optional[str] = None) -> str
             file_path = f"https://{bucket}.s3.{aws_region}.amazonaws.com/{key}"
 
         else:
-            raise ValueError("Cannot be parsed to expected virtual-hosted-file format")
+            raise ValueError(
+                "Cannot be parsed to expected virtual-hosted-file format "
+                f"Please check your input path that aws_region need to be specified: [{file_path}]"
+            )
 
     if re.search(
         rf"https://[a-z0-9.-]+\.s3\.[a-zA-Z0-9.-]+\.amazonaws.com/{key_pattern}+",
@@ -499,5 +502,6 @@ def transform_file_path(file_path: str, aws_region: Optional[str] = None) -> str
         return file_path
     else:
         raise ValueError(
-            "Error transforming into expected virtual-hosted format. Bad input?"
+            "Error transforming into expected virtual-hosted format. Bad input? "
+            f"Please check your input path: [{file_path}]"
         )

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -109,7 +109,8 @@ def transform_many_paths(paths_to_check: Union[str, Iterable[str]]) -> List[str]
     """
     if isinstance(paths_to_check, str):
         paths_to_check = paths_to_check.split(",")
-    paths = [transform_path(path) for path in paths_to_check]
+
+    paths = [transform_path(path) for path in paths_to_check if path]
     return paths
 
 

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -276,7 +276,7 @@ class TestPrivateComputationCli(TestCase):
             "12345",
             f"--config={self.temp_filename}",
             "--objective_ids=12,34,56,78,90",
-            f"--input_paths={','.join(self.temp_files_paths)}",
+            f"--input_paths={','.join(self.temp_files_paths)},",
         ]
         pc_cli.main(argv)
         run_study_mock.assert_called_once()


### PR DESCRIPTION
Summary: [pcs] ignore empty path when splitting input_paths to tansform path check

Differential Revision: D36219926

