### PR TITLE
fix task_definition in github runner & smoked meats emporium

### DIFF
--- a/fbpcs/tests/github/config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/config_one_command_runner_test.yml
@@ -28,7 +28,7 @@ private_computation:
           binary_version: latest
     OneDockerServiceConfig:
       constructor:
-        task_definition: onedocker-task-comp-ui-e2e:1#onedocker-container-comp-ui-e2e
+        task_definition: onedocker-task-pc-e2e-test:1#onedocker-container-pc-e2e-test
 pid:
   dependency:
     PIDInstanceRepository:


### PR DESCRIPTION
Summary:
## Why
* `pc-e2e-test` cluster was created and aim to replace `comp-ui-e2e`. and `comp-ui-e2e` had already clean up

* bad cw log ```https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-pc-e2e-test/log-events/ecs$252Fonedocker-container-pc-e2e-test$252F35f9c7462a5744f69e777fdd8dfb6883```
https://pxl.cl/26TZR

* In One docker svc, we passed in task definition to override it,
it's will used to create the container's id
https://fburl.com/code/rukg49w5. and in log_retriever.py
https://fburl.com/code/yvzv4i27

* when it's assembling CW log it's using the task definition from container id. the CW log can't be found as it's a mismatch

## What
Update Task definition to reflect correct cluster `pc-e2e-test` & CW log

Differential Revision: D37499955

