### PR TITLE
handle no config case to enable multi-key by default

### DIFF
--- a/fbpcs/pid/service/pid_service/pid.py
+++ b/fbpcs/pid/service/pid_service/pid.py
@@ -34,7 +34,7 @@ class PIDService:
         storage_svc: StorageService,
         instance_repository: PIDInstanceRepository,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
-        multikey_enabled: bool = False,
+        multikey_enabled: bool = True,
     ) -> None:
         """Constructor of PIDService
         Keyword arguments:

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -493,13 +493,19 @@ def _build_pid_service(
         pidinstance_repository_config, PIDInstanceRepository
     )
 
-    multikey_enabled = pid_config.get("multikey_enabled", False)
+    if "multikey_enabled" in pid_config.keys():
+        return PIDService(
+            onedocker_service,
+            storage_service,
+            repository_service,
+            onedocker_binary_config_map,
+            pid_config["multikey_enabled"],
+        )
     return PIDService(
         onedocker_service,
         storage_service,
         repository_service,
         onedocker_binary_config_map,
-        multikey_enabled,
     )
 
 


### PR DESCRIPTION
Summary: D37272438 (https://github.com/facebookresearch/fbpcs/commit/87b72871e008704faf88146c0bf9523aaac2aa83) was missing the change for the case when config was not specified. When config_path is not specified like prod, self.config_path will be none in [handler.py](ttps://fburl.com/code/p5s5r5vp).

Differential Revision: D37534197

