### PR TITLE
Fix error message at end of ExPlat runner

### DIFF
--- a/fbpcs/stage_flow/stage_flow_json_encoder.py
+++ b/fbpcs/stage_flow/stage_flow_json_encoder.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import json
+from typing import Any
+
+from fbpcs.stage_flow.stage_flow import StageFlowMeta
+
+
+class StageFlowJSONEncoder(json.JSONEncoder):
+    # pyre-ignore[2] Overriding JSON encoder API
+    def default(self, o: Any) -> str:
+        if isinstance(o, StageFlowMeta):
+            return o.__name__
+        return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
Summary:
Currently the ExPlat runner tries to print out the arguments passed to it at the end of the run for debugging purposes. This throws an exception if you use the `--stage_flow` argument since the schema will convert the string into a `PrivateComputationBaseStageFlow`. We are using `json.dumps` to encode the object into a string, but it doesn't know how to serialize `PrivateComputationBaseStageFlow`

The fix is to add a custom JSON encoder that knows how to serialize the `PrivateComputationBaseStageFlow`

Differential Revision: D36780911

