### PR TITLE
stop_service() in PIDRunProtocolStageService

### DIFF
--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -174,3 +174,27 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
                 f"Supplied {len(server_ips)} server_hostnames, but num_shards == {num_shards} (these should agree)"
             )
         return [f"http://{ip}" for ip in server_ips]
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        last_instance = pc_instance.instances[-1]
+        # make sure the last instance is the StageStageInstance appended by current stage
+        if not isinstance(last_instance, StageStateInstance):
+            raise ValueError("Have no StageState for stop_service")
+
+        assert last_instance.stage_name == pc_instance.current_stage.name
+
+        # stop containers
+        containers = last_instance.containers
+        if containers:
+            container_ids = [instance.instance_id for instance in containers]
+            errors = self._onedocker_svc.stop_containers(container_ids)
+            error_msg = [
+                (id, error) for id, error in zip(container_ids, errors) if error
+            ]
+            if error_msg:
+                raise RuntimeError(
+                    f"We encountered errors when stopping containers: {error_msg}"
+                )


### PR DESCRIPTION
Summary: In this diff, we implemented stop_service() in PIDRunProtocolStageService, which overides stop_service() in PrivateComputationStageService and will be called by cancel_current_stage() in private_computation.py

Reviewed By: joe1234wu

Differential Revision: D37398944

