### PR TITLE
Update build scripts for PCF2 PL

### DIFF
--- a/binaries_out_lists/emp_games.txt
+++ b/binaries_out_lists/emp_games.txt
@@ -1,4 +1,5 @@
 lift_calculator
+pcf2_lift_calculator
 decoupled_attribution_calculator
 decoupled_aggregation_calculator
 pcf2_attribution_calculator

--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -128,3 +128,19 @@ target_link_libraries(
   empgamecommon
   perftools)
 install(TARGETS pcf2_aggregation_calculator DESTINATION bin)
+
+# pcf2_lift
+file(GLOB pcf2_lift_calculator_src
+  "fbpcs/emp_games/lift/common/**.cpp"
+  "fbpcs/emp_games/lift/common/**.h"
+  "fbpcs/emp_games/lift/pcf2_calculator/**.cpp"
+  "fbpcs/emp_games/lift/pcf2_calculator/**.h")
+list(FILTER pcf2_lift_calculator_src EXCLUDE REGEX ".*Test.*")
+add_executable(
+  pcf2_lift_calculator
+  ${pcf2_lift_calculator_src})
+target_link_libraries(
+  pcf2_lift_calculator
+  empgamecommon
+  perftools)
+install(TARGETS pcf2_lift_calculator DESTINATION bin)

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -96,6 +96,7 @@ RUN ln -s decoupled_aggregation_calculator /home/pcs/onedocker/package/decoupled
 RUN ln -s pcf2_attribution_calculator /home/pcs/onedocker/package/pcf2_attribution
 RUN ln -s pcf2_aggregation_calculator /home/pcs/onedocker/package/pcf2_aggregation
 RUN ln -s lift_calculator /home/pcs/onedocker/package/lift
+RUN ln -s pcf2_lift_calculator /home/pcs/onedocker/package/pcf2_lift
 RUN ln -s shard_aggregator /home/pcs/onedocker/package/shard-aggregator
 
 WORKDIR /home/pcs

--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -64,6 +64,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 if [ "$PACKAGE" = "emp_games" ]; then
 docker create -ti --name temp_container "${DOCKER_IMAGE_PATH}"
 docker cp temp_container:/usr/local/bin/lift_calculator "$SCRIPT_DIR/binaries_out/."
+docker cp temp_container:/usr/local/bin/pcf2_lift_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/decoupled_attribution_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/decoupled_aggregation_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/pcf2_attribution_calculator "$SCRIPT_DIR/binaries_out/."

--- a/promote_scripts/promote_binaries.sh
+++ b/promote_scripts/promote_binaries.sh
@@ -20,6 +20,7 @@ fi
 # list of the binaries
 binary_names=(
     'private_lift/lift'
+    'private_lift/pcf2_lift'
     'private_lift/aggregator'
     'private_attribution/decoupled_attribution'
     'private_attribution/decoupled_aggregation'

--- a/upload-binaries-to-s3-test.sh
+++ b/upload-binaries-to-s3-test.sh
@@ -31,6 +31,7 @@ shift
 
 one_docker_repo="one-docker-repository-test"
 lift_package="s3://$one_docker_repo/private_lift/lift/${TAG}/lift"
+pcf2_lift_package="s3://$one_docker_repo/private_lift/pcf2_lift/${TAG}/pcf2_lift"
 attribution_repo="s3://$one_docker_repo/private_attribution"
 decoupled_attribution="$attribution_repo/decoupled_attribution/${TAG}/decoupled_attribution"
 decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_aggregation"
@@ -44,6 +45,7 @@ validation_repo="s3://$one_docker_repo/validation"
 if [ "$PACKAGE" = "emp_games" ]; then
 cd binaries_out || exit
 aws s3 cp lift_calculator "$lift_package"
+aws s3 cp pcf2_lift_calculator "$pcf2_lift_package"
 aws s3 cp decoupled_attribution_calculator "$decoupled_attribution"
 aws s3 cp decoupled_aggregation_calculator "$decoupled_aggregation"
 aws s3 cp pcf2_attribution_calculator "$pcf2_attribution"

--- a/upload-binaries-to-s3.sh
+++ b/upload-binaries-to-s3.sh
@@ -31,6 +31,7 @@ shift
 
 one_docker_repo="one-docker-repository-prod"
 lift_package="s3://$one_docker_repo/private_lift/lift/${TAG}/lift"
+pcf2_lift_package="s3://$one_docker_repo/private_lift/pcf2_lift/${TAG}/pcf2_lift"
 attribution_repo="s3://$one_docker_repo/private_attribution"
 decoupled_attribution="$attribution_repo/decoupled_attribution/${TAG}/decoupled_attribution"
 decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_aggregation"
@@ -44,6 +45,7 @@ validation_repo="s3://$one_docker_repo/validation"
 if [ "$PACKAGE" = "emp_games" ]; then
 cd binaries_out || exit
 aws s3 cp lift_calculator "$lift_package"
+aws s3 cp pcf2_lift_calculator "$pcf2_lift_package"
 aws s3 cp decoupled_attribution_calculator "$decoupled_attribution"
 aws s3 cp decoupled_aggregation_calculator "$decoupled_aggregation"
 aws s3 cp pcf2_attribution_calculator "$pcf2_attribution"


### PR DESCRIPTION
Summary: We update the build scripts in order to build the binaries for PCF2 PL and upload them to AWS, following the instructions in https://www.internalfb.com/intern/wiki/Private_Computation_Platform_(PCP)/Internal_Developer_Guide/How_to_add_a_stage_to_PCS/Step_4:_Update_Github_CI/CD/

Differential Revision: D36425842

