### PR TITLE
Add check that concurrency is less than kMaxConcurrency

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/main.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/main.cpp
@@ -63,6 +63,8 @@ int main(int argc, char* argv[]) {
         FLAGS_use_postfix);
 
     int16_t concurrency = static_cast<int16_t>(FLAGS_concurrency);
+    CHECK_LE(concurrency, pcf2_aggregation::kMaxConcurrency)
+        << "Concurrency must be at most " << pcf2_aggregation::kMaxConcurrency;
 
     common::Visibility outputVisibility = FLAGS_use_xor_encryption
         ? common::Visibility::Xor

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -51,6 +51,8 @@ int main(int argc, char* argv[]) {
         FLAGS_file_start_index,
         FLAGS_use_postfix);
     int16_t concurrency = static_cast<int16_t>(FLAGS_concurrency);
+    CHECK_LE(concurrency, pcf2_attribution::kMaxConcurrency)
+        << "Concurrency must be at most " << pcf2_attribution::kMaxConcurrency;
 
     if (FLAGS_party == common::PUBLISHER) {
       XLOGF(INFO, "Attribution Rules: {}", FLAGS_attribution_rules);


### PR DESCRIPTION
Summary: Add CHECK_LT to check if concurrency is less than kMaxConcurrency in the main files of attribution and aggregation.

Differential Revision: D36723833

