### PR TITLE
Pass spark configurations from stage service to workflow

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -69,6 +71,7 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
         Raises:
             NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
         """
+        logging.info("Start MR stage flow")
         if self is self.UNION_PID_MR_MULTIKEY:
             if args.workflow_svc is None:
                 raise NotImplementedError("workflow_svc is None")

--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -27,7 +27,7 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
     async def test_run_async(self, pid_mr_svc_mock) -> None:
 
         pc_instance = PrivateComputationInstance(
-            instance_id="123",
+            instance_id="publisher_123",
             role=PrivateComputationRole.PUBLISHER,
             instances=[],
             status=PrivateComputationInstanceStatus.PID_MR_STARTED,
@@ -36,12 +36,13 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=1,
             num_files_per_mpc_container=1,
             game_type=PrivateComputationGameType.LIFT,
-            input_path="456",
-            output_dir="789",
+            input_path="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/input.csv",
+            output_dir="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output",
             pid_configs={
                 "pid_mr": {
                     "PIDWorkflowConfigs": {"state_machine_arn": "machine_arn"},
                     "PIDRunConfigs": {"conf": "conf1"},
+                    "sparkConfigs": {"conf-2": "conf2"},
                 }
             },
         )
@@ -61,7 +62,8 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
             PrivateComputationInstanceStatus.PID_MR_COMPLETED,
         )
         self.assertEqual(
-            pc_instance.pid_mr_stage_output_data_path, "789/123_out_dir/pid_mr"
+            pc_instance.pid_mr_stage_output_data_path,
+            "https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output/publisher_123_out_dir/pid_mr",
         )
         self.assertEqual(pc_instance.instances[0].instance_id, "execution_arn")
         self.assertIsInstance(pc_instance.instances[0], StageStateInstance)

--- a/fbpcs/service/workflow.py
+++ b/fbpcs/service/workflow.py
@@ -8,7 +8,7 @@
 
 import abc
 from enum import Enum
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 
 class WorkflowStatus(Enum):
@@ -25,7 +25,7 @@ class WorkflowService(abc.ABC):
         self,
         workflow_conf: Dict[str, str],
         run_id: str,
-        run_conf: Optional[Dict[str, str]] = None,
+        run_conf: Optional[Dict[str, Any]] = None,
     ) -> str:
         pass
 


### PR DESCRIPTION
Summary:
This diff includes following changes
- Pass spark configurations to workflow service to use as part of pid run
- PID MR uses input as s3 paths with prefix s3:// while the input passed through pc is https. We need modify the prefix of the input and output paths to support the run
- Usually the instance id of publisher and partner are the same. The experimentation platform however adds a prefix to the instance_id ("publisher", "partner". In PID-MR we need to have same instance_id for on both sides as the common s3 directory for data sharing is created with this prefix. We remove these prefixes in stage service for now and revisit this for long term solution.

Reviewed By: wenqingren

Differential Revision: D37158126

