### PR TITLE
Add a flag to validate whether to use new vs old output format in PA

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
@@ -60,3 +60,4 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
@@ -26,3 +26,4 @@ DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
 DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -245,6 +245,23 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintext) {
       thresholdsLastTouch1D,
       1);
 
+  FLAGS_use_new_output_format = true;
+  auto computeAttributionLastClick1DNewOutputFormat =
+      game.computeAttributionsHelper(
+          privateTouchpoints.at(0),
+          privateConversions.at(0),
+          *lastClick1D,
+          thresholdsLastClick1D,
+          1);
+
+  auto computeAttributionLastTouch1DNewOutputFormat =
+      game.computeAttributionsHelper(
+          privateTouchpoints.at(0),
+          privateConversions.at(0),
+          *lastTouch1D,
+          thresholdsLastTouch1D,
+          1);
+
   for (size_t i = 0; i < attributionResultsLastClick1D.size(); ++i) {
     EXPECT_EQ(
         computeAttributionLastClick1D.at(i)
@@ -260,6 +277,10 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintext) {
             .getValue(),
         attributionResultsLastTouch1D.at(i));
   }
+
+  EXPECT_EQ(computeAttributionLastClick1DNewOutputFormat.size(), 0);
+
+  EXPECT_EQ(computeAttributionLastTouch1DNewOutputFormat.size(), 0);
 }
 
 TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
@@ -333,6 +354,23 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
       thresholdsLastTouch1D,
       batchSize);
 
+  FLAGS_use_new_output_format = true;
+  auto computeAttributionLastClick1DNewOutputFormat =
+      game.computeAttributionsHelper(
+          privateTouchpoints,
+          privateConversions,
+          *lastClick1D,
+          thresholdsLastClick1D,
+          batchSize);
+
+  auto computeAttributionLastTouch1DNewOutputFormat =
+      game.computeAttributionsHelper(
+          privateTouchpoints,
+          privateConversions,
+          *lastTouch1D,
+          thresholdsLastTouch1D,
+          batchSize);
+
   for (size_t i = 0; i < attributionResultsLastClick1D.size(); ++i) {
     for (size_t j = 0; j < batchSize; ++j) {
       EXPECT_EQ(
@@ -354,6 +392,10 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
           attributionResultsLastTouch1D.at(i));
     }
   }
+
+  EXPECT_EQ(computeAttributionLastClick1DNewOutputFormat.size(), 0);
+
+  EXPECT_EQ(computeAttributionLastTouch1DNewOutputFormat.size(), 0);
 }
 
 template <


### PR DESCRIPTION
Summary:
# Context
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
# This Diff
In this diff, adding a flag to validate whether to use new vs old output format in PA
# This Stack
1. **Add a flag to validate whether to use new vs old output format in PA.**
2. Modify PCS stage for attribution with the new flag.
3. Modify output format in attribution game and update unit tests for PCF2 Attribution game per the new format.
4. Modify Input parsing logic in Aggregation game.
5. Create end to end tests to test the new attribution format.

Differential Revision: D37511471

