### PR TITLE
use the free port helper to get an initial port, as opposite to pick a random port.

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -17,6 +17,7 @@
 
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcf/io/FileManagerUtil.h"
 #include "fbpcs/emp_games/common/Csv.h"
@@ -85,7 +86,9 @@ class CalculatorAppTestFixture
     partnerOutputPath_ = folly::sformat(
         "{}/res_partner_{}", tempDir, folly::Random::secureRand64());
 
-    port_ = 5000 + folly::Random::rand32() % 1000;
+    port_ = fbpcf::engine::communication::SocketInTestHelper::findNextOpenPort(
+        5000);
+
     serverIp_ = "127.0.0.1";
     tlsDir_ = fbpcf::engine::communication::setUpTlsFiles();
   }

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
@@ -15,6 +15,7 @@
 #include "folly/logging/xlog.h"
 
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/TestUtil.h"
@@ -150,7 +151,9 @@ class AggregationAppTest : public ::testing::TestWithParam<
  protected:
   void SetUp() override {
     tlsDir_ = fbpcf::engine::communication::setUpTlsFiles();
-    port_ = 5000 + folly::Random::rand32() % 1000;
+    port_ = fbpcf::engine::communication::SocketInTestHelper::findNextOpenPort(
+        5000);
+
     std::string baseDir_ =
         private_measurement::test_util::getBaseDirFromPath(__FILE__);
     std::string tempDir = std::filesystem::temp_directory_path();

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
@@ -15,6 +15,7 @@
 #include "folly/logging/xlog.h"
 
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/TestUtil.h"
@@ -106,7 +107,8 @@ class AttributionAppTest
  protected:
   void SetUp() override {
     tlsDir_ = fbpcf::engine::communication::setUpTlsFiles();
-    port_ = 5000 + folly::Random::rand32() % 1000;
+    port_ = fbpcf::engine::communication::SocketInTestHelper::findNextOpenPort(
+        5000);
     std::string baseDir_ =
         private_measurement::test_util::getBaseDirFromPath(__FILE__);
     std::string tempDir = std::filesystem::temp_directory_path();


### PR DESCRIPTION
Summary:
As title.
We will use the helper to pick an almost-for-sure-free port (the rare exception is a verified-to-be-free port is occupied between verification and our attempt to bind) in unit tests.

Reviewed By: adshastri

Differential Revision: D37505831

