### PR TITLE
Reduce repeatation of get_stage_service method in stage_flow classes

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_base_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_base_stage_flow.py
@@ -8,20 +8,23 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Type, TYPE_CHECKING, TypeVar
+from typing import Type, TypeVar
 
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+    PrivateComputationStageServiceArgs,
+)
+
 from fbpcs.private_computation.stage_flows.exceptions import (
     PCStageFlowNotFoundException,
 )
 
-if TYPE_CHECKING:
-    from fbpcs.private_computation.service.private_computation_stage_service import (
-        PrivateComputationStageService,
-        PrivateComputationStageServiceArgs,
-    )
+from fbpcs.private_computation.stage_flows.stage_selector import StageSelector
+
 from fbpcs.stage_flow.stage_flow import StageFlow, StageFlowData
 
 C = TypeVar("C", bound="PrivateComputationBaseStageFlow")
@@ -90,3 +93,12 @@ class PrivateComputationBaseStageFlow(StageFlow):
         raise NotImplementedError(
             f"get_stage_service not implemented for {self.__class__}"
         )
+
+    def get_default_stage_service(
+        self,
+        args: PrivateComputationStageServiceArgs,
+    ) -> PrivateComputationStageService:
+        stage = StageSelector.get_stage_service(self, args)
+        if stage is None:
+            raise NotImplementedError(f"No stage service configured for {self}")
+        return stage

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -7,24 +7,16 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
 from fbpcs.private_computation.service.decoupled_aggregation_stage_service import (
     AggregationStageService,
 )
 from fbpcs.private_computation.service.decoupled_attribution_stage_service import (
     AttributionStageService,
 )
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -102,20 +94,7 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.DECOUPLED_ATTRIBUTION:
+        if self is self.DECOUPLED_ATTRIBUTION:
             return AttributionStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
@@ -125,10 +104,5 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -4,12 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.pid.entity.pid_instance import UnionPIDStage
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
-)
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
 )
 from fbpcs.private_computation.service.decoupled_aggregation_stage_service import (
     AggregationStageService,
@@ -17,22 +13,10 @@ from fbpcs.private_computation.service.decoupled_aggregation_stage_service impor
 from fbpcs.private_computation.service.decoupled_attribution_stage_service import (
     AttributionStageService,
 )
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
-from fbpcs.private_computation.service.input_data_validation_stage_service import (
-    InputDataValidationStageService,
-)
-from fbpcs.private_computation.service.pid_stage_service import PIDStageService
-from fbpcs.private_computation.service.post_processing_stage_service import (
-    PostProcessingStageService,
-)
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -148,48 +132,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(
-                args.pc_validator_config,
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PID_SHARD:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_SHARD,
-                UnionPIDStage.ADV_SHARD,
-            )
-        elif self is self.PID_PREPARE:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_PREPARE,
-                UnionPIDStage.ADV_PREPARE,
-            )
-        elif self is self.ID_MATCH:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_RUN_PID,
-                UnionPIDStage.ADV_RUN_PID,
-            )
-        elif self is self.ID_MATCH_POST_PROCESS:
-            return PostProcessingStageService(
-                args.storage_svc, args.pid_post_processing_handlers
-            )
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.DECOUPLED_ATTRIBUTION:
+        if self is self.DECOUPLED_ATTRIBUTION:
             return AttributionStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
@@ -199,14 +142,5 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
-        elif self is self.POST_PROCESSING_HANDLERS:
-            return PostProcessingStageService(
-                args.storage_svc, args.post_processing_handlers
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -7,24 +7,13 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
-)
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
-from fbpcs.private_computation.service.post_processing_stage_service import (
-    PostProcessingStageService,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -101,32 +90,10 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.COMPUTE:
+        if self is self.COMPUTE:
             return ComputeMetricsStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
-        elif self is self.POST_PROCESSING_HANDLERS:
-            return PostProcessingStageService(
-                args.storage_svc, args.post_processing_handlers
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
@@ -7,18 +7,8 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
-)
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
-from fbpcs.private_computation.service.input_data_validation_stage_service import (
-    InputDataValidationStageService,
 )
 from fbpcs.private_computation.service.pid_mr_stage_service import PIDMRStageService
 from fbpcs.private_computation.service.post_processing_stage_service import (
@@ -28,7 +18,6 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -122,15 +111,7 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(
-                args.pc_validator_config,
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.UNION_PID_MR_MULTIKEY:
+        if self is self.UNION_PID_MR_MULTIKEY:
             if args.workflow_svc is None:
                 raise NotImplementedError("workflow_svc is None")
 
@@ -139,30 +120,10 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
             return PostProcessingStageService(
                 args.storage_svc, args.pid_post_processing_handlers
             )
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
         elif self is self.COMPUTE:
             return ComputeMetricsStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
-        elif self is self.POST_PROCESSING_HANDLERS:
-            return PostProcessingStageService(
-                args.storage_svc, args.post_processing_handlers
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
@@ -4,33 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.pid.entity.pid_instance import UnionPIDStage
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
-from fbpcs.private_computation.service.input_data_validation_stage_service import (
-    InputDataValidationStageService,
-)
 from fbpcs.private_computation.service.pcf2_lift_stage_service import (
     PCF2LiftStageService,
-)
-from fbpcs.private_computation.service.pid_stage_service import PIDStageService
-from fbpcs.private_computation.service.post_processing_stage_service import (
-    PostProcessingStageService,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -137,60 +120,10 @@ class PrivateComputationPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(
-                args.pc_validator_config,
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PID_SHARD:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_SHARD,
-                UnionPIDStage.ADV_SHARD,
-            )
-        elif self is self.PID_PREPARE:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_PREPARE,
-                UnionPIDStage.ADV_PREPARE,
-            )
-        elif self is self.ID_MATCH:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_RUN_PID,
-                UnionPIDStage.ADV_RUN_PID,
-            )
-        elif self is self.ID_MATCH_POST_PROCESS:
-            return PostProcessingStageService(
-                args.storage_svc, args.pid_post_processing_handlers
-            )
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PCF2_LIFT:
+        if self is self.PCF2_LIFT:
             return PCF2LiftStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
-        elif self is self.POST_PROCESSING_HANDLERS:
-            return PostProcessingStageService(
-                args.storage_svc, args.post_processing_handlers
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
@@ -7,13 +7,6 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
 from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
     PCF2AggregationStageService,
 )
@@ -24,7 +17,6 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -104,20 +96,7 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PCF2_ATTRIBUTION:
+        if self is self.PCF2_ATTRIBUTION:
             return PCF2AttributionStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
@@ -127,10 +106,5 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -4,19 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.pid.entity.pid_instance import UnionPIDStage
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
-)
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
-from fbpcs.private_computation.service.input_data_validation_stage_service import (
-    InputDataValidationStageService,
 )
 from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
     PCF2AggregationStageService,
@@ -24,15 +13,10 @@ from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
 from fbpcs.private_computation.service.pcf2_attribution_stage_service import (
     PCF2AttributionStageService,
 )
-from fbpcs.private_computation.service.pid_stage_service import PIDStageService
-from fbpcs.private_computation.service.post_processing_stage_service import (
-    PostProcessingStageService,
-)
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -147,48 +131,7 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(
-                args.pc_validator_config,
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PID_SHARD:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_SHARD,
-                UnionPIDStage.ADV_SHARD,
-            )
-        elif self is self.PID_PREPARE:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_PREPARE,
-                UnionPIDStage.ADV_PREPARE,
-            )
-        elif self is self.ID_MATCH:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_RUN_PID,
-                UnionPIDStage.ADV_RUN_PID,
-            )
-        elif self is self.ID_MATCH_POST_PROCESS:
-            return PostProcessingStageService(
-                args.storage_svc, args.pid_post_processing_handlers
-            )
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PCF2_ATTRIBUTION:
+        if self is self.PCF2_ATTRIBUTION:
             return PCF2AttributionStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
@@ -198,14 +141,5 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
-        elif self is self.POST_PROCESSING_HANDLERS:
-            return PostProcessingStageService(
-                args.storage_svc, args.post_processing_handlers
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -4,32 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from fbpcs.pid.entity.pid_instance import UnionPIDStage
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.aggregate_shards_stage_service import (
-    AggregateShardsStageService,
-)
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
-)
-from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
-from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
-    IdSpineCombinerStageService,
-)
-from fbpcs.private_computation.service.input_data_validation_stage_service import (
-    InputDataValidationStageService,
-)
-from fbpcs.private_computation.service.pid_stage_service import PIDStageService
-from fbpcs.private_computation.service.post_processing_stage_service import (
-    PostProcessingStageService,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
 )
-from fbpcs.private_computation.service.shard_stage_service import ShardStageService
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
     PrivateComputationStageFlowData,
@@ -136,60 +120,10 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
-        if self is self.CREATED:
-            return DummyStageService()
-        elif self is self.INPUT_DATA_VALIDATION:
-            return InputDataValidationStageService(
-                args.pc_validator_config,
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.PID_SHARD:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_SHARD,
-                UnionPIDStage.ADV_SHARD,
-            )
-        elif self is self.PID_PREPARE:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_PREPARE,
-                UnionPIDStage.ADV_PREPARE,
-            )
-        elif self is self.ID_MATCH:
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_RUN_PID,
-                UnionPIDStage.ADV_RUN_PID,
-            )
-        elif self is self.ID_MATCH_POST_PROCESS:
-            return PostProcessingStageService(
-                args.storage_svc, args.pid_post_processing_handlers
-            )
-        elif self is self.ID_SPINE_COMBINER:
-            return IdSpineCombinerStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-                pid_svc=args.pid_svc,
-            )
-        elif self is self.RESHARD:
-            return ShardStageService(
-                args.onedocker_svc,
-                args.onedocker_binary_config_map,
-            )
-        elif self is self.COMPUTE:
+        if self is self.COMPUTE:
             return ComputeMetricsStageService(
                 args.onedocker_binary_config_map,
                 args.mpc_svc,
             )
-        elif self is self.AGGREGATE:
-            return AggregateShardsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
-        elif self is self.POST_PROCESSING_HANDLERS:
-            return PostProcessingStageService(
-                args.storage_svc, args.post_processing_handlers
-            )
         else:
-            raise NotImplementedError(f"No stage service configured for {self}")
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/stage_selector.py
+++ b/fbpcs/private_computation/stage_flows/stage_selector.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, TYPE_CHECKING
+
+from fbpcs.pid.entity.pid_stages import UnionPIDStage
+from fbpcs.private_computation.service.aggregate_shards_stage_service import (
+    AggregateShardsStageService,
+)
+from fbpcs.private_computation.service.dummy_stage_service import DummyStageService
+from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
+    IdSpineCombinerStageService,
+)
+from fbpcs.private_computation.service.input_data_validation_stage_service import (
+    InputDataValidationStageService,
+)
+from fbpcs.private_computation.service.pid_stage_service import PIDStageService
+from fbpcs.private_computation.service.post_processing_stage_service import (
+    PostProcessingStageService,
+)
+
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+    PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.service.shard_stage_service import ShardStageService
+
+
+if TYPE_CHECKING:
+    from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+        PrivateComputationBaseStageFlow,
+    )
+
+
+class StageSelector:
+    @classmethod
+    def get_stage_service(
+        cls,
+        stage_flow: "PrivateComputationBaseStageFlow",
+        args: PrivateComputationStageServiceArgs,
+    ) -> Optional[PrivateComputationStageService]:
+        if stage_flow.name == "CREATED":
+            return DummyStageService()
+        elif stage_flow.name == "INPUT_DATA_VALIDATION":
+            return InputDataValidationStageService(
+                args.pc_validator_config,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+            )
+        elif stage_flow.name == "PID_SHARD":
+            return PIDStageService(
+                args.pid_svc,
+                UnionPIDStage.PUBLISHER_SHARD,
+                UnionPIDStage.ADV_SHARD,
+            )
+        elif stage_flow.name == "PID_PREPARE":
+            return PIDStageService(
+                args.pid_svc,
+                UnionPIDStage.PUBLISHER_PREPARE,
+                UnionPIDStage.ADV_PREPARE,
+            )
+        elif stage_flow.name == "ID_MATCH":
+            return PIDStageService(
+                args.pid_svc,
+                UnionPIDStage.PUBLISHER_RUN_PID,
+                UnionPIDStage.ADV_RUN_PID,
+            )
+        elif stage_flow.name == "ID_MATCH_POST_PROCESS":
+            return PostProcessingStageService(
+                args.storage_svc, args.pid_post_processing_handlers
+            )
+        elif stage_flow.name == "ID_SPINE_COMBINER":
+            return IdSpineCombinerStageService(
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+                pid_svc=args.pid_svc,
+            )
+        elif stage_flow.name == "RESHARD":
+            return ShardStageService(
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+            )
+        elif stage_flow.name == "AGGREGATE":
+            return AggregateShardsStageService(
+                args.onedocker_binary_config_map,
+                args.mpc_svc,
+            )
+        elif stage_flow.name == "POST_PROCESSING_HANDLERS":
+            return PostProcessingStageService(
+                args.storage_svc, args.post_processing_handlers
+            )
+        else:
+            return None


### PR DESCRIPTION
Summary:
Each stage flow is required to implement a get_stage_service method for mapping stage -> stage service.
Most stage flows only differ by 1-2 stages. To avoid maintaining tons of duplicate code across all the stage flows, I modified the get_stage_service method in base_stage_flow class as well as in its subclass. The method in base_stage class contains the shared code for all stage flows. The get_stage_service method in each subclass custom overrides and calls the super class method.

Reviewed By: joe1234wu

Differential Revision: D36620778

