### PR TITLE
Adding function to execute terraform CLIs

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
@@ -7,10 +7,12 @@
 
 from abc import ABC, abstractmethod
 
+from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandReturn
+
 
 class DeployBase(ABC):
     @abstractmethod
-    def create(self) -> None:
+    def apply(self) -> None:
         pass
 
     @abstractmethod
@@ -26,5 +28,5 @@ class DeployBase(ABC):
         pass
 
     @abstractmethod
-    def command(self) -> None:
+    def run_command(self) -> RunCommandReturn:
         pass

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RunCommandReturn:
+    return_code: int
+    output: Optional[str]
+    error: Optional[str]

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform.py
@@ -5,13 +5,23 @@
 
 # pyre-strict
 
+import logging
+import sys
+from subprocess import PIPE, Popen
+from typing import Any, List
+
 from fbpcs.infra.pce_deployment_library.deploy_library.deploy_base.deploy_base import (
     DeployBase,
 )
 
+from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandReturn
+
 
 class Terraform(DeployBase):
-    def create(self) -> None:
+    def __init__(self) -> None:
+        self.log: logging.Logger = logging.getLogger(__name__)
+
+    def apply(self) -> None:
         pass
 
     def destroy(self) -> None:
@@ -23,5 +33,44 @@ class Terraform(DeployBase):
     def plan(self) -> None:
         pass
 
-    def command(self) -> None:
-        pass
+    def get_command_list(self, command: str, *args: Any, **kwargs: Any) -> List[str]:
+        """
+        Converts string to list, which will be consumed by subprocess
+        """
+        # TODO: Add option to pass more arguments through args and kwargs
+        return command.split()
+
+    def run_command(
+        self,
+        command: str,
+        capture_output: bool = True,
+    ) -> RunCommandReturn:
+        """
+        Executes Terraform CLIs apply/destroy/init/plan
+        """
+
+        if capture_output:
+            stderr = PIPE
+            stdout = PIPE
+        else:
+            stderr = sys.stderr
+            stdout = sys.stdout
+
+        command_list = self.get_command_list(command)
+        command_str = " ".join(command_list)
+        self.log.info(f"Command: {command_str}")
+        out, err = None, None
+
+        with Popen(command_list, stdout=stdout, stderr=stderr) as p:
+            out, err = p.communicate()
+            ret_code = p.returncode
+            self.log.info(f"output: {out}")
+
+            if capture_output:
+                out = out.decode()
+                err = err.decode()
+            else:
+                out = None
+                err = None
+
+        return RunCommandReturn(return_code=ret_code, output=out, error=err)

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from subprocess import PIPE, Popen
+
+from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandReturn
+
+from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform import (
+    Terraform,
+)
+
+
+class TestTerraform(unittest.TestCase):
+    def setUp(self) -> None:
+        self.terraform = Terraform()
+
+    def test_run_command(self) -> None:
+        with self.subTest("basicCaptureTrue"):
+            command = "echo Hello World!\n"
+            capture_output = True
+            test_obj = Popen(["echo", "Hello World!"], stdout=PIPE)
+            test_stdout, test_error = test_obj.communicate()
+            test_return_code = test_obj.returncode
+            test_command_return = RunCommandReturn(
+                return_code=test_return_code,
+                output=test_stdout.decode("utf-8"),
+                error=test_error if test_error else "",
+            )
+            func_ret = self.terraform.run_command(
+                command=command, capture_output=capture_output
+            )
+            self.assertEqual(test_command_return.return_code, func_ret.return_code)
+            self.assertEqual(test_command_return.output, func_ret.output)
+            self.assertEqual(test_command_return.error, func_ret.error)
+
+        with self.subTest("basicCaptureFalse"):
+            command = "echo Hello World!\n"
+            capture_output = False
+
+            test_obj = Popen(["echo", "Hello World!"])
+            test_stdout, test_error = test_obj.communicate()
+            test_return_code = test_obj.returncode
+            test_command_return = RunCommandReturn(
+                return_code=test_return_code,
+                output=test_stdout,
+                error=test_stdout,
+            )
+
+            func_ret = self.terraform.run_command(
+                command=command, capture_output=capture_output
+            )
+            self.assertEqual(test_command_return.return_code, func_ret.return_code)
+            self.assertEqual(test_command_return.output, func_ret.output)
+            self.assertEqual(test_command_return.error, func_ret.error)
+
+        with self.subTest("TestStdErrWithCaptureOutput"):
+            command = "cp"
+            capture_output = True
+
+            func_ret = self.terraform.run_command(
+                command=command, capture_output=capture_output
+            )
+            test_command_return = RunCommandReturn(
+                return_code=1,
+                output="",
+                error="cp: missing file operand\nTry 'cp --help' for more information.\n",
+            )
+            self.assertEqual(test_command_return.return_code, func_ret.return_code)
+            self.assertEqual(test_command_return.output, func_ret.output)
+            self.assertEqual(test_command_return.error, func_ret.error)
+
+        with self.subTest("TestStdErrWithoutCaptureOutput"):
+            command = "cp"
+            capture_output = False
+
+            func_ret = self.terraform.run_command(
+                command=command, capture_output=capture_output
+            )
+            test_command_return = RunCommandReturn(
+                return_code=1,
+                output=None,
+                error=None,
+            )
+            self.assertEqual(test_command_return.return_code, func_ret.return_code)
+            self.assertEqual(test_command_return.output, func_ret.output)
+            self.assertEqual(test_command_return.error, func_ret.error)


### PR DESCRIPTION
Summary:
Adding `run_command` method in terraform library to execute terraform CLIs apply/destroy/init/plan

One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37512002

