### PR TITLE
Rename PLGraphAPIClient class to PCGraphAPIClient

### DIFF
--- a/fbpcs/pl_coordinator/pc_publisher_instance.py
+++ b/fbpcs/pl_coordinator/pc_publisher_instance.py
@@ -15,7 +15,7 @@ from fbpcs.pl_coordinator.pc_calc_instance import PrivateComputationCalcInstance
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     GRAPHAPI_INSTANCE_STATUSES,
     GraphAPIGenericException,
-    PLGraphAPIClient,
+    PCGraphAPIClient,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
@@ -34,10 +34,10 @@ class PrivateComputationPublisherInstance(PrivateComputationCalcInstance):
     """
 
     def __init__(
-        self, instance_id: str, logger: logging.Logger, client: PLGraphAPIClient
+        self, instance_id: str, logger: logging.Logger, client: PCGraphAPIClient
     ) -> None:
         super().__init__(instance_id, logger, PrivateComputationRole.PUBLISHER)
-        self.client: PLGraphAPIClient = client
+        self.client: PCGraphAPIClient = client
         self.server_ips: Optional[List[str]] = None
         self.wait_valid_status(WAIT_VALID_STATUS_TIMEOUT)
 

--- a/fbpcs/pl_coordinator/pl_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pl_graphapi_utils.py
@@ -79,7 +79,7 @@ GRAPHAPI_INSTANCE_STATUSES: Dict[str, PrivateComputationInstanceStatus] = {
 
 
 # TODO(T116610959): rename pl_graph_api_utils.py and its entities to PC equivalents
-class PLGraphAPIClient:
+class PCGraphAPIClient:
     """
     Private Lift Graph API related functions
     __init__ contains info about all the api end points used by Private Lift

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -32,7 +32,7 @@ from fbpcs.pl_coordinator.pc_partner_instance import PrivateComputationPartnerIn
 from fbpcs.pl_coordinator.pc_publisher_instance import (
     PrivateComputationPublisherInstance,
 )
-from fbpcs.pl_coordinator.pl_graphapi_utils import PLGraphAPIClient
+from fbpcs.pl_coordinator.pl_graphapi_utils import PCGraphAPIClient
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,
@@ -79,7 +79,7 @@ def run_instance(
             "Number of retries not allowed",
             f"num_tries must be between {MIN_TRIES} and {MAX_TRIES}.",
         )
-    client = PLGraphAPIClient(config, logger)
+    client = PCGraphAPIClient(config, logger)
     instance_runner = PLInstanceRunner(
         config,
         instance_id,
@@ -169,7 +169,7 @@ class PLInstanceRunner:
         num_mpc_containers: int,
         num_pid_containers: int,
         logger: logging.Logger,
-        client: PLGraphAPIClient,
+        client: PCGraphAPIClient,
         num_tries: int,
         game_type: PrivateComputationGameType,
         dry_run: Optional[bool],

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -21,7 +21,7 @@ from fbpcs.pl_coordinator.exceptions import (
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     GRAPHAPI_INSTANCE_STATUSES,
     GraphAPIGenericException,
-    PLGraphAPIClient,
+    PCGraphAPIClient,
 )
 from fbpcs.pl_coordinator.pl_instance_runner import run_instances
 from fbpcs.private_computation.entity.pcs_tier import PCSTier
@@ -75,7 +75,7 @@ def run_study(
     _validate_input(objective_ids, input_paths)
 
     # obtain study information
-    client = PLGraphAPIClient(config, logger)
+    client = PCGraphAPIClient(config, logger)
     study_data = _get_study_data(study_id, client)
 
     # Verify study can run private lift:
@@ -242,7 +242,7 @@ def _verify_mpc_objs(study_data: Dict[str, Any], objective_ids: List[str]) -> No
             )
 
 
-def _get_study_data(study_id: str, client: PLGraphAPIClient) -> Any:
+def _get_study_data(study_id: str, client: PCGraphAPIClient) -> Any:
     return json.loads(
         client.get_study_data(
             study_id,
@@ -326,7 +326,7 @@ def _get_cell_obj_instance(
 def _create_new_instances(
     cell_obj_instances: Dict[str, Dict[str, Any]],
     study_id: str,
-    client: PLGraphAPIClient,
+    client: PCGraphAPIClient,
     logger: logging.Logger,
 ) -> None:
     for cell_id in cell_obj_instances:
@@ -344,7 +344,7 @@ def _create_new_instances(
 
 
 def _create_instance_retry(
-    client: PLGraphAPIClient,
+    client: PCGraphAPIClient,
     study_id: str,
     cell_id: str,
     objective_id: str,
@@ -400,7 +400,7 @@ def _instance_to_input_path(
 def _check_versions(
     cell_obj_instances: Dict[str, Dict[str, Dict[str, Any]]],
     config: Dict[str, Any],
-    client: PLGraphAPIClient,
+    client: PCGraphAPIClient,
 ) -> None:
     """Checks that the publisher version (graph api) and the partner version (config.yml) are the same
 

--- a/fbpcs/pl_coordinator/tests/test_pl_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/tests/test_pl_graphapi_utils.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from fbpcs.pl_coordinator.exceptions import GraphAPITokenNotFound
 from fbpcs.pl_coordinator.pl_graphapi_utils import (
     FBPCS_GRAPH_API_TOKEN,
-    PLGraphAPIClient,
+    PCGraphAPIClient,
 )
 
 
@@ -26,36 +26,36 @@ class TestPLGraphAPIUtils(TestCase):
     def test_get_graph_api_token_from_dict(self) -> None:
         expected_token = "from_dict"
         config = {"graphapi": {"access_token": expected_token}}
-        actual_token = PLGraphAPIClient(config, self.mock_logger).access_token
+        actual_token = PCGraphAPIClient(config, self.mock_logger).access_token
         self.assertEqual(expected_token, actual_token)
 
     def test_get_graph_api_token_from_env_config_todo(self) -> None:
         expected_token = "from_env"
         with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: expected_token}):
             config = {"graphapi": {"access_token": "TODO"}}
-            actual_token = PLGraphAPIClient(config, self.mock_logger).access_token
+            actual_token = PCGraphAPIClient(config, self.mock_logger).access_token
             self.assertEqual(expected_token, actual_token)
 
     def test_get_graph_api_token_from_env_config_no_field(self) -> None:
         expected_token = "from_env"
         with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: expected_token}):
             config = {"graphapi": {"random_field": "not_a_token"}}
-            actual_token = PLGraphAPIClient(config, self.mock_logger).access_token
+            actual_token = PCGraphAPIClient(config, self.mock_logger).access_token
             self.assertEqual(expected_token, actual_token)
 
     def test_get_graph_api_token_dict_and_env(self) -> None:
         expected_token = "from_dict"
         with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: "from_env"}):
             config = {"graphapi": {"access_token": expected_token}}
-            actual_token = PLGraphAPIClient(config, self.mock_logger).access_token
+            actual_token = PCGraphAPIClient(config, self.mock_logger).access_token
             self.assertEqual(expected_token, actual_token)
 
     def test_get_graph_api_token_no_token_todo(self) -> None:
         config = {"graphapi": {"access_token": "TODO"}}
         with self.assertRaises(GraphAPITokenNotFound):
-            PLGraphAPIClient(config, self.mock_logger).access_token
+            PCGraphAPIClient(config, self.mock_logger).access_token
 
     def test_get_graph_api_token_no_field(self) -> None:
         config = {"graphapi": {"random_field": "not_a_token"}}
         with self.assertRaises(GraphAPITokenNotFound):
-            PLGraphAPIClient(config, self.mock_logger).access_token
+            PCGraphAPIClient(config, self.mock_logger).access_token

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional, Type
 
 import dateutil.parser
 import pytz
-from fbpcs.pl_coordinator.pl_graphapi_utils import PLGraphAPIClient
+from fbpcs.pl_coordinator.pl_graphapi_utils import PCGraphAPIClient
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
@@ -77,7 +77,7 @@ def run_attribution(
 
     ## Step 1: Validation. Function arguments and  for private attribution run.
     # obtain the values in the dataset info vector.
-    client = PLGraphAPIClient(config, logger)
+    client = PCGraphAPIClient(config, logger)
     datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
     datasets = datasets_info[DATASETS_INFORMATION]
     matched_data = {}
@@ -168,7 +168,7 @@ def _create_new_instance(
     dataset_id: str,
     timestamp: int,
     attribution_rule: str,
-    client: PLGraphAPIClient,
+    client: PCGraphAPIClient,
     logger: logging.Logger,
 ) -> str:
     instance_id = json.loads(
@@ -188,7 +188,7 @@ def _create_new_instance(
 def get_attribution_dataset_info(
     config: Dict[str, Any], dataset_id: str, logger: logging.Logger
 ) -> str:
-    client = PLGraphAPIClient(config, logger)
+    client = PCGraphAPIClient(config, logger)
 
     return json.loads(
         client.get_attribution_dataset_info(
@@ -199,7 +199,7 @@ def get_attribution_dataset_info(
 
 
 def _get_pa_instance_info(
-    client: PLGraphAPIClient, instance_id: str, logger: logging.Logger
+    client: PCGraphAPIClient, instance_id: str, logger: logging.Logger
 ) -> Any:
     return json.loads(client.get_instance(instance_id).text)
 
@@ -215,7 +215,7 @@ def _iso_date_validator(timestamp: str) -> Any:
 
 
 def _get_attribution_dataset_info(
-    client: PLGraphAPIClient, dataset_id: str, logger: logging.Logger
+    client: PCGraphAPIClient, dataset_id: str, logger: logging.Logger
 ) -> Any:
     return json.loads(
         client.get_attribution_dataset_info(
@@ -225,5 +225,5 @@ def _get_attribution_dataset_info(
     )
 
 
-def _get_existing_pa_instances(client: PLGraphAPIClient, dataset_id: str) -> Any:
+def _get_existing_pa_instances(client: PCGraphAPIClient, dataset_id: str) -> Any:
     return json.loads(client.get_existing_pa_instances(dataset_id).text)

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -36,7 +36,7 @@ from fbpcs.private_computation.stage_flows.private_computation_stage_flow import
 
 class TestPlInstanceRunner(TestCase):
     @patch("logging.Logger")
-    @patch("fbpcs.pl_coordinator.pl_graphapi_utils.PLGraphAPIClient")
+    @patch("fbpcs.pl_coordinator.pl_graphapi_utils.PCGraphAPIClient")
     def setUp(
         self,
         mock_graph_api_client,


### PR DESCRIPTION
Summary:
## What
Refactor PLGraphAPIClient class to PCGraphAPIClient

## Why
It's used by lift and attribution, avoid confusion

Reviewed By: joe1234wu, zhangpuhan

Differential Revision: D36711526

