### PR TITLE
Share publisher breakdown ids

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -168,10 +168,13 @@ void InputData::addFromCSV(
       numClicks_.push_back(parsed);
     } else if (column == "total_spend") {
       totalSpend_.push_back(parsed);
-    } else if (column == "cohort_id" || column == "breakdown_id") {
-      // Work-in-progress: we currently support cohort_id *or* feature columns
+    } else if (column == "cohort_id") {
       groupIds_.push_back(parsed);
       // We use parsed + 1 because cohorts are zero-indexed
+      numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+    } else if (column == "breakdown_id") {
+      breakdownIds_.push_back(parsed);
+      // We use parsed + 1 because breakdowns are zero-indexed
       numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
     } else if (column == "event_timestamp") {
       // When event_timestamp column presents (in standard Converter Lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -98,6 +98,10 @@ class InputData {
     return groupIds_;
   }
 
+  const std::vector<uint32_t>& getBreakdownIds() const {
+    return breakdownIds_;
+  }
+
   int64_t getNumGroups() const {
     return numGroups_;
   }
@@ -161,6 +165,7 @@ class InputData {
   std::vector<int64_t> purchaseValues_;
   std::vector<int64_t> purchaseValuesSquared_;
   std::vector<uint32_t> groupIds_;
+  std::vector<uint32_t> breakdownIds_;
   std::vector<std::vector<uint32_t>> opportunityTimestampArrays_;
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,8 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    shareNumGroupsStep();
+    privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
     privatelyShareCohortsStep();
     privatelyShareTestCohortsStep();
@@ -43,6 +45,10 @@ class InputProcessor {
 
   uint32_t getNumPartnerCohorts() const {
     return numPartnerCohorts_;
+  }
+
+  uint32_t getNumPublisherBreakdowns() const {
+    return numPublisherBreakdowns_;
   }
 
   const std::vector<std::vector<bool>> getCohortIndexShares() const {
@@ -90,8 +96,14 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Share number of groups, including cohorts and publisher breakdowns.
+  void shareNumGroupsStep();
+
   // Privately share popoulation
   void privatelySharePopulationStep();
+
+  // Privately share cohort ids and breakdown ids.
+  void privatelyShareGroupIdsStep();
 
   // Privately share number of cohorts and index shares of cohort group ids.
   void privatelyShareCohortsStep();
@@ -113,6 +125,7 @@ class InputProcessor {
   int64_t numRows_;
   int32_t numConversionsPerUser_;
   uint32_t numPartnerCohorts_;
+  uint32_t numPublisherBreakdowns_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;
@@ -125,6 +138,7 @@ class InputProcessor {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
+  SecBit<schedulerId> breakdownGroupIds_;
   std::vector<std::vector<bool>> cohortIndexShares_;
   std::vector<std::vector<bool>> testCohortIndexShares_;
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -96,6 +96,11 @@ TEST_F(InputProcessorTest, testNumPartnerCohorts) {
   EXPECT_EQ(partnerInputProcessor_.getNumPartnerCohorts(), 3);
 }
 
+TEST_F(InputProcessorTest, testNumBreakdowns) {
+  EXPECT_EQ(publisherInputProcessor_.getNumPublisherBreakdowns(), 2);
+  EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 2);
+}
+
 TEST_F(InputProcessorTest, testCohortIndexShares) {
   auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
   auto partnerShares = partnerInputProcessor_.getCohortIndexShares();


### PR DESCRIPTION
Summary: We share the publisher breakdown ids and the number of publisher breakdowns in the InputProcessor class. Since the breakdown id is either 0 or 1, we parse them as booleans in the InputData class, and store them using the SecBit type in the InputProcessor. They will be used for aggregating the metrics depending on the breakdown id in the subsequent diffs.

Reviewed By: gorel

Differential Revision: D37337517

