### PR TITLE
Onboard fbpcs e2e runner to Bolt

### DIFF
--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -49,3 +49,9 @@ class BoltJob(DataClassJsonMixin):
             )
         },
     )
+
+    def __post_init__(self) -> None:
+        if self.stage_flow is PrivateComputationBaseStageFlow:
+            raise ValueError(
+                f"Stage flow should not be {PrivateComputationBaseStageFlow}, pass a specific stage flow."
+            )

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -14,7 +14,7 @@ from time import time
 from typing import List, Optional
 
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs, BoltJob
-from fbpcs.bolt.constants import POLL_INTERVAL
+from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
 from fbpcs.bolt.exceptions import (
     NoServerIpsException,
     StageFailedException,
@@ -154,7 +154,7 @@ class BoltRunner:
             self.logger.info(
                 f"{instance_id} current status is {status}, waiting for {stage.started_status}."
             )
-            await asyncio.sleep(POLL_INTERVAL)
+            await asyncio.sleep(DEFAULT_POLL_INTERVAL_SEC)
         raise StageTimeoutException(
             f"Poll {instance_id} status timed out after {timeout}s expecting status {stage.started_status}."
         )
@@ -187,7 +187,7 @@ class BoltRunner:
             self.logger.info(
                 f"Publisher {publisher_id} status is {publisher_state.pc_instance_status}, Partner {partner_id} status is {partner_state.pc_instance_status}. Waiting for status {complete_status}."
             )
-            await asyncio.sleep(POLL_INTERVAL)
+            await asyncio.sleep(DEFAULT_POLL_INTERVAL_SEC)
         raise StageTimeoutException(
             f"Stage {stage.name} timed out after {timeout}s. Publisher status: {publisher_state.pc_instance_status}. Partner status: {partner_state.pc_instance_status}."
         )

--- a/fbpcs/bolt/constants.py
+++ b/fbpcs/bolt/constants.py
@@ -13,6 +13,6 @@ from fbpcs.private_computation.stage_flows.private_computation_stage_flow import
     PrivateComputationStageFlow,
 )
 
-POLL_INTERVAL = 60
+DEFAULT_POLL_INTERVAL_SEC = 5
 DEFAULT_ATTRIBUTION_STAGE_FLOW = PrivateComputationPCF2StageFlow
 DEFAULT_LIFT_STAGE_FLOW = PrivateComputationStageFlow

--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -62,7 +62,9 @@ def create_bolt_runner(
     )
 
     runner = BoltRunner(
-        publisher_client=publisher_client, partner_client=partner_client, logger=logger
+        publisher_client=publisher_client,
+        partner_client=partner_client,
+        logger=logger,
     )
     return runner
 


### PR DESCRIPTION
Summary:
## What
* Changed fbpcs e2e runner to call Bolt instead of pc-cli

## Why
* Bolt calls private computation services directly which uses less resources and can have performance gains
* The end goal is to integrate the fbpcs e2e runner's functionality into Bolt and deprecate this runner

Differential Revision: D37565619

