### PR TITLE
Uploading all the containers in a compressed folder to S3

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/cloud/aws_cloud.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud/aws_cloud.py
@@ -27,6 +27,7 @@ class AwsCloud(CloudBaseClass):
         self,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
         aws_region: Optional[str] = None,
         logger_name: str = "logging_service",
     ) -> None:
@@ -35,6 +36,7 @@ class AwsCloud(CloudBaseClass):
         aws_secret_access_key = aws_secret_access_key or os.environ.get(
             "AWS_SECRET_ACCESS_KEY"
         )
+        aws_session_token = aws_session_token or os.environ.get("AWS_SESSION_TOKEN")
         aws_region = aws_region or os.environ.get("AWS_REGION")
         self.log: logging.Logger = logging.getLogger(logger_name)
 
@@ -43,17 +45,21 @@ class AwsCloud(CloudBaseClass):
                 "sts",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
             )
             self.cloudwatch_client: botocore.client.BaseClient = boto3.client(
                 "logs",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
                 region_name=aws_region,
             )
             self.s3_client: botocore.client.BaseClient = boto3.client(
                 "s3",
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+                region_name=aws_region,
             )
 
         except NoCredentialsError as error:

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -207,55 +207,15 @@ class TestDownloadLogs(unittest.TestCase):
             "ResponseMetadata": {"HTTPStatusCode": 200}
         }
 
-        arn = (
+        arn = [
             "arn:aws:ecs:fake-region:123456789:task/fake-container-name/1234abcdef56789"
-        )
+        ]
         expected_key = (
             f"{self.aws_container_logs.S3_LOGGING_FOLDER}/{self.tag}/1234abcdef56789"
         )
         expected_body = "123\n456\n789".encode("utf-8")
 
-        # folders already exist, no need to create
-        with self.subTest("folder_exists"):
-            self.aws_container_logs.s3_client.list_objects_v2.return_value = {
-                "Contents": [
-                    {"Key": "f/"},
-                    {"Key": "a"},
-                    {"Key": "f2/"},
-                    {"Key": "b"},
-                    {"Key": "c"},
-                ],
-            }
-            self.aws_container_logs.upload_logs_to_s3_from_cloudwatch("bucket", arn)
-            self.aws_container_logs.s3_client.put_object.assert_called_once_with(
-                Body=expected_body, Bucket="bucket", Key=expected_key
-            )
-
-        # folders don't exist, create first
-        # TODO: Put this repeated code in a setUp block
-        with self.subTest("folder_not_exists"):
-            self.aws_container_logs.cloudwatch_client.get_log_events.reset_mock()
-            self.aws_container_logs.cloudwatch_client.get_log_events.side_effect = [
-                {"events": [{"message": "123"}], "nextForwardToken": "1"},
-                {"events": [{"message": "456"}], "nextForwardToken": "2"},
-                {"events": [{"message": "789"}], "nextForwardToken": "3"},
-                # Repeated event indicates no more data available
-                {"events": [{"message": "789"}], "nextForwardToken": "3"},
-            ]
-            self.aws_container_logs.s3_client.list_objects_v2.reset_mock()
-            self.aws_container_logs.s3_client.list_objects_v2.return_value = {}
-            self.aws_container_logs.upload_logs_to_s3_from_cloudwatch("bucket", arn)
-            self.aws_container_logs.s3_client.put_object.assert_any_call(
-                Bucket="bucket",
-                Key=f"{self.aws_container_logs.S3_LOGGING_FOLDER}/",
-            )
-            self.aws_container_logs.s3_client.put_object.assert_any_call(
-                Bucket="bucket",
-                Key=f"{self.aws_container_logs.S3_LOGGING_FOLDER}/{self.tag}/",
-            )
-            self.aws_container_logs.s3_client.put_object.assert_any_call(
-                Body=expected_body, Bucket="bucket", Key=expected_key
-            )
+        # TODO: add changes to test temp dir changes
 
         ###############
         # Error cases #

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -5,11 +5,54 @@
 
 # pyre-strict
 
+import io
 import os
 import shutil
+from typing import List
 
 
 class Utils:
+    def create_file(self, file_location: str, content: List[str]) -> None:
+        """
+        Create file in the file location with content.
+        Args:
+            file_location (str): Full path of the file location Eg: /tmp/xyz.txt
+            content (list): Content to be written in file
+        Returns:
+            None
+        """
+        content = content or []
+
+        try:
+            # write to a file, if it already exists
+            with open(file_location, "w") as file_object:
+                self.write_to_file(file_object, content)
+        except FileNotFoundError as error:
+            # T122918736 - for better execption messages
+            raise Exception(
+                f"Please check if this is the right file path. Error: {error}"
+            )
+
+    @classmethod
+    def write_to_file(
+        cls,
+        file_object: io.TextIOWrapper,
+        contents: List[str],
+        append_newline: bool = True,
+    ) -> None:
+        """
+        Write content to the file.
+        Args:
+            file_object (IO): Object of file to read/write
+            contents (list): Content to be written in file
+        Returns:
+            None
+        """
+        for content in contents:
+            if append_newline:
+                content = content + "\n"
+            file_object.write(content)
+
     @staticmethod
     def create_folder(folder_location: str) -> None:
         """
@@ -32,8 +75,9 @@ class Utils:
             folder_location (str): Complete folder path Eg /tmp/folder1
         """
         if os.path.isdir(folder_location):
-            shutil.make_archive(f"{folder_location}_zipped", "zip", folder_location)
+            shutil.make_archive(folder_location, "zip", folder_location)
         else:
+            # T122918736 - for better exception messages
             raise Exception(
                 f"Couldn't find folder {folder_location}."
                 f"Please check if folder exists.\nAborting folder compression."

--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -9,3 +9,4 @@ termcolor==1.1.0
 thriftpy2==0.4.14
 pytz>=2022.1
 thrift>=0.16.0 # logging_service client requires this
+tqdm==4.64.0


### PR DESCRIPTION
Summary:
Changing download code flow
From:
-> cloudwatch -> local (in memory) -> S3 -> Download -> compress

To:

-> Cloudwatch -> local -> compress -> S3

User can directly download zipped folder with all the logs.

This diff will be followed by adding threading in fetching multiple container logs.

Differential Revision: D36796082

