### PR TITLE
Adds unit test for aws_deployment_helper.attach_user_policy

### DIFF
--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
@@ -52,8 +52,42 @@ class TestAwsDeploymentHelper(unittest.TestCase):
             self.assertEqual(None, self.aws_deployment_helper.delete_policy(""))
 
     def test_attach_user_policy(self) -> None:
-        # T122887198
-        pass
+        self.aws_deployment_helper.iam.list_policies.return_value = {
+            "Policies": [{"PolicyName": "A"}]
+        }
+        self.aws_deployment_helper.iam.list_users.return_value = {
+            "Users": [{"UserName": "Z"}]
+        }
+
+        # Basic green path test
+        with self.subTest("basic"):
+            self.assertEqual(
+                None, self.aws_deployment_helper.attach_user_policy("A", "Z")
+            )
+
+        # Username not in current users
+        with self.subTest("user_name not in current_users"):
+            self.assertRaises(
+                Exception, self.aws_deployment_helper.attach_user_policy, "A", "Y"
+            )
+
+        # Policy not in current policies
+        with self.subTest("policy_name not in current_policies"):
+            self.assertRaises(
+                Exception, self.aws_deployment_helper.attach_user_policy, "B", "Z"
+            )
+
+        # Client error
+        with self.subTest("attach_user_policy.ClientError"):
+            self.aws_deployment_helper.iam.attach_user_policy.reset_mock()
+            self.aws_deployment_helper.iam.attach_user_policy.side_effect = ClientError(
+                error_response={"Error": {}},
+                operation_name="attach_user_policy",
+            )
+            self.assertEqual(
+                None, self.aws_deployment_helper.attach_user_policy("A", "Z")
+            )
+            self.aws_deployment_helper.iam.attach_user_policy.assert_called_once()
 
     def test_detach_user_policy(self) -> None:
         # T122887211


### PR DESCRIPTION
Summary: Added unit test for aws_deployment_helper.attach_user_policy covering all code paths.

Reviewed By: gorel

Differential Revision: D37075119

