### PR TITLE
adding stage service stop async for cancel current stage calls

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -438,15 +438,25 @@ class PrivateComputationService:
 
         # cancel the running stage
         last_instance = private_computation_instance.instances[-1]
+        stage = private_computation_instance.current_stage
+        self.logger.info(
+            f"Canceling the current stage {stage} of instance {instance_id}"
+        )
+        # TODO: T124324848 move MPCInstance/PIDInstance stop instance to StageService.stop_service()
         if isinstance(last_instance, MPCInstance):
             self.mpc_svc.stop_instance(instance_id=last_instance.instance_id)
         elif isinstance(last_instance, PIDInstance):
             self.pid_svc.stop_instance(instance_id=last_instance.instance_id)
         else:
-            self.logger.warning(
-                f"Canceling the current stage of instance {instance_id} is not supported yet."
-            )
-            return private_computation_instance
+            stage_svc = stage.get_stage_service(self.stage_service_args)
+            # TODO: T124322832 make stop service as abstract method and enforce all stage service to implement
+            try:
+                stage_svc.stop_service(private_computation_instance)
+            except NotImplementedError:
+                self.logger.warning(
+                    f"Canceling the current stage {stage} of instance {instance_id} is not supported yet."
+                )
+                return private_computation_instance
 
         # post-checks to make sure the pl instance has the updated status
         private_computation_instance = self._update_instance(

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -63,3 +63,11 @@ class PrivateComputationStageService(abc.ABC):
         pc_instance: PrivateComputationInstance,
     ) -> PrivateComputationInstanceStatus:
         ...
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        """after stop_service been called, you need to make sure get_status will return failed status for post-check"""
+        # TODO: T124322832 make stop service as abstract method and enforce all stage service to implement
+        raise NotImplementedError


### PR DESCRIPTION
Summary:
## Why
we currently only support MPCInstance and PIDInstance to stop instance during cancel current stage.
After we introduced StageStateInstance, and the goal is to move all intances to StageStateInstance, we need to support all generic type stop action for PC service to call.
In Mao's intern project, she is migrating PIDInstances to StageStateInstance, so in this diff is to support stop container logic for generic stagestate.
## What
* Adding one new `stop_service` in StageService, allow StageService to implement it's own tear down logic
* Adopt StageService stop_service call duing cancel stage
* Add UT.

Differential Revision: D37292716

