### PR TITLE
Create Custom Workflow Service for Experimentation

### DIFF
--- a/fbpcs/service/workflow_sfn_fb.py
+++ b/fbpcs/service/workflow_sfn_fb.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional
+
+import botocore
+
+from fbpcp.intern.gateway.aws_fb import FBAWSGateway
+from fbpcs.service.workflow_sfn import SfnWorkflowService
+
+
+class FBSfnWorkflowService(SfnWorkflowService, FBAWSGateway):
+    def __init__(
+        self,
+        region: str,
+        account: str,
+        role: Optional[str] = None,
+    ) -> None:
+        self.client: botocore.client.BaseClient = self.session_gen.get_client(
+            "stepfunctions"
+        )


### PR DESCRIPTION
Summary:
Context: In order to support workflow service for experimentation we need to create FB supported workflow service that automatically connects to "mpc-aem" aws account and interacts with step functions.

This diff:
- Creates Fb workflowservice with step functions that use FbAwsGateway

Next:
- Add workflow service configs to use this class

Reviewed By: wenqingren

Differential Revision: D36798511

