### PR TITLE
Reduce compiler warnings. (2/n)

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
@@ -180,7 +180,7 @@ class MeasurementAggregator : public Aggregator {
 
     // Mapping the sorted original adIds with the compressed Ids : 1 to
     // num_of_ad_ids.
-    for (auto i = 0; i < validOriginalAdIds_.size(); i++) {
+    for (auto i = 0U; i < validOriginalAdIds_.size(); i++) {
       compressedAdIdToAdIdMap.insert({i + 1, validOriginalAdIds_.at(i)});
     }
     for (auto& [adId, metrics] : _adIdToMetrics) {

--- a/fbpcs/emp_games/lift/calculator/OutputMetrics.hpp
+++ b/fbpcs/emp_games/lift/calculator/OutputMetrics.hpp
@@ -196,7 +196,7 @@ void OutputMetrics<MY_ROLE>::initNumGroups() {
         privatelyShareBitsFromPublisher<MY_ROLE>(inputData_.bitmaskFor(i), n_);
   }
 
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     partnerBitmasks_[i] =
         privatelyShareBitsFromPartner<MY_ROLE>(inputData_.bitmaskFor(i), n_);
   }
@@ -484,7 +484,7 @@ std::vector<std::vector<emp::Bit>> OutputMetrics<MY_ROLE>::calculateEvents(
     }
   }
 
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     const auto& mask = partnerBitmasks_.at(i);
     auto groupEventBits =
         private_measurement::secret_sharing::multiplyBitmask(eventArrays, mask);
@@ -580,7 +580,7 @@ void OutputMetrics<MY_ROLE>::calculateMatchCount(
     }
   }
 
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     auto groupBits = private_measurement::secret_sharing::multiplyBitmask(
         matchArrays, partnerBitmasks_.at(i));
     if (groupType == GroupType::TEST) {
@@ -624,7 +624,7 @@ std::vector<emp::Bit> OutputMetrics<MY_ROLE>::calculateImpressions(
         reachArray, publisherBitmasks_.at(i));
   }
 
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     auto groupInts = private_measurement::secret_sharing::multiplyBitmask(
         impressionsArray, partnerBitmasks_.at(i));
     auto groupBits = private_measurement::secret_sharing::multiplyBitmask(
@@ -680,7 +680,7 @@ void OutputMetrics<MY_ROLE>::calculateReachedConversions(
     }
   }
 
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     auto groupInts = private_measurement::secret_sharing::multiplyBitmask(
         reachedConversions, partnerBitmasks_.at(i));
     if (groupType == GroupType::TEST) {
@@ -762,7 +762,7 @@ void OutputMetrics<MY_ROLE>::calculateValue(
     }
   }
 
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     auto groupInts = private_measurement::secret_sharing::multiplyBitmask(
         valueArrays, partnerBitmasks_.at(i));
     if (groupType == GroupType::TEST) {
@@ -828,7 +828,7 @@ void OutputMetrics<MY_ROLE>::calculateValueSquared(
       publisherBreakdowns_[i].controlValueSquared = sum(groupInts);
     }
   }
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
+  for (size_t i = 0; i < static_cast<std::size_t>(numPartnerCohorts_); ++i) {
     const auto& mask = partnerBitmasks_.at(i);
     auto groupInts = private_measurement::secret_sharing::multiplyBitmask(
         squaredValues, mask);

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -29,9 +29,9 @@ class AggregationApp {
       const std::vector<std::string>& inputSecretShareFilePaths,
       const std::vector<std::string>& inputClearTextFilePaths,
       const std::vector<std::string>& outputFilePaths,
-      const int startFileIndex = 0,
-      const int numFiles = 1,
-      const int concurrency = 1)
+      std::int32_t startFileIndex = 0,
+      std::int32_t numFiles = 1,
+      int concurrency = 1)
       : inputEncryption_(inputEncryption),
         outputVisibility_(outputVisibility),
         communicationAgentFactory_(std::move(communicationAgentFactory)),
@@ -129,9 +129,9 @@ class AggregationApp {
   std::vector<std::string> inputSecretShareFilePaths_;
   std::vector<std::string> inputClearTextFilePaths_;
   std::vector<std::string> outputFilePaths_;
-  int startFileIndex_;
-  int numFiles_;
-  int concurrency_;
+  const std::int32_t startFileIndex_;
+  const std::int32_t numFiles_;
+  const int concurrency_;
   common::SchedulerStatistics schedulerStatistics_;
 };
 

--- a/fbpcs/emp_games/pcf2_aggregation/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_aggregation/MainUtil.h
@@ -60,7 +60,9 @@ inline common::SchedulerStatistics startAggregationAppsForShardedFilesHelper(
   common::SchedulerStatistics schedulerStatistics{0, 0, 0, 0};
 
   // split files evenly across threads
-  auto remainingFiles = inputSecretShareFilenames.size() - startFileIndex;
+  auto remainingFiles =
+      static_cast<std::int64_t>(inputSecretShareFilenames.size()) -
+      startFileIndex;
   if (remainingFiles > 0) {
     auto numFiles = (remainingThreads > remainingFiles)
         ? 1

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -30,8 +30,8 @@ class AttributionApp {
       const std::string& attributionRules,
       const std::vector<std::string>& inputFilenames,
       const std::vector<std::string>& outputFilenames,
-      const int startFileIndex = 0,
-      const int numFiles = 1)
+      std::uint32_t startFileIndex = 0U,
+      int numFiles = 1)
       : communicationAgentFactory_(std::move(communicationAgentFactory)),
         attributionRules_{attributionRules},
         inputFilenames_(inputFilenames),
@@ -105,8 +105,8 @@ class AttributionApp {
   std::string attributionRules_;
   std::vector<std::string> inputFilenames_;
   std::vector<std::string> outputFilenames_;
-  int startFileIndex_;
-  int numFiles_;
+  const std::uint32_t startFileIndex_;
+  const int numFiles_;
   common::SchedulerStatistics schedulerStatistics_;
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h
@@ -92,7 +92,7 @@ AttributionInputMetrics<usingBatch, inputEncryption>::parseTouchpoints(
       << "This implementation currently only supports unique touchpoint ids per user.";
 
   std::vector<ParsedTouchpoint> tps;
-  for (auto i = 0; i < timestamps.size(); ++i) {
+  for (auto i = 0U; i < timestamps.size(); ++i) {
     tps.push_back(ParsedTouchpoint{
         /* id */ unique_ids.at(i),
         /* isClick */ isClicks.at(i) == 1,
@@ -112,7 +112,9 @@ AttributionInputMetrics<usingBatch, inputEncryption>::parseTouchpoints(
 
   // Add padding at the end of the input data for publisher; partner data
   // consists only of padded data
-  for (auto i = tps.size(); i < FLAGS_max_num_touchpoints; ++i) {
+  for (auto i = tps.size();
+       i < static_cast<std::size_t>(FLAGS_max_num_touchpoints);
+       ++i) {
     tps.push_back(ParsedTouchpoint{-1, false, 0, 0, 0});
   }
   return tps;

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -67,7 +67,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
   common::SchedulerStatistics schedulerStatistics{0, 0, 0, 0};
 
   // split files evenly across threads
-  auto remainingFiles = inputFilenames.size() - startFileIndex;
+  auto remainingFiles =
+      static_cast<std::int64_t>(inputFilenames.size()) - startFileIndex;
   if (remainingFiles > 0) {
     auto numFiles = (remainingThreads > remainingFiles)
         ? 1


### PR DESCRIPTION
Summary:
Previously compiler warning existed:

``
/root/build/emp_game/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp: In member function 'virtual aggregation::private_aggregation::AggregationOutput aggregation::private_aggregation::{anonymous}::MeasurementAggregator::reveal() const':
/root/build/emp_game/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp:183:24: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<long int>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  183 |     for (auto i = 0; i < validOriginalAdIds_.size(); i++) {
      |

/root/build/emp_game/fbpcs/emp_games/pcf2_attribution/main.cpp:74:40:   required from here
/root/build/emp_game/fbpcs/emp_games/pcf2_attribution/MainUtil.h:72:39: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   72 |     auto numFiles = (remainingThreads > remainingFiles)
      |
```

Now fixing the code to remove the warnings.

Differential Revision: D37180017

