### PR TITLE
Fix the issue that is causing the end of deploys to fail

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -59,7 +59,8 @@ COPY data_ingestion /terraform_deployment/terraform_scripts/data_ingestion
 COPY semi_automated_data_ingestion /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
 COPY config.yml /terraform_deployment/config
 COPY cli.py /terraform_deployment
-COPY deployment_helper /terraform_deployment/deployment_helper
+RUN mkdir -p /terraform_deployment/fbpcs/infra/cloud_bridge
+COPY deployment_helper /terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/cli.py
+++ b/fbpcs/infra/cloud_bridge/cli.py
@@ -6,7 +6,9 @@
 
 import argparse
 
-from deployment_helper.aws.aws_deployment_helper_tool import AwsDeploymentHelperTool
+from fbpcs.infra.cloud_bridge.deployment_helper.aws.aws_deployment_helper_tool import (
+    AwsDeploymentHelperTool,
+)
 
 
 def main():


### PR DESCRIPTION
Summary:
When the deployment helper was made pyre-strict in D36983092 (https://github.com/facebookresearch/fbpcs/commit/60282eabe12b87379397f47780ab7f72842284a9), it introduced a
regression where the dependencies could not be resolved because the files got
moved. The fix is to create the same module structure as the one under fbpcs so
that the files can be imported as before.

Differential Revision: D37353741

