### PR TITLE
PA target id compression

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -34,6 +34,16 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       const int myRole,
       const AttributionInputMetrics<usingBatch, inputEncryption>& inputData);
 
+  std::vector<uint64_t> retrieveValidOriginalTargetIds(
+      int myRole,
+      std::vector<TouchpointT<usingBatch>>& touchpoints,
+      std::vector<ConversionT<usingBatch>>& conversions);
+
+  void replaceTargetIdWithCompressedTargetId(
+      std::vector<TouchpointT<usingBatch>>& touchpoints,
+      std::vector<ConversionT<usingBatch>>& conversions,
+      std::vector<uint64_t>& validOriginalTargetIds);
+
   using PrivateTouchpointT = ConditionalVector<
       PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
       !usingBatch>;
@@ -48,7 +58,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   std::vector<std::shared_ptr<
       const AttributionRule<schedulerId, usingBatch, inputEncryption>>>
   shareAttributionRules(
-      const int myRole,
+      int myRole,
       const std::vector<std::string>& attributionRuleNames);
 
   /**

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -9,6 +9,8 @@
 
 #include <algorithm>
 #include <exception>
+
+#include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/pcf2_attribution/AttributionGame.h"
 #include "fbpcs/emp_games/pcf2_attribution/Constants.h"
 
@@ -291,6 +293,172 @@ template <
     int schedulerId,
     bool usingBatch,
     common::InputEncryption inputEncryption>
+std::vector<uint64_t>
+AttributionGame<schedulerId, usingBatch, inputEncryption>::
+    retrieveValidOriginalTargetIds(
+        int myRole,
+        std::vector<TouchpointT<usingBatch>>& touchpoints,
+        std::vector<ConversionT<usingBatch>>& conversions) {
+  std::unordered_set<uint64_t> targetIdSet;
+
+  auto revealTargetId = [&](const auto& secOriginalTargetId) {
+    auto publisherTargetId =
+        secOriginalTargetId.openToParty(common::PUBLISHER).getValue();
+    auto partnerTargetId =
+        secOriginalTargetId.openToParty(common::PARTNER).getValue();
+    auto revealedTargetId =
+        (myRole == common::PUBLISHER) ? publisherTargetId : partnerTargetId;
+    return revealedTargetId;
+  };
+
+  auto publisherSideExtractTargetId = [&](const auto& touchpointT) {
+    SecOriginalTargetId<schedulerId, usingBatch> secOriginalTargetId;
+    if (inputEncryption == common::InputEncryption::Xor) {
+      typename SecOriginalTargetId<schedulerId, usingBatch>::ExtractedInt
+          extractedTargetId(touchpointT.targetId);
+      secOriginalTargetId = SecOriginalTargetId<schedulerId, usingBatch>(
+          std::move(extractedTargetId));
+    } else {
+      secOriginalTargetId = SecOriginalTargetId<schedulerId, usingBatch>(
+          touchpointT.targetId, common::PUBLISHER);
+    }
+    return secOriginalTargetId;
+  };
+
+  auto partnerSideExtractTargetId = [&](const auto& conversionT) {
+    SecOriginalTargetId<schedulerId, usingBatch> secOriginalTargetId;
+    if (inputEncryption == common::InputEncryption::Plaintext) {
+      secOriginalTargetId = SecOriginalTargetId<schedulerId, usingBatch>(
+          conversionT.targetId, common::PARTNER);
+    } else {
+      typename SecOriginalTargetId<schedulerId, usingBatch>::ExtractedInt
+          extractedTargetId(conversionT.targetId);
+      secOriginalTargetId = SecOriginalTargetId<schedulerId, usingBatch>(
+          std::move(extractedTargetId));
+    }
+    return secOriginalTargetId;
+  };
+
+  if constexpr (usingBatch) {
+    // publisher side
+    for (auto& touchpointT : touchpoints) {
+      // Reveal target id to publisher and partner
+      auto secOriginalTargetId = publisherSideExtractTargetId(touchpointT);
+      auto revealedTargetId = revealTargetId(secOriginalTargetId);
+
+      touchpointT.originalTargetId = revealedTargetId;
+      for (const auto& tid : revealedTargetId) {
+        if (tid > 0) {
+          targetIdSet.insert(tid);
+        }
+      }
+    }
+    // partner side
+    for (auto& conversionT : conversions) {
+      auto secOriginalTargetId = partnerSideExtractTargetId(conversionT);
+      // Reveal target id to publisher and partner
+      auto revealedTargetId = revealTargetId(secOriginalTargetId);
+
+      conversionT.originalTargetId = revealedTargetId;
+      for (const auto& tid : revealedTargetId) {
+        if (tid > 0) {
+          targetIdSet.insert(tid);
+        }
+      }
+    }
+  } else {
+    // publisher side
+    for (auto& touchpointT : touchpoints) {
+      for (auto& touchpoint : touchpointT) {
+        auto secOriginalTargetId = publisherSideExtractTargetId(touchpoint);
+        // Reveal target id to publisher and partner
+        auto revealedTargetId = revealTargetId(secOriginalTargetId);
+
+        touchpoint.originalTargetId = revealedTargetId;
+        if (revealedTargetId > 0) {
+          targetIdSet.insert(revealedTargetId);
+        }
+      }
+    }
+    // partner side
+    for (auto& conversionT : conversions) {
+      for (auto& conversion : conversionT) {
+        auto secOriginalTargetId = partnerSideExtractTargetId(conversion);
+        // Reveal target id to publisher and partner
+        auto revealedTargetId = revealTargetId(secOriginalTargetId);
+
+        conversion.originalTargetId = revealedTargetId;
+        if (revealedTargetId > 0) {
+          targetIdSet.insert(revealedTargetId);
+        }
+      }
+    }
+  }
+  XLOGF(INFO, "Number of Distinct Target Ids: {}", targetIdSet.size());
+  // Added a check here to make sure that number of target Ids never exceed
+  // 65,536 (16 unsigned bit).
+  CHECK_LE(targetIdSet.size(), 65536)
+      << "Number of target Ids cannot be more than 65,536.";
+
+  std::vector<uint64_t> validOriginalTargetIds(
+      targetIdSet.begin(), targetIdSet.end());
+  return validOriginalTargetIds;
+}
+
+template <
+    int schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption>
+void AttributionGame<schedulerId, usingBatch, inputEncryption>::
+    replaceTargetIdWithCompressedTargetId(
+        std::vector<TouchpointT<usingBatch>>& touchpoints,
+        std::vector<ConversionT<usingBatch>>& conversions,
+        std::vector<uint64_t>& validOriginalTargetIds) {
+  uint64_t compressedTargetId = 1;
+  std::unordered_map<uint64_t, uint64_t> targetIdToCompressedTargetIdMap;
+
+  for (auto targetId : validOriginalTargetIds) {
+    targetIdToCompressedTargetIdMap.insert({targetId, compressedTargetId});
+    compressedTargetId++;
+  }
+
+  auto replaceTargetId = [&](auto& attributionArray) {
+    if constexpr (usingBatch) {
+      for (auto& attributionArrayT : attributionArray) {
+        std::vector<uint64_t> compressedTargetId;
+        for (const auto& originalTargetId :
+             attributionArrayT.originalTargetId) {
+          if (originalTargetId > 0) {
+            compressedTargetId.push_back(
+                targetIdToCompressedTargetIdMap.at(originalTargetId));
+          } else {
+            compressedTargetId.push_back(originalTargetId);
+          }
+        }
+        attributionArrayT.targetId = compressedTargetId;
+      }
+    } else {
+      for (auto& attributionArrayT : attributionArray) {
+        for (auto& attributionData : attributionArrayT) {
+          if (attributionData.originalTargetId > 0) {
+            attributionData.targetId = targetIdToCompressedTargetIdMap.at(
+                attributionData.originalTargetId);
+          } else {
+            attributionData.targetId = attributionData.originalTargetId;
+          }
+        }
+      }
+    }
+  };
+
+  replaceTargetId(touchpoints);
+  replaceTargetId(conversions);
+}
+
+template <
+    int schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption>
 AttributionOutputMetrics
 AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
     const int myRole,
@@ -300,11 +468,20 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
   uint32_t numIds = ids.size();
   XLOGF(INFO, "Have {} ids", numIds);
 
+  auto touchpointArrays = inputData.getTouchpointArrays();
+  auto conversionArrays = inputData.getConversionArrays();
+
+  auto validOriginalTargetId = retrieveValidOriginalTargetIds(
+      myRole, touchpointArrays, conversionArrays);
+
+  replaceTargetIdWithCompressedTargetId(
+      touchpointArrays, conversionArrays, validOriginalTargetId);
+
   // Send over all of the data needed for this computation
   XLOG(INFO, "Privately sharing touchpoints...");
-  auto tpArrays = privatelyShareTouchpoints(inputData.getTouchpointArrays());
+  auto tpArrays = privatelyShareTouchpoints(touchpointArrays);
   XLOG(INFO, "Privately sharing conversions...");
-  auto convArrays = privatelyShareConversions(inputData.getConversionArrays());
+  auto convArrays = privatelyShareConversions(conversionArrays);
 
   // Currently we only have one attribution output format
   std::string attributionFormat = "default";
@@ -322,7 +499,7 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
 
     // Share touchpoint threshold information for computing attributions
     auto thresholdArrays = privatelyShareThresholds(
-        inputData.getTouchpointArrays(), tpArrays, *attributionRule, numIds);
+        touchpointArrays, tpArrays, *attributionRule, numIds);
     CHECK_EQ(thresholdArrays.size(), tpArrays.size())
         << "threshold arrays and touchpoint arrays are not the same length.";
 

--- a/fbpcs/emp_games/pcf2_attribution/Constants.h
+++ b/fbpcs/emp_games/pcf2_attribution/Constants.h
@@ -13,7 +13,8 @@ namespace pcf2_attribution {
 
 const int kMaxConcurrency = 16;
 const size_t timeStampWidth = 32;
-const size_t targetIdWidth = 64;
+const size_t originalTargetIdWidth = 64;
+const size_t targetIdWidth = 16;
 const size_t actionTypeWidth = 16;
 
 template <int schedulerId, bool usingBatch = true>
@@ -36,6 +37,13 @@ using PubTargetId = typename fbpcf::frontend::MpcGame<
 template <int schedulerId, bool usingBatch = true>
 using SecTargetId = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<targetIdWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubOriginalTargetId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<originalTargetIdWidth, usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecOriginalTargetId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<originalTargetIdWidth, usingBatch>;
 
 template <int schedulerId, bool usingBatch = true>
 using PubActionType = typename fbpcf::frontend::MpcGame<

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -17,6 +17,7 @@ struct Conversion {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
+  ConditionalVector<uint64_t, usingBatch> originalTargetId;
 };
 
 template <bool usingBatch>
@@ -35,22 +36,19 @@ struct PrivateConversion {
     if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
       ts =
           SecTimestamp<schedulerId, usingBatch>(conversion.ts, common::PARTNER);
-      targetId = SecTargetId<schedulerId, usingBatch>(
-          conversion.targetId, common::PARTNER);
       actionType = SecActionType<schedulerId, usingBatch>(
           conversion.actionType, common::PARTNER);
     } else {
       typename SecTimestamp<schedulerId, usingBatch>::ExtractedInt extractedTs(
           conversion.ts);
       ts = SecTimestamp<schedulerId, usingBatch>(std::move(extractedTs));
-      typename SecTargetId<schedulerId, usingBatch>::ExtractedInt extractedTids(
-          conversion.targetId);
-      targetId = SecTargetId<schedulerId, usingBatch>(std::move(extractedTids));
       typename SecActionType<schedulerId, usingBatch>::ExtractedInt
           extractedAids(conversion.actionType);
       actionType =
           SecActionType<schedulerId, usingBatch>(std::move(extractedAids));
     }
+    targetId = SecTargetId<schedulerId, usingBatch>(
+        conversion.targetId, common::PARTNER);
   }
 };
 
@@ -59,6 +57,7 @@ struct ParsedConversion {
   uint64_t ts;
   uint64_t targetId;
   uint64_t actionType;
+  uint64_t originalTargetId;
 
   bool operator<(const ParsedConversion& conv) const {
     return (ts < conv.ts);

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -19,6 +19,7 @@ struct Touchpoint {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
+  ConditionalVector<uint64_t, usingBatch> originalTargetId;
 };
 
 template <bool usingBatch>
@@ -40,9 +41,6 @@ struct PrivateTouchpoint {
       typename SecTimestamp<schedulerId, usingBatch>::ExtractedInt extractedTs(
           touchpoint.ts);
       ts = SecTimestamp<schedulerId, usingBatch>(std::move(extractedTs));
-      typename SecTargetId<schedulerId, usingBatch>::ExtractedInt extractedTids(
-          touchpoint.targetId);
-      targetId = SecTargetId<schedulerId, usingBatch>(std::move(extractedTids));
       typename SecActionType<schedulerId, usingBatch>::ExtractedInt
           extractedAids(touchpoint.actionType);
       actionType =
@@ -50,11 +48,11 @@ struct PrivateTouchpoint {
     } else {
       ts = SecTimestamp<schedulerId, usingBatch>(
           touchpoint.ts, common::PUBLISHER);
-      targetId = SecTargetId<schedulerId, usingBatch>(
-          touchpoint.targetId, common::PUBLISHER);
       actionType = SecActionType<schedulerId, usingBatch>(
           touchpoint.actionType, common::PUBLISHER);
     }
+    targetId = SecTargetId<schedulerId, usingBatch>(
+        touchpoint.targetId, common::PUBLISHER);
   }
 };
 
@@ -85,6 +83,7 @@ struct ParsedTouchpoint {
   uint64_t ts;
   uint64_t targetId;
   uint64_t actionType;
+  uint64_t originalTargetId;
 
   /**
    * If both are clicks, or both are views, the earliest one comes first.


### PR DESCRIPTION
Summary: [RFC] Compress target id in PA from uint64_t to uint16_t. This diff is for discussion about the final plan of this BE work.

Reviewed By: mdas7

Differential Revision: D37251675

