### PR TITLE
Refactoring returning list with dataclass in parse container arn

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 from botocore.exceptions import ClientError
 
 from fbpcs.infra.logging_service.download_logs.download_logs import AwsContainerLogs
+from fbpcs.infra.logging_service.download_logs.utils.utils import ContainerDetails
 
 
 class TestDownloadLogs(unittest.TestCase):
@@ -226,7 +227,11 @@ class TestDownloadLogs(unittest.TestCase):
 
         with self.subTest("normal_arn"):
             normal_arn = "arn:aws:ecs:fake-region:123456789:task/fake-container-name/1234abcdef56789"
-            expected = ["ecs", "fake-container-name", "1234abcdef56789"]
+            expected = ContainerDetails(
+                service_name="ecs",
+                container_name="fake-container-name",
+                container_id="1234abcdef56789",
+            )
             self.assertEqual(
                 expected, self.aws_container_logs._parse_container_arn(normal_arn)
             )

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -8,6 +8,8 @@
 import io
 import os
 import shutil
+
+from dataclasses import dataclass
 from typing import List
 
 
@@ -82,3 +84,10 @@ class Utils:
                 f"Couldn't find folder {folder_location}."
                 f"Please check if folder exists.\nAborting folder compression."
             )
+
+
+@dataclass
+class ContainerDetails:
+    service_name: str
+    container_name: str
+    container_id: str


### PR DESCRIPTION
Summary: Changing return type of function to parse container arn from list to Python dataclass

Differential Revision: D37149658

