### PR TITLE
Add spark configs to pid mr configurations

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -69,6 +71,7 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
+        logging.info("Start MR stage flow")
         if self is self.UNION_PID_MR_MULTIKEY:
             if args.workflow_svc is None:
                 raise NotImplementedError("workflow_svc is None")

--- a/fbpcs/service/workflow.py
+++ b/fbpcs/service/workflow.py
@@ -8,7 +8,7 @@
 
 import abc
 from enum import Enum
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 
 class WorkflowStatus(Enum):
@@ -25,7 +25,7 @@ class WorkflowService(abc.ABC):
         self,
         workflow_conf: Dict[str, str],
         run_id: str,
-        run_conf: Optional[Dict[str, str]] = None,
+        run_conf: Optional[Dict[str, Any]] = None,
     ) -> str:
         pass
 

--- a/fbpcs/service/workflow_mwaa.py
+++ b/fbpcs/service/workflow_mwaa.py
@@ -56,7 +56,7 @@ class MwaaWorkflowService(WorkflowService):
         self,
         workflow_conf: Dict[str, str],
         run_id: str,
-        run_conf: Optional[Dict[str, str]] = None,
+        run_conf: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Start workflow
         Keyword arguments:

--- a/fbpcs/service/workflow_sfn.py
+++ b/fbpcs/service/workflow_sfn.py
@@ -49,7 +49,7 @@ class SfnWorkflowService(WorkflowService):
         self,
         workflow_conf: Dict[str, str],
         run_id: str,
-        run_conf: Optional[Dict[str, str]] = None,
+        run_conf: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Start workflow
         Keyword arguments:


### PR DESCRIPTION
Summary: To allow experiment users to configure all the spark infra, the pid mr configurations are added to publisher and partner specific yamls.

Reviewed By: wenqingren

Differential Revision: D37157845

