### PR TITLE
Add setUp method for TestAwsDeploymentHelper

### DIFF
--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
@@ -7,11 +7,19 @@
 # pyre-strict
 
 import unittest
+from unittest.mock import patch
+
+from fbpcs.infra.cloud_bridge.deployment_helper.aws.aws_deployment_helper import (
+    AwsDeploymentHelper,
+)
 
 
 class TestAwsDeploymentHelper(unittest.TestCase):
     def setUp(self) -> None:
-        pass
+        with patch(
+            "fbpcs.infra.cloud_bridge.deployment_helper.aws.aws_deployment_helper.boto3"
+        ):
+            self.aws_deployment_helper = AwsDeploymentHelper()
 
     def test_create_user(self) -> None:
         pass


### PR DESCRIPTION
Summary:
# This stack
* Get this test file ready for bootcampers
# This diff
* Add setUp method to patch the boto3 library and create a base object for usage in future tests

Differential Revision: D37005810

