### PR TITLE
Added session token support to deployment flow

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -21,6 +21,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -145,7 +149,7 @@ public class DeployController {
   }
 
   @GetMapping(path = "/v1/deployment/logs")
-  public byte[] downloadDeploymentLogs() {
+  public ResponseEntity downloadDeploymentLogs() {
     logger.info("Received logs request");
     ByteArrayOutputStream bo = new ByteArrayOutputStream();
     try {
@@ -160,7 +164,10 @@ public class DeployController {
           "  Could not compress logs. Message: " + e.getMessage() + "\n" + e.getStackTrace());
     }
     logger.info("Logs request finalized");
-    return bo.toByteArray();
+    MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+    headers.add("Content-Type", "application/octet-stream");
+    headers.add("Content-Disposition", "attachment; filename=\"zipFile.zip\"");
+    return new ResponseEntity(bo.toByteArray(), headers, HttpStatus.OK);
   }
 
   private void compressIfExists(String fullFilePath, String zipName, ZipOutputStream zout) {

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -26,7 +26,7 @@ public class DeploymentParams {
 
   public String awsAccessKeyId;
   public String awsSecretAccessKey;
-
+  public String awsSessionToken;
   private final Logger logger = LoggerFactory.getLogger(DeploymentParams.class);
 
   enum LogLevel {

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -121,6 +121,9 @@ public class DeploymentRunner extends Thread {
     environmentVariables = new HashMap<String, String>();
     environmentVariables.put("AWS_ACCESS_KEY_ID", deployment.awsAccessKeyId);
     environmentVariables.put("AWS_SECRET_ACCESS_KEY", deployment.awsSecretAccessKey);
+    if (!deployment.awsSessionToken.isEmpty()) {
+      environmentVariables.put("AWS_SESSION_TOKEN", deployment.awsSessionToken);
+    }
     environmentVariables.put("TF_LOG_STREAMING", Constants.DEPLOYMENT_STREAMING_LOG_FILE);
     if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
       if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
@@ -9,6 +9,7 @@ package com.facebook.business.cloudbridge.pl.server;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeVpcsResult;
@@ -39,6 +40,14 @@ public class Validator {
   }
 
   private AWSStaticCredentialsProvider getCredentials(DeploymentParams deploymentParams) {
+    if (!deploymentParams.awsSessionToken.isEmpty()) {
+      return new AWSStaticCredentialsProvider(
+          new BasicSessionCredentials(
+              deploymentParams.awsAccessKeyId,
+              deploymentParams.awsSecretAccessKey,
+              deploymentParams.awsSessionToken));
+    }
+
     return new AWSStaticCredentialsProvider(
         new BasicAWSCredentials(
             deploymentParams.awsAccessKeyId, deploymentParams.awsSecretAccessKey));


### PR DESCRIPTION
Summary:
Since IAM user creation is disabled with admin access, people who don't have root admin access of an AWS account can not deploy infrastructure therefore they can not test.

Also, recently hackers stole our admin credentials to mine crypto https://www.internalfb.com/sevmanager/view/271860.

This diff handles this issue :

1. It retrieves session token if present cloudresource config
2. It propagates the session token to the container 'pl-service', which then sets it inside the docker environment.
3. Added auth method to verify credential as well.

Differential Revision: D36456673

