### PR TITLE
Adding PCS feature enum entity

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from enum import Enum
+
+
+class PCSFeature(Enum):
+    UNKNOWN = "unknown"
+    PCS_DUMMY = "pcs_dummy_feature"
+
+    @staticmethod
+    def from_str(feature_str: str) -> "PCSFeature":
+        """maps str (possibly feature name defined in SV) to a PCSFeature."""
+        feature_str = feature_str.casefold()
+        if feature_str == PCSFeature.PCS_DUMMY.value:
+            return PCSFeature.PCS_DUMMY
+        else:
+            logging.warning(f"can't map {feature_str} to pre-defined PCSFeature")
+            return PCSFeature.UNKNOWN


### PR DESCRIPTION
Summary:
## Why
Introducing pcs feature enum for keep those feature list in python lib
## What
* PCS Feature Enum

Differential Revision: D37566680

