### PR TITLE
Supply pid configs to MR stage service

### DIFF
--- a/fbpcs/private_computation/service/pid_mr_stage_service.py
+++ b/fbpcs/private_computation/service/pid_mr_stage_service.py
@@ -6,12 +6,10 @@
 
 # pyre-strict
 
+import logging
 from typing import List, Optional
 
-from fbpcs.common.entity.stage_state_instance import (
-    StageStateInstance,
-    StageStateInstanceStatus,
-)
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -31,6 +29,7 @@ class PIDMRStageService(PrivateComputationStageService):
 
     def __init__(self, workflow_svc: WorkflowService) -> None:
         self.workflow_svc = workflow_svc
+        self._logger: logging.Logger = logging.getLogger(__name__)
 
     async def run_async(
         self,
@@ -46,6 +45,7 @@ class PIDMRStageService(PrivateComputationStageService):
         Returns:
             An updated version of pc_instance
         """
+        self._logger.info(f"[{self}] Starting PID MR Stage Service")
         stage_state = StageStateInstance(
             pc_instance.instance_id,
             pc_instance.current_stage.name,

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
@@ -7,13 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.compute_metrics_stage_service import (
-    ComputeMetricsStageService,
-)
 from fbpcs.private_computation.service.pid_mr_stage_service import PIDMRStageService
-from fbpcs.private_computation.service.post_processing_stage_service import (
-    PostProcessingStageService,
-)
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
@@ -37,7 +31,7 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = "CREATED INPUT_DATA_VALIDATION UNION_PID_MR_MULTIKEY ID_MATCH_POST_PROCESS ID_SPINE_COMBINER RESHARD COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
+    _order_ = "CREATED INPUT_DATA_VALIDATION UNION_PID_MR_MULTIKEY"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -57,42 +51,6 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.PID_MR_STARTED,
         PrivateComputationInstanceStatus.PID_MR_COMPLETED,
         PrivateComputationInstanceStatus.PID_MR_FAILED,
-        False,
-    )
-    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
-        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
-        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
-        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
-        False,
-    )
-    ID_SPINE_COMBINER = PrivateComputationStageFlowData(
-        PrivateComputationInstanceStatus.ID_SPINE_COMBINER_STARTED,
-        PrivateComputationInstanceStatus.ID_SPINE_COMBINER_COMPLETED,
-        PrivateComputationInstanceStatus.ID_SPINE_COMBINER_FAILED,
-        False,
-    )
-    RESHARD = PrivateComputationStageFlowData(
-        PrivateComputationInstanceStatus.RESHARD_STARTED,
-        PrivateComputationInstanceStatus.RESHARD_COMPLETED,
-        PrivateComputationInstanceStatus.RESHARD_FAILED,
-        False,
-    )
-    COMPUTE = PrivateComputationStageFlowData(
-        PrivateComputationInstanceStatus.COMPUTATION_STARTED,
-        PrivateComputationInstanceStatus.COMPUTATION_COMPLETED,
-        PrivateComputationInstanceStatus.COMPUTATION_FAILED,
-        True,
-    )
-    AGGREGATE = PrivateComputationStageFlowData(
-        PrivateComputationInstanceStatus.AGGREGATION_STARTED,
-        PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
-        PrivateComputationInstanceStatus.AGGREGATION_FAILED,
-        True,
-    )
-    POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
-        PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,
-        PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED,
-        PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
         False,
     )
 
@@ -116,14 +74,17 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
                 raise NotImplementedError("workflow_svc is None")
 
             return PIDMRStageService(args.workflow_svc)
-        elif self is self.ID_MATCH_POST_PROCESS:
-            return PostProcessingStageService(
-                args.storage_svc, args.pid_post_processing_handlers
-            )
-        elif self is self.COMPUTE:
-            return ComputeMetricsStageService(
-                args.onedocker_binary_config_map,
-                args.mpc_svc,
-            )
+
+        # TODO (pnethagani): enable the other stages after test
+        # elif self is self.COMPUTE:
+        #     return ComputeMetricsStageService(
+        #         args.onedocker_binary_config_map,
+        #         args.mpc_svc,
+        #     )
+
+        # elif self is self.ID_MATCH_POST_PROCESS:
+        #     return PostProcessingStageService(
+        #         args.storage_svc, args.pid_post_processing_handlers
+        #     )
         else:
             return self.get_default_stage_service(args)

--- a/fbpcs/service/workflow_sfn_fb.py
+++ b/fbpcs/service/workflow_sfn_fb.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional
+
+import botocore
+
+from fbpcp.intern.gateway.aws_fb import FBAWSGateway
+from fbpcs.service.workflow_sfn import SfnWorkflowService
+
+
+class FBSfnWorkflowService(SfnWorkflowService, FBAWSGateway):
+    def __init__(
+        self,
+        region: str,
+        account: str,
+        role: Optional[str] = None,
+    ) -> None:
+        self.client: botocore.client.BaseClient = self.session_gen.get_client(
+            "stepfunctions"
+        )


### PR DESCRIPTION
Summary:
As part of diff series to enable experimentation with multi node multi key protocol, We need to pass the pid configs to private computation service through the handler.

Note that the publisher side configs are not passed in prod as they are picked from PCE config instead. The config is only passed for experimentation when we spin local thrift server while running mpc-aem-experimentation.

Reviewed By: wenqingren

Differential Revision: D36798870

