### PR TITLE
raise custom exception on run_next when all stages has been completed.

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -294,6 +294,9 @@ class PrivateComputationInstance(InstanceBase):
         """
         return self.stage_flow.get_next_runnable_stage_from_status(self.status)
 
+    def is_stage_flow_completed(self) -> bool:
+        return self.status is self.stage_flow.get_last_stage().completed_status
+
     def update_status(
         self, new_status: PrivateComputationInstanceStatus, logger: Logger
     ) -> None:
@@ -304,7 +307,7 @@ class PrivateComputationInstance(InstanceBase):
             logger.info(
                 f"Updating status of {self.instance_id} from {old_status} to {self.status} at time {self.status_update_ts}"
             )
-        if self.status is self.stage_flow.get_last_stage().completed_status:
+        if self.is_stage_flow_completed():
             self.end_ts = int(time.time())
 
     @property

--- a/fbpcs/private_computation/service/errors.py
+++ b/fbpcs/private_computation/service/errors.py
@@ -5,7 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 
-class PrivateComputationServiceValidationError(ValueError):
+class PrivateComputationServiceBaseException(Exception):
+    pass
+
+
+class PrivateComputationServiceValidationError(
+    PrivateComputationServiceBaseException, ValueError
+):
     """
     Error raised when private_computation_service.validate_metrics found the aggregated results doesn't match the expected results.
     """
+
+
+class PrivateComputationServiceInvalidStageError(
+    PrivateComputationServiceBaseException, RuntimeError
+):
+    pass

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -39,6 +39,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.errors import (
+    PrivateComputationServiceInvalidStageError,
     PrivateComputationServiceValidationError,
 )
 from fbpcs.private_computation.service.pcf2_attribution_stage_service import (
@@ -461,6 +462,40 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         instance._stage_flow_cls_name = flow.get_cls_name()
 
         self.assertEqual(None, instance.get_next_runnable_stage())
+
+    @mock.patch(
+        "fbpcs.private_computation.service.private_computation.PrivateComputationService.run_stage_async"
+    )
+    def test_run_next(self, mock_run_stage_async) -> None:
+        flow = PrivateComputationStageFlow
+        # pyre-fixme[16]: `Optional` has no attribute `completed_status`.
+        status = flow.ID_MATCH.previous_stage.completed_status
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        self.private_computation_service.instance_repository.read = MagicMock(
+            return_value=instance
+        )
+        self.private_computation_service.run_next(instance.instance_id)
+        mock_run_stage_async.assert_called_with(
+            instance.instance_id, flow.ID_MATCH, server_ips=None
+        )
+
+    @mock.patch(
+        "fbpcs.private_computation.service.private_computation.PrivateComputationService.run_stage_async"
+    )
+    def test_run_next_ignore_stage_flow_completed(self, mock_run_stage_async) -> None:
+        flow = PrivateComputationStageFlow
+        status = flow.get_last_stage().completed_status
+
+        instance = self.create_sample_instance(status)
+        instance._stage_flow_cls_name = flow.get_cls_name()
+
+        with self.assertRaises(PrivateComputationServiceInvalidStageError):
+            self.private_computation_service.run_next(instance.instance_id)
+
+        mock_run_stage_async.assert_not_called()
 
     def test_run_stage_correct_stage_order(
         self,


### PR DESCRIPTION
Summary:
## Why
raise custom exception on run_next when all stages have been completed
T122438804
in Sev S274601 - www codemod leads to PCService DDoS
according to tupperware log
https://www.internalfb.com/tupperware/job/tasks?handle=tsp_global%2Fprivate_lift%2FPrivateComputationServiceRC&task_id=1&task_tab=TASK_LOGS
www keep spamming request to call run_next even all stages are completed.
This Diff is from PCS to raise custom exception run_next if we already know all stage flow are completed to avoid error happened which lead thrift server unhealthy and won't count as an error in ods.
## What
* raise PrivateComputationServiceInvalidStageError on run_next request if pc instance know last stage is marked as completed.
* in Thrift server, catch PrivateComputationServiceInvalidStageError and raise InvalidRequestT to www

## Next
follow this wiki instruction - SETUP DIFFERENT EXCEPTIONS FOR USER ERRORS AND APPLICATION ERROR
https://www.internalfb.com/intern/wiki/ServiceRouter/User_Guide/Monitoring/#difference-between-fatal
which we still want to raise the InvalidRequestT exception, but don't affect how SR monitors thrift server

Differential Revision: D37424441

