### PR TITLE
use double digits for month/day/hour

### DIFF
--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
@@ -25,12 +25,13 @@ from pyspark.context import SparkContext
 from pyspark.sql.functions import (
     col,
     dayofmonth,
+    format_string,
     from_unixtime,
     hour,
     lit,
     month,
     struct,
-    to_date,
+    to_timestamp,
     year,
 )
 from pyspark.sql.types import IntegerType
@@ -140,11 +141,11 @@ for column_name in expected_column_list:
 # create columns
 augmented_df = (
     data_frame.withColumn("unixtime", data_frame["timestamp"].cast(IntegerType()))
-    .withColumn("date_col", to_date(from_unixtime(col("unixtime"))))
+    .withColumn("date_col", to_timestamp(from_unixtime(col("unixtime"))))
     .withColumn("year", year(col("date_col")))
-    .withColumn("month", month(col("date_col")))
-    .withColumn("day", dayofmonth(col("date_col")))
-    .withColumn("hour", hour(col("date_col")))
+    .withColumn("month", format_string("%02d", month(col("date_col"))))
+    .withColumn("day", format_string("%02d", dayofmonth(col("date_col"))))
+    .withColumn("hour", format_string("%02d", hour(col("date_col"))))
     .withColumn(
         "user_data",
         struct(


### PR DESCRIPTION
Summary: Currently it is using single digit for month/day/hour, e.g. month=5/. However, in CAPIG pipeline, it's double digits, e.g. month=05/. We noticed this might cause issue. This diff is to make sure it is also double digits in semi-auto pipeline.

Differential Revision: D36611556

