### PR TITLE
Include workflow service in handler TARGETS

### DIFF
--- a/fbpcs/service/workflow_sfn_fb.py
+++ b/fbpcs/service/workflow_sfn_fb.py
@@ -14,13 +14,14 @@ from fbpcp.intern.gateway.aws_fb import FBAWSGateway
 from fbpcs.service.workflow_sfn import SfnWorkflowService
 
 
-class FBSfnWorkflowService(SfnWorkflowService, FBAWSGateway):
+class FBSfnWorkflowService(FBAWSGateway, SfnWorkflowService):
     def __init__(
         self,
         region: str,
         account: str,
         role: Optional[str] = None,
     ) -> None:
+        super().__init__(account=account, role=role, region=region)
         self.client: botocore.client.BaseClient = self.session_gen.get_client(
             "stepfunctions"
         )


### PR DESCRIPTION
Summary: Since the workflow service is being used in experimentation, we need to add it to the TARGETS for the build.

Reviewed By: wenqingren

Differential Revision: D36990836

