### PR TITLE
Limit to 1 objectives per run

### DIFF
--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -30,7 +30,8 @@ MAX_TRIES = 2
 RETRY_INTERVAL = 60
 
 MIN_NUM_INSTANCES = 1
-MAX_NUM_INSTANCES = 5
+# TODO T120485688 investigate multi objective issue and re-enable the feature
+MAX_NUM_INSTANCES = 1
 PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 57600  # 8 hr instance sla, 2 tries per stage, total 16 hrs.
 

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -176,6 +176,7 @@ def _validate_input(objective_ids: List[str], input_paths: List[str]) -> None:
         err_msgs.append("objective_ids have duplicates")
     if _has_duplicates(input_paths):
         err_msgs.append("input_paths have duplicates")
+
     if len(objective_ids) != len(input_paths):
         err_msgs.append(
             "Number of objective_ids and number of input_paths don't match."


### PR DESCRIPTION
Summary: To mitigate the issue with multiple objective runs, we're restricting it to 1 instance at a time. See issue: https://fb.workplace.com/groups/331044242148818/?multi_permalinks=482632703656637&comment_id=484557013464206&notif_id=1652457179286181&notif_t=work_feedback_reaction_generic&ref=notif

Reviewed By: jrodal98

Differential Revision: D36378925

