### PR TITLE
E2E Test for PIDPrepareStageService

### DIFF
--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -7,10 +7,20 @@
 import logging
 from typing import DefaultDict, List, Optional
 
+from fbpcp.entity.container_instance import ContainerInstance
+
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
+from fbpcs.data_processing.service.pid_prepare_binary_service import (
+    PIDPrepareBinaryService,
+)
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.pid.service.pid_service.pid_stage import PIDStage
+from fbpcs.pid.service.pid_service.utils import (
+    get_max_id_column_cnt,
+    get_pid_protocol_from_num_shards,
+)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -19,6 +29,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    all_files_exist_on_cloud,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     get_pc_status_from_stage_state,
 )
@@ -63,7 +74,9 @@ class PIDPrepareStageService(PrivateComputationStageService):
             An updated version of pc_instance
         """
         self._logger.info(f"[{self}] Starting PIDPrepareStageService")
-        container_instances = []
+        container_instances = await self.start_pid_prepare_service(
+            pc_instance, server_ips
+        )
 
         self._logger.info("PIDPrepareStageService finished")
         stage_state = StageStateInstance(
@@ -87,3 +100,54 @@ class PIDPrepareStageService(PrivateComputationStageService):
             The latest status for private computation instance
         """
         return get_pc_status_from_stage_state(pc_instance, self._onedocker_svc)
+
+    async def start_pid_prepare_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]],
+    ) -> List[ContainerInstance]:
+        """start pid prepare service and spine up the container instances"""
+        logging.info("Instantiated PID prepare stage")
+        num_shards = pc_instance.num_pid_containers
+        # input_path is the output_path from PID Shard Stage
+        input_path = pc_instance.pid_stage_output_data_path
+        output_path = pc_instance.pid_stage_output_prepare_path
+        pc_role = pc_instance.role
+
+        # make sure all input files are on the storage service before proceed
+        if not await all_files_exist_on_cloud(
+            input_path, num_shards, self._storage_svc
+        ):
+            raise ValueError("Input files for PIDPrepareStageService are missing")
+
+        # generate the list of command args for publisher or partner
+        args_list = []
+        # later mltikey_enabled, protocol, and max_col_cnt wil be centralized in PrivateComputationInstance.
+        protocol = get_pid_protocol_from_num_shards(num_shards, self._multikey_enabled)
+        max_col_cnt = get_max_id_column_cnt(protocol)
+        binary_name = PIDPrepareBinaryService.get_binary_name()
+        onedocker_binary_config = self._onedocker_binary_config_map[binary_name]
+        tmp_dir = onedocker_binary_config.tmp_directory
+        for shard in range(num_shards):
+            args_per_shard = PIDPrepareBinaryService.build_args(
+                input_path=PIDStage.get_sharded_filepath(input_path, shard),
+                output_path=PIDStage.get_sharded_filepath(output_path, shard),
+                tmp_directory=tmp_dir,
+                max_column_count=max_col_cnt,
+            )
+            args_list.append(args_per_shard)
+        # start containers
+        logging.info(f"{pc_role} spinning up containers")
+
+        env_vars = {
+            "ONEDOCKER_REPOSITORY_PATH": onedocker_binary_config.repository_path
+        }
+        pid_prepare_binary_service = PIDPrepareBinaryService()
+        return await pid_prepare_binary_service.start_containers(
+            cmd_args_list=args_list,
+            onedocker_svc=self._onedocker_svc,
+            binary_version=onedocker_binary_config.binary_version,
+            binary_name=binary_name,
+            timeout=self._container_timeout,
+            env_vars=env_vars,
+        )

--- a/fbpcs/private_computation/stage_flows/private_computation_pid_migration_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pid_migration_test_stage_flow.py
@@ -11,6 +11,9 @@ from fbpcs.private_computation.entity.private_computation_status import (
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
 )
+from fbpcs.private_computation.service.pid_prepare_stage_service import (
+    PIDPrepareStageService,
+)
 
 from fbpcs.private_computation.service.pid_run_protocol_stage_service import (
     PIDRunProtocolStageService,
@@ -129,6 +132,13 @@ class PrivateComputationPIDMigrationTestStageFlow(PrivateComputationBaseStageFlo
         """
         if self is self.ID_MATCH:
             return PIDRunProtocolStageService(
+                args.storage_svc,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+                args.pid_svc.multikey_enabled,
+            )
+        elif self is self.PID_PREPARE:
+            return PIDPrepareStageService(
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from typing import List
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+
+from fbpcs.pcf.tests.async_utils import AsyncMock, to_sync
+from fbpcs.pid.entity.pid_instance import PIDProtocol
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationGameType,
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT,
+)
+from fbpcs.private_computation.service.pid_prepare_stage_service import (
+    PIDPrepareStageService,
+)
+
+from libfb.py.testutil import data_provider, MagicMock
+
+
+class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
+    @patch("fbpcp.service.storage.StorageService")
+    @patch("fbpcp.service.onedocker.OneDockerService")
+    def setUp(self, mock_onedocker_svc, mock_storage_svc) -> None:
+        self.mock_onedocker_svc = mock_onedocker_svc
+        self.mock_storage_svc = mock_storage_svc
+        self.onedocker_binary_config = OneDockerBinaryConfig(
+            tmp_directory="/tmp",
+            binary_version="latest",
+            repository_path="test_path/",
+        )
+        self.onedocker_binary_config = self.onedocker_binary_config
+        self.binary_name = "data_processing/pid_preparer"
+        self.onedocker_binary_config_map = {
+            self.binary_name: self.onedocker_binary_config
+        }
+        self.input_path = "in"
+        self.output_path = "out"
+        self.pc_instance_id = "test_instance_123"
+        self.container_timeout = 43200
+
+    @data_provider(
+        lambda: (
+            itertools.product(
+                [PrivateComputationRole.PUBLISHER, PrivateComputationRole.PARTNER],
+                [True, False],
+                [1, 2],
+            )
+        )
+    )
+    @to_sync
+    async def test_pid_prepare_stage_service(
+        self,
+        pc_role: PrivateComputationRole,
+        multikey_enabled: bool,
+        test_num_containers: int,
+    ) -> None:
+        pid_protocol = (
+            PIDProtocol.UNION_PID_MULTIKEY
+            if test_num_containers == 1 and multikey_enabled
+            else PIDProtocol.UNION_PID
+        )
+        max_col_cnt_expect = (
+            DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT
+            if pid_protocol is PIDProtocol.UNION_PID_MULTIKEY
+            else 1
+        )
+        pc_instance = self.create_sample_pc_instance(pc_role, test_num_containers)
+        stage_svc = PIDPrepareStageService(
+            storage_svc=self.mock_storage_svc,
+            onedocker_svc=self.mock_onedocker_svc,
+            onedocker_binary_config_map=self.onedocker_binary_config_map,
+            multikey_enabled=multikey_enabled,
+        )
+        containers = [
+            await self.create_container_instance() for _ in range(test_num_containers)
+        ]
+        # All files should exist on cloud, or else the stage service won't proceed.
+        self.mock_storage_svc.file_exists.return_value = True
+        self.mock_onedocker_svc.start_containers = MagicMock(return_value=containers)
+        self.mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
+            return_value=containers
+        )
+        updated_pc_instance = await stage_svc.run_async(pc_instance=pc_instance)
+        # assert file_exists is called in self.stage_svc.run_async()
+        self.mock_storage_svc.file_exists.assert_called()
+        env_vars = {
+            "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
+        }
+        args_ls_expect = self.get_args_expect(
+            pc_role, test_num_containers, max_col_cnt_expect
+        )
+        # test the start_containers is called with expected parameters
+        self.mock_onedocker_svc.start_containers.assert_called_with(
+            package_name=self.binary_name,
+            version=self.onedocker_binary_config.binary_version,
+            cmd_args_list=args_ls_expect,
+            timeout=self.container_timeout,
+            env_vars=env_vars,
+        )
+        # test the return value is as expected
+        self.assertEqual(
+            len(updated_pc_instance.instances),
+            1,
+            "Failed to add the StageStageInstance into pc_instance",
+        )
+        stage_state_expect = StageStateInstance(
+            pc_instance.instance_id,
+            pc_instance.current_stage.name,
+            containers=containers,
+        )
+        stage_state_actual = updated_pc_instance.instances[0]
+        self.assertEqual(
+            stage_state_actual,
+            stage_state_expect,
+            "Appended StageStageInstance is not as expected",
+        )
+
+    def create_sample_pc_instance(
+        self, pc_role: PrivateComputationRole, test_num_containers: int
+    ) -> PrivateComputationInstance:
+        return PrivateComputationInstance(
+            instance_id=self.pc_instance_id,
+            role=pc_role,
+            instances=[],
+            status=PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+            status_update_ts=1600000000,
+            num_pid_containers=test_num_containers,
+            num_mpc_containers=test_num_containers,
+            num_files_per_mpc_container=test_num_containers,
+            game_type=PrivateComputationGameType.LIFT,
+            input_path=self.input_path,
+            output_dir=self.output_path,
+            pid_use_row_numbers=True,
+        )
+
+    async def create_container_instance(self) -> ContainerInstance:
+        return ContainerInstance(
+            instance_id="test_container_instance_123",
+            ip_address="127.0.0.1",
+            status=ContainerInstanceStatus.COMPLETED,
+        )
+
+    def get_args_expect(
+        self,
+        pc_role: PrivateComputationRole,
+        test_num_containers: int,
+        max_col_cnt_expect: int,
+    ) -> List[str]:
+        arg_ls = []
+        if (
+            pc_role is PrivateComputationRole.PUBLISHER
+            and max_col_cnt_expect is DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT
+        ):
+            arg_ls = [
+                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_prepared_{i} --tmp_directory=/tmp --max_column_cnt=6"
+                for i in range(test_num_containers)
+            ]
+        elif (
+            pc_role is PrivateComputationRole.PUBLISHER
+            and max_col_cnt_expect is not DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT
+        ):
+            arg_ls = [
+                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_prepared_{i} --tmp_directory=/tmp --max_column_cnt=1"
+                for i in range(test_num_containers)
+            ]
+        elif (
+            pc_role is PrivateComputationRole.PARTNER
+            and max_col_cnt_expect is DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT
+        ):
+            arg_ls = [
+                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_prepared_{i} --tmp_directory=/tmp --max_column_cnt=6"
+                for i in range(test_num_containers)
+            ]
+        elif (
+            pc_role is PrivateComputationRole.PARTNER
+            and max_col_cnt_expect is not DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT
+        ):
+            arg_ls = [
+                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_prepared_{i} --tmp_directory=/tmp --max_column_cnt=1"
+                for i in range(test_num_containers)
+            ]
+        return arg_ls


### PR DESCRIPTION
Summary:
We are migrating PIDService to StageFlow, and the second step is use PIDPrepareStageService in PID_PREPARE stage.
In order to run E2E test for PIDPrepareStageService, we use the new StageFlow called PrivateComputationPIDMigrationTestStageFlow, which has the similar stage flow as PrivateComputationStageFlow but the ID_MATCH stage uses  PIDRunProtocolStageService and PID_PREPARE stage uses PIDPrepareStageService.

Reviewed By: joe1234wu

Differential Revision: D37101178

