### PR TITLE
Remove redundant code. Reduce compiler warnings. (4/n)

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
@@ -60,7 +60,7 @@ class MeasurementAggregator : public Aggregator {
     validOriginalAdIds_ = validAdIds;
     for (uint16_t compressedAdId = 1; compressedAdId <= numValidAdIds;
          compressedAdId++) {
-      _adIdToMetrics.push_back(std::make_pair(
+      adIdToMetrics_.push_back(std::make_pair(
           emp::Integer{INT_SIZE_16, compressedAdId, emp::PUBLIC},
           PrivateConvMetrics{}));
     }
@@ -114,7 +114,7 @@ class MeasurementAggregator : public Aggregator {
         const auto& conversion =
             touchpointConversionResult.measurementConversionMetadata;
 
-        for (auto& [adId, metrics] : _adIdToMetrics) {
+        for (auto& [adId, metrics] : adIdToMetrics_) {
           const emp::Integer zero{INT_SIZE_32, 0, emp::PUBLIC};
           const emp::Integer one{INT_SIZE_32, 1, emp::PUBLIC};
 
@@ -180,10 +180,10 @@ class MeasurementAggregator : public Aggregator {
 
     // Mapping the sorted original adIds with the compressed Ids : 1 to
     // num_of_ad_ids.
-    for (auto i = 0u; i < validOriginalAdIds_.size(); i++) {
+    for (auto i = 0U; i < validOriginalAdIds_.size(); i++) {
       compressedAdIdToAdIdMap.insert({i + 1, validOriginalAdIds_.at(i)});
     }
-    for (auto& [adId, metrics] : _adIdToMetrics) {
+    for (auto& [adId, metrics] : adIdToMetrics_) {
       const auto compressedAdId =
           static_cast<uint16_t>(adId.reveal<uint32_t>());
       const auto rAdId = compressedAdIdToAdIdMap.at(compressedAdId);
@@ -196,7 +196,7 @@ class MeasurementAggregator : public Aggregator {
   }
 
  private:
-  PrivateConvMap _adIdToMetrics;
+  PrivateConvMap adIdToMetrics_;
 };
 } // namespace
 

--- a/fbpcs/emp_games/common/Util.h
+++ b/fbpcs/emp_games/common/Util.h
@@ -19,7 +19,7 @@ namespace common {
 
 // utility method used for parsing string information to vector of type T.
 template <typename T>
-static const std::vector<T> getInnerArray(std::string& str) {
+static const std::vector<T> getInnerArray(const std::string& str) {
   // Strip the brackets [] before splitting into individual timestamp values
   auto innerString = str;
   innerString.erase(

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -56,9 +56,9 @@ struct PrivateConversion {
 
 // Used for parsing conversions from input CSV files
 struct ParsedConversion {
-  uint64_t ts;
-  uint64_t targetId;
-  uint64_t actionType;
+  uint64_t ts = 0U;
+  uint64_t targetId = 0U;
+  uint64_t actionType = 0U;
 
   bool operator<(const ParsedConversion& conv) const {
     return (ts < conv.ts);

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -80,11 +80,11 @@ struct PrivateIsClick {
 
 // Used for parsing touchpoints from input CSV files
 struct ParsedTouchpoint {
-  int64_t id;
-  bool isClick;
-  uint64_t ts;
-  uint64_t targetId;
-  uint64_t actionType;
+  int64_t id = -1;
+  bool isClick = false;
+  uint64_t ts = 0U;
+  uint64_t targetId = 0U;
+  uint64_t actionType = 0U;
 
   /**
    * If both are clicks, or both are views, the earliest one comes first.


### PR DESCRIPTION
Summary:
- Continuting to remove some more compiler warnings from the code.
- Minor refactor to remove redundant code like populating containers with 0s or sequences [1, 2, 3...]
- Minor change to suffix '_' (underscore) for private members. Fbcode style/standards.

Differential Revision: D37359189

