### PR TITLE
Add cost logging to PCF2 PL stage service

### DIFF
--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -54,6 +54,8 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument({"name": "file_start_index", "required": False}),
             OneDockerArgument({"name": "num_files", "required": True}),
             OneDockerArgument({"name": "concurrency", "required": True}),
+            OneDockerArgument({"name": "log_cost", "required": False}),
+            OneDockerArgument({"name": "run_name", "required": False}),
         ],
     },
     GameNames.SHARD_AGGREGATOR.value: {

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -21,6 +21,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
@@ -149,12 +150,26 @@ class PCF2LiftStageService(PrivateComputationStageService):
         Returns:
             MPC game args to be used by onedocker
         """
+        if self._log_cost_to_s3:
+            run_name = (
+                private_computation_instance.instance_id
+                + "_"
+                + GameNames.PCF2_LIFT.value
+            )
+            if private_computation_instance.post_processing_data:
+                private_computation_instance.post_processing_data.s3_cost_export_output_paths.add(
+                    f"pl-logs/{run_name}_{private_computation_instance.role.value.title()}.json"
+                )
+        else:
+            run_name = ""
 
         common_compute_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
             "num_files": private_computation_instance.num_files_per_mpc_container,
             "concurrency": private_computation_instance.concurrency,
+            "run_name": run_name,
+            "log_cost": self._log_cost_to_s3,
         }
 
         game_args = []

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -67,20 +67,27 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
     def test_get_game_args(self) -> None:
         # TODO: add game args test for attribution args
         private_computation_instance = self._create_pc_instance()
+        run_name = (
+            private_computation_instance.instance_id + "_" + GameNames.PCF2_LIFT.value
+            if self.stage_svc._log_cost_to_s3
+            else ""
+        )
+        common_game_args = {
+            "input_base_path": private_computation_instance.data_processing_output_path,
+            "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
+            "num_files": private_computation_instance.num_files_per_mpc_container,
+            "concurrency": private_computation_instance.concurrency,
+            "run_name": run_name,
+            "log_cost": True,
+        }
         test_game_args = [
             {
-                "input_base_path": private_computation_instance.data_processing_output_path,
-                "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
+                **common_game_args,
                 "file_start_index": 0,
-                "num_files": private_computation_instance.num_files_per_mpc_container,
-                "concurrency": private_computation_instance.concurrency,
             },
             {
-                "input_base_path": private_computation_instance.data_processing_output_path,
-                "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
+                **common_game_args,
                 "file_start_index": private_computation_instance.num_files_per_mpc_container,
-                "num_files": private_computation_instance.num_files_per_mpc_container,
-                "concurrency": private_computation_instance.concurrency,
             },
         ]
 


### PR DESCRIPTION
Summary: We add the `run_name` and `log_cost` arguments to the PCF2 PL stage service, in order to log costs to S3 when running the binary.

Reviewed By: gorel

Differential Revision: D36532404

