### PR TITLE
Add code to suppress SIGPIPE for affected stages

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <gflags/gflags.h>
+#include <signal.h>
 
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/io/FileManagerUtil.h>
@@ -35,6 +36,8 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
 
   std::filesystem::path outputPath{FLAGS_output_path};
   std::filesystem::path tmpDirectory{FLAGS_tmp_directory};

--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombiner.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 
 #include <gflags/gflags.h>
+#include <signal.h>
 
 #include "folly/init/Init.h"
 
@@ -21,6 +22,8 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
 
   std::filesystem::path tmpDirectory{FLAGS_tmp_directory};
 

--- a/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 
 #include <gflags/gflags.h>
+#include <signal.h>
 
 #include "folly/init/Init.h"
 
@@ -29,6 +30,8 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
 
   std::filesystem::path tmpDirectory{FLAGS_tmp_directory};
   measurement::pid::UnionPIDDataPreparer preparer{

--- a/fbpcs/emp_games/lift/calculator/main.cpp
+++ b/fbpcs/emp_games/lift/calculator/main.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 
 #include <glog/logging.h>
+#include <signal.h>
 #include <filesystem>
 #include <sstream>
 #include <string>
@@ -83,6 +84,9 @@ using namespace private_lift;
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
+
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   std::vector<std::string> inputFilepaths;

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <glog/logging.h>
+#include <signal.h>
 #include <filesystem>
 #include <sstream>
 #include <string>
@@ -88,6 +89,9 @@ int main(int argc, char** argv) {
 
   folly::init(&argc, &argv);
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
+
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   // since DEFINE_INT16 is not supported, cast int32_t FLAGS_concurrency to

--- a/fbpcs/emp_games/pcf2_aggregation/main.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gflags/gflags.h>
+#include <signal.h>
 
 #include "folly/Format.h"
 #include "folly/init/Init.h"
@@ -26,6 +27,9 @@ int main(int argc, char* argv[]) {
 
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  signal(SIGPIPE, SIG_IGN);
+
   fbpcf::AwsSdk::aquire();
 
   FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gflags/gflags.h>
+#include <signal.h>
 #include <string>
 
 #include "folly/Format.h"
@@ -27,6 +28,9 @@ int main(int argc, char* argv[]) {
 
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  signal(SIGPIPE, SIG_IGN);
+
   fbpcf::AwsSdk::aquire();
 
   FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner


### PR DESCRIPTION
Summary: There is a mysterious error with PCF IO APIs where it returns a SIGPIPE (code 141) even though all operations complete successfully. Wenhai and I spent several weeks debugging this, and got nowhere. When running it locally, I was not able to reproduce it.

Reviewed By: chualynn

Differential Revision: D37494312

