### PR TITLE
Adding detailed unitests for check_s3_buckets_exists

### DIFF
--- a/fbpcs/infra/pce_deployment_library/cloud_library/aws/aws.py
+++ b/fbpcs/infra/pce_deployment_library/cloud_library/aws/aws.py
@@ -125,7 +125,7 @@ class AWS(CloudBase):
                 CreateBucketConfiguration=bucket_configuration,
             )
             self.log.info(
-                f"Create S3 bucket {s3_bucket_name} opeeration was successful."
+                f"Create S3 bucket {s3_bucket_name} operation was successful."
             )
         except ClientError as error:
             error_code = error.response.get("Error", {}).get("Code", None)

--- a/fbpcs/infra/pce_deployment_library/test/test_aws.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_aws.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec
 
 from botocore.exceptions import ClientError
 
@@ -21,29 +21,49 @@ from fbpcs.infra.pce_deployment_library.errors_library.aws_errors import (
 class TestAws(unittest.TestCase):
     def setUp(self) -> None:
         self.aws = AWS()
-        self.aws.sts.get_caller_identity = MagicMock(return_value=None)
+        self.aws.sts.get_caller_identity = create_autospec(
+            self.aws.sts.get_caller_identity
+        )
 
     def test_check_s3_buckets_exists(self) -> None:
         s3_bucket_name = "fake_bucket"
-        self.aws.s3_client.head_bucket = MagicMock(return_value=None)
+        self.aws.s3_client.head_bucket = create_autospec(self.aws.s3_client.head_bucket)
 
         with self.subTest("basic"):
-            self.assertIsNone(
-                self.aws.check_s3_buckets_exists(s3_bucket_name=s3_bucket_name)
-            )
+            with self.assertLogs() as captured:
+                self.aws.check_s3_buckets_exists(
+                    s3_bucket_name=s3_bucket_name, bucket_version=False
+                )
+                self.assertEqual(len(captured.records), 2)
+                self.assertEqual(
+                    captured.records[1].getMessage(),
+                    f"S3 bucket {s3_bucket_name} already exists in the AWS account.",
+                )
 
         with self.subTest("BucketNotFound"):
-            self.aws.s3_client.create_bucket = MagicMock(return_value=None)
-            self.aws.s3_client.put_bucket_versionin = MagicMock(return_value=None)
+            self.aws.s3_client.create_bucket = create_autospec(
+                self.aws.s3_client.create_bucket
+            )
+            self.aws.s3_client.put_bucket_versioning = create_autospec(
+                self.aws.s3_client.put_bucket_versioning
+            )
             self.aws.s3_client.head_bucket.side_effect = ClientError(
                 error_response={"Error": {"Code": "404"}},
                 operation_name="head_bucket",
             )
-            self.assertIsNone(
+            with self.assertLogs() as captured:
                 self.aws.check_s3_buckets_exists(
                     s3_bucket_name=s3_bucket_name, bucket_version=False
                 )
-            )
+                self.assertEqual(len(captured.records), 4)
+                self.assertEqual(
+                    captured.records[2].getMessage(),
+                    f"Creating new S3 bucket {s3_bucket_name}",
+                )
+                self.assertEqual(
+                    captured.records[3].getMessage(),
+                    f"Create S3 bucket {s3_bucket_name} operation was successful.",
+                )
 
         with self.subTest("AccessDenied"):
             self.aws.s3_client.head_bucket.side_effect = ClientError(


### PR DESCRIPTION
Summary:
Adding detailed unitests for check_s3_buckets_exists.

This diff addresses review comments on D37446115 (https://github.com/facebookresearch/fbpcs/commit/0c28929bcd163f3fbea5cbb2d8bfa823ba80f161)

Differential Revision: D37479056

