### PR TITLE
fixing typo in TEE binary files

### DIFF
--- a/build-docker-tee-experiment.sh
+++ b/build-docker-tee-experiment.sh
@@ -65,8 +65,8 @@ else
   fi
 fi
 
-DOCKER_PACKAGE="tee_experiment"
-printf "\nBuilding tee_experiment %s docker image...\n" "${OS_VARIANT}"
+DOCKER_PACKAGE="tee-experiment"
+printf "\nBuilding %s %s docker image...\n" "${DOCKER_PACKAGE}" "${OS_VARIANT}"
 docker build  \
   --build-arg tag="${TAG}" \
   --build-arg os_release="${OS_RELEASE}" \

--- a/docker/tee_experiment/CMakeLists.txt
+++ b/docker/tee_experiment/CMakeLists.txt
@@ -14,7 +14,7 @@ include("perf_tools.cmake")
 
 # plain_text_lift_calculator
 add_executable(
-  plain_text_calculator
+  plain_text_lift_calculator
   "fbpcs/emp_games/lift/calculator/test/main.cpp"
   "fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.h"
   "fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp"


### PR DESCRIPTION
Summary: line 30 should be the same as line 17 (the name of the executable)

Differential Revision: D36296229

