### PR TITLE
Remove repeating compiler warning.

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -63,7 +63,7 @@ void Attributor<
 
   int stepSize = 1; // we process the array elements in pairs with indices
                     // differing by stepSize
-  int firstIndex = 0; // first index at this level
+  auto firstIndex = 0ULL; // first index at this level
   while (firstIndex < eventArray.size() / 2) {
     for (size_t i = firstIndex; i < eventArray.size(); i += 2 * stepSize) {
       if (i + stepSize < eventArray.size()) {


### PR DESCRIPTION
Summary:
Previously,
fbpcs> ./build-docker onedocker

Following errors repeats quite a bit, making compilation output noisy and difficult to debug:

```
In file included from /root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/main.cpp:20:
/root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/MainUtil.h: In instantiation of 'common::SchedulerStatistics pcf2_aggregation::startAggregationAppsForShardedFilesHelper(common::InputEncryption, common::Visibility, int, int, int, std::string, int, std::string, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&) [with int PARTY = 0; int index = 13; std::string = std::__cxx11::basic_string<char>]':
/root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/MainUtil.h:104:72:   recursively required from 'common::SchedulerStatistics pcf2_aggregation::startAggregationAppsForShardedFilesHelper(common::InputEncryption, common::Visibility, int, int, int, std::string, int, std::string, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&) [with int PARTY = 0; int index = 1; std::string = std::__cxx11::basic_string<char>]'
/root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/MainUtil.h:104:72:   required from 'common::SchedulerStatistics pcf2_aggregation::startAggregationAppsForShardedFilesHelper(common::InputEncryption, common::Visibility, int, int, int, std::string, int, std::string, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&) [with int PARTY = 0; int index = 0; std::string = std::__cxx11::basic_string<char>]'
/root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/MainUtil.h:140:61:   required from 'common::SchedulerStatistics pcf2_aggregation::startAggregationAppsForShardedFiles(common::InputEncryption, common::Visibility, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, int16_t, std::string, int, std::string) [with int PARTY = 0; int16_t = short int; std::string = std::__cxx11::basic_string<char>]'
/root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/main.cpp:99:32:   required from here
/root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/MainUtil.h:65:39: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   65 |     auto numFiles = (remainingThreads > remainingFiles)
      |                     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
In file included from /root/build/emp_game/fbpcs/emp_games/pcf2_aggregation/AggregationGame.h:101,
```

Differential Revision: D37122698

