### PR TITLE
Reveal breakdown output from aggregation

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -77,6 +77,11 @@ class Aggregator {
     return cohortMetrics_;
   }
 
+  const std::unordered_map<int64_t, OutputMetricsData> getBreakdownMetrics()
+      const {
+    return publisherBreakdowns_;
+  }
+
   std::string toJson() const;
 
  private:
@@ -116,6 +121,16 @@ class Aggregator {
       std::vector<NativeIntp<isSigned, width>>,
       std::vector<NativeIntp<isSigned, width>>>
   revealCohortOutput(
+      std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+      bool testOnly) const;
+
+  // Reveal breakdown output from aggregation output as a pair consisting of the
+  // test breakdown metrics and optionally the control breakdown metrics.
+  template <bool isSigned, int8_t width>
+  std::pair<
+      std::vector<NativeIntp<isSigned, width>>,
+      std::vector<NativeIntp<isSigned, width>>>
+  revealBreakdownOutput(
       std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
       bool testOnly) const;
 
@@ -159,8 +174,7 @@ class Aggregator {
   std::vector<std::vector<bool>> indexShares_;
   std::vector<std::vector<bool>> testIndexShares_;
   std::unordered_map<int64_t, OutputMetricsData> cohortMetrics_;
-  std::unordered_map<int64_t, OutputMetricsData>
-      publisherBreakdowns_; // place holder for publisher breakdown metrics.
+  std::unordered_map<int64_t, OutputMetricsData> publisherBreakdowns_;
 };
 } // namespace private_lift
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -50,6 +50,9 @@ class Aggregator {
         attributor_{std::move(attributor)},
         numRows_{inputProcessor.getNumRows()},
         numPartnerCohorts_{inputProcessor.getNumPartnerCohorts()},
+        numPublisherBreakdowns_{inputProcessor.getNumPublisherBreakdowns()},
+        numGroups_{inputProcessor.getNumGroups()},
+        numTestGroups_{inputProcessor.getNumTestGroups()},
         numConversionsPerUser_{numConversionsPerUser},
         communicationAgentFactory_{communicationAgentFactory},
         indexShares_{inputProcessor.getIndexShares()},
@@ -129,6 +132,7 @@ class Aggregator {
   std::unique_ptr<Attributor<schedulerId>> attributor_;
   int64_t numRows_;
   uint32_t numPartnerCohorts_;
+  uint32_t numPublisherBreakdowns_;
   uint32_t numGroups_;
   uint32_t numTestGroups_;
   int32_t numConversionsPerUser_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -106,25 +106,23 @@ class Aggregator {
           fbpcf::mpc_std_lib::oram::IWriteOnlyOram<Intp<isSigned, width>>> oram)
       const;
 
-  // Reveal cohort output from aggregation output as a tuple consisting of the
-  // test/control metrics, the test cohort metrics, and the control cohort
-  // metrics.
+  // Reveal cohort output from aggregation output as a pair consisting of the
+  // test cohort metrics and optionally the control cohort metrics.
   template <bool isSigned, int8_t width>
-  std::tuple<
-      std::vector<NativeIntp<isSigned, width>>,
+  std::pair<
       std::vector<NativeIntp<isSigned, width>>,
       std::vector<NativeIntp<isSigned, width>>>
-  revealCohortOutput(std::vector<SecInt<schedulerId, isSigned, width>>
-                         aggregationOutput) const;
+  revealCohortOutput(
+      std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+      bool testOnly) const;
 
-  // Reveal cohort output from aggregation output as a tuple consisting of the
-  // test metrics and the test cohort metrics.
+  // Reveal population output from aggregation output as a pair consisting
+  // of the test metrics and optionally the control metrics.
   template <bool isSigned, int8_t width>
-  std::tuple<
-      NativeIntp<isSigned, width>,
-      std::vector<NativeIntp<isSigned, width>>>
-  revealTestCohortOutput(std::vector<SecInt<schedulerId, isSigned, width>>
-                             aggregationOutput) const;
+  std::pair<NativeIntp<isSigned, width>, NativeIntp<isSigned, width>>
+  revealPopulationOutput(
+      std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+      bool testOnly) const;
 
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
@@ -127,12 +127,13 @@ void Aggregator<schedulerId>::sumEvents() {
       indexShares_, valueSharesArray, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testEvents = std::get<0>(cohortOutput).at(0);
-  metrics_.controlEvents = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testEvents = std::get<0>(populationOutput);
+  metrics_.controlEvents = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testEvents = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlEvents = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testEvents = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlEvents = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -148,12 +149,13 @@ void Aggregator<schedulerId>::sumConverters() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testConverters = std::get<0>(cohortOutput).at(0);
-  metrics_.controlConverters = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testConverters = std::get<0>(populationOutput);
+  metrics_.controlConverters = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testConverters = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlConverters = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testConverters = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlConverters = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -168,12 +170,13 @@ void Aggregator<schedulerId>::sumNumConvSquared() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testNumConvSquared = std::get<0>(cohortOutput).at(0);
-  metrics_.controlNumConvSquared = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testNumConvSquared = std::get<0>(populationOutput);
+  metrics_.controlNumConvSquared = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testNumConvSquared = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlNumConvSquared = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testNumConvSquared = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlNumConvSquared = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -189,12 +192,13 @@ void Aggregator<schedulerId>::sumMatch() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testMatchCount = std::get<0>(cohortOutput).at(0);
-  metrics_.controlMatchCount = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testMatchCount = std::get<0>(populationOutput);
+  metrics_.controlMatchCount = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testMatchCount = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlMatchCount = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testMatchCount = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlMatchCount = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -214,10 +218,11 @@ void Aggregator<schedulerId>::sumReachedConversions() {
       testIndexShares_, valueSharesArray, numTestGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealTestCohortOutput(aggregationOutput);
-  metrics_.reachedConversions = std::get<0>(cohortOutput);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, true);
+  metrics_.reachedConversions = std::get<0>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, true);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].reachedConversions = std::get<1>(cohortOutput).at(i);
+    cohortMetrics_[i].reachedConversions = std::get<0>(cohortOutput).at(i);
   }
 }
 
@@ -235,12 +240,13 @@ void Aggregator<schedulerId>::sumValues() {
       indexShares_, valueSharesArray, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testValue = std::get<0>(cohortOutput).at(0);
-  metrics_.controlValue = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testValue = std::get<0>(populationOutput);
+  metrics_.controlValue = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testValue = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlValue = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testValue = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlValue = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -258,10 +264,11 @@ void Aggregator<schedulerId>::sumReachedValues() {
       testIndexShares_, valueSharesArray, numTestGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealTestCohortOutput(aggregationOutput);
-  metrics_.reachedValue = std::get<0>(cohortOutput);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, true);
+  metrics_.reachedValue = std::get<0>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, true);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].reachedValue = std::get<1>(cohortOutput).at(i);
+    cohortMetrics_[i].reachedValue = std::get<0>(cohortOutput).at(i);
   }
 }
 
@@ -276,12 +283,13 @@ void Aggregator<schedulerId>::sumValueSquared() {
       indexShares_, valueShares, numGroups_, std::move(oram));
 
   // Extract metrics
-  auto cohortOutput = revealCohortOutput(aggregationOutput);
-  metrics_.testValueSquared = std::get<0>(cohortOutput).at(0);
-  metrics_.controlValueSquared = std::get<0>(cohortOutput).at(1);
+  auto populationOutput = revealPopulationOutput(aggregationOutput, false);
+  metrics_.testValueSquared = std::get<0>(populationOutput);
+  metrics_.controlValueSquared = std::get<1>(populationOutput);
+  auto cohortOutput = revealCohortOutput(aggregationOutput, false);
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    cohortMetrics_[i].testValueSquared = std::get<1>(cohortOutput).at(i);
-    cohortMetrics_[i].controlValueSquared = std::get<2>(cohortOutput).at(i);
+    cohortMetrics_[i].testValueSquared = std::get<0>(cohortOutput).at(i);
+    cohortMetrics_[i].controlValueSquared = std::get<1>(cohortOutput).at(i);
   }
 }
 
@@ -319,23 +327,33 @@ Aggregator<schedulerId>::aggregate(
 
 template <int schedulerId>
 template <bool isSigned, int8_t width>
-std::tuple<
-    std::vector<NativeIntp<isSigned, width>>,
+std::pair<
     std::vector<NativeIntp<isSigned, width>>,
     std::vector<NativeIntp<isSigned, width>>>
 Aggregator<schedulerId>::revealCohortOutput(
-    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput) const {
+    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+    bool testOnly) const {
   std::vector<NativeIntp<isSigned, width>> testCohortOutput;
   std::vector<NativeIntp<isSigned, width>> controlCohortOutput;
   for (size_t i = 0; i < numPartnerCohorts_; ++i) {
     // Extract cohort metrics
     testCohortOutput.push_back(
         aggregationOutput.at(i).extractIntShare().getValue());
-    controlCohortOutput.push_back(aggregationOutput.at(i + numPartnerCohorts_)
-                                      .extractIntShare()
-                                      .getValue());
+    if (!testOnly) {
+      controlCohortOutput.push_back(aggregationOutput.at(i + numPartnerCohorts_)
+                                        .extractIntShare()
+                                        .getValue());
+    }
   }
+  return std::make_pair(testCohortOutput, controlCohortOutput);
+}
 
+template <int schedulerId>
+template <bool isSigned, int8_t width>
+std::pair<NativeIntp<isSigned, width>, NativeIntp<isSigned, width>>
+Aggregator<schedulerId>::revealPopulationOutput(
+    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput,
+    bool testOnly) const {
   // Initialize test/control metrics for the case where there are no partner
   // cohorts
   auto test = aggregationOutput.at(0);
@@ -345,37 +363,16 @@ Aggregator<schedulerId>::revealCohortOutput(
     // Compute test/control metrics by summing up cohort metrics for each
     // population
     test = test + aggregationOutput.at(i);
-    control = control + aggregationOutput.at(i + numPartnerCohorts_);
+    if (!testOnly) {
+      control = control + aggregationOutput.at(i + numPartnerCohorts_);
+    }
   }
-  std::vector<NativeIntp<isSigned, width>> testControlOutput;
-  testControlOutput.push_back(test.extractIntShare().getValue());
-  testControlOutput.push_back(control.extractIntShare().getValue());
-  return std::make_tuple(
-      testControlOutput, testCohortOutput, controlCohortOutput);
-}
-
-template <int schedulerId>
-template <bool isSigned, int8_t width>
-std::tuple<
-    NativeIntp<isSigned, width>,
-    std::vector<NativeIntp<isSigned, width>>>
-Aggregator<schedulerId>::revealTestCohortOutput(
-    std::vector<SecInt<schedulerId, isSigned, width>> aggregationOutput) const {
-  // Extract metrics
-  std::vector<NativeIntp<isSigned, width>> testCohortOutput;
-  for (size_t i = 0; i < numPartnerCohorts_; ++i) {
-    testCohortOutput.push_back(
-        aggregationOutput.at(i).extractIntShare().getValue());
+  auto testOutput = test.extractIntShare().getValue();
+  NativeIntp<isSigned, width> controlOutput;
+  if (!testOnly) {
+    controlOutput = control.extractIntShare().getValue();
   }
-
-  // Initialize test metrics for the case where there are no partner cohorts
-  auto test = aggregationOutput.at(0);
-  for (size_t i = 1; i < numPartnerCohorts_; ++i) {
-    // Compute test metrics by summing by cohort metrics
-    test = test + aggregationOutput.at(i);
-  }
-
-  return std::make_tuple(test.extractIntShare().getValue(), testCohortOutput);
+  return std::make_pair(testOutput, controlOutput);
 }
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -13,7 +13,7 @@ namespace private_lift {
 
 const int kMaxConcurrency = 16;
 
-const size_t groupWidth = 6; // at most 32 cohorts
+const size_t groupWidth = 7; // at most 32 cohorts and 2 publisher breakdowns
 const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -30,6 +30,7 @@ class InputProcessor {
     shareNumGroupsStep();
     privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
+    privatelyShareGroupIdsStep();
     privatelyShareIndexSharesStep();
     privatelyShareTestIndexSharesStep();
     privatelyShareTimestampsStep();
@@ -150,6 +151,7 @@ class InputProcessor {
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
   SecBit<schedulerId> breakdownGroupIds_;
+  SecGroup<schedulerId> testGroupIds_;
   std::vector<std::vector<bool>> indexShares_;
   std::vector<std::vector<bool>> testIndexShares_;
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -104,6 +104,11 @@ TEST_F(AggregatorTest, testEvents) {
   EXPECT_EQ(cohort[0].controlEvents, 2);
   EXPECT_EQ(cohort[1].controlEvents, 2);
   EXPECT_EQ(cohort[2].controlEvents, 1);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].testEvents, 4);
+  EXPECT_EQ(breakdown[1].testEvents, 5);
+  EXPECT_EQ(breakdown[0].controlEvents, 4);
+  EXPECT_EQ(breakdown[1].controlEvents, 1);
 }
 
 TEST_F(AggregatorTest, testConverters) {
@@ -118,6 +123,11 @@ TEST_F(AggregatorTest, testConverters) {
   EXPECT_EQ(cohort[0].controlConverters, 2);
   EXPECT_EQ(cohort[1].controlConverters, 1);
   EXPECT_EQ(cohort[2].controlConverters, 1);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].testConverters, 3);
+  EXPECT_EQ(breakdown[1].testConverters, 4);
+  EXPECT_EQ(breakdown[0].controlConverters, 3);
+  EXPECT_EQ(breakdown[1].controlConverters, 1);
 }
 
 TEST_F(AggregatorTest, testNumConvSquared) {
@@ -132,6 +142,11 @@ TEST_F(AggregatorTest, testNumConvSquared) {
   EXPECT_EQ(cohort[0].controlNumConvSquared, 2);
   EXPECT_EQ(cohort[1].controlNumConvSquared, 4);
   EXPECT_EQ(cohort[2].controlNumConvSquared, 1);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].testNumConvSquared, 6);
+  EXPECT_EQ(breakdown[1].testNumConvSquared, 7);
+  EXPECT_EQ(breakdown[0].controlNumConvSquared, 6);
+  EXPECT_EQ(breakdown[1].controlNumConvSquared, 1);
 }
 
 TEST_F(AggregatorTest, testMatchCount) {
@@ -146,6 +161,11 @@ TEST_F(AggregatorTest, testMatchCount) {
   EXPECT_EQ(cohort[0].controlMatchCount, 4);
   EXPECT_EQ(cohort[1].controlMatchCount, 2);
   EXPECT_EQ(cohort[2].controlMatchCount, 1);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].testMatchCount, 6);
+  EXPECT_EQ(breakdown[1].testMatchCount, 6);
+  EXPECT_EQ(breakdown[0].controlMatchCount, 6);
+  EXPECT_EQ(breakdown[1].controlMatchCount, 1);
 }
 
 TEST_F(AggregatorTest, testReachedConversions) {
@@ -156,6 +176,9 @@ TEST_F(AggregatorTest, testReachedConversions) {
   EXPECT_EQ(cohort[0].reachedConversions, 1);
   EXPECT_EQ(cohort[1].reachedConversions, 0);
   EXPECT_EQ(cohort[2].reachedConversions, 3);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].reachedConversions, 1);
+  EXPECT_EQ(breakdown[1].reachedConversions, 3);
 }
 
 TEST_F(AggregatorTest, testValues) {
@@ -170,6 +193,11 @@ TEST_F(AggregatorTest, testValues) {
   EXPECT_EQ(cohort[0].controlValue, 40);
   EXPECT_EQ(cohort[1].controlValue, 30);
   EXPECT_EQ(cohort[2].controlValue, -50);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].testValue, 30);
+  EXPECT_EQ(breakdown[1].testValue, 90);
+  EXPECT_EQ(breakdown[0].controlValue, 70);
+  EXPECT_EQ(breakdown[1].controlValue, -50);
 }
 
 TEST_F(AggregatorTest, testReachedValues) {
@@ -179,6 +207,9 @@ TEST_F(AggregatorTest, testReachedValues) {
   EXPECT_EQ(cohort[0].reachedValue, 20);
   EXPECT_EQ(cohort[1].reachedValue, 0);
   EXPECT_EQ(cohort[2].reachedValue, 80);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].reachedValue, 50);
+  EXPECT_EQ(breakdown[1].reachedValue, 50);
 }
 
 TEST_F(AggregatorTest, testValueSquared) {
@@ -193,6 +224,11 @@ TEST_F(AggregatorTest, testValueSquared) {
   EXPECT_EQ(cohort[0].controlValueSquared, 800);
   EXPECT_EQ(cohort[1].controlValueSquared, 900);
   EXPECT_EQ(cohort[2].controlValueSquared, 2500);
+  auto breakdown = publisherAggregator_->getBreakdownMetrics();
+  EXPECT_EQ(breakdown[0].testValueSquared, 5900);
+  EXPECT_EQ(breakdown[1].testValueSquared, 2100);
+  EXPECT_EQ(breakdown[0].controlValueSquared, 1700);
+  EXPECT_EQ(breakdown[1].controlValueSquared, 2500);
 }
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -168,13 +168,6 @@ TEST_P(CalculatorAppTestFixture, TestCorrectness) {
 
   auto expectedResult =
       GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputPath));
-
-  // In this test we are not worried about publisher breakdowns yet.
-  // TODO: update this test once the breakdown aggregations are
-  // implemented.
-  result.publisherBreakdowns.clear();
-  expectedResult.publisherBreakdowns.clear();
-
   EXPECT_EQ(expectedResult, result);
 }
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
@@ -124,10 +124,6 @@ TEST_P(CalculatorGameTestFixture, TestCorrectness) {
   // Read expected output from file
   auto expectedRes =
       GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputFilename));
-  expectedRes.publisherBreakdowns.clear();
-  res.publisherBreakdowns
-      .clear(); // we don't have publisher breakdown implemented.
-
   EXPECT_EQ(expectedRes, res);
 }
 


### PR DESCRIPTION
Summary: We add methods to reveal the breakdown output from the ORAM aggregation, and we modify the CalculatorGame and CalculatorApp tests accordingly.

Reviewed By: RuiyuZhu

Differential Revision: D37367352

