### PR TITLE
split __post_init__ in PCInstance

### DIFF
--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -18,12 +18,13 @@ from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 from fbpcs.bolt.bolt_runner import BoltClient, BoltState
 from fbpcs.bolt.constants import DEFAULT_ATTRIBUTION_STAGE_FLOW, DEFAULT_LIFT_STAGE_FLOW
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
-from fbpcs.private_computation.entity.pce_config import PCEConfig
-from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
     PrivateComputationGameType,
     PrivateComputationRole,
 )
+from fbpcs.private_computation.entity.pce_config import PCEConfig
+from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
+
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
     AttributionRule,

--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -22,12 +22,13 @@ from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
     PrivateComputationGameType,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
-    PrivateComputationRole,
 )
+
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )

--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -13,8 +13,8 @@ from typing import Any, Dict, List, Optional
 from fbpcs.pl_coordinator.constants import WAIT_VALID_STATUS_TIMEOUT
 from fbpcs.pl_coordinator.exceptions import PCInstanceCalculationException
 from fbpcs.pl_coordinator.pc_calc_instance import PrivateComputationCalcInstance
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationRole,
 )

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -32,9 +32,7 @@ from fbpcs.pl_coordinator.pc_partner_instance import PrivateComputationPartnerIn
 from fbpcs.pl_coordinator.pc_publisher_instance import (
     PrivateComputationPublisherInstance,
 )
-from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
-)
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -3,7 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional, Union
 
@@ -64,6 +65,13 @@ class InfraConfig(DataClassJsonMixin):
     _stage_flow_cls_name: str = "PrivateComputationStageFlow"
 
     retry_counter: int = 0
-    creation_ts: int = 0
+    creation_ts: int = field(default_factory=lambda: int(time.time()))
     end_ts: int = 0
     mpc_compute_concurrency: int = 1
+
+    def __post_init__(self) -> None:
+        # TODO: I will create hook for this check later
+        if self.num_pid_containers > self.num_mpc_containers:
+            raise ValueError(
+                f"num_pid_containers must be less than or equal to num_mpc_containers. Received num_pid_containers = {self.num_pid_containers} and num_mpc_containers = {self.num_mpc_containers}"
+            )

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -39,7 +39,6 @@ from fbpcs.post_processing_handler.post_processing_instance import (
 )
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
-    PrivateComputationGameType,
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.private_computation_status import (
@@ -47,7 +46,6 @@ from fbpcs.private_computation.entity.private_computation_status import (
 )
 from fbpcs.private_computation.entity.product_config import (
     AttributionConfig,
-    AttributionRule,
     LiftConfig,
     ProductConfig,
 )
@@ -70,21 +68,6 @@ class PrivateComputationInstance(InstanceBase):
 
     infra_config: InfraConfig
     product_config: ProductConfig
-
-    def __post_init__(self) -> None:
-        if self.infra_config.num_pid_containers > self.infra_config.num_mpc_containers:
-            raise ValueError(
-                f"num_pid_containers must be less than or equal to num_mpc_containers. Received num_pid_containers = {self.infra_config.num_pid_containers} and num_mpc_containers = {self.infra_config.num_mpc_containers}"
-            )
-        if (
-            self.infra_config.game_type is PrivateComputationGameType.ATTRIBUTION
-            and isinstance(self.product_config, AttributionConfig)
-            and self.product_config.attribution_rule is None
-        ):
-            self.product_config.attribution_rule = AttributionRule.LAST_CLICK_1D
-
-        if self.infra_config.creation_ts == 0:
-            self.infra_config.creation_ts = int(time.time())
 
     def dumps_schema(self) -> str:
         json_object = json.loads(super().dumps_schema())

--- a/fbpcs/private_computation/entity/product_config.py
+++ b/fbpcs/private_computation/entity/product_config.py
@@ -85,8 +85,8 @@ class AttributionConfig(ProductConfig):
                             used to infer the metrics_format_type argument of the shard aggregator game.
     """
 
-    attribution_rule: AttributionRule
     aggregation_type: AggregationType
+    attribution_rule: AttributionRule = AttributionRule.LAST_CLICK_1D
 
 
 @dataclass_json

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -15,10 +15,8 @@ import pytz
 from fbpcs.pl_coordinator.exceptions import IncorrectVersionError, sys_exit_after
 from fbpcs.pl_coordinator.pc_graphapi_utils import PCGraphAPIClient
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.pcs_tier import PCSTier
-from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
-)
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
     AttributionRule,

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -13,8 +13,8 @@ from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -14,8 +14,8 @@ from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -16,11 +16,13 @@ from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.private_computation_instance import (
-    AttributionRule,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.entity.product_config import AttributionConfig
+from fbpcs.private_computation.entity.product_config import (
+    AttributionConfig,
+    AttributionRule,
+)
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -14,8 +14,8 @@ from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -22,12 +22,14 @@ from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
-from fbpcs.private_computation.entity.infra_config import InfraConfig
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    PrivateComputationGameType,
+)
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.pce_config import PCEConfig
 from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/service/private_computation_service_data.py
+++ b/fbpcs/private_computation/service/private_computation_service_data.py
@@ -7,13 +7,12 @@
 # pyre-strict
 
 from dataclasses import dataclass
+
 from typing import Dict, Optional
 
 from fbpcs.data_processing.service.id_spine_combiner import IdSpineCombinerService
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
-from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
-)
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.repository.private_computation_game import (
     PRIVATE_COMPUTATION_GAME_CONFIG,
 )

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -36,8 +36,8 @@ from fbpcs.onedocker_binary_config import (
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.service.pid_service.pid_stage import PIDStage
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/entity/generate_instance_json.py
+++ b/fbpcs/private_computation/test/entity/generate_instance_json.py
@@ -28,10 +28,12 @@ from fbpcs.post_processing_handler.post_processing_instance import (
     PostProcessingInstanceStatus,
 )
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
-from fbpcs.private_computation.entity.infra_config import InfraConfig
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    PrivateComputationGameType,
+)
 from fbpcs.private_computation.entity.pce_config import PCEConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationRole,
 )

--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -12,9 +12,11 @@ import unittest
 
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -74,29 +76,19 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
 
     def test_create_with_invalid_num_containers(self) -> None:
         instance_id = self._get_random_id()
-        infra_config: InfraConfig = InfraConfig(
-            instance_id=instance_id,
-            role=PrivateComputationRole.PUBLISHER,
-            status=PrivateComputationInstanceStatus.CREATED,
-            status_update_ts=1600000000,
-            instances=[self.test_mpc_instance],
-            game_type=PrivateComputationGameType.LIFT,
-            num_pid_containers=8,
-            num_mpc_containers=4,
-            num_files_per_mpc_container=40,
-            mpc_compute_concurrency=1,
-        )
-        common: CommonProductConfig = CommonProductConfig(
-            input_path="in",
-            output_dir="out",
-        )
-        product_config: ProductConfig = LiftConfig(
-            common=common,
-        )
+
         with self.assertRaises(ValueError):
-            PrivateComputationInstance(
-                infra_config=infra_config,
-                product_config=product_config,
+            InfraConfig(
+                instance_id=instance_id,
+                role=PrivateComputationRole.PUBLISHER,
+                status=PrivateComputationInstanceStatus.CREATED,
+                status_update_ts=1600000000,
+                instances=[self.test_mpc_instance],
+                game_type=PrivateComputationGameType.LIFT,
+                num_pid_containers=8,
+                num_mpc_containers=4,
+                num_files_per_mpc_container=40,
+                mpc_compute_concurrency=1,
             )
 
     def test_update(self) -> None:

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -11,9 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -14,9 +14,11 @@ from fbpcp.entity.mpc_instance import MPCParty
 from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -11,16 +11,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
-    AttributionRule,
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
     AttributionConfig,
+    AttributionRule,
     CommonProductConfig,
     ProductConfig,
 )

--- a/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
@@ -11,10 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
-    AttributionRule,
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -22,6 +23,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
     AttributionConfig,
+    AttributionRule,
     CommonProductConfig,
     ProductConfig,
 )

--- a/fbpcs/private_computation/test/service/test_id_match_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_match_stage_service.py
@@ -13,9 +13,11 @@ from fbpcs.pid.entity.pid_instance import (
     PIDProtocol,
     PIDRole,
 )
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -10,9 +10,11 @@ from unittest.mock import patch
 
 from fbpcs.data_processing.service.id_spine_combiner import IdSpineCombinerService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -15,10 +15,12 @@ from fbpcs.onedocker_binary_config import (
     OneDockerBinaryConfig,
 )
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
-from fbpcs.private_computation.entity.infra_config import InfraConfig
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    PrivateComputationGameType,
+)
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
     PrivateComputationRole,
 )

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -11,16 +11,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
-    AttributionRule,
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
     AttributionConfig,
+    AttributionRule,
     CommonProductConfig,
     ProductConfig,
 )

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -11,10 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
-    AttributionRule,
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
@@ -22,6 +23,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
     AttributionConfig,
+    AttributionRule,
     CommonProductConfig,
     ProductConfig,
 )

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -14,9 +14,11 @@ from fbpcp.entity.mpc_instance import MPCParty
 from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -8,9 +8,11 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
 
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -15,9 +15,11 @@ from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 
 from fbpcs.pcf.tests.async_utils import AsyncMock, to_sync
 from fbpcs.pid.entity.pid_instance import PIDProtocol
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -22,9 +22,11 @@ from fbpcs.onedocker_binary_config import (
 )
 from fbpcs.pcf.tests.async_utils import AsyncMock, to_sync
 from fbpcs.pid.entity.pid_instance import PIDProtocol
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -14,9 +14,11 @@ from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 
 from fbpcs.pcf.tests.async_utils import AsyncMock, to_sync
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_pid_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_stage_service.py
@@ -14,9 +14,11 @@ from fbpcs.pid.entity.pid_instance import (
     PIDRole,
 )
 from fbpcs.pid.entity.pid_stages import UnionPIDStage
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_post_processing_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_post_processing_stage_service.py
@@ -15,9 +15,11 @@ from fbpcs.post_processing_handler.post_processing_instance import (
     PostProcessingInstanceStatus,
 )
 from fbpcs.post_processing_handler.tests.dummy_handler import PostProcessingDummyHandler
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
@@ -12,9 +12,11 @@ from fbpcs.data_processing.service.id_spine_combiner import IdSpineCombinerServi
 from fbpcs.data_processing.service.sharding_service import ShardingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation/test/service/test_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_shard_stage_service.py
@@ -10,9 +10,11 @@ from unittest.mock import patch
 
 from fbpcs.data_processing.service.sharding_service import ShardingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.private_computation.entity.infra_config import InfraConfig
-from fbpcs.private_computation.entity.private_computation_instance import (
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
     PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -56,8 +56,8 @@ from fbpcs.infra.logging_service.client.meta.client_manager import ClientManager
 from fbpcs.infra.logging_service.client.meta.data_model.lift_run_info import LiftRunInfo
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
 from fbpcs.pl_coordinator.pl_study_runner import run_study
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -24,11 +24,13 @@ from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.repository.pid_instance import PIDInstanceRepository
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
-from fbpcs.private_computation.entity.infra_config import PrivateComputationRole
+from fbpcs.private_computation.entity.infra_config import (
+    PrivateComputationGameType,
+    PrivateComputationRole,
+)
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.pcs_tier import PCSTier
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
 )
 from fbpcs.private_computation.entity.product_config import (

--- a/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_instance_runner.py
@@ -18,10 +18,10 @@ from fbpcs.pl_coordinator.pl_instance_runner import (
 )
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
+    PrivateComputationGameType,
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationInstance,
 )
 from fbpcs.private_computation.entity.private_computation_status import (

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -13,11 +13,11 @@ from fbpcp.service.container import ContainerService
 from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.storage import StorageService
 from fbpcs.pid.repository.pid_instance import PIDInstanceRepository
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 
 from fbpcs.private_computation.entity.pcs_tier import PCSTier
 
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationGameType,
     PrivateComputationRole,
 )
 from fbpcs.private_computation.repository.private_computation_instance import (


### PR DESCRIPTION
Summary:
# What:
split ____post___init__ in PCInstance class:

# How:
There were three parts:
 1. num_pid_containers and num_mpc_containers check: goes into infra_config.py
 2. set default value for attribution_rule: goes into AttributionConfig class in product_config.py
 3. set default value for creation_ts: goes into infra_config.py

# Additional work:
For this move, we will delete some unused import statements in private_computation_instance.py, which leads to many other changes of the import statements in other files.

Reviewed By: joe1234wu

Differential Revision: D37573884

