### PR TITLE
rename MULTIKEY_PID to UNION_PID_MULTIKEY

### DIFF
--- a/fbpcs/pid/entity/pid_instance.py
+++ b/fbpcs/pid/entity/pid_instance.py
@@ -41,7 +41,7 @@ class PIDStageStatus(Enum):
 class PIDProtocol(IntEnum):
     UNION_PID = 0
     PS3I_M_TO_M = 1
-    MULTIKEY_PID = 2
+    UNION_PID_MULTIKEY = 2
 
 
 class PIDInstanceStatus(Enum):

--- a/fbpcs/pid/service/pid_service/pid_execution_map.py
+++ b/fbpcs/pid/service/pid_service/pid_execution_map.py
@@ -63,10 +63,10 @@ PIDDispatcherFlowMap: Dict[PIDExecutionFlowLookupKey, PIDFlow] = {
         PIDRole.PARTNER, PIDProtocol.UNION_PID
     ): UnionPIDAdvertiserFlow,
     PIDExecutionFlowLookupKey(
-        PIDRole.PUBLISHER, PIDProtocol.MULTIKEY_PID
+        PIDRole.PUBLISHER, PIDProtocol.UNION_PID_MULTIKEY
     ): MultiKeyPIDPublisherFlow,
     PIDExecutionFlowLookupKey(
-        PIDRole.PARTNER, PIDProtocol.MULTIKEY_PID
+        PIDRole.PARTNER, PIDProtocol.UNION_PID_MULTIKEY
     ): MultiKeyPIDAdvertiserFlow,
 }
 

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -90,7 +90,7 @@ class PIDProtocolRunStage(PIDStage):
             self.logger.info("Publisher spinning up containers")
             try:
                 binary = OneDockerBinaryNames.PID_SERVER.value
-                if self.protocol == PIDProtocol.MULTIKEY_PID:
+                if self.protocol == PIDProtocol.UNION_PID_MULTIKEY:
                     binary = OneDockerBinaryNames.PID_MULTI_KEY_SERVER.value
                 pending_containers = self.onedocker_svc.start_containers(
                     package_name=binary,
@@ -100,9 +100,9 @@ class PIDProtocolRunStage(PIDStage):
                         output_path=output_paths[0],
                         num_shards=num_shards,
                         use_row_numbers=stage_input.pid_use_row_numbers
-                        and (self.protocol != PIDProtocol.MULTIKEY_PID),
+                        and (self.protocol != PIDProtocol.UNION_PID_MULTIKEY),
                         enable_metric_logging=(
-                            self.protocol == PIDProtocol.MULTIKEY_PID
+                            self.protocol == PIDProtocol.UNION_PID_MULTIKEY
                         ),
                     ),
                     env_vars=self._gen_env_vars(),
@@ -158,7 +158,7 @@ class PIDProtocolRunStage(PIDStage):
             self.logger.info("Partner spinning up containers")
             try:
                 binary = OneDockerBinaryNames.PID_CLIENT.value
-                if self.protocol == PIDProtocol.MULTIKEY_PID:
+                if self.protocol == PIDProtocol.UNION_PID_MULTIKEY:
                     binary = OneDockerBinaryNames.PID_MULTI_KEY_CLIENT.value
                 pending_containers = self.onedocker_svc.start_containers(
                     package_name=binary,
@@ -169,9 +169,9 @@ class PIDProtocolRunStage(PIDStage):
                         num_shards=num_shards,
                         server_hostnames=hostnames,
                         use_row_numbers=stage_input.pid_use_row_numbers
-                        and (self.protocol != PIDProtocol.MULTIKEY_PID),
+                        and (self.protocol != PIDProtocol.UNION_PID_MULTIKEY),
                         enable_metric_logging=(
-                            self.protocol == PIDProtocol.MULTIKEY_PID
+                            self.protocol == PIDProtocol.UNION_PID_MULTIKEY
                         ),
                     ),
                     env_vars=self._gen_env_vars(),

--- a/fbpcs/pid/service/pid_service/pid_stage_mapper.py
+++ b/fbpcs/pid/service/pid_service/pid_stage_mapper.py
@@ -66,7 +66,7 @@ class PIDStageMapper:
             )
         elif stage is UnionPIDStage.PUBLISHER_RUN_PID:
             binary_name = OneDockerBinaryNames.PID_SERVER.value
-            if protocol == PIDProtocol.MULTIKEY_PID:
+            if protocol == PIDProtocol.UNION_PID_MULTIKEY:
                 binary_name = OneDockerBinaryNames.PID_MULTI_KEY_SERVER.value
             return PIDProtocolRunStage(
                 stage,
@@ -101,7 +101,7 @@ class PIDStageMapper:
             )
         elif stage is UnionPIDStage.ADV_RUN_PID:
             binary_name = OneDockerBinaryNames.PID_CLIENT.value
-            if protocol == PIDProtocol.MULTIKEY_PID:
+            if protocol == PIDProtocol.UNION_PID_MULTIKEY:
                 binary_name = OneDockerBinaryNames.PID_MULTI_KEY_CLIENT.value
             return PIDProtocolRunStage(
                 stage,

--- a/fbpcs/pid/service/pid_service/utils.py
+++ b/fbpcs/pid/service/pid_service/utils.py
@@ -13,7 +13,7 @@ from fbpcs.private_computation.service.constants import (
 
 
 def get_max_id_column_cnt(pid_protocol: PIDProtocol) -> int:
-    if pid_protocol is PIDProtocol.MULTIKEY_PID:
+    if pid_protocol is PIDProtocol.UNION_PID_MULTIKEY:
         return DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT
     return 1
 
@@ -22,5 +22,5 @@ def get_pid_protocol_from_num_shards(
     num_pid_containers: int, multikey_enabled: bool
 ) -> PIDProtocol:
     if num_pid_containers == 1 and multikey_enabled:
-        return PIDProtocol.MULTIKEY_PID
+        return PIDProtocol.UNION_PID_MULTIKEY
     return DEFAULT_PID_PROTOCOL


### PR DESCRIPTION
Summary: We renamed MULTIKEY_PID (an attribute of pid_instance) to UNION_PID_MULTIKEY.

Differential Revision: D36332301

