### PR TITLE
Share number of groups for aggregation

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -168,10 +168,13 @@ void InputData::addFromCSV(
       numClicks_.push_back(parsed);
     } else if (column == "total_spend") {
       totalSpend_.push_back(parsed);
-    } else if (column == "cohort_id" || column == "breakdown_id") {
-      // Work-in-progress: we currently support cohort_id *or* feature columns
+    } else if (column == "cohort_id") {
       groupIds_.push_back(parsed);
       // We use parsed + 1 because cohorts are zero-indexed
+      numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+    } else if (column == "breakdown_id") {
+      breakdownIds_.push_back(parsed);
+      // We use parsed + 1 because breakdowns are zero-indexed
       numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
     } else if (column == "event_timestamp") {
       // When event_timestamp column presents (in standard Converter Lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -98,6 +98,10 @@ class InputData {
     return groupIds_;
   }
 
+  const std::vector<uint32_t>& getBreakdownIds() const {
+    return breakdownIds_;
+  }
+
   int64_t getNumGroups() const {
     return numGroups_;
   }
@@ -161,6 +165,7 @@ class InputData {
   std::vector<int64_t> purchaseValues_;
   std::vector<int64_t> purchaseValuesSquared_;
   std::vector<uint32_t> groupIds_;
+  std::vector<uint32_t> breakdownIds_;
   std::vector<std::vector<uint32_t>> opportunityTimestampArrays_;
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -27,6 +27,8 @@ class InputProcessor {
         numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
+    shareNumGroupsStep();
+    privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
     privatelyShareCohortsStep();
     privatelyShareTestCohortsStep();
@@ -43,6 +45,10 @@ class InputProcessor {
 
   uint32_t getNumPartnerCohorts() const {
     return numPartnerCohorts_;
+  }
+
+  uint32_t getNumPublisherBreakdowns() const {
+    return numPublisherBreakdowns_;
   }
 
   const std::vector<std::vector<bool>> getCohortIndexShares() const {
@@ -90,8 +96,14 @@ class InputProcessor {
   // Make sure input files have the same size
   void validateNumRowsStep();
 
+  // Share number of groups, including cohorts and publisher breakdowns.
+  void shareNumGroupsStep();
+
   // Privately share popoulation
   void privatelySharePopulationStep();
+
+  // Privately share cohort ids and breakdown ids.
+  void privatelyShareGroupIdsStep();
 
   // Privately share number of cohorts and index shares of cohort group ids.
   void privatelyShareCohortsStep();
@@ -113,6 +125,7 @@ class InputProcessor {
   int64_t numRows_;
   int32_t numConversionsPerUser_;
   uint32_t numPartnerCohorts_;
+  uint32_t numPublisherBreakdowns_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;
@@ -125,6 +138,7 @@ class InputProcessor {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
+  SecBit<schedulerId> breakdownGroupIds_;
   std::vector<std::vector<bool>> cohortIndexShares_;
   std::vector<std::vector<bool>> testCohortIndexShares_;
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -51,6 +51,14 @@ class InputProcessor {
     return numPublisherBreakdowns_;
   }
 
+  uint32_t getNumGroups() const {
+    return numGroups_;
+  }
+
+  uint32_t getNumTestGroups() const {
+    return numTestGroups_;
+  }
+
   const std::vector<std::vector<bool>> getCohortIndexShares() const {
     return cohortIndexShares_;
   }
@@ -126,6 +134,8 @@ class InputProcessor {
   int32_t numConversionsPerUser_;
   uint32_t numPartnerCohorts_;
   uint32_t numPublisherBreakdowns_;
+  uint32_t numGroups_;
+  uint32_t numTestGroups_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -63,6 +63,16 @@ void InputProcessor<schedulerId>::shareNumGroupsStep() {
         << " publisher breakdowns but we only support 2 publisher breakdowns.";
     exit(1);
   }
+  // The number of groups is 2 (for test/control population) times the number of
+  // partner cohorts and the number of publisher breakdowns. If there are no
+  // cohorts or breakdowns, we multiply by 1 instead.
+  numGroups_ = 2 * std::max(uint32_t(1), numPartnerCohorts_) *
+      std::max(uint32_t(1), numPublisherBreakdowns_);
+  // The test groups consist of the groups corresponding to the test population,
+  // and one additional group for the control population (disregarding
+  // breakdown or cohort id). These are used for computing reach metrics, which
+  // are only for the test population.
+  numTestGroups_ = 1 + numGroups_ / 2;
   XLOG(INFO) << "Will be computing metrics for " << numPublisherBreakdowns_
              << " publisher breakdowns and " << numPartnerCohorts_
              << " partner cohorts";

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -96,6 +96,11 @@ TEST_F(InputProcessorTest, testNumPartnerCohorts) {
   EXPECT_EQ(partnerInputProcessor_.getNumPartnerCohorts(), 3);
 }
 
+TEST_F(InputProcessorTest, testNumBreakdowns) {
+  EXPECT_EQ(publisherInputProcessor_.getNumPublisherBreakdowns(), 2);
+  EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 2);
+}
+
 TEST_F(InputProcessorTest, testCohortIndexShares) {
   auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
   auto partnerShares = partnerInputProcessor_.getCohortIndexShares();

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -101,6 +101,16 @@ TEST_F(InputProcessorTest, testNumBreakdowns) {
   EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 2);
 }
 
+TEST_F(InputProcessorTest, testNumGroups) {
+  EXPECT_EQ(publisherInputProcessor_.getNumGroups(), 12);
+  EXPECT_EQ(partnerInputProcessor_.getNumGroups(), 12);
+}
+
+TEST_F(InputProcessorTest, testNumTestGroups) {
+  EXPECT_EQ(publisherInputProcessor_.getNumTestGroups(), 7);
+  EXPECT_EQ(partnerInputProcessor_.getNumTestGroups(), 7);
+}
+
 TEST_F(InputProcessorTest, testCohortIndexShares) {
   auto publisherShares = publisherInputProcessor_.getCohortIndexShares();
   auto partnerShares = partnerInputProcessor_.getCohortIndexShares();


### PR DESCRIPTION
Summary:
We share the number of groups for computing aggregation. We will aggregate over 3 types of groups, namely the test/control population, the partner cohorts and the publisher breakdowns. To do the ORAM aggregation efficiently, we will generate a combined group id that encodes all 3 groups, which will be done in subsequent diffs.

We also do two types of aggregation, one where we consider both test/control population, and another where we only consider the test population. The latter is for the reached metrics. Hence we share the number of groups for both types of aggregation as `numGroups_` and `numTestGroups_` respectively.
- `numGroups_` is the product of the number of populations (2), the number of cohorts and the number of breakdowns.
- `numTestGroups_` is the product of the number of cohorts and the number of breakdowns for the test population, and we add 1 group for the control population (disregarding the cohorts/breakdowns).

Reviewed By: gorel

Differential Revision: D37337932

