### PR TITLE
Pyre Strict in test_private_computation_game.py

### DIFF
--- a/fbpcs/private_computation/test/repository/test_private_computation_game.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_game.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 import unittest
 from typing import List
 from unittest.mock import patch


### PR DESCRIPTION
Summary: Add `# pyre-strict` to test_private_computation_game.py for type checking.

Differential Revision: D37144081

