### PR TITLE
Disable files_exist in PID stage services

### DIFF
--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -32,7 +32,6 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
-    all_files_exist_on_cloud,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     get_pc_status_from_stage_state,
 )
@@ -116,15 +115,6 @@ class PIDPrepareStageService(PrivateComputationStageService):
         input_path = pc_instance.pid_stage_output_data_path
         output_path = pc_instance.pid_stage_output_prepare_path
         pc_role = pc_instance.role
-
-        # make sure all input files are on the storage service before proceed
-        if not await all_files_exist_on_cloud(
-            input_path, num_shards, self._storage_svc
-        ):
-            raise ValueError(
-                f"At least one input file for PIDPrepareStageService are missing in {input_path}"
-            )
-
         # generate the list of command args for publisher or partner
         args_list = []
         # later mltikey_enabled, protocol, and max_col_cnt wil be centralized in PrivateComputationInstance.

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -31,10 +31,7 @@ from fbpcs.private_computation.service.constants import DEFAULT_SERVER_PORT_NUMB
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
-from fbpcs.private_computation.service.utils import (
-    all_files_exist_on_cloud,
-    get_pc_status_from_stage_state,
-)
+from fbpcs.private_computation.service.utils import get_pc_status_from_stage_state
 
 
 class PIDRunProtocolStageService(PrivateComputationStageService):
@@ -115,11 +112,6 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
         input_path = pc_instance.pid_stage_output_prepare_path
         output_path = pc_instance.pid_stage_output_spine_path
         pc_role = pc_instance.role
-        # make sure all input files are on the storage service before proceed
-        if not await all_files_exist_on_cloud(
-            input_path, num_shards, self._storage_svc
-        ):
-            raise ValueError("Input files for PID run protocol service are missing")
         protocol = get_pid_protocol_from_num_shards(num_shards, self._multikey_enabled)
         metric_paths = self.get_metric_paths(pc_role, output_path, num_shards)
         server_hostnames = self.get_server_hostnames(pc_role, server_ips, num_shards)

--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -26,7 +26,6 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 from fbpcs.private_computation.service.utils import (
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
-    file_exists_async,
     get_pc_status_from_stage_state,
 )
 
@@ -102,10 +101,6 @@ class PIDShardStageService(PrivateComputationStageService):
         input_path = pc_instance.input_path
         output_base_path = pc_instance.pid_stage_output_data_path
         pc_role = pc_instance.role
-        # make sure the input file is on the storage service before proceed
-        if not await file_exists_async(self._storage_svc, input_path):
-            raise ValueError("Input file for PIDShardStageService are missing")
-
         sharding_binary_service = ShardingService()
         # generate the list of command args for publisher or partner
         binary_name = ShardingService.get_binary_name(ShardType.HASHED_FOR_PID)

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -87,15 +87,11 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         containers = [
             self.create_container_instance() for _ in range(test_num_containers)
         ]
-        # All files should exist on cloud, or else the stage service won't proceed.
-        self.mock_storage_svc.file_exists.return_value = True
         self.mock_onedocker_svc.start_containers = MagicMock(return_value=containers)
         self.mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
             return_value=containers
         )
         updated_pc_instance = await stage_svc.run_async(pc_instance=pc_instance)
-        # assert file_exists is called in self.stage_svc.run_async()
-        self.mock_storage_svc.file_exists.assert_called()
         env_vars = {
             "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
         }

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -82,8 +82,6 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
             await self.create_container_instance()
             for _ in range(self.test_num_containers)
         ]
-        # All files should exist on cloud, or else the stage service won't proceed.
-        self.mock_storage_svc.file_exists.return_value = True
         self.mock_onedocker_svc.start_containers = MagicMock(return_value=containers)
         self.mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
             return_value=containers
@@ -91,8 +89,6 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
         updated_pc_instance = await stage_svc.run_async(
             pc_instance=pc_instance, server_ips=self.server_ips
         )
-        # assert file_exists is called in self.stage_svc.run_async()
-        self.mock_storage_svc.file_exists.assert_called()
 
         binary_name = PIDRunProtocolBinaryService.get_binary_name(protocol, pc_role)
         binary_config = self.onedocker_binary_config_map[binary_name]

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -79,15 +79,11 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
         containers = [
             self.create_container_instance() for _ in range(test_num_containers)
         ]
-        # The input file should exist on cloud, or else the stage service won't proceed.
-        self.mock_storage_svc.file_exists.return_value = True
         self.mock_onedocker_svc.start_containers = MagicMock(return_value=containers)
         self.mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
             return_value=containers
         )
         updated_pc_instance = await stage_svc.run_async(pc_instance=pc_instance)
-        # assert file_exists is called in self.stage_svc.run_async()
-        self.mock_storage_svc.file_exists.assert_called()
         env_vars = {
             "ONEDOCKER_REPOSITORY_PATH": self.onedocker_binary_config.repository_path
         }


### PR DESCRIPTION
Summary: We have a case where FBPCS does not have read permission on S3 file due to pl-coordinator-env not granted the S3 read access. And new PID stage Services will not check if file exist anymore.

Reviewed By: yuyashiraki

Differential Revision: D37401621

