### PR TITLE
Change tqdm version from 4.64.0 to 4.55.1

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -9,4 +9,4 @@ termcolor==1.1.0
 thriftpy2==0.4.14
 pytz>=2022.1
 thrift>=0.16.0 # logging_service client requires this
-tqdm==4.64.0
+tqdm>=4.55.1


### PR DESCRIPTION
Summary: Change tqdm version from 4.64.0 to 4.55.1 as it was causing fbpcs docker build failure.

Differential Revision: D37081963

