### PR TITLE
Modify PCS stage for attribution with the new flag (#1176)

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -31,13 +31,15 @@ class AttributionApp {
       const std::vector<std::string>& inputFilenames,
       const std::vector<std::string>& outputFilenames,
       std::uint32_t startFileIndex = 0U,
-      int numFiles = 1)
+      int numFiles = 1,
+      bool useNewOutputFormat = false)
       : communicationAgentFactory_(std::move(communicationAgentFactory)),
         attributionRules_{attributionRules},
         inputFilenames_(inputFilenames),
         outputFilenames_(outputFilenames),
         startFileIndex_(startFileIndex),
         numFiles_(numFiles),
+        useNewOutputFormat_{useNewOutputFormat},
         schedulerStatistics_{0, 0, 0, 0} {}
 
   void run() {
@@ -54,7 +56,8 @@ class AttributionApp {
       CHECK_LT(i, inputFilenames_.size())
           << "File index exceeds number of files.";
       auto inputData = getInputData(inputFilenames_.at(i));
-      auto output = game.computeAttributions(MY_ROLE, inputData);
+      auto output =
+          game.computeAttributions(MY_ROLE, inputData, useNewOutputFormat_);
       putOutputData(output, outputFilenames_.at(i));
     }
 
@@ -109,6 +112,7 @@ class AttributionApp {
   std::vector<std::string> outputFilenames_;
   const std::uint32_t startFileIndex_;
   const int numFiles_;
+  const bool useNewOutputFormat_;
   common::SchedulerStatistics schedulerStatistics_;
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -32,7 +32,8 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   AttributionOutputMetrics computeAttributions(
       const int myRole,
-      const AttributionInputMetrics<usingBatch, inputEncryption>& inputData);
+      const AttributionInputMetrics<usingBatch, inputEncryption>& inputData,
+      bool useNewOutputFormat);
 
   using PrivateTouchpointT = ConditionalVector<
       PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
@@ -89,7 +90,8 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
           attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
           thresholds,
-      size_t batchSize);
+      size_t batchSize,
+      bool useNewOutputFormat);
 };
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -191,7 +191,8 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
             attributionRule,
         const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
             thresholds,
-        size_t batchSize) {
+        size_t batchSize,
+        bool /*useNewOutputFormat*/) {
   if constexpr (usingBatch) {
     if (batchSize == 0) {
       throw std::invalid_argument(
@@ -208,6 +209,11 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::
   // know that it is the preferred touchpoint as well.
   // Thus at the end we will get the fully reversed attribution match vector of
   // conversions and touchpoints.
+
+  // TODO: new format for attribution output
+  // We have added flag to validate new vs old output format
+  // if flag is false, will use the old output format
+  // else if flag is true, will use the new format (which will implement)
   for (auto conversion = conversions.rbegin(); conversion != conversions.rend();
        ++conversion) {
     auto conv = *conversion;
@@ -294,7 +300,8 @@ template <
 AttributionOutputMetrics
 AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
     const int myRole,
-    const AttributionInputMetrics<usingBatch, inputEncryption>& inputData) {
+    const AttributionInputMetrics<usingBatch, inputEncryption>& inputData,
+    bool useNewOutputFormat) {
   XLOG(INFO, "Running attribution");
   auto ids = inputData.getIds();
   uint32_t numIds = ids.size();
@@ -330,7 +337,12 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
 
     if constexpr (usingBatch) {
       attributions = computeAttributionsHelper(
-          tpArrays, convArrays, *attributionRule, thresholdArrays, numIds);
+          tpArrays,
+          convArrays,
+          *attributionRule,
+          thresholdArrays,
+          numIds,
+          useNewOutputFormat);
     } else {
       // Compute row by row if not using batch
       for (size_t i = 0; i < numIds; ++i) {
@@ -339,7 +351,8 @@ AttributionGame<schedulerId, usingBatch, inputEncryption>::computeAttributions(
             convArrays.at(i),
             *attributionRule,
             thresholdArrays.at(i),
-            numIds);
+            numIds,
+            useNewOutputFormat);
         attributions.push_back(std::move(attributionRow));
       }
     }

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
@@ -60,3 +60,4 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
@@ -26,3 +26,4 @@ DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
 DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -64,7 +64,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     int port,
     std::string attributionRules,
     std::vector<std::string>& inputFilenames,
-    std::vector<std::string>& outputFilenames) {
+    std::vector<std::string>& outputFilenames,
+    bool useNewOutputFormat) {
   // aggregate scheduler statistics across apps
   common::SchedulerStatistics schedulerStatistics{
       0, 0, 0, 0, folly::dynamic::object()};
@@ -105,7 +106,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
         inputFilenames,
         outputFilenames,
         startFileIndex,
-        numFiles);
+        numFiles,
+        useNewOutputFormat);
 
     auto future = std::async([&app]() {
       app->run();
@@ -125,7 +127,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
             port,
             attributionRules,
             inputFilenames,
-            outputFilenames);
+            outputFilenames,
+            useNewOutputFormat);
         schedulerStatistics.add(remainingStats);
       }
     }
@@ -142,7 +145,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
     int16_t concurrency,
     std::string serverIp,
     int port,
-    std::string attributionRules) {
+    std::string attributionRules,
+    bool useNewOutputFormat) {
   // use only as many threads as the number of files
   auto numThreads =
       std::min(static_cast<std::int16_t>(inputFilenames.size()), concurrency);
@@ -158,7 +162,8 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
       port,
       attributionRules,
       inputFilenames,
-      outputFilenames);
+      outputFilenames,
+      useNewOutputFormat);
 }
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -75,7 +75,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_output_format);
       } else if (FLAGS_input_encryption == 2) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -87,7 +88,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_output_format);
       } else {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -99,7 +101,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_output_format);
       }
 
     } else if (FLAGS_party == common::PARTNER) {
@@ -117,7 +120,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_output_format);
       } else if (FLAGS_input_encryption == 2) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
@@ -129,7 +133,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_output_format);
 
       } else {
         schedulerStatistics =
@@ -142,7 +147,8 @@ int main(int argc, char* argv[]) {
                 concurrency,
                 FLAGS_server_ip,
                 FLAGS_port,
-                FLAGS_attribution_rules);
+                FLAGS_attribution_rules,
+                FLAGS_use_new_output_format);
       }
 
     } else {

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -236,14 +236,16 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintext) {
       privateConversions.at(0),
       *lastClick1D,
       thresholdsLastClick1D,
-      1);
+      1,
+      false);
 
   auto computeAttributionLastTouch1D = game.computeAttributionsHelper(
       privateTouchpoints.at(0),
       privateConversions.at(0),
       *lastTouch1D,
       thresholdsLastTouch1D,
-      1);
+      1,
+      false);
 
   for (size_t i = 0; i < attributionResultsLastClick1D.size(); ++i) {
     EXPECT_EQ(
@@ -324,14 +326,16 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
       privateConversions,
       *lastClick1D,
       thresholdsLastClick1D,
-      batchSize);
+      batchSize,
+      false);
 
   auto computeAttributionLastTouch1D = game.computeAttributionsHelper(
       privateTouchpoints,
       privateConversions,
       *lastTouch1D,
       thresholdsLastTouch1D,
-      batchSize);
+      batchSize,
+      false);
 
   for (size_t i = 0; i < attributionResultsLastClick1D.size(); ++i) {
     for (size_t j = 0; j < batchSize; ++j) {
@@ -370,7 +374,7 @@ AttributionOutputMetrics computeAttributionsWithScheduler(
   auto game = std::make_unique<
       AttributionGame<schedulerId, usingBatch, inputEncryption>>(
       std::move(scheduler));
-  return game->computeAttributions(myId, inputData);
+  return game->computeAttributions(myId, inputData, false);
 }
 
 template <bool usingBatch, common::InputEncryption inputEncryption>

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -121,6 +121,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="use_new_output_format", required=False),
         ],
     },
     GameNames.PCF2_AGGREGATION.value: {

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -177,6 +177,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             "attribution_rules": attribution_rule.value,
             "use_xor_encryption": True,
             "use_postfix": True,
+            "use_new_output_format": False,
         }
 
         game_args = [

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -80,6 +80,7 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             "use_xor_encryption": True,
             "use_postfix": True,
             "log_cost": True,
+            "use_new_output_format": False,
         }
         test_game_args = [
             {


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/1176

# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
In this diff, adding a flag to validate whether to use new vs old output format in Private Attribution.
# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Attribution.
2. **Modify PCS stage for attribution with the new flag.**
3. Modify output format in attribution game and update unit tests for PCF2 Attribution game per the new format.
4. Add a flag to validate whether to use new vs old input format of attribution in Private Aggregation.
5. Modify PCS stage for aggregation with the new flag.
6. Modify Input parsing logic in Aggregation game and update unit tests.
7. Create end to end tests to test the new attribution format.

Differential Revision: D37541926

