### PR TITLE
Construct index shares including breakdowns

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -50,6 +50,9 @@ class Aggregator {
         attributor_{std::move(attributor)},
         numRows_{inputProcessor.getNumRows()},
         numPartnerCohorts_{inputProcessor.getNumPartnerCohorts()},
+        numPublisherBreakdowns_{inputProcessor.getNumPublisherBreakdowns()},
+        numGroups_{inputProcessor.getNumGroups()},
+        numTestGroups_{inputProcessor.getNumTestGroups()},
         numConversionsPerUser_{numConversionsPerUser},
         communicationAgentFactory_{communicationAgentFactory},
         indexShares_{inputProcessor.getIndexShares()},
@@ -129,6 +132,7 @@ class Aggregator {
   std::unique_ptr<Attributor<schedulerId>> attributor_;
   int64_t numRows_;
   uint32_t numPartnerCohorts_;
+  uint32_t numPublisherBreakdowns_;
   uint32_t numGroups_;
   uint32_t numTestGroups_;
   int32_t numConversionsPerUser_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -106,25 +106,23 @@ class Aggregator {
           fbpcf::mpc_std_lib::oram::IWriteOnlyOram<Intp<isSigned, width>>> oram)
       const;
 
-  // Reveal cohort output from aggregation output as a tuple consisting of the
-  // test/control metrics, the test cohort metrics, and the control cohort
-  // metrics.
+  // Reveal cohort output from aggregation output as a pair consisting of the
+  // test cohort metrics and optionally the control cohort metrics.
   template <bool isSigned, int8_t width>
-  std::tuple<
-      std::vector<NativeIntp<isSigned, width>>,
+  std::pair<
       std::vector<NativeIntp<isSigned, width>>,
       std::vector<NativeIntp<isSigned, width>>>
-  revealCohortOutput(std::vector<SecInt<schedulerId, isSigned, width>>
-                         aggregationOutput) const;
+  revealCohortOutput(
+      std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+      bool testOnly) const;
 
-  // Reveal cohort output from aggregation output as a tuple consisting of the
-  // test metrics and the test cohort metrics.
+  // Reveal population output from aggregation output as a pair consisting
+  // of the test metrics and optionally the control metrics.
   template <bool isSigned, int8_t width>
-  std::tuple<
-      NativeIntp<isSigned, width>,
-      std::vector<NativeIntp<isSigned, width>>>
-  revealTestCohortOutput(std::vector<SecInt<schedulerId, isSigned, width>>
-                             aggregationOutput) const;
+  std::pair<NativeIntp<isSigned, width>, NativeIntp<isSigned, width>>
+  revealPopulationOutput(
+      std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+      bool testOnly) const;
 
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
@@ -127,12 +127,13 @@ void Aggregator<schedulerId>::sumEvents() {
       indexShares_, valueSharesArray, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testEvents = std::get<0>(cohortOutput).at(0);
-  metrics_.controlEvents = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testEvents = std::get<0>(populationOutput);
+  metrics_.controlEvents = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testEvents = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlEvents = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testEvents = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlEvents = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -148,12 +149,13 @@ void Aggregator<schedulerId>::sumConverters() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testConverters = std::get<0>(cohortOutput).at(0);
-  metrics_.controlConverters = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testConverters = std::get<0>(populationOutput);
+  metrics_.controlConverters = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testConverters = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlConverters = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testConverters = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlConverters = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -168,12 +170,13 @@ void Aggregator<schedulerId>::sumNumConvSquared() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testNumConvSquared = std::get<0>(cohortOutput).at(0);
-  metrics_.controlNumConvSquared = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testNumConvSquared = std::get<0>(populationOutput);
+  metrics_.controlNumConvSquared = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testNumConvSquared = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlNumConvSquared = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testNumConvSquared = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlNumConvSquared = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -189,12 +192,13 @@ void Aggregator<schedulerId>::sumMatch() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testMatchCount = std::get<0>(cohortOutput).at(0);
-  metrics_.controlMatchCount = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testMatchCount = std::get<0>(populationOutput);
+  metrics_.controlMatchCount = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testMatchCount = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlMatchCount = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testMatchCount = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlMatchCount = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -214,10 +218,11 @@ void Aggregator<schedulerId>::sumReachedConversions() {
       testIndexShares_, valueSharesArray, numTestGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealTestCohortOutput(aggregationOutput);
-  metrics_.reachedConversions = std::get<0>(cohortOutput);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, true);
+  metrics_.reachedConversions = std::get<0>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, true);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].reachedConversions = std::get<1>(cohortOutput).at(i);
+    cohortMetrics_[i].reachedConversions = std::get<0>(cohortOutput).at(i);
   }
 }
 
@@ -235,12 +240,13 @@ void Aggregator<schedulerId>::sumValues() {
       indexShares_, valueSharesArray, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testValue = std::get<0>(cohortOutput).at(0);
-  metrics_.controlValue = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testValue = std::get<0>(populationOutput);
+  metrics_.controlValue = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testValue = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlValue = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testValue = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlValue = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -258,10 +264,11 @@ void Aggregator<schedulerId>::sumReachedValues() {
       testIndexShares_, valueSharesArray, numTestGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealTestCohortOutput(aggregationOutput);
-  metrics_.reachedValue = std::get<0>(cohortOutput);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, true);
+  metrics_.reachedValue = std::get<0>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, true);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].reachedValue = std::get<1>(cohortOutput).at(i);
+    cohortMetrics_[i].reachedValue = std::get<0>(cohortOutput).at(i);
   }
 }
 
@@ -276,12 +283,13 @@ void Aggregator<schedulerId>::sumValueSquared() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testValueSquared = std::get<0>(cohortOutput).at(0);
-  metrics_.controlValueSquared = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testValueSquared = std::get<0>(populationOutput);
+  metrics_.controlValueSquared = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testValueSquared = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlValueSquared = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testValueSquared = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlValueSquared = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -319,23 +327,33 @@ Aggregator<schedulerId>::aggregate(
 
 template <int schedulerId>
 template <bool isSigned, int8_t width>
-std::tuple<
-    std::vector<NativeIntp<isSigned, width>>,
+std::pair<
     std::vector<NativeIntp<isSigned, width>>,
     std::vector<NativeIntp<isSigned, width>>>
 Aggregator<schedulerId>::revealCohortOutput(
-    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput) const {
+    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+    bool testOnly) const {
   std::vector<NativeIntp<isSigned, width>> testCohortOutput;
   std::vector<NativeIntp<isSigned, width>> controlCohortOutput;
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
     // Extract cohort metrics
     testCohortOutput.push_back(
         aggregationOutput.at(i).extractIntShare().getValue());
-    controlCohortOutput.push_back(aggregationOutput.at(i + numPartnerCohorts_)
-                                      .extractIntShare()
-                                      .getValue());
+    if (!testOnly) {
+      controlCohortOutput.push_back(aggregationOutput.at(i + numPartnerCohorts_)
+                                        .extractIntShare()
+                                        .getValue());
+    }
   }
+  return std::make_pair(testCohortOutput, controlCohortOutput);
+}
 
+template <int schedulerId>
+template <bool isSigned, int8_t width>
+std::pair<NativeIntp<isSigned, width>, NativeIntp<isSigned, width>>
+Aggregator<schedulerId>::revealPopulationOutput(
+    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+    bool testOnly) const {
   // Initialize test/control metrics for the case where there are no partner
   // cohorts
   auto test = aggregationOutput.at(0);
@@ -345,37 +363,16 @@ Aggregator<schedulerId>::revealCohortOutput(
     // Compute test/control metrics by summing up cohort metrics for each
     // population
     test = test + aggregationOutput.at(i);
-    control = control + aggregationOutput.at(i + numPartnerCohorts_);
+    if (!testOnly) {
+      control = control + aggregationOutput.at(i + numPartnerCohorts_);
+    }
   }
-  std::vector<NativeIntp<isSigned, width>> testControlOutput;
-  testControlOutput.push_back(test.extractIntShare().getValue());
-  testControlOutput.push_back(control.extractIntShare().getValue());
-  return std::make_tuple(
-      testControlOutput, testCohortOutput, controlCohortOutput);
-}
-
-template <int schedulerId>
-template <bool isSigned, int8_t width>
-std::tuple<
-    NativeIntp<isSigned, width>,
-    std::vector<NativeIntp<isSigned, width>>>
-Aggregator<schedulerId>::revealTestCohortOutput(
-    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput) const {
-  // Extract metrics
-  std::vector<NativeIntp<isSigned, width>> testCohortOutput;
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    testCohortOutput.push_back(
-        aggregationOutput.at(i).extractIntShare().getValue());
+  auto testOutput = test.extractIntShare().getValue();
+  NativeIntp<isSigned, width> controlOutput;
+  if (!testOnly) {
+    controlOutput = control.extractIntShare().getValue();
   }
-
-  // Initialize test metrics for the case where there are no partner cohorts
-  auto test = aggregationOutput.at(0);
-  for (size_t i = 1; i < numPartnerCohorts_; ++i) {
-    // Compute test metrics by summing by cohort metrics
-    test = test + aggregationOutput.at(i);
-  }
-
-  return std::make_tuple(test.extractIntShare().getValue(), testCohortOutput);
+  return std::make_pair(testOutput, controlOutput);
 }
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -13,7 +13,7 @@ namespace private_lift {
 
 const int kMaxConcurrency = 16;
 
-const size_t groupWidth = 6; // at most 32 cohorts
+const size_t groupWidth = 7; // at most 32 cohorts and 2 publisher breakdowns
 const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -30,6 +30,7 @@ class InputProcessor {
     shareNumGroupsStep();
     privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
+    privatelyShareGroupIdsStep();
     privatelyShareIndexSharesStep();
     privatelyShareTestIndexSharesStep();
     privatelyShareTimestampsStep();
@@ -150,6 +151,7 @@ class InputProcessor {
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
   SecBit<schedulerId> breakdownGroupIds_;
+  SecGroup<schedulerId> testGroupIds_;
   std::vector<std::vector<bool>> indexShares_;
   std::vector<std::vector<bool>> testIndexShares_;
 };


### PR DESCRIPTION
Summary:
We construct index shares for doing ORAM aggregation over the populations, cohorts and breakdowns. Previously, we only considered the population and cohorts, and in this diff we add logic to include breakdowns as well. To do this, we encode the three types of groups into a single group id, which we convert to boolean index shares that are input to the ORAM.

Since there are at most 2 populations (test/control) and 2 breakdowns (0/1), there are up to 4 * numPartnerCohorts_ group ids in total. We assign the first 2 * numPartnerCohorts_ group ids to the test population, and the second half to the control population. Within the test population, we assign the group ids 0 to numPartnerCohorts_ - 1 to breakdown id 0, and the group ids from numPartnerCohorts_ to 2 * numPartnerCohorts_ - 1 to breakdown id 1. We similarly assign the group ids for the control population.

For the case where we only consider the test population, we assign the all group ids corresponding to the control as a single group id, while the logic for assigning test group ids remains the same.

Reviewed By: RuiyuZhu

Differential Revision: D37367013

