### PR TITLE
Modify PCS stage for attribution with the new flag (#1176)

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -31,13 +31,15 @@ class AttributionApp {
       const std::vector<std::string>& inputFilenames,
       const std::vector<std::string>& outputFilenames,
       std::uint32_t startFileIndex = 0U,
-      int numFiles = 1)
+      int numFiles = 1,
+      bool use_new_format = false)
       : communicationAgentFactory_(std::move(communicationAgentFactory)),
         attributionRules_{attributionRules},
         inputFilenames_(inputFilenames),
         outputFilenames_(outputFilenames),
         startFileIndex_(startFileIndex),
         numFiles_(numFiles),
+        use_new_format_{use_new_format},
         schedulerStatistics_{0, 0, 0, 0} {}
 
   void run() {
@@ -53,7 +55,8 @@ class AttributionApp {
       CHECK_LT(i, inputFilenames_.size())
           << "File index exceeds number of files.";
       auto inputData = getInputData(inputFilenames_.at(i));
-      auto output = game.computeAttributions(MY_ROLE, inputData);
+      auto output =
+          game.computeAttributions(MY_ROLE, inputData, use_new_format_);
       putOutputData(output, outputFilenames_.at(i));
     }
 
@@ -107,6 +110,7 @@ class AttributionApp {
   std::vector<std::string> outputFilenames_;
   const std::uint32_t startFileIndex_;
   const int numFiles_;
+  const bool use_new_format_;
   common::SchedulerStatistics schedulerStatistics_;
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -32,14 +32,14 @@ class AttributionApp {
       const std::vector<std::string>& outputFilenames,
       std::uint32_t startFileIndex = 0U,
       int numFiles = 1,
-      bool use_new_format = false)
+      bool useNewOutputFormat = false)
       : communicationAgentFactory_(std::move(communicationAgentFactory)),
         attributionRules_{attributionRules},
         inputFilenames_(inputFilenames),
         outputFilenames_(outputFilenames),
         startFileIndex_(startFileIndex),
         numFiles_(numFiles),
-        use_new_format_{use_new_format},
+        useNewOutputFormat_{useNewOutputFormat},
         schedulerStatistics_{0, 0, 0, 0} {}
 
   void run() {
@@ -56,7 +56,7 @@ class AttributionApp {
           << "File index exceeds number of files.";
       auto inputData = getInputData(inputFilenames_.at(i));
       auto output =
-          game.computeAttributions(MY_ROLE, inputData, use_new_format_);
+          game.computeAttributions(MY_ROLE, inputData, useNewOutputFormat_);
       putOutputData(output, outputFilenames_.at(i));
     }
 
@@ -110,7 +110,7 @@ class AttributionApp {
   std::vector<std::string> outputFilenames_;
   const std::uint32_t startFileIndex_;
   const int numFiles_;
-  const bool use_new_format_;
+  const bool useNewOutputFormat_;
   common::SchedulerStatistics schedulerStatistics_;
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -32,7 +32,8 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   AttributionOutputMetrics computeAttributions(
       const int myRole,
-      const AttributionInputMetrics<usingBatch, inputEncryption>& inputData);
+      const AttributionInputMetrics<usingBatch, inputEncryption>& inputData,
+      bool use_new_format);
 
   using PrivateTouchpointT = ConditionalVector<
       PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
@@ -89,7 +90,8 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
           attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
           thresholds,
-      size_t batchSize);
+      size_t batchSize,
+      bool use_new_format);
 };
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -33,7 +33,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   AttributionOutputMetrics computeAttributions(
       const int myRole,
       const AttributionInputMetrics<usingBatch, inputEncryption>& inputData,
-      bool use_new_format);
+      bool useNewOutputFormat);
 
   using PrivateTouchpointT = ConditionalVector<
       PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
@@ -91,7 +91,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
           thresholds,
       size_t batchSize,
-      bool use_new_format);
+      bool useNewOutputFormat);
 };
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -192,7 +192,7 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
         const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
             thresholds,
         size_t batchSize,
-        bool use_new_format) {
+        bool /*useNewOutputFormat*/) {
   if constexpr (usingBatch) {
     if (batchSize == 0) {
       throw std::invalid_argument(
@@ -210,7 +210,10 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
   // Thus at the end we will get the fully reversed attribution match vector of
   // conversions and touchpoints.
 
-  // TODO: new format for attribution
+  // TODO: new format for attribution output
+  // We have added a flag to for new or old format in PA
+  // if the flag is false, then will use the old attribution output format
+  // else if the flag is true, then will use the new attribution output format (which will be implemented)
   for (auto conversion = conversions.rbegin(); conversion != conversions.rend();
        ++conversion) {
     auto conv = *conversion;
@@ -298,7 +301,7 @@ AttributionOutputMetrics
 AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
     const int myRole,
     const AttributionInputMetrics<usingBatch, inputEncryption>& inputData,
-    bool use_new_format) {
+    bool useNewOutputFormat) {
   XLOG(INFO, "Running attribution");
   auto ids = inputData.getIds();
   uint32_t numIds = ids.size();
@@ -339,7 +342,7 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
           *attributionRule,
           thresholdArrays,
           numIds,
-          use_new_format);
+          useNewOutputFormat);
     } else {
       // Compute row by row if not using batch
       for (size_t i = 0; i < numIds; ++i) {
@@ -349,7 +352,7 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
             *attributionRule,
             thresholdArrays.at(i),
             numIds,
-            use_new_format);
+            useNewOutputFormat);
         attributions.push_back(std::move(attributionRow));
       }
     }

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -191,7 +191,8 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
             attributionRule,
         const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
             thresholds,
-        size_t batchSize) {
+        size_t batchSize,
+        bool use_new_format) {
   if constexpr (usingBatch) {
     if (batchSize == 0) {
       throw std::invalid_argument(
@@ -208,6 +209,8 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
   // know that it is the preferred touchpoint as well.
   // Thus at the end we will get the fully reversed attribution match vector of
   // conversions and touchpoints.
+
+  // TODO: new format for attribution
   for (auto conversion = conversions.rbegin(); conversion != conversions.rend();
        ++conversion) {
     auto conv = *conversion;
@@ -294,7 +297,8 @@ template <
 AttributionOutputMetrics
 AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
     const int myRole,
-    const AttributionInputMetrics<usingBatch, inputEncryption>& inputData) {
+    const AttributionInputMetrics<usingBatch, inputEncryption>& inputData,
+    bool use_new_format) {
   XLOG(INFO, "Running attribution");
   auto ids = inputData.getIds();
   uint32_t numIds = ids.size();
@@ -330,7 +334,12 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
 
     if constexpr (usingBatch) {
       attributions = computeAttributionsHelper(
-          tpArrays, convArrays, *attributionRule, thresholdArrays, numIds);
+          tpArrays,
+          convArrays,
+          *attributionRule,
+          thresholdArrays,
+          numIds,
+          use_new_format);
     } else {
       // Compute row by row if not using batch
       for (size_t i = 0; i < numIds; ++i) {
@@ -339,7 +348,8 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
             convArrays.at(i),
             *attributionRule,
             thresholdArrays.at(i),
-            numIds);
+            numIds,
+            use_new_format);
         attributions.push_back(std::move(attributionRow));
       }
     }

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
@@ -60,4 +60,4 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_bool(use_new_format, false, "New Format of Attribution output");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
@@ -60,3 +60,4 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
+DEFINE_bool(use_new_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
@@ -26,3 +26,4 @@ DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
 DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
+DECLARE_bool(use_new_format);

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
@@ -26,4 +26,4 @@ DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
 DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
-DECLARE_bool(use_new_format);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -64,7 +64,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     std::string attributionRules,
     std::vector<std::string>& inputFilenames,
     std::vector<std::string>& outputFilenames,
-    bool use_new_format) {
+    bool useNewOutputFormat) {
   // aggregate scheduler statistics across apps
   common::SchedulerStatistics schedulerStatistics{0, 0, 0, 0};
 
@@ -101,7 +101,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
         outputFilenames,
         startFileIndex,
         numFiles,
-        use_new_format);
+        useNewOutputFormat);
 
     auto future = std::async([&app]() {
       app->run();
@@ -122,7 +122,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
             attributionRules,
             inputFilenames,
             outputFilenames,
-            use_new_format);
+            useNewOutputFormat);
         schedulerStatistics.add(remainingStats);
       }
     }
@@ -140,7 +140,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
     std::string serverIp,
     int port,
     std::string attributionRules,
-    bool use_new_format) {
+    bool useNewOutputFormat) {
   // use only as many threads as the number of files
   auto numThreads =
       std::min(static_cast<std::int16_t>(inputFilenames.size()), concurrency);
@@ -157,7 +157,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
       attributionRules,
       inputFilenames,
       outputFilenames,
-      use_new_format);
+      useNewOutputFormat);
 }
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -63,7 +63,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     int port,
     std::string attributionRules,
     std::vector<std::string>& inputFilenames,
-    std::vector<std::string>& outputFilenames) {
+    std::vector<std::string>& outputFilenames,
+    bool use_new_format) {
   // aggregate scheduler statistics across apps
   common::SchedulerStatistics schedulerStatistics{0, 0, 0, 0};
 
@@ -99,7 +100,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
         inputFilenames,
         outputFilenames,
         startFileIndex,
-        numFiles);
+        numFiles,
+        use_new_format);
 
     auto future = std::async([&app]() {
       app->run();
@@ -119,7 +121,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
             port,
             attributionRules,
             inputFilenames,
-            outputFilenames);
+            outputFilenames,
+            use_new_format);
         schedulerStatistics.add(remainingStats);
       }
     }
@@ -136,7 +139,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
     int16_t concurrency,
     std::string serverIp,
     int port,
-    std::string attributionRules) {
+    std::string attributionRules,
+    bool use_new_format) {
   // use only as many threads as the number of files
   auto numThreads =
       std::min(static_cast<std::int16_t>(inputFilenames.size()), concurrency);
@@ -152,7 +156,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
       port,
       attributionRules,
       inputFilenames,
-      outputFilenames);
+      outputFilenames,
+      use_new_format);
 }
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -75,7 +75,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_format);
       } else if (FLAGS_input_encryption == 2) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -87,7 +88,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_format);
       } else {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -99,7 +101,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_format);
       }
 
     } else if (FLAGS_party == common::PARTNER) {
@@ -117,7 +120,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_format);
       } else if (FLAGS_input_encryption == 2) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -129,7 +133,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_format);
 
       } else {
         schedulerStatistics =
@@ -142,7 +147,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_format);
       }
 
     } else {

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
                 FLAGS_server_ip,
                 FLAGS_port,
                 FLAGS_attribution_rules,
-                FLAGS_use_new_format);
+                FLAGS_use_new_output_format);
       } else if (FLAGS_input_encryption == 2) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -89,7 +89,7 @@ int main(int argc, char* argv[]) {
                 FLAGS_server_ip,
                 FLAGS_port,
                 FLAGS_attribution_rules,
-                FLAGS_use_new_format);
+                FLAGS_use_new_output_format);
       } else {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
                 FLAGS_server_ip,
                 FLAGS_port,
                 FLAGS_attribution_rules,
-                FLAGS_use_new_format);
+                FLAGS_use_new_output_format);
       }
 
     } else if (FLAGS_party == common::PARTNER) {
@@ -121,7 +121,7 @@ int main(int argc, char* argv[]) {
                 FLAGS_server_ip,
                 FLAGS_port,
                 FLAGS_attribution_rules,
-                FLAGS_use_new_format);
+                FLAGS_use_new_output_format);
       } else if (FLAGS_input_encryption == 2) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -134,7 +134,7 @@ int main(int argc, char* argv[]) {
                 FLAGS_server_ip,
                 FLAGS_port,
                 FLAGS_attribution_rules,
-                FLAGS_use_new_format);
+                FLAGS_use_new_output_format);
 
       } else {
         schedulerStatistics =
@@ -148,7 +148,7 @@ int main(int argc, char* argv[]) {
                 FLAGS_server_ip,
                 FLAGS_port,
                 FLAGS_attribution_rules,
-                FLAGS_use_new_format);
+                FLAGS_use_new_output_format);
       }
 
     } else {

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -236,14 +236,16 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintext) {
       privateConversions.at(0),
       *lastClick1D,
       thresholdsLastClick1D,
-      1);
+      1,
+      false);
 
   auto computeAttributionLastTouch1D = game.computeAttributionsHelper(
       privateTouchpoints.at(0),
       privateConversions.at(0),
       *lastTouch1D,
       thresholdsLastTouch1D,
-      1);
+      1,
+      false);
 
   for (size_t i = 0; i < attributionResultsLastClick1D.size(); ++i) {
     EXPECT_EQ(
@@ -324,14 +326,16 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
       privateConversions,
       *lastClick1D,
       thresholdsLastClick1D,
-      batchSize);
+      batchSize,
+      false);
 
   auto computeAttributionLastTouch1D = game.computeAttributionsHelper(
       privateTouchpoints,
       privateConversions,
       *lastTouch1D,
       thresholdsLastTouch1D,
-      batchSize);
+      batchSize,
+      false);
 
   for (size_t i = 0; i < attributionResultsLastClick1D.size(); ++i) {
     for (size_t j = 0; j < batchSize; ++j) {
@@ -370,7 +374,7 @@ AttributionOutputMetrics computeAttributionsWithScheduler(
   auto game = std::make_unique<
       AttributionGame<schedulerId, usingBatch, inputEncryption>>(
       std::move(scheduler));
-  return game->computeAttributions(myId, inputData);
+  return game->computeAttributions(myId, inputData, false);
 }
 
 template <bool usingBatch, common::InputEncryption inputEncryption>

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -121,6 +121,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="use_new_output_format", required=True),
         ],
     },
     GameNames.PCF2_AGGREGATION.value: {

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -177,6 +177,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             "attribution_rules": attribution_rule.value,
             "use_xor_encryption": True,
             "use_postfix": True,
+            "use_new_output_format": False,
         }
 
         game_args = [

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -80,6 +80,7 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             "use_xor_encryption": True,
             "use_postfix": True,
             "log_cost": True,
+            "use_new_output_format": False,
         }
         test_game_args = [
             {


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/1176

# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
In this diff, adding a flag to validate whether to use new vs old output format in Private Attribution.
# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Attribution.
2. **Modify PCS stage for attribution with the new flag.**
3. Modify output format in attribution game and update unit tests for PCF2 Attribution game per the new format.
4. Add a flag to validate whether to use new vs old input format of attribution in Private Aggregation.
5. Modify PCS stage for aggregation with the new flag.
6. Modify Input parsing logic in Aggregation game and update unit tests.
7. Create end to end tests to test the new attribution format.

Differential Revision: D37528719

