### PR TITLE
Rename methods and variables involving cohorts

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -52,8 +52,8 @@ class Aggregator {
         numPartnerCohorts_{inputProcessor.getNumPartnerCohorts()},
         numConversionsPerUser_{numConversionsPerUser},
         communicationAgentFactory_{communicationAgentFactory},
-        cohortIndexShares_{inputProcessor.getCohortIndexShares()},
-        testCohortIndexShares_{inputProcessor.getTestCohortIndexShares()} {
+        indexShares_{inputProcessor.getIndexShares()},
+        testIndexShares_{inputProcessor.getTestIndexShares()} {
     initOram();
     sumEvents();
     sumConverters();
@@ -131,31 +131,31 @@ class Aggregator {
   std::unique_ptr<Attributor<schedulerId>> attributor_;
   int64_t numRows_;
   uint32_t numPartnerCohorts_;
+  uint32_t numGroups_;
+  uint32_t numTestGroups_;
   int32_t numConversionsPerUser_;
-  uint32_t numCohortGroups_;
-  uint32_t numTestCohortGroups_;
   OutputMetricsData metrics_;
 
   std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
       communicationAgentFactory_;
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<false, valueWidth>>>
-      cohortUnsignedWriteOnlyOramFactory_;
+      unsignedWriteOnlyOramFactory_;
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<true, valueWidth>>>
-      cohortSignedWriteOnlyOramFactory_;
+      signedWriteOnlyOramFactory_;
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<false, valueWidth>>>
-      testCohortUnsignedWriteOnlyOramFactory_;
+      testUnsignedWriteOnlyOramFactory_;
   std::unique_ptr<
       fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<Intp<true, valueWidth>>>
-      testCohortSignedWriteOnlyOramFactory_;
+      testSignedWriteOnlyOramFactory_;
   std::unique_ptr<fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<
       Intp<false, valueSquaredWidth>>>
       valueSquaredWriteOnlyOramFactory_;
 
-  std::vector<std::vector<bool>> cohortIndexShares_;
-  std::vector<std::vector<bool>> testCohortIndexShares_;
+  std::vector<std::vector<bool>> indexShares_;
+  std::vector<std::vector<bool>> testIndexShares_;
   std::unordered_map<int64_t, OutputMetricsData> cohortMetrics_;
   std::unordered_map<int64_t, OutputMetricsData>
       publisherBreakdowns_; // place holder for publisher breakdown metrics.

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -168,10 +168,13 @@ void InputData::addFromCSV(
       numClicks_.push_back(parsed);
     } else if (column == "total_spend") {
       totalSpend_.push_back(parsed);
-    } else if (column == "cohort_id" || column == "breakdown_id") {
-      // Work-in-progress: we currently support cohort_id *or* feature columns
+    } else if (column == "cohort_id") {
       groupIds_.push_back(parsed);
       // We use parsed + 1 because cohorts are zero-indexed
+      numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+    } else if (column == "breakdown_id") {
+      breakdownIds_.push_back(parsed);
+      // We use parsed + 1 because breakdowns are zero-indexed
       numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
     } else if (column == "event_timestamp") {
       // When event_timestamp column presents (in standard Converter Lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -98,6 +98,10 @@ class InputData {
     return groupIds_;
   }
 
+  const std::vector<uint32_t>& getBreakdownIds() const {
+    return breakdownIds_;
+  }
+
   int64_t getNumGroups() const {
     return numGroups_;
   }
@@ -161,6 +165,7 @@ class InputData {
   std::vector<int64_t> purchaseValues_;
   std::vector<int64_t> purchaseValuesSquared_;
   std::vector<uint32_t> groupIds_;
+  std::vector<uint32_t> breakdownIds_;
   std::vector<std::vector<uint32_t>> opportunityTimestampArrays_;
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,8 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    shareNumGroupsStep();
+    privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
     privatelyShareCohortsStep();
     privatelyShareTestCohortsStep();
@@ -43,6 +45,10 @@ class InputProcessor {
 
   uint32_t getNumPartnerCohorts() const {
     return numPartnerCohorts_;
+  }
+
+  uint32_t getNumPublisherBreakdowns() const {
+    return numPublisherBreakdowns_;
   }
 
   const std::vector<std::vector<bool>> getCohortIndexShares() const {
@@ -90,8 +96,14 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Share number of groups, including cohorts and publisher breakdowns.
+  void shareNumGroupsStep();
+
   // Privately share popoulation
   void privatelySharePopulationStep();
+
+  // Privately share cohort ids and breakdown ids.
+  void privatelyShareGroupIdsStep();
 
   // Privately share number of cohorts and index shares of cohort group ids.
   void privatelyShareCohortsStep();
@@ -113,6 +125,7 @@ class InputProcessor {
   int64_t numRows_;
   int32_t numConversionsPerUser_;
   uint32_t numPartnerCohorts_;
+  uint32_t numPublisherBreakdowns_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;
@@ -125,6 +138,7 @@ class InputProcessor {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
+  SecBit<schedulerId> breakdownGroupIds_;
   std::vector<std::vector<bool>> cohortIndexShares_;
   std::vector<std::vector<bool>> testCohortIndexShares_;
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -30,8 +30,8 @@ class InputProcessor {
     shareNumGroupsStep();
     privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
-    privatelyShareCohortsStep();
-    privatelyShareTestCohortsStep();
+    privatelyShareIndexSharesStep();
+    privatelyShareTestIndexSharesStep();
     privatelyShareTimestampsStep();
     privatelySharePurchaseValuesStep();
     privatelyShareTestReachStep();
@@ -59,12 +59,12 @@ class InputProcessor {
     return numTestGroups_;
   }
 
-  const std::vector<std::vector<bool>> getCohortIndexShares() const {
-    return cohortIndexShares_;
+  const std::vector<std::vector<bool>> getIndexShares() const {
+    return indexShares_;
   }
 
-  const std::vector<std::vector<bool>> getTestCohortIndexShares() const {
-    return testCohortIndexShares_;
+  const std::vector<std::vector<bool>> getTestIndexShares() const {
+    return testIndexShares_;
   }
 
   const SecTimestamp<schedulerId> getOpportunityTimestamps() const {
@@ -113,11 +113,12 @@ class InputProcessor {
   // Privately share cohort ids and breakdown ids.
   void privatelyShareGroupIdsStep();
 
-  // Privately share number of cohorts and index shares of cohort group ids.
-  void privatelyShareCohortsStep();
+  // Privately share index shares of group ids encoding the population, cohorts
+  // and publisher breakdowns.
+  void privatelyShareIndexSharesStep();
 
-  // Privately share cohort group ids for the test population only.
-  void privatelyShareTestCohortsStep();
+  // Privately share index shares of group ids for the test population only.
+  void privatelyShareTestIndexSharesStep();
 
   // Privately share timestamps
   void privatelyShareTimestampsStep();
@@ -149,8 +150,8 @@ class InputProcessor {
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
   SecBit<schedulerId> breakdownGroupIds_;
-  std::vector<std::vector<bool>> cohortIndexShares_;
-  std::vector<std::vector<bool>> testCohortIndexShares_;
+  std::vector<std::vector<bool>> indexShares_;
+  std::vector<std::vector<bool>> testIndexShares_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -51,6 +51,14 @@ class InputProcessor {
     return numPublisherBreakdowns_;
   }
 
+  uint32_t getNumGroups() const {
+    return numGroups_;
+  }
+
+  uint32_t getNumTestGroups() const {
+    return numTestGroups_;
+  }
+
   const std::vector<std::vector<bool>> getCohortIndexShares() const {
     return cohortIndexShares_;
   }
@@ -126,6 +134,8 @@ class InputProcessor {
   int32_t numConversionsPerUser_;
   uint32_t numPartnerCohorts_;
   uint32_t numPublisherBreakdowns_;
+  uint32_t numGroups_;
+  uint32_t numTestGroups_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -63,6 +63,16 @@ void InputProcessor<schedulerId>::shareNumGroupsStep() {
         << " publisher breakdowns but we only support 2 publisher breakdowns.";
     exit(1);
   }
+  // The number of groups is 2 (for test/control population) times the number of
+  // partner cohorts and the number of publisher breakdowns. If there are no
+  // cohorts or breakdowns, we multiply by 1 instead.
+  numGroups_ = 2 * std::max(uint32_t(1), numPartnerCohorts_) *
+      std::max(uint32_t(1), numPublisherBreakdowns_);
+  // The test groups consist of the groups corresponding to the test population,
+  // and one additional group for the control population (disregarding
+  // breakdown or cohort id). These are used for computing reach metrics, which
+  // are only for the test population.
+  numTestGroups_ = 1 + numGroups_ / 2;
   XLOG(INFO) << "Will be computing metrics for " << numPublisherBreakdowns_
              << " publisher breakdowns and " << numPartnerCohorts_
              << " partner cohorts";

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -96,7 +96,7 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
 }
 
 template <int schedulerId>
-void InputProcessor<schedulerId>::privatelyShareCohortsStep() {
+void InputProcessor<schedulerId>::privatelyShareIndexSharesStep() {
   // We compute the metrics for both test/control populations and cohorts. To
   // differentiate the cohort group ids for the test/control population, we set
   // the test group ids as the original group ids, and the control group ids as
@@ -118,15 +118,15 @@ void InputProcessor<schedulerId>::privatelyShareCohortsStep() {
   // We now set the group ids depending on whether each row is a test or
   // control
   auto groupIds = cohortGroupIds_.mux(controlPopulation_, secControlGroupIds);
-  cohortIndexShares_ = groupIds.extractIntShare().getBooleanShares();
+  indexShares_ = groupIds.extractIntShare().getBooleanShares();
   // Resize to width needed for the number of groups
   size_t cohortWidth =
       std::ceil(std::log2(std::max(uint32_t(2), 2 * numPartnerCohorts_)));
-  cohortIndexShares_.resize(cohortWidth);
+  indexShares_.resize(cohortWidth);
 }
 
 template <int schedulerId>
-void InputProcessor<schedulerId>::privatelyShareTestCohortsStep() {
+void InputProcessor<schedulerId>::privatelyShareTestIndexSharesStep() {
   // We only compute the reach metrics for the test population, hence we also
   // contruct cohort index shares for just the test population. To differentiate
   // the cohort group ids for the test/control population, we set the test group
@@ -141,11 +141,11 @@ void InputProcessor<schedulerId>::privatelyShareTestCohortsStep() {
   // We now set the group ids depending on whether each row is a test or
   // control
   auto groupIds = cohortGroupIds_.mux(controlPopulation_, secControlGroupIds);
-  testCohortIndexShares_ = groupIds.extractIntShare().getBooleanShares();
+  testIndexShares_ = groupIds.extractIntShare().getBooleanShares();
   // Resize to width needed for the number of groups
   size_t testCohortWidth =
       std::ceil(std::log2(std::max(uint32_t(2), numPartnerCohorts_ + 1)));
-  testCohortIndexShares_.resize(testCohortWidth);
+  testIndexShares_.resize(testCohortWidth);
 }
 
 template <int schedulerId>

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -96,6 +96,11 @@ TEST_F(InputProcessorTest, testNumPartnerCohorts) {
   EXPECT_EQ(partnerInputProcessor_.getNumPartnerCohorts(), 3);
 }
 
+TEST_F(InputProcessorTest, testNumBreakdowns) {
+  EXPECT_EQ(publisherInputProcessor_.getNumPublisherBreakdowns(), 2);
+  EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 2);
+}
+
 TEST_F(InputProcessorTest, testCohortIndexShares) {
   auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
   auto partnerShares = partnerInputProcessor_.getCohortIndexShares();

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -101,6 +101,16 @@ TEST_F(InputProcessorTest, testNumBreakdowns) {
   EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 2);
 }
 
+TEST_F(InputProcessorTest, testNumGroups) {
+  EXPECT_EQ(publisherInputProcessor_.getNumGroups(), 12);
+  EXPECT_EQ(partnerInputProcessor_.getNumGroups(), 12);
+}
+
+TEST_F(InputProcessorTest, testNumTestGroups) {
+  EXPECT_EQ(publisherInputProcessor_.getNumTestGroups(), 7);
+  EXPECT_EQ(partnerInputProcessor_.getNumTestGroups(), 7);
+}
+
 TEST_F(InputProcessorTest, testCohortIndexShares) {
   auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
   auto partnerShares = partnerInputProcessor_.getCohortIndexShares();

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -112,8 +112,8 @@ TEST_F(InputProcessorTest, testNumTestGroups) {
 }
 
 TEST_F(InputProcessorTest, testCohortIndexShares) {
-  auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
-  auto partnerShares = partnerInputProcessor_.getCohortIndexShares();
+  auto publisherShares = publisherInputProcessor_.getIndexShares();
+  auto partnerShares = partnerInputProcessor_.getIndexShares();
   // 0 1 3 0 0 4 1 1 3 1 1 3 0 1 4 0 0 3 0 0 3 0 0 3 0 0 2 2 0 0 2 2 5
   std::vector<std::vector<bool>> expectCohortIndexShares = {
       {0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0,
@@ -126,8 +126,8 @@ TEST_F(InputProcessorTest, testCohortIndexShares) {
 }
 
 TEST_F(InputProcessorTest, testTestCohortIndexShares) {
-  auto publisherShares = publisherInputProcessor_.getTestCohortIndexShares();
-  auto partnerShares = partnerInputProcessor_.getTestCohortIndexShares();
+  auto publisherShares = publisherInputProcessor_.getTestIndexShares();
+  auto partnerShares = partnerInputProcessor_.getTestIndexShares();
   // 0 1 3 0 0 3 1 1 3 1 1 3 0 1 3 0 0 3 0 0 3 0 0 3 0 0 2 2 0 0 2 2 3
   std::vector<std::vector<bool>> expectTestCohortIndexShares = {
       {0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0,


### PR DESCRIPTION
Summary: In this diff, we rename the methods and variables involving cohorts to have more general names. Previously, we were only doing aggregation over the populations and cohorts. In the subsequent diffs, we will modify these methods to include breakdowns as well, hence the renaming.

Reviewed By: gorel

Differential Revision: D37337965

