### PR TITLE
Add padding size as input to LiftIdSpineCombiner

### DIFF
--- a/fbpcs/data_processing/service/id_spine_combiner.py
+++ b/fbpcs/data_processing/service/id_spine_combiner.py
@@ -31,6 +31,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
         # TODO T106159008: padding_size and run_name are only temporarily optional
         # because Lift does not use them. It should and will be required to use them.
         padding_size: Optional[int] = None,
+        multi_conversion_limit: Optional[int] = None,
         # run_name is the binary name used by the log cost to s3 feature
         run_name: Optional[str] = None,
         log_cost: Optional[bool] = False,
@@ -51,6 +52,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
                 tmp_directory=tmp_directory,
                 max_id_column_cnt=max_id_column_cnt,
                 padding_size=padding_size,
+                multi_conversion_limit=multi_conversion_limit,
                 run_name=run_name,
                 sort_strategy=sort_strategy,
                 log_cost=log_cost,

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -47,12 +47,14 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         pid_svc: Optional[PIDService] = None,
+        padding_size: Optional[int] = None,
     ) -> None:
         self._onedocker_svc = onedocker_svc
         self._pid_svc = pid_svc
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._log_cost_to_s3 = log_cost_to_s3
         self._logger: logging.Logger = logging.getLogger(__name__)
+        self.padding_size = padding_size
 
     async def run_async(
         self,

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -256,10 +256,14 @@ async def start_combiner_service(
             int,
             private_computation_instance.product_config.common.padding_size,
         )
+        multi_conversion_limit = None
         log_cost = log_cost_to_s3
     else:
         run_name = None
         padding_size = None
+        multi_conversion_limit = (
+            private_computation_instance.product_config.common.padding_size
+        )
         log_cost = None
 
     combiner_service = checked_cast(
@@ -276,6 +280,7 @@ async def start_combiner_service(
         max_id_column_cnt=max_id_column_count,
         run_name=run_name,
         padding_size=padding_size,
+        multi_conversion_limit=multi_conversion_limit,
         log_cost=log_cost,
     )
     env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}


### PR DESCRIPTION
Summary:
We add the padding size as an input to the LiftIdSpineCombiner. The command line flag for the binary is called `multi_conversion_limit` instead of `padding_size` like in the AttributionIdCombiner: (https://www.internalfb.com/code/fbsource/[e1b93a73364f1c40a21bfed436408565c722c9cd]/fbcode/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp?lines=23-26)
Hence we store the padding size as the multi_conversion_limit when running Lift, for building the command line arguments to the binary.

Reviewed By: gorel

Differential Revision: D36793182

