### PR TITLE
stop_service() in PIDPrepareStageService

### DIFF
--- a/fbpcs/common/entity/stage_state_instance.py
+++ b/fbpcs/common/entity/stage_state_instance.py
@@ -78,3 +78,12 @@ class StageStateInstance(InstanceBase):
             self.status = StageStateInstanceStatus.UNKNOWN
 
         return self.status
+
+    def stop_containers(self, onedocker_svc: OneDockerService) -> None:
+        container_ids = [instance.instance_id for instance in self.containers]
+        errors = onedocker_svc.stop_containers(container_ids)
+        error_msg = [(id, error) for id, error in zip(container_ids, errors) if error]
+        if error_msg:
+            raise RuntimeError(
+                f"We encountered errors when stopping containers: {error_msg}"
+            )

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -34,6 +34,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     get_pc_status_from_stage_state,
+    stop_stage_service,
 )
 
 
@@ -142,3 +143,9 @@ class PIDPrepareStageService(PrivateComputationStageService):
             timeout=self._container_timeout,
             env_vars=env_vars,
         )
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        stop_stage_service(pc_instance, self._onedocker_svc)

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -547,3 +547,15 @@ async def all_files_exist_on_cloud(
         *[file_exists_async(storage_svc, path) for path in input_paths]
     )
     return sum(tasks) == num_shards
+
+
+def stop_stage_service(
+    pc_instance: PrivateComputationInstance, onedocker_svc: OneDockerService
+) -> None:
+    last_instance = pc_instance.infra_config.instances[-1]
+    # make sure the last instance is the StageStageInstance appended by current stage
+    if not isinstance(last_instance, StageStateInstance):
+        raise ValueError("Have no StageState for stop_service")
+    assert last_instance.stage_name == pc_instance.current_stage.name
+    # stop containers
+    last_instance.stop_containers(onedocker_svc)

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -33,7 +33,6 @@ from fbpcs.private_computation.service.constants import (
 from fbpcs.private_computation.service.pid_prepare_stage_service import (
     PIDPrepareStageService,
 )
-
 from libfb.py.testutil import data_provider, MagicMock
 
 
@@ -91,7 +90,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             multikey_enabled=multikey_enabled,
         )
         containers = [
-            self.create_container_instance() for _ in range(test_num_containers)
+            self.create_container_instance(i) for i in range(test_num_containers)
         ]
         self.mock_onedocker_svc.start_containers = MagicMock(return_value=containers)
         self.mock_onedocker_svc.wait_for_pending_containers = AsyncMock(
@@ -131,14 +130,17 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         )
 
     def create_sample_pc_instance(
-        self, pc_role: PrivateComputationRole, test_num_containers: int
+        self,
+        pc_role: PrivateComputationRole = PrivateComputationRole.PUBLISHER,
+        test_num_containers: int = 1,
+        status: PrivateComputationInstanceStatus = PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
     ) -> PrivateComputationInstance:
         infra_config: InfraConfig = InfraConfig(
             instance_id=self.pc_instance_id,
             role=pc_role,
-            status=PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
-            status_update_ts=1600000000,
             instances=[],
+            status=status,
+            status_update_ts=1600000000,
             game_type=PrivateComputationGameType.LIFT,
             num_pid_containers=test_num_containers,
             num_mpc_containers=test_num_containers,
@@ -157,11 +159,15 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             product_config=product_config,
         )
 
-    def create_container_instance(self) -> ContainerInstance:
+    def create_container_instance(
+        self,
+        id: int,
+        container_status: ContainerInstanceStatus = ContainerInstanceStatus.COMPLETED,
+    ) -> ContainerInstance:
         return ContainerInstance(
-            instance_id="test_container_instance_123",
-            ip_address="127.0.0.1",
-            status=ContainerInstanceStatus.COMPLETED,
+            instance_id=f"test_container_instance_{id}",
+            ip_address=f"127.0.0.{id}",
+            status=container_status,
         )
 
     def get_args_expected(


### PR DESCRIPTION
Summary:
In this diff, we implemented stop_service() in PIDPrepareStageService, which overides stop_service() in PrivateComputationStageService and will be called by cancel_current_stage() in private_computation.py

# Details:
1, create the business logic of stop_pid_stage_service() to utils.py, so that all 3 PID stage services can share it;
2, call stop_pid_stage_service() in PIDPrePareStageService's stop_service();
3, run unit test for this stop_service().

Reviewed By: jrodal98

Differential Revision: D37431398

