### PR TITLE
scripts for PID stress test

### DIFF
--- a/fbpcs/scripts/gen_pid_stress_test_data.py
+++ b/fbpcs/scripts/gen_pid_stress_test_data.py
@@ -1,0 +1,256 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+
+
+def gen_random_id(
+    token_size: int,
+    lo: int,
+    hi: int,
+):
+    # gen random value with token sized digits between lo and hi
+    pii_value = random.randint(
+        lo * (10 ** (token_size - 1)), hi * (10 ** (token_size - 1))
+    )
+    return pii_value
+
+
+def gen_event_values(
+    role: str,
+    product: str,
+):
+    # add PA/PL values
+    if role == "partner" and product == "lift":
+        # id_,value,event_timestamp
+        return "0,1600002228"
+    elif role == "publisher" and product == "lift":
+        # id_,test_flag,opportunity_timestamp,num_impressions,num_clicks,total_spend
+        return "1,1600002544,1,3,860"
+    elif role == "partner" and product == "attribution":
+        # id_,conversion_timestamp,conversion_value,conversion_metadata
+        return "1600000200,1001,3"
+    elif role == "publisher" and product == "attribution":
+        # id_,ad_id,timestamp,is_click,campaign_metadata
+        return "1,1600000100,1,99"
+    return ""
+
+
+def gen_input(
+    sample_size: int,
+    token_size: int,
+    lo: int,
+    hi: int,
+    product: str,
+    partner_num_ids: int,
+    partner_file: str,
+    publisher_num_ids: int,
+    publisher_file: str,
+):
+    # create files for server and client
+    with open(partner_file, "a") as f1, open(publisher_file, "a") as f2:
+        partner_written = 0
+        publisher_written = 0
+        for _i in range(0, sample_size):
+            partner_pii_values = ""
+            publisher_pii_values = ""
+
+            # generate identifisers of each row
+            for j in range(0, max(partner_num_ids, publisher_num_ids)):
+                pii_value = gen_random_id(token_size, lo, hi)
+                if j < partner_num_ids:
+                    partner_pii_values += f"{pii_value},"
+                if j < publisher_num_ids:
+                    publisher_pii_values += f"{pii_value},"
+
+            # only when num ids > 0, write to file
+            if partner_num_ids > 0:
+                partner_pii_values += f"{gen_event_values('partner', product)}"
+                f1.write(f"{partner_pii_values}\n")
+                partner_written += 1
+            if publisher_num_ids > 0:
+                publisher_pii_values += f"{gen_event_values('publisher', product)}"
+                f2.write(f"{publisher_pii_values}\n")
+                publisher_written += 1
+        print(f"partner_written: {partner_written}\n")
+        print(f"publisher_written: {publisher_written}\n")
+
+
+def gen_header(
+    product: str,
+    role: str,
+    filename: str,
+    num_ids: int,
+):
+    with open(filename, "w") as f:
+        id_header = ""
+        for i in range(0, num_ids):
+            id_header += f"id_{i},"
+        if role == "partner" and product == "lift":
+            f.write(f"{id_header}value,event_timestamp\n")
+        elif role == "publisher" and product == "lift":
+            f.write(
+                f"{id_header}test_flag,opportunity_timestamp,num_impressions,num_clicks,total_spend\n"
+            )
+        elif role == "partner" and product == "attribution":
+            f.write(
+                f"{id_header}conversion_timestamp,conversion_value,conversion_metadata\n"
+            )
+        elif role == "publisher" and product == "attribution":
+            f.write(f"{id_header}ad_id,timestamp,is_click,campaign_metadata\n")
+
+
+def gen_all(
+    base_name: str,
+    product: str,
+    intersect_pct: float,
+    partner_sample_size: int,
+    publisher_sample_size: int,
+    token_size: int,
+    partner_num_ids: int,
+    publisher_num_ids: int,
+):
+    intersect = int(intersect_pct * 100)
+    intersect_n = int(partner_sample_size * intersect_pct)
+    if intersect_n > publisher_sample_size:
+        print("ERROR: publisher_sample_size smaller than intersection size")
+        return
+
+    partner_file = (
+        base_name
+        + f"_{product}_client_{intersect}_{partner_sample_size}_{publisher_sample_size}_{token_size}_{partner_num_ids}_{publisher_num_ids}.csv"
+    )
+    publisher_file = (
+        base_name
+        + f"_{product}_server_{intersect}_{partner_sample_size}_{publisher_sample_size}_{token_size}_{partner_num_ids}_{publisher_num_ids}.csv"
+    )
+
+    # add header
+    gen_header(product, "partner", partner_file, partner_num_ids)
+    gen_header(product, "publisher", publisher_file, publisher_num_ids)
+
+    # first add lines common between server and client
+    gen_input(
+        intersect_n,
+        token_size,
+        2,
+        3,
+        product,
+        partner_num_ids,
+        partner_file,
+        publisher_num_ids,
+        publisher_file,
+    )
+
+    # add lines that are not common between server and client
+    # partner-side
+    gen_input(
+        partner_sample_size - intersect_n,
+        token_size,
+        1,
+        2,
+        product,
+        partner_num_ids,
+        partner_file,
+        0,
+        publisher_file,
+    )
+    # publisher-side
+    gen_input(
+        publisher_sample_size - intersect_n,
+        token_size,
+        3,
+        4,
+        product,
+        0,
+        partner_file,
+        publisher_num_ids,
+        publisher_file,
+    )
+
+
+token_size = 64
+intersect_pct = 0.2
+
+# gen stacked single-key files
+stackedkey_publisher_sample_size_list = [5000000, 10000000]
+stackedkey_partner_sample_size_list = [5000000]
+
+stackedkey_partner_num_ids = 1
+stackedkey_publisher_num_ids = 1
+for stackedkey_publisher_sample_size in stackedkey_publisher_sample_size_list:
+    for stackedkey_partner_sample_size in stackedkey_partner_sample_size_list:
+        print(
+            f"start: stacked key attribution files {stackedkey_publisher_sample_size} {stackedkey_partner_sample_size}"
+        )
+        gen_all(
+            "./pid_stress_test_data/test",
+            "attribution",
+            intersect_pct,
+            stackedkey_partner_sample_size,
+            stackedkey_publisher_sample_size,
+            token_size,
+            stackedkey_partner_num_ids,
+            stackedkey_publisher_num_ids,
+        )
+        print(
+            f"end: stacked key attribution files {stackedkey_publisher_sample_size} {stackedkey_partner_sample_size}"
+        )
+        print(
+            f"start: stacked key lift files {stackedkey_publisher_sample_size} {stackedkey_partner_sample_size}"
+        )
+        gen_all(
+            "./pid_stress_test_data/test",
+            "lift",
+            intersect_pct,
+            stackedkey_partner_sample_size,
+            stackedkey_publisher_sample_size,
+            token_size,
+            stackedkey_partner_num_ids,
+            stackedkey_publisher_num_ids,
+        )
+        print(
+            f"end: stacked key lift files {stackedkey_publisher_sample_size} {stackedkey_partner_sample_size}"
+        )
+
+# gen multi-key files
+multikey_publisher_sample_size = 5000000
+multikey_partner_sample_size = 5000000
+multikey_partner_num_ids_list = [*range(1, 6)]
+multikey_publisher_num_ids_list = [*range(1, 13)]
+for multikey_publisher_num_ids in multikey_publisher_num_ids_list:
+    for multikey_partner_num_ids in multikey_partner_num_ids_list:
+        print(
+            f"start: multi-key attribution files {multikey_partner_num_ids} {multikey_publisher_num_ids}"
+        )
+        gen_all(
+            "./pid_stress_test_data/test",
+            "attribution",
+            intersect_pct,
+            multikey_partner_sample_size,
+            multikey_publisher_sample_size,
+            token_size,
+            multikey_partner_num_ids,
+            multikey_publisher_num_ids,
+        )
+        print(
+            f"end: multi-key attribution files {multikey_partner_num_ids} {multikey_publisher_num_ids}"
+        )
+        print(
+            f"start: multi-key lift files {multikey_partner_num_ids} {multikey_publisher_num_ids}"
+        )
+        gen_all(
+            "./pid_stress_test_data/test",
+            "lift",
+            intersect_pct,
+            multikey_partner_sample_size,
+            multikey_publisher_sample_size,
+            token_size,
+            multikey_partner_num_ids,
+            multikey_publisher_num_ids,
+        )
+        print(
+            f"end: multi-key lift files {multikey_partner_num_ids} {multikey_publisher_num_ids}"
+        )

--- a/fbpcs/scripts/run_pid_stress_test.sh
+++ b/fbpcs/scripts/run_pid_stress_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+protocol="$1"
+intersect_size=20
+sk_partner_sample_size=5000000
+mk_partner_sample_size=5000000
+mk_publisher_sample_size=5000000
+token_size=64
+
+run_and_save_test() {
+    product=$1
+    partner_sample_size=$2
+    publisher_sample_size=$3
+    partner_num_ids_start=$4
+    partner_num_ids_end=$5
+    publisher_num_ids_start=$6
+    publisher_num_ids_end=$7
+    for (( publisher_num_ids=publisher_num_ids_start; publisher_num_ids<=publisher_num_ids_end; publisher_num_ids++ ))
+    do
+      for (( partner_num_ids=partner_num_ids_start; partner_num_ids<=partner_num_ids_end; partner_num_ids++ ))
+      do
+        echo command: buck run //identity/private_aggregation/mpc_aem/experimentation_platform:mpc_aem_exp_platform_runner -- "benchmark_${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}" \
+        --publisher_input="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/test_${product}_server_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv" \
+        --partner_input="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/test_${product}_client_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv" \
+        --game="${product}" --tier="test"
+
+        buck run //identity/private_aggregation/mpc_aem/experimentation_platform:mpc_aem_exp_platform_runner -- "benchmark_${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}" \
+        --publisher_input="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/test_${product}_server_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv" \
+        --partner_input="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/test_${product}_client_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv" \
+        --game="${product}" --tier="test" 2>&1 | tee "$HOME/logs/${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.log" || true
+
+        pastry -t "${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}_python_log" \
+        < "$HOME/logs/${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.log"
+
+        for party in "publisher" "partner"
+        do
+          pastry -t "${party}_benchmark_${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}" \
+          < "./${party}_benchmark_${product}_${intersect_size}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}0"
+        done
+      done
+    done
+
+}
+
+for product in "lift" "attribution"
+do
+  if [ "$protocol" = "single-key" ]
+  then
+    for sk_publisher_sample_size in 5000000 10000000
+    do
+      run_and_save_test $product $sk_partner_sample_size $sk_publisher_sample_size 1 1 1 1
+    done
+  fi
+
+  if [ "$protocol" = "multi-key" ]
+  then
+    run_and_save_test $product $mk_partner_sample_size $mk_publisher_sample_size 1 5 1 12
+  fi
+done

--- a/fbpcs/scripts/upload_pid_stress_test_data_to_aws.sh
+++ b/fbpcs/scripts/upload_pid_stress_test_data_to_aws.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+account_id=$1
+
+eval $(awsume api "$account_id" SSOAdmin)
+export https_proxy=fwdproxy:8080
+
+intersect=20
+sk_partner_sample_size=5000000
+mk_partner_sample_size=5000000
+mk_publisher_sample_size=5000000
+token_size=64
+
+upload_all() {
+    partner_sample_size=$1
+    publisher_sample_size=$2
+    publisher_num_ids_start=$3
+    publisher_num_ids_end=$4
+    partner_num_ids_start=$5
+    partner_num_ids_end=$6
+    for product in "lift" "attribution"
+    do
+        for (( publisher_num_ids=publisher_num_ids_start; publisher_num_ids<=publisher_num_ids_end; publisher_num_ids++ ))
+        do
+            for (( partner_num_ids=partner_num_ids_start; partner_num_ids<=partner_num_ids_end; partner_num_ids++ ))
+            do
+                aws s3 cp "./pid_stress_test_data/test_${product}_client_${intersect}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv" "s3://mpc-aem-exp-platform-input/pid_test_data/stress_test/test_${product}_client_${intersect}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv"
+                aws s3 cp "./pid_stress_test_data/test_${product}_server_${intersect}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv" "s3://mpc-aem-exp-platform-input/pid_test_data/stress_test/test_${product}_server_${intersect}_${partner_sample_size}_${publisher_sample_size}_${token_size}_${partner_num_ids}_${publisher_num_ids}.csv"
+            done
+        done
+    done
+}
+
+for sk_publisher_sample_size in 5000000 10000000
+do
+    upload_all $sk_partner_sample_size $sk_publisher_sample_size 1 1 1 1
+done
+
+upload_all $mk_partner_sample_size $mk_publisher_sample_size 1 12 1 5


### PR DESCRIPTION
Summary:
# Context
We are running PID stress test as we have planned in [the plan](https://docs.google.com/document/d/1iLNyJjuqQLJirM3PB7I79QaaVE07tV2jfX01glGgRfY/edit?usp=sharing). We are building scripts to automate the PID stress test as much as possible.

# Details
In this diff, we created two scripts.
- `gen_pid_stress_test_data.py`: It generates test datasets with various sample size and number of ids.
- `run_pid_stress_test.sh`: It runs EP for each dataset.

Differential Revision: D36147571

