### PR TITLE
Add the new 'pc_test_event_code' string column to the events schema

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -81,6 +81,7 @@ def lambda_handler(
         action_source = row_data.get("action_source")
         timestamp = row_data.get("event_time")
         event_type = row_data.get("event_name")
+        pc_test_event_code = row_data.get("pc_test_event_code")
         dummy_dict = {}
         currency_type = row_data.get("custom_data", dummy_dict).get("currency")
         conversion_value = row_data.get("custom_data", dummy_dict).get("value")
@@ -148,6 +149,8 @@ def lambda_handler(
         data["conversion_value"] = conversion_value
         data["event_type"] = event_type
         data["action_source"] = action_source
+        if pc_test_event_code:
+            data["pc_test_event_code"] = pc_test_event_code
         if email:
             user_data["email"] = email
         if device_id:

--- a/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/tests/data_transformation_lambda_test.py
@@ -23,6 +23,7 @@ class TestDataIngestion(TestCase):
                 "event_time": 1234,
                 "custom_data": {"currency": "usd", "value": 2},
                 "event_name": "Purchase",
+                "pc_test_event_code": "sample_test_event",
                 "user_data": {
                     "em": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11111111111111111111111111111111",
                     "madid": "bbbbbbbbbbbbbbbb2222222222222222",
@@ -52,6 +53,10 @@ class TestDataIngestion(TestCase):
             decoded_dict["data_source_id"], self.sample_record_data["pixelId"]
         )
         self.assertEqual(decoded_dict["timestamp"], server_side_event["event_time"])
+        self.assertEqual(
+            decoded_dict["pc_test_event_code"], server_side_event["pc_test_event_code"]
+        )
+
         self.assertEqual(
             decoded_dict["currency_type"], server_side_event["custom_data"]["currency"]
         )


### PR DESCRIPTION
Summary: For the canary system, we will need a field to track the test event workflow and filter out these test events when querying. This adds support for a new column for this purpose.

Differential Revision: D36787174

