### PR TITLE
Upload container logs to S3 after fetching from AWS CloudWatch

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+from typing import List, IO
+
+
+def create_file(self, file_location: str, content: List) -> None:
+    """
+    Create file in the file location with content.
+    Args:
+        file_location (str): Full path of the file location Eg: /tmp/xyz.txt
+        content (list): Content to be written in file
+    Returns:
+        None
+    """
+    if not content:
+        content = []
+    try:
+        # write to a file, if it already exists
+        with open(file_location, "w") as file_object:
+            self.write_to_file(file_object, content)
+    except FileNotFoundError:
+        # create a file if it doesn't exist and write to file
+        with open(file_location, "x") as file_object:
+            self.write_to_file(file_object, content)
+
+
+@staticmethod
+def write_to_file(file_object: IO[bytes], contents: List) -> None:
+    """
+    Write content to the file.
+    Args:
+        file_object (IO): Object of file to read/write
+        contents (list): Content to be written in file
+    Returns:
+        None
+    """
+    for content in contents:
+        file_object.write(content)
+
+
+@staticmethod
+def remove_file(file_location: str) -> None:
+    """
+    Remove file from the given file path
+    Args:
+        file_location (str): Full path of the file location Eg: /tmp/xyz.txt
+    Returns:
+        None
+    """
+    if os.path.isfile(file_location):
+        os.remove(file_location)


### PR DESCRIPTION
Summary:
This change uploads fetched logs from cloudwatch to amazon S3. We are following the path cloudwatch watch => download logs locally => upload on S3

Reason for taking this approach is, AWS doesn't allow export of logs if the S3 bucket is KMS encrypted. And we will be moving towards KMS encryption in near future.

This diff is part of the series of diffs which will download logs from partner side AWS account. Following is the list of diff details:
```
diff #1 : [D36136606 (https://github.com/facebookresearch/fbpcs/commit/9ba40a9ab1b8c7ecd9ff019376a7d29b44e242f8)]  Fetched container logs from cloudwatch
diff #2 : [D36193153] Creates folder structure in S3 to store fetched logs
diff #3 : [this diff] Exports logs from cloudwatch to the folders created in S3
diff #4 : [upcoming] Let's user download the S3 folders which contains all the logs
```

More details of the design can be found here: https://docs.google.com/document/d/1PVo20EgB5pD5uATa6aF1Bv56NIX0rWxp2w-5ORCAQDE/edit?usp=sharing

Logging service design: https://docs.google.com/document/d/1vze4JalYZfpLxtXVpQJToB2Tb_LNOeuxJJSAGArZY0k/edit#heading=h.3b1n6r5gq4y0

Differential Revision: D36322339

