### PR TITLE
Add name when creating a new connection

### DIFF
--- a/fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessorFactory.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessorFactory.h
@@ -27,7 +27,9 @@ class DummyDataProcessorFactory final
 
   std::unique_ptr<IDataProcessor<schedulerId>> create() {
     return std::make_unique<DummyDataProcessor<schedulerId>>(
-        myId_, partnerId_, agentFactory_.create(partnerId_));
+        myId_,
+        partnerId_,
+        agentFactory_.create(partnerId_, "Dummy_Data_Processor_Traffic"));
   }
 
  private:


### PR DESCRIPTION
Summary: In this diff, we give each connection a name such that we know how to interpret the metrics.

Reviewed By: adshastri

Differential Revision: D37305211

