### PR TITLE
Create PIDRunProtocolBinaryService

### DIFF
--- a/fbpcs/data_processing/service/pid_run_protocol_binary_service.py
+++ b/fbpcs/data_processing/service/pid_run_protocol_binary_service.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+
+from fbpcs.pid.entity.pid_instance import PIDProtocol
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.service.run_binary_base_service import (
+    RunBinaryBaseService,
+)
+
+
+class PIDRunProtocolBinaryService(RunBinaryBaseService):
+    @staticmethod
+    def build_args(
+        input_path: str,
+        output_path: str,
+        port: int,
+        use_row_numbers: bool = False,
+        server_hostname: Optional[str] = None,
+        metric_path: Optional[str] = None,
+    ) -> str:
+
+        cmd_ls = []
+
+        if server_hostname:
+            cmd_ls.append(f"--company {server_hostname}:{port}")
+        else:
+            cmd_ls.append(f"--host 0.0.0.0:{port}")
+
+        cmd_ls.extend(
+            [
+                f"--input {input_path}",
+                f"--output {output_path}",
+            ]
+        )
+
+        if metric_path is not None:
+            cmd_ls.append(f"--metric-path {metric_path}")
+
+        cmd_ls.append("--no-tls")
+
+        if use_row_numbers:
+            cmd_ls.append("--use-row-numbers")
+
+        return " ".join(cmd_ls)
+
+    @staticmethod
+    def get_binary_name(protocol: PIDProtocol, pc_role: PrivateComputationRole):
+        if pc_role is PrivateComputationRole.PARTNER:
+            binary = OneDockerBinaryNames.PID_SERVER.value
+            if protocol is PIDProtocol.UNION_PID_MULTIKEY:
+                binary = OneDockerBinaryNames.PID_MULTI_KEY_SERVER.value
+        elif pc_role is PrivateComputationRole.PUBLISHER:
+            binary = OneDockerBinaryNames.PID_CLIENT.value
+            if protocol is PIDProtocol.UNION_PID_MULTIKEY:
+                binary = OneDockerBinaryNames.PID_MULTI_KEY_CLIENT.value
+        else:
+            raise ValueError(f"Unsupported PrivateComputationRole passed: {pc_role}")
+        return binary

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import logging
+
+from fbpcp.service.onedocker import OneDockerService
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
+from fbpcs.pid.service.pid_service.pid import PIDService
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+)
+
+from fbpcs.private_computation.service.utils import get_pc_status_from_stage_state
+
+
+class PIDRunProtocolStageService(PrivateComputationStageService):
+    """Handles business logic for the PID run protocol stage
+
+    Private attributes:
+        _onedocker_svc: Spins up containers that run binaries in the cloud
+        _pid_svc: Retains the parameters from PID config
+    """
+
+    def __init__(
+        self,
+        onedocker_svc: OneDockerService,
+        pid_svc: PIDService,
+    ) -> None:
+        self._onedocker_svc = onedocker_svc
+        self._pid_svc = pid_svc
+        self._logger: logging.Logger = logging.getLogger(__name__)
+
+    async def run_async(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstance:
+        """Runs the PID run protocol stage
+
+        Args:
+            pc_instance: the private computation instance to run pid protocol stage
+
+        Returns:
+            An updated version of pc_instance
+        """
+        self._logger.info(f"[{self}] Starting PIDRunProtocolStageService")
+
+        # TODO: implement run protocol stage
+
+        container_instances = []
+        self._logger.info("PIDRunProtocolStageService finished")
+
+        stage_state = StageStateInstance(
+            pc_instance.instance_id,
+            pc_instance.current_stage.name,
+            containers=container_instances,
+        )
+
+        pc_instance.instances.append(stage_state)
+        return pc_instance
+
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """Gets the latest PrivateComputationInstance status.
+
+        Arguments:
+            private_computation_instance: The PC instance that is being updated
+
+        Returns:
+            The latest status for private_computation_instance
+        """
+        return get_pc_status_from_stage_state(pc_instance, self._onedocker_svc)


### PR DESCRIPTION
Summary:
Description:
This is the second step to migrate PIDProtocolRunStage to StageFlow service. PIDRunProtocolBinaryService is a RunBinaryBaseService, which takes care of building arguments to pass to binary, which will be used to build binaries and to obtain a binary path.
* The function build_args() which is migrated from _gen_command_args in pid_run_protocol_stage.py

Differential Revision: D36470148

