### PR TITLE
Cli for the end user to download the container logs locally

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/logging_cli.py
+++ b/fbpcs/infra/logging_service/download_logs/logging_cli.py
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+
+from download_logs import AwsContainerLogs
+
+
+def main():
+    cli_parser = argparse.ArgumentParser()
+
+    subparsers = cli_parser.add_subparsers(dest="platform")
+
+    cloud_parser = subparsers.add_parser(
+        "aws",
+        help="Download logs for aws containers. ACCESS and SECRET keys should be env variables.",
+    )
+
+    cloud_parser = aws_parser_arguments(cloud_parser)
+
+    download_logs_parser_arguments(cloud_parser)
+
+    cli_args = cli_parser.parse_args()
+
+    aws_download_logs_obj = AwsContainerLogs(
+        tag_name=cli_args.tag_name,
+        aws_region=cli_args.aws_region,
+    )
+
+    if cli_args.download_logs:
+        aws_download_logs_obj.download_logs(
+            s3_bucket_name=cli_args.s3_bucket_name,
+            tag_name=cli_args.tag_name,
+            local_download_dir=cli_args.download_log_dir,
+        )
+
+
+def aws_parser_arguments(aws_parser: argparse) -> argparse:
+    """
+    Common arguments needed for AWS verification
+    """
+    aws_parser.add_argument(
+        "--aws_region", type=str, required=False, help="Region of the AWS account"
+    )
+    aws_parser.add_argument(
+        "--tag_name",
+        type=str,
+        required=True,
+        help="Tag name to uniquely identify downloaded logs",
+    )
+    return aws_parser
+
+
+def download_logs_parser_arguments(aws_parser: argparse):
+    """
+    Arguments for downloading logs
+    """
+    download_logs_command_group = aws_parser.add_argument_group(
+        "download_logs", "Arguments to download logs"
+    )
+
+    download_logs_command_group.add_argument(
+        "--download_logs",
+        action="store_true",
+        help="Download container logs from cloudwatch to AWS S3",
+    )
+    download_logs_command_group.add_argument(
+        "--s3_bucket_name",
+        type=str,
+        required=True,
+        help="S3 bucket name to store the logs intermediately",
+    )
+    download_logs_command_group.add_argument(
+        "--download_log_dir",
+        type=str,
+        required=False,
+        help="Local folder location where logs should be downloaded",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -6,52 +6,35 @@
 # pyre-strict
 
 import os
-from typing import IO, List
+import shutil
 
 
-def create_file(self, file_location: str, content: List) -> None:
-    """
-    Create file in the file location with content.
-    Args:
-        file_location (str): Full path of the file location Eg: /tmp/xyz.txt
-        content (list): Content to be written in file
-    Returns:
-        None
-    """
-    if not content:
-        content = []
-    try:
-        # write to a file, if it already exists
-        with open(file_location, "w") as file_object:
-            self.write_to_file(file_object, content)
-    except FileNotFoundError:
-        # create a file if it doesn't exist and write to file
-        with open(file_location, "x") as file_object:
-            self.write_to_file(file_object, content)
+class Utils:
+    @staticmethod
+    def create_folder(folder_location) -> None:
+        """
+        Creates folder in the given path
+        Args:
+            folder_location (str): Path were folder will be created. Path includes new folder name.
+                                   Eg: If creating folder `test` in location `/tmp`, folder_location should be `/tmp/test`
+        Returns:
+            None
+        """
 
+        if not os.path.exists(folder_location):
+            os.makedirs(folder_location)
 
-@staticmethod
-def write_to_file(file_object: IO[bytes], contents: List) -> None:
-    """
-    Write content to the file.
-    Args:
-        file_object (IO): Object of file to read/write
-        contents (list): Content to be written in file
-    Returns:
-        None
-    """
-    for content in contents:
-        file_object.write(content)
-
-
-@staticmethod
-def remove_file(file_location: str) -> None:
-    """
-    Remove file from the given file path
-    Args:
-        file_location (str): Full path of the file location Eg: /tmp/xyz.txt
-    Returns:
-        None
-    """
-    if os.path.isfile(file_location):
-        os.remove(file_location)
+    @staticmethod
+    def compress_downloaded_logs(folder_location: str) -> None:
+        """
+        Compresses folder passed to the function in arguments
+        Args:
+            folder_location (str): Complete folder path Eg /tmp/folder1
+        """
+        if os.path.isdir(folder_location):
+            shutil.make_archive(f"{folder_location}_zipped", "zip", folder_location)
+        else:
+            raise Exception(
+                f"Couldn't find folder {folder_location}."
+                f"Please check if folder exists.\nAborting folder compression."
+            )


### PR DESCRIPTION
Summary:
Adding cli to download the logs from S3 to local and compress the logs.

This diff is part of the series of diffs which will download logs from partner side AWS account. Following is the list of diff details:
```
diff #1 : [D36136606 (https://github.com/facebookresearch/fbpcs/commit/9ba40a9ab1b8c7ecd9ff019376a7d29b44e242f8)]  Fetched container logs from cloudwatch
diff #2 : [D36193153 (https://github.com/facebookresearch/fbpcs/commit/5f48221632c47d3b841c20b2d8edcd1c148b1dd7)] Creates folder structure in S3 to store fetched logs
diff #3 : [D36322339 (https://github.com/facebookresearch/fbpcs/commit/019a82462ced940df2da3cddc1a18b7a5ee7c794)] Exports logs from cloudwatch to the folders created in S3
diff #4 : [this diff] Let's user download the S3 folders which contains all the logs
```
More details of the design can be found here: https://docs.google.com/document/d/1PVo20EgB5pD5uATa6aF1Bv56NIX0rWxp2w-5ORCAQDE/edit?usp=sharing

Logging service design: https://docs.google.com/document/d/1vze4JalYZfpLxtXVpQJToB2Tb_LNOeuxJJSAGArZY0k/edit#heading=h.3b1n6r5gq4y0

Differential Revision: D36377823

