### PR TITLE
Adding factory for getting cloud specific object

### DIFF
--- a/fbpcs/infra/pce_deployment_library/cloud_library/aws/aws.py
+++ b/fbpcs/infra/pce_deployment_library/cloud_library/aws/aws.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from fbpcs.infra.pce_deployment_library.cloud_library.cloud_base.cloud_base import (
+    CloudBase,
+)
+
+
+class AWS(CloudBase):
+    pass

--- a/fbpcs/infra/pce_deployment_library/cloud_library/cloud_base/cloud_base.py
+++ b/fbpcs/infra/pce_deployment_library/cloud_library/cloud_base/cloud_base.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from abc import ABC
+
+
+class CloudBase(ABC):
+    pass

--- a/fbpcs/infra/pce_deployment_library/cloud_library/cloud_factory.py
+++ b/fbpcs/infra/pce_deployment_library/cloud_library/cloud_factory.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Any, Dict, List, Type, Union
+
+from fbpcs.infra.pce_deployment_library.cloud_library.aws.aws import AWS
+from fbpcs.infra.pce_deployment_library.cloud_library.cloud_base.cloud_base import (
+    CloudBase,
+)
+from fbpcs.infra.pce_deployment_library.cloud_library.defaults import CloudPlatforms
+from fbpcs.infra.pce_deployment_library.cloud_library.gcp.gcp import GCP
+
+
+class CloudFactory:
+    CLOUD_TYPES: Dict[CloudPlatforms, Type[Union[AWS, GCP]]] = {
+        CloudPlatforms.AWS: AWS,
+        CloudPlatforms.GCP: GCP,
+    }
+
+    def create_cloud_object(
+        self, cloud_type: CloudPlatforms, **kwargs: Any
+    ) -> CloudBase:
+        supported_cloud_platform = self.get_supported_cloud_platforms()
+        if self.CLOUD_TYPES.get(cloud_type, None) is None:
+            raise Exception(
+                f"{cloud_type} is not a supported cloud platform. Supported platforms are {supported_cloud_platform}"
+            )
+        return self.CLOUD_TYPES[cloud_type](**kwargs)
+
+    def get_supported_cloud_platforms(self) -> List[str]:
+        return CloudPlatforms.list()

--- a/fbpcs/infra/pce_deployment_library/cloud_library/defaults.py
+++ b/fbpcs/infra/pce_deployment_library/cloud_library/defaults.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from enum import Enum
+from typing import List
+
+
+class CloudPlatforms(str, Enum):
+    AWS = "aws"
+    GCP = "gcp"
+
+    @classmethod
+    def list(cls) -> List[str]:
+        return [e.value for e in CloudPlatforms]

--- a/fbpcs/infra/pce_deployment_library/cloud_library/gcp/gcp.py
+++ b/fbpcs/infra/pce_deployment_library/cloud_library/gcp/gcp.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from fbpcs.infra.pce_deployment_library.cloud_library.cloud_base.cloud_base import (
+    CloudBase,
+)
+
+
+class GCP(CloudBase):
+    pass


### PR DESCRIPTION
Summary:
Adding a python factory to return cloud object based on the cloud type.

Since deploy.sh is common for both AWS and GCP, this factory will return respective object based on the cloud type.

Differential Revision: D36992054

