### PR TITLE
Add main file

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -11,6 +11,8 @@
 
 namespace private_lift {
 
+const int kMaxConcurrency = 16;
+
 const size_t groupWidth = 6; // at most 32 cohorts
 const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;

--- a/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gflags/gflags.h>
+#include <future>
+#include <memory>
+
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp.h"
+
+namespace private_lift {
+
+inline std::pair<std::vector<std::string>, std::vector<std::string>>
+getIOFilepaths(
+    std::string inputBasePath,
+    std::string outputBasePath,
+    std::string inputDirectory,
+    std::string outputDirectory,
+    std::string inputFilenames,
+    std::string outputFilenames,
+    int32_t numFiles,
+    int32_t fileStartIndex) {
+  std::vector<std::string> inputFilepaths;
+  std::vector<std::string> outputFilepaths;
+
+  if (!inputBasePath.empty()) {
+    std::string inputBasePathPrefix = inputBasePath + "_";
+    std::string outputBasePathPrefix = outputBasePath + "_";
+    for (auto i = fileStartIndex; i < fileStartIndex + numFiles; ++i) {
+      inputFilepaths.push_back(inputBasePathPrefix + std::to_string(i));
+      outputFilepaths.push_back(outputBasePathPrefix + std::to_string(i));
+    }
+  } else {
+    std::filesystem::path inputDir{inputDirectory};
+    std::filesystem::path outputDir{outputDirectory};
+
+    std::vector<std::string> inputFilenamesVector;
+    folly::split(',', inputFilenames, inputFilenamesVector);
+
+    std::vector<std::string> outputFilenamesVector;
+    folly::split(",", outputFilenames, outputFilenamesVector);
+
+    // Make sure the number of input files equals output files
+    CHECK_EQ(inputFilenamesVector.size(), outputFilenamesVector.size())
+        << "Error: input_filenames and output_filenames have unequal sizes";
+
+    for (std::size_t i = 0; i < inputFilenamesVector.size(); ++i) {
+      inputFilepaths.push_back(inputDir / inputFilenamesVector[i]);
+      outputFilepaths.push_back(outputDir / outputFilenamesVector[i]);
+    }
+  }
+  return std::make_pair(inputFilepaths, outputFilepaths);
+}
+
+template <int PARTY, int index>
+inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
+    int startFileIndex,
+    int remainingThreads,
+    int numThreads,
+    std::string serverIp,
+    int port,
+    std::vector<std::string>& inputFilepaths,
+    std::vector<std::string>& outputFilepaths,
+    int numConversionsPerUser,
+    int epoch) {
+  // aggregate scheduler statistics across apps
+  common::SchedulerStatistics schedulerStatistics{0, 0, 0, 0};
+
+  // split files evenly across threads
+  auto remainingFiles = inputFilepaths.size() - startFileIndex;
+  if (remainingFiles > 0) {
+    auto numFiles = (remainingThreads > remainingFiles)
+        ? 1
+        : (remainingFiles / remainingThreads);
+
+    std::map<
+        int,
+        fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
+            PartyInfo>
+        partyInfos(
+            {{0, {serverIp, port + index * 100}},
+             {1, {serverIp, port + index * 100}}});
+
+    auto communicationAgentFactory = std::make_unique<
+        fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
+        PARTY, partyInfos, false, "");
+
+    // Each CalculatorApp runs numFiles sequentially on a single thread
+    // Publisher uses even schedulerId and partner uses odd schedulerId
+    auto app = std::make_unique<CalculatorApp<2 * index + PARTY>>(
+        PARTY,
+        std::move(communicationAgentFactory),
+        numConversionsPerUser,
+        epoch,
+        inputFilepaths,
+        outputFilepaths,
+        startFileIndex,
+        numFiles);
+
+    auto future = std::async([&app]() {
+      app->run();
+      return app->getSchedulerStatistics();
+    });
+
+    // We construct a CalculatorApp for each thread recursively because each app
+    // has a different schedulerId, which is a template parameter
+    if constexpr (index < kMaxConcurrency) {
+      if (remainingThreads > 1) {
+        auto remainingStats =
+            startCalculatorAppsForShardedFilesHelper<PARTY, index + 1>(
+                startFileIndex + numFiles,
+                remainingThreads - 1,
+                numThreads,
+                serverIp,
+                port,
+                inputFilepaths,
+                outputFilepaths,
+                numConversionsPerUser,
+                epoch);
+        schedulerStatistics.add(remainingStats);
+      }
+    }
+    auto stats = future.get();
+    schedulerStatistics.add(stats);
+  }
+  return schedulerStatistics;
+}
+
+template <int PARTY>
+inline common::SchedulerStatistics startCalculatorAppsForShardedFiles(
+    std::vector<std::string>& inputFilepaths,
+    std::vector<std::string>& outputFilepaths,
+    int16_t concurrency,
+    std::string serverIp,
+    int port,
+    int numConversionsPerUser,
+    int epoch) {
+  // use only as many threads as the number of files
+  auto numThreads = std::min((int)inputFilepaths.size(), (int)concurrency);
+
+  return startCalculatorAppsForShardedFilesHelper<PARTY, 0>(
+      0,
+      numThreads,
+      numThreads,
+      serverIp,
+      port,
+      inputFilepaths,
+      outputFilepaths,
+      numConversionsPerUser,
+      epoch);
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <glog/logging.h>
+#include <filesystem>
+#include <sstream>
+#include <string>
+
+#include "folly/init/Init.h"
+#include "folly/logging/xlog.h"
+
+#include "fbpcf/aws/AwsSdk.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h"
+
+DEFINE_int32(party, 1, "1 = publisher, 2 = partner");
+DEFINE_string(server_ip, "127.0.0.1", "Server's IP Address");
+DEFINE_int32(
+    port,
+    10000,
+    "Network port for establishing connection to other player");
+DEFINE_string(
+    input_directory,
+    "",
+    "Data directory where input files are located");
+DEFINE_string(
+    input_filenames,
+    "in.csv_0[,in.csv_1,in.csv_2,...]",
+    "List of input file names that should be parsed (should have a header)");
+DEFINE_string(
+    output_directory,
+    "",
+    "Local or s3 path where output files are written to");
+DEFINE_string(
+    output_filenames,
+    "out.csv_0[,out.csv_1,out.csv_2,...]",
+    "List of output file names that correspond to input filenames (positionally)");
+DEFINE_string(
+    input_base_path,
+    "",
+    "Local or s3 base path for the sharded input files");
+DEFINE_string(
+    output_base_path,
+    "",
+    "Local or s3 base path where output files are written to");
+DEFINE_int32(
+    file_start_index,
+    0,
+    "First file that will be read with base path");
+DEFINE_int32(num_files, 0, "Number of files that should be read");
+DEFINE_int64(
+    epoch,
+    1546300800,
+    "Unixtime of 2019-01-01. Used as our 'new epoch' for timestamps");
+DEFINE_bool(
+    is_conversion_lift,
+    true,
+    "Use conversion_lift logic (as opposed to converter_lift logic)");
+DEFINE_bool(
+    use_xor_encryption,
+    true,
+    "Reveal output with XOR secret shares instead of in the clear to both parties");
+DEFINE_int32(
+    num_conversions_per_user,
+    25,
+    "Cap and pad to this many conversions per user");
+DEFINE_int32(
+    concurrency,
+    1,
+    "max number of game(s) that will run concurrently?");
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  fbpcf::AwsSdk::aquire();
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // since DEFINE_INT16 is not supported, cast int32_t FLAGS_concurrency to
+  // int16_t is necessary here
+  int16_t concurrency = static_cast<int16_t>(FLAGS_concurrency);
+  CHECK_LE(concurrency, private_lift::kMaxConcurrency)
+      << "Concurrency must be at most " << private_lift::kMaxConcurrency;
+
+  auto filepaths = private_lift::getIOFilepaths(
+      FLAGS_input_base_path,
+      FLAGS_output_base_path,
+      FLAGS_input_directory,
+      FLAGS_output_directory,
+      FLAGS_input_filenames,
+      FLAGS_output_filenames,
+      FLAGS_num_files,
+      FLAGS_file_start_index);
+  auto inputFilepaths = filepaths.first;
+  auto outputFilepaths = filepaths.second;
+
+  {
+    // Build a quick list of input/output files to log
+    std::ostringstream inputFileLogList;
+    for (auto inputFilepath : inputFilepaths) {
+      inputFileLogList << "\t\t" << inputFilepath << "\n";
+    }
+    std::ostringstream outputFileLogList;
+    for (auto outputFilepath : outputFilepaths) {
+      outputFileLogList << "\t\t" << outputFilepath << "\n";
+    }
+    XLOG(INFO) << "Running conversion lift with settings:\n"
+               << "\tparty: " << FLAGS_party << "\n"
+               << "\tserver_ip_address: " << FLAGS_server_ip << "\n"
+               << "\tport: " << FLAGS_port << "\n"
+               << "\tconcurrency: " << FLAGS_concurrency << "\n"
+               << "\tinput: " << inputFileLogList.str()
+               << "\toutput: " << outputFileLogList.str();
+  }
+
+  FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner
+                 // instead of 1 and 2
+  common::SchedulerStatistics schedulerStatistics;
+
+  XLOG(INFO) << "Start Private Lift...";
+  if (FLAGS_party == common::PUBLISHER) {
+    XLOG(INFO)
+        << "Starting Private Lift as Publisher, will wait for Partner...";
+    schedulerStatistics =
+        private_lift::startCalculatorAppsForShardedFiles<common::PUBLISHER>(
+            inputFilepaths,
+            outputFilepaths,
+            concurrency,
+            FLAGS_server_ip,
+            FLAGS_port,
+            FLAGS_num_conversions_per_user,
+            FLAGS_epoch);
+  } else if (FLAGS_party == common::PARTNER) {
+    XLOG(INFO)
+        << "Starting Private Lift as Partner, will wait for Publisher...";
+    schedulerStatistics =
+        private_lift::startCalculatorAppsForShardedFiles<common::PARTNER>(
+            inputFilepaths,
+            outputFilepaths,
+            concurrency,
+            FLAGS_server_ip,
+            FLAGS_port,
+            FLAGS_num_conversions_per_user,
+            FLAGS_epoch);
+  } else {
+    XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
+  }
+
+  XLOGF(
+      INFO,
+      "Non-free gate count = {}, Free gate count = {}",
+      schedulerStatistics.nonFreeGates,
+      schedulerStatistics.freeGates);
+
+  XLOGF(
+      INFO,
+      "Sent network traffic = {}, Received network traffic = {}",
+      schedulerStatistics.sentNetwork,
+      schedulerStatistics.receivedNetwork);
+
+  return 0;
+}

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/MainUtilTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/MainUtilTest.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h"
+
+namespace private_lift {
+
+TEST(MainUtilTest, TestInputBasePathEmptyInputDirectory) {
+  auto filepaths =
+      getIOFilepaths("inputBasePath", "outputBasePath", "", "", "", "", 3, 0);
+  EXPECT_EQ(
+      filepaths.first,
+      (std::vector<std::string>{
+          "inputBasePath_0", "inputBasePath_1", "inputBasePath_2"}));
+  EXPECT_EQ(
+      filepaths.second,
+      (std::vector<std::string>{
+          "outputBasePath_0", "outputBasePath_1", "outputBasePath_2"}));
+}
+
+TEST(MainUtilTest, TestInputBasePathNonEmptyInputDirectory) {
+  auto filepaths = getIOFilepaths(
+      "inputBasePath",
+      "outputBasePath",
+      "inputDirectory",
+      "outputDirectory",
+      "input.csv",
+      "output.csv",
+      3,
+      0);
+  EXPECT_EQ(
+      filepaths.first,
+      (std::vector<std::string>{
+          "inputBasePath_0", "inputBasePath_1", "inputBasePath_2"}));
+  EXPECT_EQ(
+      filepaths.second,
+      (std::vector<std::string>{
+          "outputBasePath_0", "outputBasePath_1", "outputBasePath_2"}));
+}
+
+TEST(MainUtilTest, TestInputBasePathNumFilesZero) {
+  auto filepaths = getIOFilepaths(
+      "inputBasePath",
+      "outputBasePath",
+      "inputDirectory",
+      "outputDirectory",
+      "input.csv",
+      "output.csv",
+      0,
+      1);
+  EXPECT_EQ(filepaths.first.size(), 0);
+  EXPECT_EQ(filepaths.second.size(), 0);
+}
+
+TEST(MainUtilTest, TestInputDirectory) {
+  auto filepaths = getIOFilepaths(
+      "",
+      "",
+      "inputDirectory",
+      "outputDirectory",
+      "input1.csv,input2.csv",
+      "output1.csv,output2.csv",
+      0,
+      1);
+  EXPECT_EQ(
+      filepaths.first,
+      (std::vector<std::string>{
+          "inputDirectory/input1.csv", "inputDirectory/input2.csv"}));
+  EXPECT_EQ(
+      filepaths.second,
+      (std::vector<std::string>{
+          "outputDirectory/output1.csv", "outputDirectory/output2.csv"}));
+}
+
+} // namespace private_lift


### PR DESCRIPTION
Summary: We add a main file for running PL. For consistency with the original (EMP-based) PL, we keep the command line options and the processing of the input/output filenames to be the same. The main change is in how we create CalculatorApps accounting for concurrency and multiple files per thread, which is done in the same way as in the PCF2 attribution/aggregation apps.

Reviewed By: RuiyuZhu

Differential Revision: D36253018

