### PR TITLE
Add CalculatorGame correctness tests with random inputs

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp
@@ -56,7 +56,8 @@ OutputMetricsData LiftCalculator::compute(
     std::ifstream& inFilePublisher,
     std::ifstream& inFilePartner,
     std::unordered_map<std::string, int32_t>& colNameToIndex,
-    int32_t tsOffset) const {
+    int32_t tsOffset,
+    bool useAdvancedLift) const {
   OutputMetricsData out;
   uint64_t opportunity = 0;
   uint64_t numImpressions = 0;
@@ -161,10 +162,12 @@ OutputMetricsData LiftCalculator::compute(
     // will see. If we ever have a weird input where the rows have different
     // lengths, doing this sort of "new max" will ensure this still works.
     // Also remember to go one *past* the size to leave a bucket for 0 convs
-    for (size_t i = out.testConvHistogram.size(); i <= eventTimestamps.size();
-         ++i) {
-      out.testConvHistogram.push_back(0);
-      out.controlConvHistogram.push_back(0);
+    if (useAdvancedLift) {
+      for (size_t i = out.testConvHistogram.size(); i <= eventTimestamps.size();
+           ++i) {
+        out.testConvHistogram.push_back(0);
+        out.controlConvHistogram.push_back(0);
+      }
     }
 
     auto valuesIdx = colNameToIndex.find("values") != colNameToIndex.end()
@@ -214,7 +217,9 @@ OutputMetricsData LiftCalculator::compute(
         }
         out.testValueSquared += value_subsum * value_subsum;
         out.testNumConvSquared += convCount * convCount;
-        ++out.testConvHistogram[convCount];
+        if (useAdvancedLift) {
+          ++out.testConvHistogram[convCount];
+        }
       } else {
         for (std::size_t i = 0; i < eventTimestamps.size(); ++i) {
           if (opportunityTimestamp > 0 && eventTimestamps.at(i) > 0 &&
@@ -240,7 +245,9 @@ OutputMetricsData LiftCalculator::compute(
         out.controlValue += value_subsum;
         out.controlValueSquared += value_subsum * value_subsum;
         out.controlNumConvSquared += convCount * convCount;
-        ++out.controlConvHistogram[convCount];
+        if (useAdvancedLift) {
+          ++out.controlConvHistogram[convCount];
+        }
       }
     }
   }

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h
@@ -25,7 +25,8 @@ class LiftCalculator {
       std::ifstream& inFilePublisher,
       std::ifstream& inFilePartner,
       std::unordered_map<std::string, int32_t>& colNameToIndex,
-      int32_t tsOffset) const;
+      int32_t tsOffset,
+      bool useAdvancedLift = true) const;
 
  private:
   // Parse input string with format [111,222,333,...]


### PR DESCRIPTION
Summary: We add correctness tests for the CalculatorGame with random inputs. These tests are similar to the tests for the EMP-based calculator here https://www.internalfb.com/code/fbsource/[35556e0ca39cd79c3f7ac4dda1059e648bb340dc]/fbcode/fbpcs/emp_games/lift/calculator/test/CalculatorGameTest.cpp except without advanced lift and with 25 conversions per user (instead of 4).

Reviewed By: RuiyuZhu

Differential Revision: D35989844

