### PR TITLE
Update dockerfile to add non-root users

### DIFF
--- a/fbpcs/Dockerfile
+++ b/fbpcs/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim
 
+# Install Dependencies
 RUN apt-get update
 RUN apt-get install -y software-properties-common
 RUN apt-get update && apt-get install -y \
@@ -9,9 +10,18 @@ RUN apt-get update && apt-get install -y \
     unzip \
     vim
 
-RUN mkdir /pl_coordinator_env
-COPY fbpcs/ /pl_coordinator_env/fbpcs/
-WORKDIR /pl_coordinator_env
+# Create the pcs user
+RUN useradd -ms /bin/bash pcs
+
+# Switch to pcs user
+USER pcs
+
+RUN mkdir /home/pcs/pl_coordinator_env
+COPY fbpcs/ /home/pcs/pl_coordinator_env/fbpcs/
+WORKDIR /home/pcs/pl_coordinator_env
+
+# Switch back to root to ensure root user run compatible
+USER root
 RUN python3.8 -m pip install -r fbpcs/pip_requirements.txt
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Summary:
## Why
Amazon wants to start containers as non-root users, however our docker image only support root users by default, this diff is to update dockerfile of production image to add non-root user (`pcs`)

We want the image to be backwards compatible (both root and non-root users can use it)

## What
* Adding pcs user in Dockerfile
* moving pcs repo from `/pl_coordinator_env` to `/home/pcs/pl_coordinator_env`
* set default working directory from `/pl_coordinator_env` to `/home/pcs/pl_coordinator_env`

## Note
Here are some changes needed for Amazon to run `non-root` user (`pcs`)
example: D37252318

Differential Revision: D37251639

