### PR TITLE
add frozen_field_hook test

### DIFF
--- a/fbpcs/common/entity/frozen_field_hook.py
+++ b/fbpcs/common/entity/frozen_field_hook.py
@@ -1,0 +1,76 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Callable, Iterable, Optional, TypeVar
+
+from fbpcs.common.entity.dataclasses_hooks import (
+    DataclassHook,
+    DataclassHookMixin,
+    HookEventType,
+)
+from fbpcs.common.entity.instance_base_config import (
+    InstanceBaseMetadata,
+    IS_FROZEN_FIELD,
+)
+
+T = TypeVar("T")
+
+
+class FrozenFieldHook(DataclassHook[T]):
+    def __init__(
+        self, other_field: str, freeze_when: Optional[Callable[[T], bool]] = None
+    ) -> None:
+        self.other_field: str = other_field
+        self.freeze_when: Callable[[T], bool] = freeze_when or (lambda _: True)
+        self._triggers: Iterable[HookEventType] = [
+            HookEventType.POST_UPDATE,
+            HookEventType.POST_DELETE,
+        ]
+
+    def run(
+        self,
+        instance: T,
+        field_name: str,
+        # pyre-ignore Missing parameter annotation [2]
+        previous_field_value: Any,
+        # pyre-ignore Missing parameter annotation [2]
+        new_field_value: Any,
+        hook_event: HookEventType,
+    ) -> None:
+        if previous_field_value != new_field_value and self.freeze_when(instance):
+            self._freeze_field(instance, self.other_field)
+
+    @property
+    def triggers(self) -> Iterable[HookEventType]:
+        return self._triggers
+
+    def _freeze_field(self, instance: T, field_name: str) -> None:
+        """
+        This function will freeze the field with field_name in object: instance
+        """
+        # pyre-ignore Undefined attribute [16]: instance has no attribute __dataclass_fields__
+        field_obj = instance.__dataclass_fields__[field_name]
+
+        # if this field is mutable now
+        if not field_obj.metadata.get(IS_FROZEN_FIELD, False):
+            # get the hooks of this field
+            hooks: Iterable[HookEventType] = field_obj.metadata.get(
+                DataclassHookMixin.HOOK_METADATA_STR, None
+            )
+
+            if hooks is None:
+                # No hooks, so just set the metadata as immutable
+                field_obj.metadata = InstanceBaseMetadata.IMMUTABLE.value
+            else:
+                # if this field has hooks
+                # We want to set the metadata as immutable and keep a record
+                # of the existing hooks (field metadata can't be updated because
+                # it is a "mappingproxy" object, not a real dict)
+                field_obj.metadata = {
+                    **InstanceBaseMetadata.IMMUTABLE.value,
+                    **DataclassHookMixin.get_metadata(hooks),
+                }

--- a/fbpcs/common/tests/entity/test_frozen_field_hook.py
+++ b/fbpcs/common/tests/entity/test_frozen_field_hook.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyer-strict
+
+import unittest
+from dataclasses import dataclass, field
+
+from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin
+from fbpcs.common.entity.exceptions import InstanceFrozenFieldError
+from fbpcs.common.entity.frozen_field_hook import FrozenFieldHook
+from fbpcs.common.entity.instance_base import InstanceBase, mutable_field
+from fbpcs.common.entity.instance_base_config import InstanceBaseMetadata
+
+# create a hook obj
+# frozen input when status is complete
+frozen_input_hook: FrozenFieldHook = FrozenFieldHook(
+    "input_path", lambda obj: obj.status == "complete"
+)
+
+# create a hook obj
+# frozen output when status is complete
+frozen_output_hook: FrozenFieldHook = FrozenFieldHook(
+    "output_path", lambda obj: obj.status == "complete"
+)
+
+# create a hook obj
+# frozen location when user is deleted
+frozen_location_hook: FrozenFieldHook = FrozenFieldHook(
+    "location", lambda obj: getattr(obj, "user", None) is None
+)
+
+
+@dataclass
+class DummyInstance(InstanceBase):
+    """
+    Dummy instance class to be used in unit tests.
+
+    """
+
+    instance_id: str
+    name: str
+
+    input_path: str
+    output_path: str
+
+    user: str = field(
+        metadata={
+            **DataclassHookMixin.get_metadata(frozen_location_hook),
+            **InstanceBaseMetadata.IMMUTABLE.value,
+        },
+    )
+    location: str = mutable_field()
+
+    status: str = field(
+        default="start",
+        metadata={
+            **DataclassHookMixin.get_metadata(frozen_input_hook, frozen_output_hook),
+            **InstanceBaseMetadata.MUTABLE.value,
+        },
+    )
+
+    def get_instance_id(self) -> str:
+        return self.instance_id
+
+
+class TestFrozenFieldHook(unittest.TestCase):
+    def setUp(self) -> None:
+        # create an obj
+        self.dummy_obj = DummyInstance(
+            "01",
+            "Tupper01",
+            "//fbsource",
+            "//fbsource:output",
+            "//fbsource:storage",
+            "Meta",
+            "Seattle",
+        )
+
+    def test_update_event_frozen_field_hook(self) -> None:
+        # input_path and output_path are mutable now
+        self.dummy_obj.input_path = "//fbcode"
+        self.dummy_obj.output_path = "//fbsource:output"
+
+        # change the status
+        self.dummy_obj.status = "complete"
+
+        # assert input is frozen when status is complete
+        with self.assertRaises(InstanceFrozenFieldError):
+            self.dummy_obj.input_path = "//www"
+        # assert output is frozen when status is complete
+        with self.assertRaises(InstanceFrozenFieldError):
+            self.dummy_obj.output_path = "//www:output"
+
+    def test_delete_event_frozen_field_hook(self) -> None:
+        # location is mutable now
+        self.dummy_obj.location = "Kirkland"
+
+        # delete user
+        del self.dummy_obj.user
+
+        with self.assertRaises(AttributeError):
+            self.dummy_obj.user
+
+        # assert location is frozen when user is deleted
+        with self.assertRaises(InstanceFrozenFieldError):
+            self.dummy_obj.location = "Bellevue"


### PR DESCRIPTION
Summary:
This is a unittest for frozen_hook.py
DummyInstance is a subclass of InstanceBase.
It is an example to use frozen_field hooks.
1. frozen input and output when status is complete
2. frozen location when user is deleted

Reviewed By: gorel

Differential Revision: D37099761

