### PR TITLE
Add #pyre-strict in pid_flow_structs.py

### DIFF
--- a/fbpcs/pid/service/pid_service/pid_flow_structs.py
+++ b/fbpcs/pid/service/pid_service/pid_flow_structs.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import dataclasses
 from typing import Dict, List
 


### PR DESCRIPTION
Summary:
Add #pyre-strict to file and check for Type Errors
- No errors were found

Differential Revision: D36332461

