### PR TITLE
Remove LiftGranularityType

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -67,7 +67,6 @@ CalculatorGameConfig CalculatorApp<schedulerId>::getInputData(
   InputData inputData{
       inputPath,
       InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Conversion,
       epoch_,
       numConversionsPerUser_};
   CalculatorGameConfig config = {inputData, true, numConversionsPerUser_};

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -25,11 +25,9 @@ static const std::string kFeaturePrefix = "feature_";
 InputData::InputData(
     std::string filepath,
     LiftMPCType liftMpcType,
-    LiftGranularityType liftGranularityType,
     int64_t epoch,
     int32_t numConversionsPerUser)
     : liftMpcType_{liftMpcType},
-      liftGranularityType_{liftGranularityType},
       epoch_{epoch},
       numConversionsPerUser_{numConversionsPerUser} {
   auto readLine = [&](const std::vector<std::string>& header,

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -25,13 +25,11 @@ namespace private_lift {
 class InputData {
  public:
   enum class LiftMPCType { SecretShare, Standard };
-  enum class LiftGranularityType { Conversion, Converter };
 
   // Constructor -- input is a path to a CSV along with the new epoch to use
   explicit InputData(
       std::string filepath,
       LiftMPCType liftMpcType,
-      LiftGranularityType liftGranularityType,
       int64_t epoch = 0,
       int32_t numConversionsPerUser = INT32_MAX);
 
@@ -125,10 +123,6 @@ class InputData {
     return numRows_;
   }
 
-  LiftGranularityType getLiftGranularityType() const {
-    return liftGranularityType_;
-  }
-
   // Helper function to determine if a header contains any feature columns
   bool anyFeatureColumns(const std::vector<std::string>& header);
 
@@ -168,7 +162,6 @@ class InputData {
       const std::vector<std::string>& parts);
 
   LiftMPCType liftMpcType_;
-  LiftGranularityType liftGranularityType_;
   int64_t epoch_;
   std::vector<bool> testPopulation_;
   std::vector<bool> controlPopulation_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -59,13 +59,11 @@ class AggregatorTest : public ::testing::Test {
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser);
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -51,13 +51,11 @@ class AttributorTest : public ::testing::Test {
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser);
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
@@ -51,7 +51,6 @@ class CalculatorGameTestFixture
     InputData inputData{
         inputPath,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser};
     CalculatorGameConfig config = {inputData, true, numConversionsPerUser};

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
@@ -38,11 +38,7 @@ class InputDataTest : public ::testing::Test {
 
 TEST_F(InputDataTest, TestInputDataPublisher) {
   InputData inputData{
-      aliceInputFilename_,
-      InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Conversion,
-      1546300800,
-      4};
+      aliceInputFilename_, InputData::LiftMPCType::Standard, 1546300800, 4};
   std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
                                             0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
   std::vector<bool> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
@@ -62,11 +58,7 @@ TEST_F(InputDataTest, TestInputDataPublisher) {
 
 TEST_F(InputDataTest, TestInputDataPublisherOppColLast) {
   InputData inputData{
-      aliceInputFilename2_,
-      InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Conversion,
-      1546300800,
-      4};
+      aliceInputFilename2_, InputData::LiftMPCType::Standard, 1546300800, 4};
   std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
                                             0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
   std::vector<bool> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
@@ -88,7 +80,6 @@ TEST_F(InputDataTest, TestInputDataPartner) {
   InputData inputData{
       bobInputFilename_,
       InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Conversion,
       1546300800, /* epoch */
       4 /* num_conversions_per_user */};
   std::vector<std::vector<uint32_t>> expectGetPurchaseTimestampArrays = {
@@ -134,7 +125,6 @@ TEST_F(InputDataTest, TestInputDataPartnerConverterLift) {
   InputData inputData{
       bobInputFilename2_,
       InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Converter,
       0, /* epoch */
       1 /* num_conversions_per_user */};
   std::vector<std::vector<uint32_t>> expectGetPurchaseTimestamps = {
@@ -158,7 +148,6 @@ TEST_F(InputDataTest, TestAnyFeatureColumns) {
   InputData inputData{
       bobInputFilename_,
       InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Conversion,
       1546300800, /* epoch */
       4 /* num_conversions_per_user */};
 
@@ -176,7 +165,6 @@ TEST_F(InputDataTest, TestGetBitmaskFor) {
   InputData inputData{
       bobInputFilename_,
       InputData::LiftMPCType::Standard,
-      InputData::LiftGranularityType::Conversion,
       1546300800, /* epoch */
       4 /* num_conversions_per_user */};
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -49,13 +49,11 @@ class InputProcessorTest : public ::testing::Test {
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
-        InputData::LiftGranularityType::Conversion,
         epoch,
         numConversionsPerUser);
 


### PR DESCRIPTION
Summary: LiftGranularityType defined in pcf2_calculator/InputData.h is deprecated. This changeset removes it and updates all the uses in the files under pcf2_calculator.

Differential Revision: D36649094

