### PR TITLE
Reorganize file to have public API before private helpers

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/cloud/aws_cloud.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud/aws_cloud.py
@@ -7,11 +7,15 @@
 
 import logging
 import os
+from typing import Optional
 
 import boto3
+import botocore
 from botocore.exceptions import NoCredentialsError, NoRegionError
 
-from .cloud_baseclass import CloudBaseClass
+from fbpcs.infra.logging_service.download_logs.cloud.cloud_baseclass import (
+    CloudBaseClass,
+)
 
 # TODO: Convert this to factory
 class AwsCloud(CloudBaseClass):
@@ -21,39 +25,35 @@ class AwsCloud(CloudBaseClass):
 
     def __init__(
         self,
-        aws_access_key_id: str = None,
-        aws_secret_access_key: str = None,
-        aws_region: str = None,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_region: Optional[str] = None,
         logger_name: str = "logging_service",
-    ):
+    ) -> None:
 
-        self.aws_access_key_id = aws_access_key_id or os.environ.get(
-            "AWS_ACCESS_KEY_ID"
-        )
-        self.aws_secret_access_key = aws_secret_access_key or os.environ.get(
+        aws_access_key_id = aws_access_key_id or os.environ.get("AWS_ACCESS_KEY_ID")
+        aws_secret_access_key = aws_secret_access_key or os.environ.get(
             "AWS_SECRET_ACCESS_KEY"
         )
-        self.aws_region = aws_region or os.environ.get("AWS_REGION")
-        self.cloudwatch_client = None
-        self.s3_client = None
+        aws_region = aws_region or os.environ.get("AWS_REGION")
         self.log: logging.Logger = logging.getLogger(logger_name)
 
         try:
             sts = boto3.client(
                 "sts",
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
             )
-            self.cloudwatch_client = boto3.client(
+            self.cloudwatch_client: botocore.client.BaseClient = boto3.client(
                 "logs",
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
-                region_name=self.aws_region,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region_name=aws_region,
             )
-            self.s3_client = boto3.client(
+            self.s3_client: botocore.client.BaseClient = boto3.client(
                 "s3",
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
             )
 
         except NoCredentialsError as error:

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -182,6 +182,7 @@ class AwsContainerLogs(AwsCloud):
             container_name = task_id_list[1].replace("-cluster", "-container")
             container_id = task_id_list[2]
         except IndexError as error:
+            # TODO: Raise more specific exception
             raise Exception(
                 f"Error in getting container name and container ID: {error}"
             )

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -106,6 +106,7 @@ class AwsContainerLogs(AwsCloud):
                     f"Unexpected error occured in fetching the log event log group {log_group_name} and log stream {log_stream_name}\n"
                     f"{error}\n"
                 )
+            # TODO: Raise more specific exception
             raise Exception(f"{error_message}")
 
         return messages

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -263,6 +263,7 @@ class AwsContainerLogs(AwsCloud):
                     f"Unexpected error occurred in finding log stream name {log_stream_name} in log grpup {log_group_name}\n"
                     f"{error}\n"
                 )
+            # TODO: Raise more specific exception
             raise Exception(f"{error_message}")
 
         return len(response.get("logStreams", [])) == 1
@@ -287,6 +288,7 @@ class AwsContainerLogs(AwsCloud):
             error_message = (
                 f"Failed to create folder {folder_name} in S3 bucket {bucket_name}\n"
             )
+            # TODO: Raise more specific exception
             raise Exception(f"{error_message}")
 
     def ensure_folder_exists(self, bucket_name: str, folder_name: str) -> bool:
@@ -339,6 +341,7 @@ class AwsContainerLogs(AwsCloud):
             error_message = f"Couldn't find folder. Please check if S3 bucket name {bucket_name} and folder name {folder_name} are correct"
             if error.response.get("Error", {}).get("Code") == "NoSuchBucket":
                 error_message = f"Couldn't find folder {folder_name} in S3 bucket {bucket_name}\n{error}"
+            # TODO: Raise more specific exception
             raise Exception({error_message})
 
         return response
@@ -507,6 +510,7 @@ class AwsContainerLogs(AwsCloud):
         if not self._verify_log_stream(
             log_group_name=log_group_name, log_stream_name=log_stream_name
         ):
+            # TODO: Raise more specific exception
             raise Exception(
                 f"Couldn't find log stream {log_stream_name} in log group {log_group_name}"
             )

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -6,11 +6,12 @@
 # pyre-strict
 
 
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from botocore.exceptions import ClientError
-from cloud.aws_cloud import AwsCloud
-from utils.utils import Utils
+
+from fbpcs.infra.logging_service.download_logs.cloud.aws_cloud import AwsCloud
+from fbpcs.infra.logging_service.download_logs.utils.utils import Utils
 
 
 class AwsContainerLogs(AwsCloud):
@@ -27,10 +28,10 @@ class AwsContainerLogs(AwsCloud):
     def __init__(
         self,
         tag_name: str,
-        aws_access_key_id: str = None,
-        aws_secret_access_key: str = None,
-        aws_region: str = None,
-    ):
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_region: Optional[str] = None,
+    ) -> None:
         super().__init__(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
@@ -40,8 +41,11 @@ class AwsContainerLogs(AwsCloud):
         self.utils = Utils()
 
     def get_cloudwatch_logs(
-        self, log_group_name: str, log_stream_name: str, container_arn: str = None
-    ) -> List[Dict]:
+        self,
+        log_group_name: str,
+        log_stream_name: str,
+        container_arn: Optional[str] = None,
+    ) -> List[str]:
         """
         Fetches cloudwatch logs from the AWS account for a given log group and log stream
         Args:
@@ -137,7 +141,7 @@ class AwsContainerLogs(AwsCloud):
 
         return [service_name, container_name, container_id]
 
-    def _parse_log_events(self, log_events: List[Dict]) -> List[str]:
+    def _parse_log_events(self, log_events: List[Dict[str, Any]]) -> List[str]:
         """
         AWS returns events metadata with other fields like logStreamName, timestamp etc.
         Following is the sample events returned:
@@ -153,7 +157,7 @@ class AwsContainerLogs(AwsCloud):
         Returns: list
         """
 
-        return [event.get("message") for event in log_events]
+        return [event["message"] for event in log_events]
 
     def _get_container_name_id(self, task_id: str) -> List[str]:
         """
@@ -295,8 +299,11 @@ class AwsContainerLogs(AwsCloud):
         return "Contents" in response
 
     def get_s3_folder_contents(
-        self, bucket_name: str, folder_name: str, next_continuation_token: str = None
-    ) -> Dict:
+        self,
+        bucket_name: str,
+        folder_name: str,
+        next_continuation_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Fetches folders in a given S3 bucket and folders information
 
@@ -373,7 +380,10 @@ class AwsContainerLogs(AwsCloud):
         return files_to_download
 
     def download_logs(
-        self, s3_bucket_name: str, tag_name: str, local_download_dir=None
+        self,
+        s3_bucket_name: str,
+        tag_name: str,
+        local_download_dir: Optional[str] = None,
     ) -> None:
         """
         Download logs from S3 to local

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -414,6 +414,7 @@ class AwsContainerLogs(AwsCloud):
             folder_name=f"{self.S3_LOGGING_FOLDER}/{tag_name}",
         )
         if not s3_folders_contents:
+            # TODO: Raise more specific exception
             raise Exception(
                 f"Folder name {self.S3_LOGGING_FOLDER}/{tag_name} not found in bucket {s3_bucket_name}."
                 f"Please check if tag name {tag_name} and S3 bucket name {s3_bucket_name} are passed set correctly."
@@ -425,6 +426,7 @@ class AwsContainerLogs(AwsCloud):
         )
 
         # check for download folder in local
+        # TODO: Use pathlib instead of creating paths ourselves
         local_path = f"{local_download_dir}/{tag_name}"
 
         self.utils.create_folder(folder_location=local_path)

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -187,6 +187,7 @@ class AwsContainerLogs(AwsCloud):
                 f"Error in getting container name and container ID: {error}"
             )
 
+        # TODO: Return dataclass object instead of list
         return [container_name, container_id]
 
     def _verify_log_group(self, log_group_name: str) -> bool:
@@ -222,6 +223,7 @@ class AwsContainerLogs(AwsCloud):
                     f"Unexpected error occurred in fetching log group name {log_group_name}.\n"
                     f"{error}\n"
                 )
+            # TODO: Raise more specific exception
             raise Exception(f"{error_message}")
 
         return len(response.get("logGroups", [])) == 1

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -471,7 +471,9 @@ class AwsContainerLogs(AwsCloud):
             if error.response.get("Error", {}).get("Code") == "NoSuchBucket":
                 error_message = f"Couldn't find bucket in the AWS account.\n{error}\n"
             else:
+                # TODO: This error message doesn't seem right
                 error_message = "Couldn't find the S3 bucket in AWS account. Please use the right AWS S3 bucket name\n"
+            # TODO: Raise more specific exception
             raise Exception(f"{error_message}")
 
         # create logging folder

--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -111,7 +111,7 @@ class AwsContainerLogs(AwsCloud):
 
         return messages
 
-    def _parse_container_arn(self, container_arn: str) -> List[str]:
+    def _parse_container_arn(self, container_arn: Optional[str]) -> List[str]:
         """
         Parses container arn to get the container name and id needed to derive log name and log stream
         Example ARN looks like:
@@ -123,6 +123,7 @@ class AwsContainerLogs(AwsCloud):
         service_name, container_name, container_id = None, None, None
 
         if container_arn is None:
+            # TODO: Raise more specific exception
             raise Exception(
                 "Container arn is missing. Please check the arn of the container"
             )
@@ -138,8 +139,10 @@ class AwsContainerLogs(AwsCloud):
             task_id = container_arn_list[5]
             container_name, container_id = self._get_container_name_id(task_id=task_id)
         except IndexError as error:
+            # TODO: Raise more specific exception
             raise Exception(f"Error in getting service name and task ID: {error}")
 
+        # TODO: Return dataclass object instead of list
         return [service_name, container_name, container_id]
 
     def _parse_log_events(self, log_events: List[Dict[str, Any]]) -> List[str]:

--- a/fbpcs/infra/logging_service/download_logs/logging_cli.py
+++ b/fbpcs/infra/logging_service/download_logs/logging_cli.py
@@ -5,7 +5,7 @@
 
 import argparse
 
-from download_logs import AwsContainerLogs
+from fbpcs.infra.logging_service.download_logs.download_logs import AwsContainerLogs
 
 
 def main():
@@ -37,7 +37,9 @@ def main():
         )
 
 
-def aws_parser_arguments(aws_parser: argparse) -> argparse:
+def aws_parser_arguments(
+    aws_parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
     """
     Common arguments needed for AWS verification
     """
@@ -53,7 +55,7 @@ def aws_parser_arguments(aws_parser: argparse) -> argparse:
     return aws_parser
 
 
-def download_logs_parser_arguments(aws_parser: argparse):
+def download_logs_parser_arguments(aws_parser: argparse.ArgumentParser) -> None:
     """
     Arguments for downloading logs
     """

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -82,7 +82,13 @@ class TestDownloadLogs(unittest.TestCase):
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_parse_log_events(self, mock_boto3) -> None:
-        pass
+        aws_container_logs = AwsContainerLogs("my_tag")
+        events = [
+            {"message": "hello", "code": 200, "other": "ignore"},
+            {"message": "world", "code": 200, "other": "ignore"},
+        ]
+        expected = ["hello", "world"]
+        self.assertEqual(expected, aws_container_logs._parse_log_events(events))
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_container_name_id(self, mock_boto3) -> None:

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -13,6 +13,9 @@ from fbpcs.infra.logging_service.download_logs.download_logs import AwsContainer
 
 
 class TestDownloadLogs(unittest.TestCase):
+    ##############################
+    # Tests for public interface #
+    ##############################
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_cloudwatch_logs(self, mock_boto3) -> None:
         aws_container_logs = AwsContainerLogs("my_tag")
@@ -63,131 +66,6 @@ class TestDownloadLogs(unittest.TestCase):
         with self.assertRaisesRegex(Exception, "Unexpected error.*"):
             aws_container_logs.get_cloudwatch_logs("foo", "bar")
             aws_container_logs.cloudwatch_client.get_log_events.assert_called()
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_parse_container_arn(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        with self.assertRaisesRegex(Exception, "Container arn is missing.*"):
-            aws_container_logs._parse_container_arn(None)
-
-        bad_arn = "abc:123"
-        with self.assertRaisesRegex(Exception, "Error in getting service name.*"):
-            aws_container_logs._parse_container_arn(bad_arn)
-
-        normal_arn = (
-            "arn:aws:ecs:fake-region:123456789:task/fake-container-name/1234abcdef56789"
-        )
-        expected = ["ecs", "fake-container-name", "1234abcdef56789"]
-        self.assertEqual(expected, aws_container_logs._parse_container_arn(normal_arn))
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_parse_log_events(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        events = [
-            {"message": "hello", "code": 200, "other": "ignore"},
-            {"message": "world", "code": 200, "other": "ignore"},
-        ]
-        expected = ["hello", "world"]
-        self.assertEqual(expected, aws_container_logs._parse_log_events(events))
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_get_container_name_id(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        bad_task_id = "abc/123"
-        with self.assertRaisesRegex(Exception, "Error in getting container name.*"):
-            aws_container_logs._get_container_name_id(bad_task_id)
-
-        # Simple test
-        normal_task_id = "task/container-name/abc123"
-        expected = ["container-name", "abc123"]
-        self.assertEqual(
-            expected, aws_container_logs._get_container_name_id(normal_task_id)
-        )
-
-        # Replace -cluster
-        cluster_task_id = "task/my-cluster/abc123"
-        expected = ["my-container", "abc123"]
-        self.assertEqual(
-            expected, aws_container_logs._get_container_name_id(cluster_task_id)
-        )
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_verify_log_group(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        aws_container_logs.cloudwatch_client.describe_log_groups.return_value = {
-            "logGroups": ["my_log_group"]
-        }
-        self.assertTrue(aws_container_logs._verify_log_group("my_log_group"))
-
-        aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock()
-        aws_container_logs.cloudwatch_client.describe_log_groups.side_effect = (
-            ClientError(
-                error_response={"Error": {"Code": "InvalidParameterException"}},
-                operation_name="describe_log_groups",
-            )
-        )
-        with self.assertRaisesRegex(Exception, "Wrong parameters.*"):
-            aws_container_logs._verify_log_group("my_log_group")
-
-        aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock()
-        aws_container_logs.cloudwatch_client.describe_log_groups.side_effect = (
-            ClientError(
-                error_response={"Error": {"Code": "ResourceNotFoundException"}},
-                operation_name="describe_log_groups",
-            )
-        )
-        with self.assertRaisesRegex(Exception, "Couldn't find.*"):
-            aws_container_logs._verify_log_group("my_log_group")
-
-        aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock()
-        aws_container_logs.cloudwatch_client.describe_log_groups.side_effect = (
-            ClientError(
-                error_response={"Error": {"Code": "SomethingElseHappenedException"}},
-                operation_name="describe_log_groups",
-            )
-        )
-        with self.assertRaisesRegex(Exception, "Unexpected error.*"):
-            aws_container_logs._verify_log_group("my_log_group")
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_verify_log_stream(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        aws_container_logs.cloudwatch_client.describe_log_streams.return_value = {
-            "logStreams": ["my_log_stream"]
-        }
-        self.assertTrue(
-            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
-        )
-
-        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
-        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
-            ClientError(
-                error_response={"Error": {"Code": "InvalidParameterException"}},
-                operation_name="describe_log_streams",
-            )
-        )
-        with self.assertRaisesRegex(Exception, "Wrong parameters.*"):
-            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
-
-        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
-        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
-            ClientError(
-                error_response={"Error": {"Code": "ResourceNotFoundException"}},
-                operation_name="describe_log_streams",
-            )
-        )
-        with self.assertRaisesRegex(Exception, "Couldn't find.*"):
-            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
-
-        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
-        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
-            ClientError(
-                error_response={"Error": {"Code": "SomethingElseHappenedException"}},
-                operation_name="describe_log_streams",
-            )
-        )
-        with self.assertRaisesRegex(Exception, "Unexpected error.*"):
-            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_create_s3_folder(self, mock_boto3) -> None:
@@ -249,54 +127,6 @@ class TestDownloadLogs(unittest.TestCase):
         )
         with self.assertRaisesRegex(Exception, "Couldn't find folder.*"):
             aws_container_logs.get_s3_folder_contents("bucket", "folder")
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_get_s3_folder_path(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        aws_container_logs.S3_LOGGING_FOLDER = "aaa"
-        expected = "aaa/bbb/ccc"
-        self.assertEqual(expected, aws_container_logs._get_s3_folder_path("bbb", "ccc"))
-
-    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
-    def test_get_files_to_download_logs(self, mock_boto3) -> None:
-        aws_container_logs = AwsContainerLogs("my_tag")
-        expected = ["a", "b", "c"]
-        # Basic test
-        aws_container_logs.s3_client.list_objects_v2.side_effect = [
-            {
-                "Contents": [{"Key": "a"}, {"Key": "b"}, {"Key": "c"}],
-            }
-        ]
-        self.assertEqual(
-            expected, aws_container_logs._get_files_to_download_logs("bucket", "folder")
-        )
-
-        # Check with continuation tokens
-        aws_container_logs.s3_client.list_objects_v2.reset_mock()
-        aws_container_logs.s3_client.list_objects_v2.side_effect = [
-            {"NextContinuationToken": "abc123", "Contents": [{"Key": "a"}]},
-            {"NextContinuationToken": "abc456", "Contents": [{"Key": "b"}]},
-            {"Contents": [{"Key": "c"}]},
-        ]
-        self.assertEqual(
-            expected, aws_container_logs._get_files_to_download_logs("bucket", "folder")
-        )
-
-        # Ensure folders aren't included
-        aws_container_logs.s3_client.list_objects_v2.side_effect = [
-            {
-                "Contents": [
-                    {"Key": "f/"},
-                    {"Key": "a"},
-                    {"Key": "f2/"},
-                    {"Key": "b"},
-                    {"Key": "c"},
-                ],
-            }
-        ]
-        self.assertEqual(
-            expected, aws_container_logs._get_files_to_download_logs("bucket", "folder")
-        )
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     @patch("fbpcs.infra.logging_service.download_logs.download_logs.Utils")
@@ -459,3 +289,179 @@ class TestDownloadLogs(unittest.TestCase):
         )
         with self.assertRaisesRegex(Exception, "Couldn't find log stream.*"):
             aws_container_logs.upload_logs_to_s3_from_cloudwatch("bucket", arn)
+
+    #######################################
+    # Tests for logically private methods #
+    #######################################
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_parse_container_arn(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        with self.assertRaisesRegex(Exception, "Container arn is missing.*"):
+            aws_container_logs._parse_container_arn(None)
+
+        bad_arn = "abc:123"
+        with self.assertRaisesRegex(Exception, "Error in getting service name.*"):
+            aws_container_logs._parse_container_arn(bad_arn)
+
+        normal_arn = (
+            "arn:aws:ecs:fake-region:123456789:task/fake-container-name/1234abcdef56789"
+        )
+        expected = ["ecs", "fake-container-name", "1234abcdef56789"]
+        self.assertEqual(expected, aws_container_logs._parse_container_arn(normal_arn))
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_parse_log_events(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        events = [
+            {"message": "hello", "code": 200, "other": "ignore"},
+            {"message": "world", "code": 200, "other": "ignore"},
+        ]
+        expected = ["hello", "world"]
+        self.assertEqual(expected, aws_container_logs._parse_log_events(events))
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_container_name_id(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        bad_task_id = "abc/123"
+        with self.assertRaisesRegex(Exception, "Error in getting container name.*"):
+            aws_container_logs._get_container_name_id(bad_task_id)
+
+        # Simple test
+        normal_task_id = "task/container-name/abc123"
+        expected = ["container-name", "abc123"]
+        self.assertEqual(
+            expected, aws_container_logs._get_container_name_id(normal_task_id)
+        )
+
+        # Replace -cluster
+        cluster_task_id = "task/my-cluster/abc123"
+        expected = ["my-container", "abc123"]
+        self.assertEqual(
+            expected, aws_container_logs._get_container_name_id(cluster_task_id)
+        )
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_verify_log_group(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        aws_container_logs.cloudwatch_client.describe_log_groups.return_value = {
+            "logGroups": ["my_log_group"]
+        }
+        self.assertTrue(aws_container_logs._verify_log_group("my_log_group"))
+
+        aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_groups.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "InvalidParameterException"}},
+                operation_name="describe_log_groups",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Wrong parameters.*"):
+            aws_container_logs._verify_log_group("my_log_group")
+
+        aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_groups.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "ResourceNotFoundException"}},
+                operation_name="describe_log_groups",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Couldn't find.*"):
+            aws_container_logs._verify_log_group("my_log_group")
+
+        aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_groups.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "SomethingElseHappenedException"}},
+                operation_name="describe_log_groups",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Unexpected error.*"):
+            aws_container_logs._verify_log_group("my_log_group")
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_verify_log_stream(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        aws_container_logs.cloudwatch_client.describe_log_streams.return_value = {
+            "logStreams": ["my_log_stream"]
+        }
+        self.assertTrue(
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+        )
+
+        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "InvalidParameterException"}},
+                operation_name="describe_log_streams",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Wrong parameters.*"):
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+
+        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "ResourceNotFoundException"}},
+                operation_name="describe_log_streams",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Couldn't find.*"):
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+
+        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "SomethingElseHappenedException"}},
+                operation_name="describe_log_streams",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Unexpected error.*"):
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_s3_folder_path(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        aws_container_logs.S3_LOGGING_FOLDER = "aaa"
+        expected = "aaa/bbb/ccc"
+        self.assertEqual(expected, aws_container_logs._get_s3_folder_path("bbb", "ccc"))
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_files_to_download_logs(self, mock_boto3) -> None:
+        aws_container_logs = AwsContainerLogs("my_tag")
+        expected = ["a", "b", "c"]
+        # Basic test
+        aws_container_logs.s3_client.list_objects_v2.side_effect = [
+            {
+                "Contents": [{"Key": "a"}, {"Key": "b"}, {"Key": "c"}],
+            }
+        ]
+        self.assertEqual(
+            expected, aws_container_logs._get_files_to_download_logs("bucket", "folder")
+        )
+
+        # Check with continuation tokens
+        aws_container_logs.s3_client.list_objects_v2.reset_mock()
+        aws_container_logs.s3_client.list_objects_v2.side_effect = [
+            {"NextContinuationToken": "abc123", "Contents": [{"Key": "a"}]},
+            {"NextContinuationToken": "abc456", "Contents": [{"Key": "b"}]},
+            {"Contents": [{"Key": "c"}]},
+        ]
+        self.assertEqual(
+            expected, aws_container_logs._get_files_to_download_logs("bucket", "folder")
+        )
+
+        # Ensure folders aren't included
+        aws_container_logs.s3_client.list_objects_v2.side_effect = [
+            {
+                "Contents": [
+                    {"Key": "f/"},
+                    {"Key": "a"},
+                    {"Key": "f2/"},
+                    {"Key": "b"},
+                    {"Key": "c"},
+                ],
+            }
+        ]
+        self.assertEqual(
+            expected, aws_container_logs._get_files_to_download_logs("bucket", "folder")
+        )

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -66,7 +66,19 @@ class TestDownloadLogs(unittest.TestCase):
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_parse_container_arn(self, mock_boto3) -> None:
-        pass
+        aws_container_logs = AwsContainerLogs("my_tag")
+        with self.assertRaisesRegex(Exception, "Container arn is missing.*"):
+            aws_container_logs._parse_container_arn(None)
+
+        bad_arn = "abc:123"
+        with self.assertRaisesRegex(Exception, "Error in getting service name.*"):
+            aws_container_logs._parse_container_arn(bad_arn)
+
+        normal_arn = (
+            "arn:aws:ecs:fake-region:123456789:task/fake-container-name/1234abcdef56789"
+        )
+        expected = ["ecs", "fake-container-name", "1234abcdef56789"]
+        self.assertEqual(expected, aws_container_logs._parse_container_arn(normal_arn))
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_parse_log_events(self, mock_boto3) -> None:

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -14,3 +14,51 @@ class TestDownloadLogs(unittest.TestCase):
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_cloudwatch_logs(self, mock_boto3) -> None:
         pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_parse_container_arn(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_parse_log_events(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_container_name_id(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_verify_log_group(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_verify_log_stream(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_create_s3_folder(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_ensure_folder_exists(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_s3_folder_contents(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_s3_folder_path(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_files_to_download_logs(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_download_logs(self, mock_boto3) -> None:
+        pass
+
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_upload_logs_to_s3_from_cloudwatch(self, mock_boto3) -> None:
+        pass

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -151,7 +151,43 @@ class TestDownloadLogs(unittest.TestCase):
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_verify_log_stream(self, mock_boto3) -> None:
-        pass
+        aws_container_logs = AwsContainerLogs("my_tag")
+        aws_container_logs.cloudwatch_client.describe_log_streams.return_value = {
+            "logStreams": ["my_log_stream"]
+        }
+        self.assertTrue(
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+        )
+
+        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "InvalidParameterException"}},
+                operation_name="describe_log_streams",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Wrong parameters.*"):
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+
+        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "ResourceNotFoundException"}},
+                operation_name="describe_log_streams",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Couldn't find.*"):
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
+
+        aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
+        aws_container_logs.cloudwatch_client.describe_log_streams.side_effect = (
+            ClientError(
+                error_response={"Error": {"Code": "SomethingElseHappenedException"}},
+                operation_name="describe_log_streams",
+            )
+        )
+        with self.assertRaisesRegex(Exception, "Unexpected error.*"):
+            aws_container_logs._verify_log_stream("my_log_group", "my_log_stream")
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_create_s3_folder(self, mock_boto3) -> None:

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -252,7 +252,10 @@ class TestDownloadLogs(unittest.TestCase):
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_s3_folder_path(self, mock_boto3) -> None:
-        pass
+        aws_container_logs = AwsContainerLogs("my_tag")
+        aws_container_logs.S3_LOGGING_FOLDER = "aaa"
+        expected = "aaa/bbb/ccc"
+        self.assertEqual(expected, aws_container_logs._get_s3_folder_path("bbb", "ccc"))
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_files_to_download_logs(self, mock_boto3) -> None:

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import patch
+
+from fbpcs.infra.logging_service.download_logs.download_logs import AwsContainerLogs
+
+
+class TestDownloadLogs(unittest.TestCase):
+    @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
+    def test_get_cloudwatch_logs(self, mock_boto3) -> None:
+        pass

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -92,7 +92,24 @@ class TestDownloadLogs(unittest.TestCase):
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_container_name_id(self, mock_boto3) -> None:
-        pass
+        aws_container_logs = AwsContainerLogs("my_tag")
+        bad_task_id = "abc/123"
+        with self.assertRaisesRegex(Exception, "Error in getting container name.*"):
+            aws_container_logs._get_container_name_id(bad_task_id)
+
+        # Simple test
+        normal_task_id = "task/container-name/abc123"
+        expected = ["container-name", "abc123"]
+        self.assertEqual(
+            expected, aws_container_logs._get_container_name_id(normal_task_id)
+        )
+
+        # Replace -cluster
+        cluster_task_id = "task/my-cluster/abc123"
+        expected = ["my-container", "abc123"]
+        self.assertEqual(
+            expected, aws_container_logs._get_container_name_id(cluster_task_id)
+        )
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_verify_log_group(self, mock_boto3) -> None:

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -209,7 +209,15 @@ class TestDownloadLogs(unittest.TestCase):
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_ensure_folder_exists(self, mock_boto3) -> None:
-        pass
+        aws_container_logs = AwsContainerLogs("my_tag")
+        aws_container_logs.s3_client.list_objects_v2.return_value = {
+            "Contents": ["a", "b", "c"]
+        }
+        self.assertTrue(aws_container_logs.ensure_folder_exists("bucket", "folder"))
+
+        aws_container_logs.s3_client.list_objects_v2.reset_mock()
+        aws_container_logs.s3_client.list_objects_v2.return_value = {}
+        self.assertFalse(aws_container_logs.ensure_folder_exists("bucket", "folder"))
 
     @patch("fbpcs.infra.logging_service.download_logs.cloud.aws_cloud.boto3")
     def test_get_s3_folder_contents(self, mock_boto3) -> None:

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -11,7 +11,7 @@ import shutil
 
 class Utils:
     @staticmethod
-    def create_folder(folder_location) -> None:
+    def create_folder(folder_location: str) -> None:
         """
         Creates folder in the given path
         Args:


### PR DESCRIPTION
Summary:
# This stack:
* Adding tests for download_logs/
# This diff:
* In both the download_logs.py and test file, reorganize the functions so that the public API comes before private helper methods

Reviewed By: marksliva

Differential Revision:
D36861913

LaMa Project: L1089718

