### PR TITLE
Migrate PID Preparer to use new BufferedReader

### DIFF
--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
@@ -18,6 +18,15 @@ struct UnionPIDDataPreparerResults {
   int64_t duplicateIdCount = 0;
 };
 
+/*
+ * This chunk size has to be large enough that we don't make
+ * unnecessary trips to cloud storage but small enough that
+ * we don't cause OOM issues. This chunk size was chosen based
+ * on the size of our containers as well as the expected size
+ * of our files to fit the aforementioned constraints.
+ */
+constexpr size_t kBufferedReaderChunkSize = 1073741824; // 2^30
+
 class UnionPIDDataPreparer {
  public:
   UnionPIDDataPreparer(


### PR DESCRIPTION
Summary: This diff makes the change PID Preparer to use the new Buffered Reader.

Reviewed By: adshastri

Differential Revision: D37180250

