### PR TITLE
Fix broken link in fbpcs README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Facebook Private Computation Solutions provides multiple solutions that leverage various Privacy Enhancing Technologies (e.g., multi-party computation, differential privacy) used across Measurement and Signals. The existing solutions includes Private Lift and Private Attribution, which allow calculations of Lift and Attribution metrics without revealing opportunity or conversion data on an individual level through 2PC.
 
 ## AWS Infra Set-up
-* [Instruction](fbpcs/infra/Readme.md)
+* [Instruction](fbpcs/infra/cloud_bridge/README.md)
 
 ## Docker Images
 * [Data processing](fbpcs/data_processing/README.md)


### PR DESCRIPTION
Summary: D32223993 (https://github.com/facebookresearch/fbpcs/commit/ece91fea01ca4c1d7d4259add096e087ad583b80) removed the fbpcs/infra/Readme.md with Partner instructions in favor of https://fburl.com/code/1mx36v5m. However, we still have a reference to the removed file in our top-level Readme. Updating it.

Reviewed By: jrodal98

Differential Revision: D37204295

