### PR TITLE
add unittest for pc_infra_config.py

### DIFF
--- a/fbpcs/private_computation/entity/pc_infra_config.py
+++ b/fbpcs/private_computation/entity/pc_infra_config.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Set
+
+from fbpcs.private_computation.entity.pc_infra_config_data import (
+    PrivateComputationInfraConfigInfo,
+)
+
+
+@dataclass
+class PrivateComputationInfraConfig:
+    cloud: str
+    base_dir: Optional[str]
+    region: Optional[str]
+    cluster: Optional[str]
+    subnets: Optional[str]
+    tmp_directory: str
+    binary_version: Optional[str]
+    task_definition: Optional[str]
+
+    def __init__(self, infra_config: Dict[str, Any]) -> None:
+        self.cloud = infra_config.get("cloud", "AWS")
+        self.base_dir = infra_config.get("base_dir", None)
+        self.region = infra_config.get("region", None)
+        self.cluster = infra_config.get("cluster", None)
+        self.subnets = infra_config.get("subnets", None)
+        self.tmp_directory = infra_config.get("tmp_directory", "/tmp")
+        self.binary_version = infra_config.get("binary_version", "latest")
+        self.task_definition = infra_config.get("task_definition", None)
+
+    @classmethod
+    def build_full_config(cls, yml_config: Dict[str, Any]) -> Dict[str, Any]:
+        input_config = yml_config["private_computation"]
+
+        if "infra_config" in input_config:
+            # if this is new version -> convert into old version
+            yml_config = input_config
+
+            infra_config = cls(yml_config.pop("infra_config"))
+
+            pc = infra_config._generate_pc()
+
+            pid = infra_config._generate_pid()
+            mpc = infra_config._generate_mpc()
+
+            yml_config["private_computation"] = pc
+            yml_config["pid"] = pid
+            yml_config["mpc"] = mpc
+
+            # TODO: add code for overrides config.yml
+            # Partner can only override dependencies
+
+        return yml_config
+
+    #############################
+    # Helper functions
+    #############################
+
+    @classmethod
+    def _get_defaults(cls) -> Dict[str, PrivateComputationInfraConfigInfo]:
+        """
+        Return info for the classes with name and constructor arguments in PC-dependency parts in config.yml.
+
+        """
+        dict_defaults = {
+            "PrivateComputationInstanceRepository": PrivateComputationInfraConfigInfo.PC_INSTANCE_REPO,
+            "ContainerService": PrivateComputationInfraConfigInfo.CONTAINER_SERVICE,
+            "StorageService": PrivateComputationInfraConfigInfo.STORAGE_SERVICE,
+            "PCValidatorConfig": PrivateComputationInfraConfigInfo.PC_VALIDATOR_CONFIG,
+        }
+        return dict_defaults
+
+    def _generate_pc(self) -> Dict[str, Any]:
+        pc = {}
+        pc["dependency"] = {}
+
+        # add ValidationConfig
+        pc["dependency"]["ValidationConfig"] = {
+            "is_validating": False,
+            "synthetic_shard_path": None,
+        }
+        # add OneDockerBinaryConfig
+        pc["dependency"]["OneDockerBinaryConfig"] = {
+            "default": {
+                "constructor": {
+                    "tmp_directory": self.tmp_directory,
+                    "binary_version": self.binary_version,
+                }
+            }
+        }
+        # add OneDockerServiceConfig
+        pc["dependency"]["OneDockerServiceConfig"] = {
+            "constructor": {"task_definition": self.task_definition}
+        }
+
+        # add other dependencies
+        dependencies = self._get_defaults()
+        for dp_key, dp_value in dependencies.items():
+            self._generate_dependency(pc, dp_key, dp_value)
+
+        return pc
+
+    def _generate_pid(self) -> Dict[str, Any]:
+        pid = {}
+        pid["dependency"] = {}
+
+        self._generate_dependency(
+            pid,
+            "PIDInstanceRepository",
+            PrivateComputationInfraConfigInfo.PID_INSTANCE_REPO,
+        )
+
+        return pid
+
+    def _generate_mpc(self) -> Dict[str, Any]:
+        mpc = {}
+        mpc["dependency"] = {}
+
+        class_name_service = (
+            PrivateComputationInfraConfigInfo.MPC_GAME_SERVICE.value.cls_name
+        )
+        class_name_game_repo = (
+            PrivateComputationInfraConfigInfo.PC_GAME_REPO.value.cls_name
+        )
+
+        mpc["dependency"]["MPCGameService"] = {
+            "class": class_name_service,
+            "dependency": {
+                "PrivateComputationGameRepository": {
+                    "class": class_name_game_repo,
+                }
+            },
+        }
+
+        self._generate_dependency(
+            mpc,
+            "MPCInstanceRepository",
+            PrivateComputationInfraConfigInfo.MPC_INSTANCE_REPO,
+        )
+
+        return mpc
+
+    def _generate_dependency(
+        self,
+        dp_dict: Dict[str, Any],
+        dp_name: str,
+        dp_value: PrivateComputationInfraConfigInfo,
+    ) -> None:
+        constructor = self._generate_constructor(dp_value.value.args)
+        dp_dict["dependency"][dp_name] = {
+            "class": dp_value.value.cls_name,
+            "constructor": constructor,
+        }
+
+    def _generate_constructor(self, args: Set[str]) -> Dict[str, Any]:
+        constructor = {}
+        for arg in args:
+            constructor[arg] = getattr(self, arg)
+        return constructor

--- a/fbpcs/private_computation/entity/pc_infra_config_data.py
+++ b/fbpcs/private_computation/entity/pc_infra_config_data.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Set
+
+
+@dataclass(frozen=True)
+class PrivateComputationInfraConfigData:
+    cls_name: str
+    args: Set[str]
+
+
+class PrivateComputationInfraConfigInfo(Enum):
+
+    CONTAINER_SERVICE = PrivateComputationInfraConfigData(
+        "fbpcp.service.container_aws.AWSContainerService",
+        {"region", "cluster", "subnets"},
+    )
+
+    PC_INSTANCE_REPO = PrivateComputationInfraConfigData(
+        "fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository",
+        {"base_dir"},
+    )
+
+    STORAGE_SERVICE = PrivateComputationInfraConfigData(
+        "fbpcp.service.storage_s3.S3StorageService",
+        {"region"},
+    )
+
+    PC_VALIDATOR_CONFIG = PrivateComputationInfraConfigData(
+        "fbpcs.private_computation.entity.pc_validator_config.PCValidatorConfig",
+        {"region"},
+    )
+
+    PID_INSTANCE_REPO = PrivateComputationInfraConfigData(
+        "fbpcs.pid.repository.pid_instance_local.LocalPIDInstanceRepository",
+        {"base_dir"},
+    )
+
+    MPC_GAME_SERVICE = PrivateComputationInfraConfigData(
+        "fbpcp.service.mpc_game.MPCGameService",
+        set(),
+    )
+
+    PC_GAME_REPO = PrivateComputationInfraConfigData(
+        "fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository",
+        set(),
+    )
+
+    MPC_INSTANCE_REPO = PrivateComputationInfraConfigData(
+        "fbpcs.common.repository.mpc_instance_local.LocalMPCInstanceRepository",
+        {"base_dir"},
+    )

--- a/fbpcs/private_computation/test/entity/expect_mini_config.yml
+++ b/fbpcs/private_computation/test/entity/expect_mini_config.yml
@@ -1,0 +1,55 @@
+private_computation:
+  dependency:
+    PrivateComputationInstanceRepository:
+      class: fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository
+      constructor:
+        base_dir: TODO
+    ContainerService:
+      class: fbpcp.service.container_aws.AWSContainerService
+      constructor:
+        # AWS region - ex. us-west-2
+        region: TODO
+        # ECS cluster name - ex. pl-cluster-private-attribution-partner
+        cluster: TODO
+        # AWS subnet IDs - ex. [subnet-123456789abcdefgh, subnet-987654321abcdefgh]
+        subnets: TODO
+    StorageService:
+      class: fbpcp.service.storage_s3.S3StorageService
+      constructor:
+        # AWS region - ex. us-west-2
+        region: TODO
+    ValidationConfig:
+      is_validating: false
+      synthetic_shard_path:
+    OneDockerBinaryConfig:
+      default:
+        constructor:
+          tmp_directory: TODO
+          binary_version: TODO
+    OneDockerServiceConfig:
+      constructor:
+        task_definition: TODO
+    PCValidatorConfig:
+      class: fbpcs.private_computation.entity.pc_validator_config.PCValidatorConfig
+      constructor:
+        ### AWS region - ex. us-west-2
+        region: TODO
+pid:
+  dependency:
+    PIDInstanceRepository:
+      class: fbpcs.pid.repository.pid_instance_local.LocalPIDInstanceRepository
+      constructor:
+        base_dir: TODO
+mpc:
+  dependency:
+    MPCGameService:
+      class: fbpcp.service.mpc_game.MPCGameService
+      dependency:
+        PrivateComputationGameRepository:
+          class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository
+    MPCInstanceRepository:
+      class: fbpcs.common.repository.mpc_instance_local.LocalMPCInstanceRepository
+      constructor:
+        base_dir: TODO
+graphapi:
+  access_token: TODO

--- a/fbpcs/private_computation/test/entity/mini_config.yml
+++ b/fbpcs/private_computation/test/entity/mini_config.yml
@@ -1,0 +1,11 @@
+private_computation:
+  graphapi:
+    access_token: TODO
+  infra_config:
+    base_dir: TODO
+    region: TODO
+    cluster: TODO
+    subnets: TODO
+    tmp_directory: TODO
+    binary_version: TODO
+    task_definition: TODO

--- a/fbpcs/private_computation/test/entity/test_pc_infra_config.py
+++ b/fbpcs/private_computation/test/entity/test_pc_infra_config.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from pathlib import Path
+
+from fbpcp.util import yaml
+from fbpcs.private_computation.entity.pc_infra_config import (
+    PrivateComputationInfraConfig,
+)
+
+
+class TestPrivateComputationInfraConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        # call Path.revolve() to make the path absolute
+        self.input_dir = Path(__file__).resolve().parent
+
+    def test_build_full_config(self) -> None:
+        config_path = self.input_dir / "expect_mini_config.yml"
+        yml_config = yaml.load(config_path)
+
+        actual_config = PrivateComputationInfraConfig.build_full_config(yml_config)
+
+        self.assertEqual(yml_config, actual_config)
+
+    def test_build_full_config_mini(self) -> None:
+        expect_mini_config_path = self.input_dir / "expect_mini_config.yml"
+        expect_mini_config = yaml.load(expect_mini_config_path)
+
+        mini_config_path = self.input_dir / "mini_config.yml"
+        yml_config = yaml.load(mini_config_path)
+        actual_config = PrivateComputationInfraConfig.build_full_config(yml_config)
+
+        self.assertEqual(actual_config, expect_mini_config)


### PR DESCRIPTION
Summary:
This is the unittest for pc_infra_config.py
The ouput of reading mini_config.yml (mini new version) should be the same as reading expect_mini_config.yml (old long version).

Differential Revision: D36841454

