### PR TITLE
Rename pl_graphapi_utils.py to pc_graphapi_utils.py and updated references

### DIFF
--- a/fbpcs/pl_coordinator/pc_calc_instance.py
+++ b/fbpcs/pl_coordinator/pc_calc_instance.py
@@ -17,7 +17,7 @@ from fbpcs.pl_coordinator.constants import (
     POLL_INTERVAL,
 )
 from fbpcs.pl_coordinator.exceptions import PCInstanceCalculationException
-from fbpcs.pl_coordinator.pl_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
+from fbpcs.pl_coordinator.pc_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
 )

--- a/fbpcs/pl_coordinator/pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pc_graphapi_utils.py
@@ -78,7 +78,6 @@ GRAPHAPI_INSTANCE_STATUSES: Dict[str, PrivateComputationInstanceStatus] = {
 }
 
 
-# TODO(T116610959): rename pl_graph_api_utils.py and its entities to PC equivalents
 class PCGraphAPIClient:
     """
     Private Lift Graph API related functions

--- a/fbpcs/pl_coordinator/pc_publisher_instance.py
+++ b/fbpcs/pl_coordinator/pc_publisher_instance.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 
 from fbpcs.pl_coordinator.constants import WAIT_VALID_STATUS_TIMEOUT
 from fbpcs.pl_coordinator.pc_calc_instance import PrivateComputationCalcInstance
-from fbpcs.pl_coordinator.pl_graphapi_utils import (
+from fbpcs.pl_coordinator.pc_graphapi_utils import (
     GRAPHAPI_INSTANCE_STATUSES,
     GraphAPIGenericException,
     PCGraphAPIClient,

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -28,11 +28,11 @@ from fbpcs.pl_coordinator.exceptions import (
     PCInstanceCalculationException,
     PCStudyValidationException,
 )
+from fbpcs.pl_coordinator.pc_graphapi_utils import PCGraphAPIClient
 from fbpcs.pl_coordinator.pc_partner_instance import PrivateComputationPartnerInstance
 from fbpcs.pl_coordinator.pc_publisher_instance import (
     PrivateComputationPublisherInstance,
 )
-from fbpcs.pl_coordinator.pl_graphapi_utils import PCGraphAPIClient
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,
     AttributionRule,

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -18,7 +18,7 @@ from fbpcs.pl_coordinator.exceptions import (
     PCStudyValidationException,
     sys_exit_after,
 )
-from fbpcs.pl_coordinator.pl_graphapi_utils import (
+from fbpcs.pl_coordinator.pc_graphapi_utils import (
     GRAPHAPI_INSTANCE_STATUSES,
     GraphAPIGenericException,
     PCGraphAPIClient,

--- a/fbpcs/pl_coordinator/tests/test_pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/tests/test_pc_graphapi_utils.py
@@ -8,14 +8,13 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from fbpcs.pl_coordinator.exceptions import GraphAPITokenNotFound
-from fbpcs.pl_coordinator.pl_graphapi_utils import (
+from fbpcs.pl_coordinator.pc_graphapi_utils import (
     FBPCS_GRAPH_API_TOKEN,
     PCGraphAPIClient,
 )
 
 
-# TODO(T116610959): rename pl_graph_api_utils.py and its entities to PC equivalents
-class TestPLGraphAPIUtils(TestCase):
+class TestPCGraphAPIUtils(TestCase):
     @patch("logging.Logger")
     def setUp(
         self,

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional, Type
 
 import dateutil.parser
 import pytz
-from fbpcs.pl_coordinator.pl_graphapi_utils import PCGraphAPIClient
+from fbpcs.pl_coordinator.pc_graphapi_utils import PCGraphAPIClient
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance
 from fbpcs.private_computation.entity.private_computation_instance import (
     AggregationType,

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -10,7 +10,7 @@ from unittest import TestCase
 from unittest.mock import patch, PropertyMock
 
 import requests
-from fbpcs.pl_coordinator.pl_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
+from fbpcs.pl_coordinator.pc_graphapi_utils import GRAPHAPI_INSTANCE_STATUSES
 from fbpcs.pl_coordinator.pl_instance_runner import (
     IncompatibleStageError,
     PCInstanceCalculationException,
@@ -36,7 +36,7 @@ from fbpcs.private_computation.stage_flows.private_computation_stage_flow import
 
 class TestPlInstanceRunner(TestCase):
     @patch("logging.Logger")
-    @patch("fbpcs.pl_coordinator.pl_graphapi_utils.PCGraphAPIClient")
+    @patch("fbpcs.pl_coordinator.pc_graphapi_utils.PCGraphAPIClient")
     def setUp(
         self,
         mock_graph_api_client,


### PR DESCRIPTION
Summary:
## What
Renamed pl_graphapi_utils.py, test_pl_graphapi_utils.py to pc_graphapi_utils.py and test_pc_graphapi_utils.py

## Why
Keep consistency with PLGraphAPIClient -> PCGraphAPIClient change

Differential Revision: D36718728

