### PR TITLE
change default value of multikey_enabled in PCS to True

### DIFF
--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -474,9 +474,9 @@ def _build_pid_service(
         pidinstance_repository_config, PIDInstanceRepository
     )
 
-    multikey_enabled = False
-    if "multikey_enabled" in pid_config.keys() and pid_config["multikey_enabled"]:
-        multikey_enabled = True
+    multikey_enabled = True
+    if "multikey_enabled" in pid_config.keys() and not pid_config["multikey_enabled"]:
+        multikey_enabled = False
     return PIDService(
         onedocker_service,
         storage_service,


### PR DESCRIPTION
Summary:
The PID team is onboarding single-node multi-key. Please see [the design doc](https://docs.google.com/document/d/1UrTmsG9ChUOtjuyvnNvG1bgZpS6StgXFFOi1dwf8lpU/edit?usp=sharing) for more details about the overview of project.

In this diff, we are enabling multi-key for single-node runs by default. After D36538750 lands, we will ship this diff so that multi-key protocol usage is properly gated based on advertiser.
Please see [SNMK Technical Roll-out Plan](https://docs.google.com/document/d/1UrTmsG9ChUOtjuyvnNvG1bgZpS6StgXFFOi1dwf8lpU/edit#bookmark=id.jval8rq1tayh) for technical context.

Differential Revision: D36539199

