### PR TITLE
Set num_mpc_containers as 5*num_pid_containers in pl_instance_runner

### DIFF
--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -136,7 +136,7 @@ def run_instances(
                     "config": config,
                     "instance_id": instance_id,
                     "input_path": input_path,
-                    "num_mpc_containers": num_shards,
+                    "num_mpc_containers": num_shards,  # Currently ignored due to D35852672.
                     "num_pid_containers": num_shards,
                     "stage_flow": stage_flow,
                     "logger": LoggerAdapter(logger=logger, prefix=instance_id),


### PR DESCRIPTION
Summary:
See context in https://fburl.com/8kn41i2w to semi-decouple PID and MPC num containers.

This is step 2 of the plan below---

Eng changes required:
1. [Done in D35852672 (https://github.com/facebookresearch/fbpcs/commit/42b25ec6bff70a7fc7d8cfe2785ac0a6704d40f3) and pushed to prod] Specific to PL: Make python changes in private_computation.py so num_mpc_containers = 5 * request.num_pid_containers if game_type is Lift. Otherwise, num_mpc_containers = request.num_mpc_containers.
2. [This Diff] Specific to PL: Once code change from (1) is in production, we will update code in https://fburl.com/code/zglysd98 (D36393217, fb-side) and https://fburl.com/code/so6d88oa (this diff, advertiser-side) to use num_mpc_containers = 5 * num_pid_containers.
3. Applies to both PL and PA: Once code change from (1) is in production, we will update the SV PRIVATE_LIFT_MAX_ROWS_PER_SHARD from 1M to 5M rows/shard.
4. Specific to PL: Once code change from (2) is in production, we can clean up code changes made through (1).

We have already changed the logic in create_instance of PrivateComputationService (in D35852672 (https://github.com/facebookresearch/fbpcs/commit/42b25ec6bff70a7fc7d8cfe2785ac0a6704d40f3)) so the num_mpc_containers field is ignored while we complete step 2. So the change in this diff would have no impact.

Differential Revision: D36393378

