### PR TITLE
Fix warning in FBPCS related to s3_cost_export_output_paths

### DIFF
--- a/fbpcs/private_computation/entity/post_processing_data.py
+++ b/fbpcs/private_computation/entity/post_processing_data.py
@@ -8,7 +8,8 @@
 from dataclasses import dataclass, field
 from typing import Set
 
-from dataclasses_json import dataclass_json
+from dataclasses_json import config, dataclass_json
+from marshmallow import fields
 
 
 @dataclass_json
@@ -24,7 +25,9 @@ class PostProcessingData:
 
     # TODO : Add breakdown key to PostProcessingData.
     dataset_timestamp: int = 0
-    s3_cost_export_output_paths: Set[str] = field(default_factory=set)
+    s3_cost_export_output_paths: Set[str] = field(
+        default_factory=set, metadata=config(mm_field=fields.List(fields.String))
+    )
 
     def __str__(self) -> str:
         # pyre-ignore


### PR DESCRIPTION
Summary:
This diff fixes the warning we've been seeing since D36140878 (https://github.com/facebookresearch/fbpcs/commit/2bfb1299ab66a0802723b5fa9f5798eb717dfa53)

`usr/local/lib/python3.8/site-packages/dataclasses_json/mm.py:270: UserWarning: Unknown type typing.Set[str] at PostProcessingData.s3_cost_export_output_paths: typing.Set[str] It's advised to pass the correct marshmallow type to mm_field.`

Differential Revision: D36948039

