### PR TITLE
Ignore run_next when all stages has been completed.

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -280,6 +280,9 @@ class PrivateComputationInstance(InstanceBase):
         """
         return self.stage_flow.get_next_runnable_stage_from_status(self.status)
 
+    def is_stage_flow_completed(self) -> bool:
+        return self.status is self.stage_flow.get_last_stage().completed_status
+
     def update_status(
         self, new_status: PrivateComputationInstanceStatus, logger: Logger
     ) -> None:
@@ -290,5 +293,6 @@ class PrivateComputationInstance(InstanceBase):
             logger.info(
                 f"Updating status of {self.instance_id} from {old_status} to {self.status} at time {self.status_update_ts}"
             )
-        if self.status is self.stage_flow.get_last_stage().completed_status:
+
+        if self.is_stage_flow_completed():
             self.end_ts = int(time.time())

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -287,6 +287,12 @@ class PrivateComputationService:
     ) -> PrivateComputationInstance:
         """Fetches the next eligible stage in the instance's stage flow and runs it"""
         pc_instance = self.get_instance(instance_id)
+        if pc_instance.is_stage_flow_completed():
+            self.logger.warning(
+                f"Instance {instance_id} stage flow completed. (status: {pc_instance.status}). Ignored"
+            )
+            return pc_instance
+
         next_stage = pc_instance.get_next_runnable_stage()
         if not next_stage:
             # TODO(T106517341): Raise a custom exception instead of something generic

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -456,6 +456,37 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(None, instance.get_next_runnable_stage())
 
+    @mock.patch(
+        "fbpcs.private_computation.service.private_computation.PrivateComputationService.run_stage_async"
+    )
+    def test_run_next(self, mock_run_stage_async) -> None:
+        flow = PrivateComputationStageFlow
+        status = flow.ID_MATCH.previous_stage.completed_status
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.private_computation_service.instance_repository.read = MagicMock(
+            return_value=instance
+        )
+        self.private_computation_service.run_next(instance.instance_id)
+        mock_run_stage_async.assert_called_with(
+            instance.instance_id, flow.ID_MATCH, server_ips=None
+        )
+
+    @mock.patch(
+        "fbpcs.private_computation.service.private_computation.PrivateComputationService.run_stage_async"
+    )
+    def test_run_next_ignore_stage_flow_completed(self, mock_run_stage_async) -> None:
+        flow = PrivateComputationStageFlow
+        status = flow.get_last_stage().completed_status
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.private_computation_service.run_next(instance.instance_id)
+        mock_run_stage_async.assert_not_called()
+
     def test_run_stage_correct_stage_order(
         self,
     ) -> None:


### PR DESCRIPTION
Summary:
## Why
Ignore run_next when all stages has been completed
T122438804
in Sev S274601 - www codemod leads to PCService DDoS
according to tupperware log
https://www.internalfb.com/tupperware/job/tasks?handle=tsp_global%2Fprivate_lift%2FPrivateComputationServiceRC&task_id=1&task_tab=TASK_LOGS
www keep spamming request to call run_next even all stages are completed.

This Diff is from PCS to ignore run_next if we already know all stage flow are completed to avoid error happend which lead thrift server unhealty

## What
Ignore run_next request if pc instance know last stage is marked as completed.

## Note
D36943937 is the WWW fix to avoid Spamming requests

Differential Revision: D36911774

