### PR TITLE
Add padding size as input to PCF2 PL

### DIFF
--- a/fbpcs/data_processing/service/id_spine_combiner.py
+++ b/fbpcs/data_processing/service/id_spine_combiner.py
@@ -31,6 +31,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
         # TODO T106159008: padding_size and run_name are only temporarily optional
         # because Lift does not use them. It should and will be required to use them.
         padding_size: Optional[int] = None,
+        multi_conversion_limit: Optional[int] = None,
         # run_name is the binary name used by the log cost to s3 feature
         run_name: Optional[str] = None,
         log_cost: Optional[bool] = False,
@@ -51,6 +52,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
                 tmp_directory=tmp_directory,
                 max_id_column_cnt=max_id_column_cnt,
                 padding_size=padding_size,
+                multi_conversion_limit=multi_conversion_limit,
                 run_name=run_name,
                 sort_strategy=sort_strategy,
                 log_cost=log_cost,

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -56,6 +56,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="file_start_index", required=False),
             OneDockerArgument(name="num_files", required=True),
             OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="num_conversions_per_user", required=False),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
         ],

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -47,12 +47,14 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         pid_svc: Optional[PIDService] = None,
+        padding_size: Optional[int] = None,
     ) -> None:
         self._onedocker_svc = onedocker_svc
         self._pid_svc = pid_svc
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._log_cost_to_s3 = log_cost_to_s3
         self._logger: logging.Logger = logging.getLogger(__name__)
+        self.padding_size = padding_size
 
     async def run_async(
         self,

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -25,7 +25,10 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
-from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_LOG_COST_TO_S3,
+    LIFT_DEFAULT_PADDING_SIZE,
+)
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )
@@ -53,11 +56,13 @@ class PCF2LiftStageService(PrivateComputationStageService):
         self,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
+        padding_size: int = LIFT_DEFAULT_PADDING_SIZE,
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
     ) -> None:
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._mpc_service = mpc_service
+        self.padding_size = padding_size
         self._log_cost_to_s3 = log_cost_to_s3
         self._container_timeout = container_timeout
 
@@ -174,6 +179,7 @@ class PCF2LiftStageService(PrivateComputationStageService):
             "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
             "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
             "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
+            "num_conversions_per_user": private_computation_instance.product_config.common.padding_size,
             "run_name": run_name,
             "log_cost": self._log_cost_to_s3,
         }

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -256,10 +256,14 @@ async def start_combiner_service(
             int,
             private_computation_instance.product_config.common.padding_size,
         )
+        multi_conversion_limit = None
         log_cost = log_cost_to_s3
     else:
         run_name = None
         padding_size = None
+        multi_conversion_limit = (
+            private_computation_instance.product_config.common.padding_size
+        )
         log_cost = None
 
     combiner_service = checked_cast(
@@ -276,6 +280,7 @@ async def start_combiner_service(
         max_id_column_cnt=max_id_column_count,
         run_name=run_name,
         padding_size=padding_size,
+        multi_conversion_limit=multi_conversion_limit,
         log_cost=log_cost,
     )
     env_vars = {ONEDOCKER_REPOSITORY_PATH: binary_config.repository_path}

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -48,7 +48,8 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             )
         )
         self.stage_svc = PCF2LiftStageService(
-            onedocker_binary_config_map, self.mock_mpc_svc
+            onedocker_binary_config_map,
+            self.mock_mpc_svc,
         )
 
     async def test_compute_metrics(self) -> None:
@@ -88,6 +89,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
             "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
             "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
+            "num_conversions_per_user": private_computation_instance.product_config.common.padding_size,
             "run_name": run_name,
             "log_cost": True,
         }


### PR DESCRIPTION
Summary: We add the padding size as an input to the PCF2 PL stage, in order to specify whether to run basic or advanced lift. The command line flag for the padding size in the PL binary is called `num_conversions_per_user`. The current default is 25 for advanced lift, and to run basic lift, we can specify the padding size to be 4.

Reviewed By: gorel

Differential Revision: D36795001

