### PR TITLE
Add cost estimation logging to PCF2 PL

### DIFF
--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -28,6 +28,7 @@ const std::unordered_map<std::string, std::string> SUPPORTED_APPLICATIONS(
     {{"data_processing", "dp-logs"},
      {"attributor", "att-logs"},
      {"aggregator", "agg-logs"},
+     {"lift", "pl-logs"},
      {"shard_aggregator", "sa-logs"}});
 const std::vector<std::string> SUPPORTED_VERSIONS{"decoupled", "pcf2"};
 const std::string S3_COST_BUCKET = "cost-estimation-logs";


### PR DESCRIPTION
Summary: We add cost estimation logging for the PCF2.0 PL binaries. We do this in the same way as how it is currently being done for PA, using the CostEstimation class. We also create a new S3 folder `cost-estimation-logs/pl_logs` to store the logs for PL.

Reviewed By: robotal

Differential Revision: D36531104

