### PR TITLE
Develop start_pid_prepare_service() to call in PIDPrepareStageService

### DIFF
--- a/fbpcs/onedocker_binary_config.py
+++ b/fbpcs/onedocker_binary_config.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 
 from dataclasses_json import dataclass_json
 
+ONEDOCKER_REPOSITORY_PATH = "ONEDOCKER_REPOSITORY_PATH"
+
 
 @dataclass_json
 @dataclass

--- a/fbpcs/pid/service/pid_service/pid_prepare_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_prepare_stage.py
@@ -10,6 +10,7 @@ from typing import Optional
 from fbpcs.data_processing.pid_preparer.union_pid_preparer_cpp import (
     CppUnionPIDDataPreparerService,
 )
+from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
 from fbpcs.pid.entity.pid_instance import PIDStageStatus
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
@@ -77,7 +78,7 @@ class PIDPrepareStage(PIDStage):
             next_input_path = self.get_sharded_filepath(input_path, shard)
             next_output_path = self.get_sharded_filepath(output_path, shard)
             env_vars = {
-                "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
+                ONEDOCKER_REPOSITORY_PATH: self.onedocker_binary_config.repository_path
             }
             coro = preparer.prepare_on_container_async(
                 input_path=next_input_path,

--- a/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py
@@ -10,7 +10,10 @@ from typing import Dict, List, Optional
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcp.util.typing import checked_cast
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.pid.entity.pid_instance import PIDProtocol, PIDStageStatus
 from fbpcs.pid.entity.pid_stages import UnionPIDStage
@@ -282,6 +285,6 @@ class PIDProtocolRunStage(PIDStage):
     def _gen_env_vars(self) -> Dict[str, str]:
         env_vars = {
             "RUST_LOG": "info",
-            "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path,
+            ONEDOCKER_REPOSITORY_PATH: self.onedocker_binary_config.repository_path,
         }
         return env_vars

--- a/fbpcs/pid/service/pid_service/pid_shard_stage.py
+++ b/fbpcs/pid/service/pid_service/pid_shard_stage.py
@@ -9,6 +9,7 @@
 from typing import Optional
 
 from fbpcs.data_processing.service.sharding_service import ShardingService, ShardType
+from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
 from fbpcs.pid.entity.pid_instance import PIDStageStatus
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.pid.service.pid_service.pid_stage_input import PIDStageInput
@@ -96,7 +97,7 @@ class PIDShardStage(PIDStage):
                 hmac_key=hmac_key,
             )
             env_vars = {
-                "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
+                ONEDOCKER_REPOSITORY_PATH: self.onedocker_binary_config.repository_path
             }
             binary_name = sharder.get_binary_name(ShardType.HASHED_FOR_PID)
             containers = await sharder.start_containers(

--- a/fbpcs/private_computation/service/input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/service/input_data_validation_stage_service.py
@@ -11,7 +11,10 @@ from typing import DefaultDict, List, Optional
 
 from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -87,7 +90,7 @@ class InputDataValidationStageService(PrivateComputationStageService):
         binary_config = self._onedocker_binary_config_map[binary_name]
         cmd_args = get_cmd_args(pc_instance.input_path, region, binary_config)
 
-        env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
+        env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}
         container_instances = await RunBinaryBaseService().start_containers(
             [cmd_args],
             self._onedocker_svc,

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -7,10 +7,23 @@
 import logging
 from typing import DefaultDict, List, Optional
 
+from fbpcp.entity.container_instance import ContainerInstance
+
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.data_processing.service.pid_prepare_binary_service import (
+    PIDPrepareBinaryService,
+)
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
+from fbpcs.pid.service.pid_service.pid_stage import PIDStage
+from fbpcs.pid.service.pid_service.utils import (
+    get_max_id_column_cnt,
+    get_pid_protocol_from_num_shards,
+)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -19,6 +32,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    all_files_exist_on_cloud,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     get_pc_status_from_stage_state,
 )
@@ -63,7 +77,9 @@ class PIDPrepareStageService(PrivateComputationStageService):
             An updated version of pc_instance
         """
         self._logger.info(f"[{self}] Starting PIDPrepareStageService")
-        container_instances = []
+        container_instances = await self.start_pid_prepare_service(
+            pc_instance, server_ips
+        )
 
         self._logger.info("PIDPrepareStageService finished")
         stage_state = StageStateInstance(
@@ -87,3 +103,52 @@ class PIDPrepareStageService(PrivateComputationStageService):
             The latest status for private computation instance
         """
         return get_pc_status_from_stage_state(pc_instance, self._onedocker_svc)
+
+    async def start_pid_prepare_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]],
+    ) -> List[ContainerInstance]:
+        """start pid prepare service and spine up the container instances"""
+        logging.info("Instantiated PID prepare stage")
+        num_shards = pc_instance.num_pid_containers
+        # input_path is the output_path from PID Shard Stage
+        input_path = pc_instance.pid_stage_output_data_path
+        output_path = pc_instance.pid_stage_output_prepare_path
+        pc_role = pc_instance.role
+
+        # make sure all input files are on the storage service before proceed
+        if not await all_files_exist_on_cloud(
+            input_path, num_shards, self._storage_svc
+        ):
+            raise ValueError(
+                f"At least one input file for PIDPrepareStageService are missing in {input_path}"
+            )
+
+        # generate the list of command args for publisher or partner
+        args_list = []
+        # later mltikey_enabled, protocol, and max_col_cnt wil be centralized in PrivateComputationInstance.
+        protocol = get_pid_protocol_from_num_shards(num_shards, self._multikey_enabled)
+        binary_name = PIDPrepareBinaryService.get_binary_name()
+        onedocker_binary_config = self._onedocker_binary_config_map[binary_name]
+        for shard in range(num_shards):
+            args_per_shard = PIDPrepareBinaryService.build_args(
+                input_path=PIDStage.get_sharded_filepath(input_path, shard),
+                output_path=PIDStage.get_sharded_filepath(output_path, shard),
+                tmp_directory=onedocker_binary_config.tmp_directory,
+                max_column_count=get_max_id_column_cnt(protocol),
+            )
+            args_list.append(args_per_shard)
+        # start containers
+        logging.info(f"{pc_role} spinning up containers")
+
+        env_vars = {ONEDOCKER_REPOSITORY_PATH: onedocker_binary_config.repository_path}
+        pid_prepare_binary_service = PIDPrepareBinaryService()
+        return await pid_prepare_binary_service.start_containers(
+            cmd_args_list=args_list,
+            onedocker_svc=self._onedocker_svc,
+            binary_version=onedocker_binary_config.binary_version,
+            binary_name=binary_name,
+            timeout=self._container_timeout,
+            env_vars=env_vars,
+        )

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -15,7 +15,10 @@ from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.data_processing.service.pid_run_protocol_binary_service import (
     PIDRunProtocolBinaryService,
 )
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
 from fbpcs.pid.entity.pid_instance import PIDProtocol
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
 from fbpcs.pid.service.pid_service.utils import get_pid_protocol_from_num_shards
@@ -141,9 +144,7 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
         logging.info(f"{pc_role} spinning up containers")
         binary_name = pid_run_protocol_binary_service.get_binary_name(protocol, pc_role)
         onedocker_binary_config = self._onedocker_binary_config_map[binary_name]
-        env_vars = {
-            "ONEDOCKER_REPOSITORY_PATH": onedocker_binary_config.repository_path
-        }
+        env_vars = {ONEDOCKER_REPOSITORY_PATH: onedocker_binary_config.repository_path}
         return await pid_run_protocol_binary_service.start_containers(
             cmd_args_list=args_list,
             onedocker_svc=self._onedocker_svc,

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any, Dict, List
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus
+from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.service.input_data_validation_stage_service import (
     PRE_VALIDATION_CHECKS_TIMEOUT,
@@ -38,7 +39,7 @@ class PreValidateService:
         onedocker_svc = pc_service.onedocker_svc
         binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
         binary_config = pc_service.onedocker_binary_config_map[binary_name]
-        env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
+        env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}
 
         cmd_args = [
             get_cmd_args(input_path, region, binary_config)

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -29,7 +29,10 @@ from fbpcs.common.entity.stage_state_instance import (
 from fbpcs.data_processing.service.id_spine_combiner import IdSpineCombinerService
 from fbpcs.data_processing.service.sharding_service import ShardingService, ShardType
 from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
@@ -263,7 +266,7 @@ async def start_combiner_service(
         padding_size=padding_size,
         log_cost=log_cost,
     )
-    env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
+    env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}
     return await combiner_service.start_containers(
         cmd_args_list=args,
         onedocker_svc=onedocker_svc,
@@ -331,7 +334,7 @@ async def start_sharder_service(
         args_list.append(args_per_shard)
 
     binary_name = sharder.get_binary_name(ShardType.ROUND_ROBIN)
-    env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
+    env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}
     return await sharder.start_containers(
         cmd_args_list=args_list,
         onedocker_svc=onedocker_svc,

--- a/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_input_data_validation_stage_service.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -85,7 +88,7 @@ class TestInputDataValidationStageService(IsolatedAsyncioTestCase):
 
         await stage_service.run_async(pc_instance)
 
-        env_vars = {"ONEDOCKER_REPOSITORY_PATH": "test_path/"}
+        env_vars = {ONEDOCKER_REPOSITORY_PATH: "test_path/"}
         mock_run_binary_base_service_start_containers.assert_called_with(
             [expected_cmd_args],
             mock_onedocker_svc,

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -14,7 +14,10 @@ from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.data_processing.service.pid_run_protocol_binary_service import (
     PIDRunProtocolBinaryService,
 )
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.onedocker_binary_config import (
+    ONEDOCKER_REPOSITORY_PATH,
+    OneDockerBinaryConfig,
+)
 from fbpcs.pcf.tests.async_utils import AsyncMock, to_sync
 from fbpcs.pid.entity.pid_instance import PIDProtocol
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -93,7 +96,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
 
         binary_name = PIDRunProtocolBinaryService.get_binary_name(protocol, pc_role)
         binary_config = self.onedocker_binary_config_map[binary_name]
-        env_vars = {"ONEDOCKER_REPOSITORY_PATH": binary_config.repository_path}
+        env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}
         args_str_expect = self.get_args_expect(pc_role, protocol, self.use_row_numbers)
         # test the start_containers is called with expected parameters
         self.mock_onedocker_svc.start_containers.assert_called_with(


### PR DESCRIPTION
Summary:
In this diff, I implemented function start_pid_prepare_service() as a step to deprecate the old system PIDPrepareStage. This function takes care of the logic to spin up containers in AWS.
Function Details:
set up the arguments for the containers
uses PIDPrepareBinaryService to generate commands from the arguments
calls start_containers in PIDPrepareBinaryService, and return those containers
And it will be called by the function run_async() in  PIDPrepareStageService.

Differential Revision: D36922117

