### PR TITLE
Back out "PA target id compression"

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -34,16 +34,6 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       const int myRole,
       const AttributionInputMetrics<usingBatch, inputEncryption>& inputData);
 
-  std::vector<uint64_t> retrieveValidOriginalTargetIds(
-      int myRole,
-      std::vector<TouchpointT<usingBatch>>& touchpoints,
-      std::vector<ConversionT<usingBatch>>& conversions);
-
-  void replaceTargetIdWithCompressedTargetId(
-      std::vector<TouchpointT<usingBatch>>& touchpoints,
-      std::vector<ConversionT<usingBatch>>& conversions,
-      std::vector<uint64_t>& validOriginalTargetIds);
-
   using PrivateTouchpointT = ConditionalVector<
       PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
       !usingBatch>;
@@ -58,7 +48,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   std::vector<std::shared_ptr<
       const AttributionRule<schedulerId, usingBatch, inputEncryption>>>
   shareAttributionRules(
-      int myRole,
+      const int myRole,
       const std::vector<std::string>& attributionRuleNames);
 
   /**

--- a/fbpcs/emp_games/pcf2_attribution/Constants.h
+++ b/fbpcs/emp_games/pcf2_attribution/Constants.h
@@ -13,8 +13,7 @@ namespace pcf2_attribution {
 
 const int kMaxConcurrency = 16;
 const size_t timeStampWidth = 32;
-const size_t originalTargetIdWidth = 64;
-const size_t targetIdWidth = 16;
+const size_t targetIdWidth = 64;
 const size_t actionTypeWidth = 16;
 
 template <int schedulerId, bool usingBatch = true>
@@ -37,13 +36,6 @@ using PubTargetId = typename fbpcf::frontend::MpcGame<
 template <int schedulerId, bool usingBatch = true>
 using SecTargetId = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<targetIdWidth, usingBatch>;
-
-template <int schedulerId, bool usingBatch = true>
-using PubOriginalTargetId = typename fbpcf::frontend::MpcGame<
-    schedulerId>::template PubUnsignedInt<originalTargetIdWidth, usingBatch>;
-template <int schedulerId, bool usingBatch = true>
-using SecOriginalTargetId = typename fbpcf::frontend::MpcGame<
-    schedulerId>::template SecUnsignedInt<originalTargetIdWidth, usingBatch>;
 
 template <int schedulerId, bool usingBatch = true>
 using PubActionType = typename fbpcf::frontend::MpcGame<

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -17,7 +17,6 @@ struct Conversion {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
-  ConditionalVector<uint64_t, usingBatch> originalTargetId;
 };
 
 template <bool usingBatch>
@@ -36,19 +35,22 @@ struct PrivateConversion {
     if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
       ts =
           SecTimestamp<schedulerId, usingBatch>(conversion.ts, common::PARTNER);
+      targetId = SecTargetId<schedulerId, usingBatch>(
+          conversion.targetId, common::PARTNER);
       actionType = SecActionType<schedulerId, usingBatch>(
           conversion.actionType, common::PARTNER);
     } else {
       typename SecTimestamp<schedulerId, usingBatch>::ExtractedInt extractedTs(
           conversion.ts);
       ts = SecTimestamp<schedulerId, usingBatch>(std::move(extractedTs));
+      typename SecTargetId<schedulerId, usingBatch>::ExtractedInt extractedTids(
+          conversion.targetId);
+      targetId = SecTargetId<schedulerId, usingBatch>(std::move(extractedTids));
       typename SecActionType<schedulerId, usingBatch>::ExtractedInt
           extractedAids(conversion.actionType);
       actionType =
           SecActionType<schedulerId, usingBatch>(std::move(extractedAids));
     }
-    targetId = SecTargetId<schedulerId, usingBatch>(
-        conversion.targetId, common::PARTNER);
   }
 };
 
@@ -57,7 +59,6 @@ struct ParsedConversion {
   uint64_t ts;
   uint64_t targetId;
   uint64_t actionType;
-  uint64_t originalTargetId;
 
   bool operator<(const ParsedConversion& conv) const {
     return (ts < conv.ts);

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -19,7 +19,6 @@ struct Touchpoint {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
-  ConditionalVector<uint64_t, usingBatch> originalTargetId;
 };
 
 template <bool usingBatch>
@@ -41,6 +40,9 @@ struct PrivateTouchpoint {
       typename SecTimestamp<schedulerId, usingBatch>::ExtractedInt extractedTs(
           touchpoint.ts);
       ts = SecTimestamp<schedulerId, usingBatch>(std::move(extractedTs));
+      typename SecTargetId<schedulerId, usingBatch>::ExtractedInt extractedTids(
+          touchpoint.targetId);
+      targetId = SecTargetId<schedulerId, usingBatch>(std::move(extractedTids));
       typename SecActionType<schedulerId, usingBatch>::ExtractedInt
           extractedAids(touchpoint.actionType);
       actionType =
@@ -48,11 +50,11 @@ struct PrivateTouchpoint {
     } else {
       ts = SecTimestamp<schedulerId, usingBatch>(
           touchpoint.ts, common::PUBLISHER);
+      targetId = SecTargetId<schedulerId, usingBatch>(
+          touchpoint.targetId, common::PUBLISHER);
       actionType = SecActionType<schedulerId, usingBatch>(
           touchpoint.actionType, common::PUBLISHER);
     }
-    targetId = SecTargetId<schedulerId, usingBatch>(
-        touchpoint.targetId, common::PUBLISHER);
   }
 };
 
@@ -83,7 +85,6 @@ struct ParsedTouchpoint {
   uint64_t ts;
   uint64_t targetId;
   uint64_t actionType;
-  uint64_t originalTargetId;
 
   /**
    * If both are clicks, or both are views, the earliest one comes first.


### PR DESCRIPTION
Summary:
Original commit changeset: daf9887ac372

Original Phabricator Diff: D37251675 (https://github.com/facebookresearch/fbpcs/commit/8486d5fa18afa232a75fe8a09bf0d728f7586ca9)
Back out because of performance regression found due to the secret share revealing of target id to both parties. Leave for future solution by PCF team with UDP RuiyuZhu

Reviewed By: ajinkya-ghonge

Differential Revision: D37404081

