### PR TITLE
Add strip of null into sharder

### DIFF
--- a/fbpcs/data_processing/sharding/test/HashBasedSharderTest.cpp
+++ b/fbpcs/data_processing/sharding/test/HashBasedSharderTest.cpp
@@ -288,4 +288,44 @@ TEST(HashBasedSharderTest, TestShardMultiKeyWithHmacKey) {
       outputPaths.at(1), expected1);
 }
 
+TEST(HashBasedSharderTest, TestShardMultiKeyWithNullsQuotes) {
+  std::vector<std::string> rows{
+      "id_email,id_phone,a,b,c",
+      "\"abcd\",null,1,2,3",
+      "'abcd',\"hijk\",4,5,6",
+      "null,'defg',7,8,9",
+      "null,NULL,0,0,0",
+  };
+  std::string hmacKey = "abcd1234";
+
+  std::string inputPath = "/tmp/HashBasedSharderTestShardInput" +
+      std::to_string(folly::Random::secureRand64());
+  data_processing::test_utils::writeVecToFile(rows, inputPath);
+  // TODO: Would be great to mock out inputstream/outputstream stuff
+  auto randStart = folly::Random::secureRand64();
+  std::vector<std::string> outputPaths{
+      "/tmp/HashBasedSharderTestShardOutput" + std::to_string(randStart),
+      "/tmp/HashBasedSharderTestShardOutput" + std::to_string(randStart + 1),
+  };
+  HashBasedSharder sharder{inputPath, outputPaths, 123, hmacKey};
+  sharder.shard();
+
+  // HMAC was applied offline, which is how we got these expected lines
+  // HMAC_SHA256(CAST(id AS VARBINARY), FROM_BASE64(hmacKey)) in Presto is a
+  // good way to generate more of these given our I/O specification.
+  std::vector<std::string> expected0{
+      "id_email,id_phone,a,b,c",
+      ",bSRNJ92+ML97JRfp1lEvqssXNCX+lI2T/HQtHRTkBk4=,7,8,9", // ,defg line
+  };
+  std::vector<std::string> expected1{
+      "id_email,id_phone,a,b,c",
+      "9BX9ClsYtFj3L8N023K3mJnw1vemIGqenY5vfAY0/cg=,,1,2,3", // abcd, line
+      "9BX9ClsYtFj3L8N023K3mJnw1vemIGqenY5vfAY0/cg=,ZGCVov/c63+N2Swslf6pY6pWsNzS1IkXKVi+lmAD6yU=,4,5,6", // abcd,hijk line
+  };
+  data_processing::test_utils::expectFileRowsEqual(
+      outputPaths.at(0), expected0);
+  data_processing::test_utils::expectFileRowsEqual(
+      outputPaths.at(1), expected1);
+}
+
 } // namespace data_processing::sharder


### PR DESCRIPTION
Summary:
As we saw in the test of D36932431, Hive2S3Operator fill NULL columns with `null` instead of leaving it empty. In this diff, we are striping null columns.

We made sure that Athena query would leave it empty when the column value is NULL.

Differential Revision: D37160867

