### PR TITLE
Adding bootcamp tasks for unittests in test_utils.py

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/utils/test/test_utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/test/test_utils.py
@@ -6,14 +6,28 @@
 # pyre-strict
 
 import unittest
+from unittest.mock import mock_open, patch
+
+from fbpcs.infra.logging_service.download_logs.utils.utils import Utils
 
 
 class TestUtils(unittest.TestCase):
     def setUp(self) -> None:
-        pass
+        self.utils = Utils()
 
     def test_create_file(self) -> None:
-        pass
+        with self.subTest("basic"):
+            fake_file_path = "fake/file/path"
+            content_list = ["This is test string"]
+            with patch(
+                "fbpcs.infra.logging_service.download_logs.utils.utils.open",
+                mock_open(),
+            ) as mocked_file:
+                self.utils.create_file(
+                    file_location=fake_file_path, content=content_list
+                )
+                mocked_file.assert_called_once_with(fake_file_path, "w")
+                mocked_file().write.assert_called_once_with(content_list[0] + "\n")
 
     def test_write_to_file(self) -> None:
         pass

--- a/fbpcs/infra/logging_service/download_logs/utils/test/test_utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/test/test_utils.py
@@ -30,13 +30,17 @@ class TestUtils(unittest.TestCase):
                 mocked_file().write.assert_called_once_with(content_list[0] + "\n")
 
     def test_write_to_file(self) -> None:
+        # T124340651
         pass
 
     def test_create_folder(self) -> None:
+        # T124340830
         pass
 
     def test_compress_downloaded_logs(self) -> None:
+        # T124340929
         pass
 
     def test_copy_file(self) -> None:
+        # T124341053
         pass


### PR DESCRIPTION
Summary: Add bootcamp tasks for unittests in test_utils.py

Reviewed By: gorel

Differential Revision: D37396534

