### PR TITLE
Change OneDockerArgument from TypedDict to dataclass

### DIFF
--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, TypedDict
 
@@ -25,7 +26,8 @@ class GameNames(Enum):
     PCF2_AGGREGATION = "pcf2_aggregation"
 
 
-class OneDockerArgument(TypedDict):
+@dataclass
+class OneDockerArgument:
     name: str
     required: bool
 
@@ -39,106 +41,102 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
     GameNames.LIFT.value: {
         "onedocker_package_name": OneDockerBinaryNames.LIFT_COMPUTE.value,
         "arguments": [
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument({"name": "output_base_path", "required": True}),
-            OneDockerArgument({"name": "file_start_index", "required": False}),
-            OneDockerArgument({"name": "num_files", "required": True}),
-            OneDockerArgument({"name": "concurrency", "required": True}),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="file_start_index", required=False),
+            OneDockerArgument(name="num_files", required=True),
+            OneDockerArgument(name="concurrency", required=True),
         ],
     },
     GameNames.PCF2_LIFT.value: {
         "onedocker_package_name": OneDockerBinaryNames.PCF2_LIFT.value,
         "arguments": [
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument({"name": "output_base_path", "required": True}),
-            OneDockerArgument({"name": "file_start_index", "required": False}),
-            OneDockerArgument({"name": "num_files", "required": True}),
-            OneDockerArgument({"name": "concurrency", "required": True}),
-            OneDockerArgument({"name": "log_cost", "required": False}),
-            OneDockerArgument({"name": "run_name", "required": False}),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="file_start_index", required=False),
+            OneDockerArgument(name="num_files", required=True),
+            OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
         ],
     },
     GameNames.SHARD_AGGREGATOR.value: {
         "onedocker_package_name": OneDockerBinaryNames.SHARD_AGGREGATOR.value,
         "arguments": [
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument({"name": "num_shards", "required": True}),
-            OneDockerArgument({"name": "output_path", "required": True}),
-            OneDockerArgument({"name": "metrics_format_type", "required": True}),
-            OneDockerArgument({"name": "threshold", "required": True}),
-            OneDockerArgument({"name": "first_shard_index", "required": False}),
-            OneDockerArgument({"name": "log_cost", "required": False}),
-            OneDockerArgument({"name": "run_name", "required": False}),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="num_shards", required=True),
+            OneDockerArgument(name="output_path", required=True),
+            OneDockerArgument(name="metrics_format_type", required=True),
+            OneDockerArgument(name="threshold", required=True),
+            OneDockerArgument(name="first_shard_index", required=False),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
         ],
     },
     GameNames.DECOUPLED_ATTRIBUTION.value: {
         "onedocker_package_name": OneDockerBinaryNames.DECOUPLED_ATTRIBUTION.value,
         "arguments": [
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument({"name": "output_base_path", "required": True}),
-            OneDockerArgument({"name": "attribution_rules", "required": True}),
-            OneDockerArgument({"name": "aggregators", "required": False}),
-            OneDockerArgument({"name": "concurrency", "required": True}),
-            OneDockerArgument({"name": "num_files", "required": True}),
-            OneDockerArgument({"name": "file_start_index", "required": True}),
-            OneDockerArgument({"name": "use_xor_encryption", "required": True}),
-            OneDockerArgument({"name": "use_postfix", "required": True}),
-            OneDockerArgument({"name": "log_cost", "required": False}),
-            OneDockerArgument({"name": "run_name", "required": False}),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="attribution_rules", required=True),
+            OneDockerArgument(name="aggregators", required=False),
+            OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="num_files", required=True),
+            OneDockerArgument(name="file_start_index", required=True),
+            OneDockerArgument(name="use_xor_encryption", required=True),
+            OneDockerArgument(name="use_postfix", required=True),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
         ],
     },
     GameNames.DECOUPLED_AGGREGATION.value: {
         "onedocker_package_name": OneDockerBinaryNames.DECOUPLED_AGGREGATION.value,
         "arguments": [
-            OneDockerArgument({"name": "aggregators", "required": True}),
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument(
-                {"name": "input_base_path_secret_share", "required": True}
-            ),
-            OneDockerArgument({"name": "output_base_path", "required": True}),
-            OneDockerArgument({"name": "attribution_rules", "required": False}),
-            OneDockerArgument({"name": "concurrency", "required": True}),
-            OneDockerArgument({"name": "num_files", "required": True}),
-            OneDockerArgument({"name": "file_start_index", "required": True}),
-            OneDockerArgument({"name": "use_xor_encryption", "required": True}),
-            OneDockerArgument({"name": "use_postfix", "required": True}),
-            OneDockerArgument({"name": "log_cost", "required": False}),
-            OneDockerArgument({"name": "run_name", "required": False}),
+            OneDockerArgument(name="aggregators", required=True),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="input_base_path_secret_share", required=True),
+            OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="attribution_rules", required=False),
+            OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="num_files", required=True),
+            OneDockerArgument(name="file_start_index", required=True),
+            OneDockerArgument(name="use_xor_encryption", required=True),
+            OneDockerArgument(name="use_postfix", required=True),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
         ],
     },
     GameNames.PCF2_ATTRIBUTION.value: {
         "onedocker_package_name": OneDockerBinaryNames.PCF2_ATTRIBUTION.value,
         "arguments": [
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument({"name": "output_base_path", "required": True}),
-            OneDockerArgument({"name": "attribution_rules", "required": True}),
-            OneDockerArgument({"name": "aggregators", "required": False}),
-            OneDockerArgument({"name": "concurrency", "required": True}),
-            OneDockerArgument({"name": "num_files", "required": True}),
-            OneDockerArgument({"name": "file_start_index", "required": True}),
-            OneDockerArgument({"name": "use_xor_encryption", "required": True}),
-            OneDockerArgument({"name": "use_postfix", "required": True}),
-            OneDockerArgument({"name": "log_cost", "required": False}),
-            OneDockerArgument({"name": "run_name", "required": False}),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="attribution_rules", required=True),
+            OneDockerArgument(name="aggregators", required=False),
+            OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="num_files", required=True),
+            OneDockerArgument(name="file_start_index", required=True),
+            OneDockerArgument(name="use_xor_encryption", required=True),
+            OneDockerArgument(name="use_postfix", required=True),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
         ],
     },
     GameNames.PCF2_AGGREGATION.value: {
         "onedocker_package_name": OneDockerBinaryNames.PCF2_AGGREGATION.value,
         "arguments": [
-            OneDockerArgument({"name": "aggregators", "required": True}),
-            OneDockerArgument({"name": "input_base_path", "required": True}),
-            OneDockerArgument(
-                {"name": "input_base_path_secret_share", "required": True}
-            ),
-            OneDockerArgument({"name": "output_base_path", "required": True}),
-            OneDockerArgument({"name": "attribution_rules", "required": False}),
-            OneDockerArgument({"name": "concurrency", "required": True}),
-            OneDockerArgument({"name": "num_files", "required": True}),
-            OneDockerArgument({"name": "file_start_index", "required": True}),
-            OneDockerArgument({"name": "use_xor_encryption", "required": True}),
-            OneDockerArgument({"name": "use_postfix", "required": True}),
-            OneDockerArgument({"name": "log_cost", "required": False}),
-            OneDockerArgument({"name": "run_name", "required": False}),
+            OneDockerArgument(name="aggregators", required=True),
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="input_base_path_secret_share", required=True),
+            OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="attribution_rules", required=False),
+            OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="num_files", required=True),
+            OneDockerArgument(name="file_start_index", required=True),
+            OneDockerArgument(name="use_xor_encryption", required=True),
+            OneDockerArgument(name="use_postfix", required=True),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
         ],
     },
 }
@@ -156,7 +154,7 @@ class PrivateComputationGameRepository(MPCGameRepository):
 
         game_config = self.private_computation_game_config[name]
         arguments: List[MPCGameArgument] = [
-            MPCGameArgument(name=argument["name"], required=argument["required"])
+            MPCGameArgument(name=argument.name, required=argument.required)
             for argument in game_config["arguments"]
         ]
 

--- a/fbpcs/private_computation/test/repository/test_private_computation_game.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_game.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from fbpcp.entity.mpc_game_config import MPCGameArgument
 from fbpcs.private_computation.repository.private_computation_game import (
+    OneDockerArgument,
     PrivateComputationGameRepository,
 )
 
@@ -21,10 +22,10 @@ class TestPrivateComputationGameRepository(unittest.TestCase):
             "attribution_compute_dev": {
                 "onedocker_package_name": "private_attribution/compute-dev",
                 "arguments": [
-                    {"name": "aggregators", "required": True},
-                    {"name": "input_path", "required": True},
-                    {"name": "output_path", "required": True},
-                    {"name": "attribution_rules", "required": True},
+                    OneDockerArgument(name="aggregators", required=True),
+                    OneDockerArgument(name="input_path", required=True),
+                    OneDockerArgument(name="output_path", required=True),
+                    OneDockerArgument(name="attribution_rules", required=True),
                 ],
             },
         },
@@ -41,7 +42,7 @@ class TestPrivateComputationGameRepository(unittest.TestCase):
         attribution_game_config = self.game_repository.get_game(expected_game_name)
 
         expected_arguments: List[MPCGameArgument] = [
-            MPCGameArgument(name=argument["name"], required=argument["required"])
+            MPCGameArgument(name=argument.name, required=argument.required)
             for argument in game_config[expected_game_name]["arguments"]
         ]
         self.assertEqual(attribution_game_config.game_name, expected_game_name)


### PR DESCRIPTION
Summary: OneDockerArgument makes far more sense as a dataclass instead of a TypedDict

Differential Revision: D36731973

