### PR TITLE
make Glue crawler more robust by adding more folders to the excluded filters

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -76,7 +76,9 @@ resource "aws_glue_crawler" "mpc_events_crawler" {
     exclusions = [
       "processing-failed**",
       "${var.data_upload_key_path}/**",
-      "${var.query_results_key_path}/**"
+      "${var.query_results_key_path}/**",
+      "athena/**",
+      "Unsaved/**"
     ]
   }
 


### PR DESCRIPTION
Summary: Based on the bootcamp task:T124095076 to add athena and Unsaved folder to filter rules.

Reviewed By: wenhaizhu

Differential Revision: D37387617

