### PR TITLE
Add cohort and breakdown entities for computing lift metrics (#1095)

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/sample_input/correctness_output.json
+++ b/fbpcs/emp_games/lift/pcf2_calculator/sample_input/correctness_output.json
@@ -73,5 +73,42 @@
             "controlConvHistogram": []
         }
     ],
-    "publisherBreakdowns": []
+    "publisherBreakdowns": [
+        {
+            "testConversions": 4,
+            "controlConversions": 4,
+            "testConverters": 3,
+            "controlConverters": 3,
+            "testNumConvSquared": 6,
+            "controlNumConvSquared": 6,
+            "testMatchCount": 6,
+            "controlMatchCount": 6,
+            "reachedConversions": 1,
+            "testValue": 30,
+            "controlValue": 70,
+            "reachedValue": 50,
+            "testValueSquared": 5900,
+            "controlValueSquared": 1700,
+            "testConvHistogram": [],
+            "controlConvHistogram": []
+        },
+        {
+            "testConversions": 5,
+            "controlConversions": 1,
+            "testConverters": 4,
+            "controlConverters": 1,
+            "testNumConvSquared": 7,
+            "controlNumConvSquared": 1,
+            "testMatchCount": 6,
+            "controlMatchCount": 1,
+            "reachedConversions": 3,
+            "testValue": 90,
+            "controlValue": -50,
+            "reachedValue": 50,
+            "testValueSquared": 2100,
+            "controlValueSquared": 2500,
+            "testConvHistogram": [],
+            "controlConvHistogram": []
+        }
+    ]
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -223,6 +223,7 @@ TEST_P(CalculatorAppTestFixture, TestCorrectnessRandomInput) {
       inFilePublisher, inFilePartner, colNameToIndex, tsOffset, false);
 
   res.publisherBreakdowns.clear();
+  res.publisherBreakdowns.clear();
   expectedResult.publisherBreakdowns.clear();
   expectedResult.cohortMetrics.clear();
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -169,10 +169,11 @@ TEST_P(CalculatorAppTestFixture, TestCorrectness) {
   auto expectedResult =
       GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputPath));
 
-  // In this test we are not worried about cohorts or publisher breakdowns yet.
+  // In this test we are not worried about publisher breakdowns yet.
   // TODO: update this test once the breakdown aggregations are
   // implemented.
   result.publisherBreakdowns.clear();
+  expectedResult.publisherBreakdowns.clear();
 
   EXPECT_EQ(expectedResult, result);
 }
@@ -221,11 +222,6 @@ TEST_P(CalculatorAppTestFixture, TestCorrectnessRandomInput) {
       liftCalculator.mapColToIndex(headerPublisher, headerPartner);
   GroupedLiftMetrics expectedResult = liftCalculator.compute(
       inFilePublisher, inFilePartner, colNameToIndex, tsOffset, false);
-
-  res.publisherBreakdowns.clear();
-  res.publisherBreakdowns.clear();
-  expectedResult.publisherBreakdowns.clear();
-  expectedResult.cohortMetrics.clear();
 
   EXPECT_EQ(expectedResult, res);
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -223,7 +223,6 @@ TEST_P(CalculatorAppTestFixture, TestCorrectnessRandomInput) {
       inFilePublisher, inFilePartner, colNameToIndex, tsOffset, false);
 
   res.publisherBreakdowns.clear();
-  res.publisherBreakdowns.clear();
   expectedResult.publisherBreakdowns.clear();
   expectedResult.cohortMetrics.clear();
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h
@@ -70,6 +70,87 @@ class LiftCalculator {
     return out;
   }
 
+  /**
+   * Updates the `GroupedLiftMetrics` with metrics related to **Test** group.
+   */
+  void updateTestMetrics(
+      GroupedLiftMetrics& glm,
+      const uint64_t& opportunityTimestamp,
+      const std::vector<uint64_t>& eventTimestamps,
+      const uint8_t cohortId,
+      const uint8_t breakdownId,
+      const uint64_t tsOffset,
+      const uint64_t numImpressions,
+      const int64_t valuesIdx,
+      const std::vector<int64_t>& values) const;
+
+  /**
+   * Updates the `GroupedLiftMetrics` with metrics related to **Control** group.
+   */
+  void updateControlMetrics(
+      GroupedLiftMetrics& glm,
+      const uint64_t& opportunityTimestamp,
+      const std::vector<uint64_t>& eventTimestamps,
+      const uint8_t cohortId,
+      const uint8_t breakdownId,
+      const uint64_t tsOffset,
+      const int64_t valuesIdx,
+      const std::vector<int64_t>& values) const;
+
+  /**
+   * Checks if the control event occurred after opportunity time and if was
+   * attributed already increments match count and returns true.
+   */
+  bool checkAndUpdateControlMatchCount(
+      GroupedLiftMetrics& glm,
+      uint64_t opportunityTimestamp,
+      uint64_t eventTimestamp,
+      bool countedMatchAlready,
+      uint8_t cohortId,
+      uint8_t breakdownId) const;
+
+  /**
+   * Checks if the test event occurred after opportunity + tsOffset  time and if
+   * was attributed already increments match count and returns true.
+   */
+  bool checkAndUpdateTestMatchCount(
+      GroupedLiftMetrics& glm,
+      uint64_t opportunityTimestamp,
+      uint64_t eventTimestamp,
+      bool countedMatchAlready,
+      uint8_t cohortId,
+      uint8_t breakdownId) const;
+
+  /**
+   * Checks if the control event occurred after opportunity + tsOffset time and
+   * increments control conversions. If the conversion was a valid conversion,
+   * then increments controlConverters.
+   * @return true if opportunityTime < (event + tsOffset)
+   */
+  bool checkAndUpdateControlConversions(
+      GroupedLiftMetrics& glm,
+      uint64_t opportunityTimestamp,
+      uint64_t eventTimestamp,
+      int32_t tsOffset,
+      bool converted,
+      uint8_t cohortId,
+      uint8_t breakdownId) const;
+
+  /**
+   * Checks if the test event occurred after opportunity + tsOffset time and
+   * increments control conversions. If the conversion was a valid conversion,
+   * then increments controlConverters.
+   * @return true if opportunityTime < (event + tsOffset)
+   */
+  bool checkAndUpdateTestConversions(
+      GroupedLiftMetrics& glm,
+      uint64_t opportunityTimestamp,
+      uint64_t eventTimestamp,
+      int32_t tsOffset,
+      bool converted,
+      uint8_t cohortId,
+      uint8_t breakdownId) const;
+
   std::tuple<uint64_t, bool> parseUint64OrDie(
       const std::string& column,
       const std::vector<std::string>& inLine,

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftCalculatorLocalTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftCalculatorLocalTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include <fbpcf/io/FileManagerUtil.h>
+#include "fbpcs/emp_games/common/TestUtil.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h"
+
+namespace private_lift {
+
+TEST(LiftCalculatorLocalTest, JsonCorrectnessTest) {
+  uint64_t epoch = 1546300800;
+  uint64_t numCohorts = 3;
+  uint64_t numPublisherBreakdowns = 2;
+  std::string baseDir =
+      private_measurement::test_util::getBaseDirFromPath(__FILE__);
+  std::string publisherInputPath =
+      baseDir + "../../../sample_input/publisher_unittest3.csv";
+  std::string partnerInputPath =
+      baseDir + "../../../sample_input/partner_2_convs_unittest.csv";
+  std::string expectedOutputPath =
+      baseDir + "../../../sample_input/correctness_output.json";
+
+  LiftCalculator liftCalculator(numCohorts, numPublisherBreakdowns, epoch);
+  std::ifstream inFilePublisher{publisherInputPath};
+  std::ifstream inFilePartner{partnerInputPath};
+  int32_t tsOffset = 10;
+  std::string linePublisher;
+  std::string linePartner;
+  getline(inFilePublisher, linePublisher);
+  getline(inFilePartner, linePartner);
+  auto headerPublisher =
+      private_measurement::csv::splitByComma(linePublisher, false);
+  auto headerPartner =
+      private_measurement::csv::splitByComma(linePartner, false);
+  std::unordered_map<std::string, int> colNameToIndex =
+      liftCalculator.mapColToIndex(headerPublisher, headerPartner);
+  GroupedLiftMetrics result = liftCalculator.compute(
+      inFilePublisher, inFilePartner, colNameToIndex, tsOffset, false);
+  GroupedLiftMetrics expectedResult =
+      GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputPath));
+
+  EXPECT_EQ(result, expectedResult);
+}
+
+} // namespace private_lift


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/1095

# Context
This commit adds <entity> aggregations to compute LiftMetrics in plaintext LiftCalculator.
<entity> : [cohorts, publisherBreakdowns]
# Changes in this diff
1. correctness json test file that contains results for publisher breakdown.
2. New unittest file that checks this correctness.
3. Changes to LiftCalculator that implments the context of this summary.
 a. The clang-tidy linter was complaining about cyclomatic complexity of the `comput()` function. So or so, I have divided the the method into test update and control update

Reviewed By: chualynn

Differential Revision: D37246880

