### PR TITLE
Write test for create_user_workflow

### DIFF
--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
@@ -117,8 +117,14 @@ class TestAwsDeploymentHelper(unittest.TestCase):
         pass
 
     def test_create_user_workflow(self) -> None:
-        # T122887368
-        pass
+        self.aws_deployment_helper.iam.create_user_workflow.return_value = True
+        self.assertEqual(None, self.aws_deployment_helper.create_user_workflow("user1"))
+        self.aws_deployment_helper.iam.create_user.assert_called_once_with(
+            UserName="user1"
+        )
+        self.aws_deployment_helper.iam.create_access_key.assert_called_once_with(
+            UserName="user1"
+        )
 
     def test_delete_user_workflow(self) -> None:
         # T122887387


### PR DESCRIPTION
Summary:
Write test for create_user_workflow.
Only test one path, i.e., create_user_workflow work success, create_user and create_access_key mocks were called.

Reviewed By: gorel

Differential Revision: D37074519

