### PR TITLE
Share number of bits needed for values and valueSquared

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Constants.h
@@ -17,6 +17,8 @@ const size_t groupWidth = 7; // at most 32 cohorts and 2 publisher breakdowns
 const size_t numConvSquaredWidth = 32;
 const size_t valueWidth = 32;
 const size_t valueSquaredWidth = 64;
+// only need log_2(64) < 8 bits to store value and valueSquared width
+const size_t numBitsForValuesWidth = 8;
 const size_t timeStampWidth = 32;
 
 template <int schedulerId, bool usingBatch = true>

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -28,6 +28,7 @@ class InputProcessor {
         numConversionsPerUser_{numConversionsPerUser} {
     validateNumRowsStep();
     shareNumGroupsStep();
+    shareBitsForValuesStep();
     privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
     privatelyShareGroupIdsStep();
@@ -58,6 +59,14 @@ class InputProcessor {
 
   uint32_t getNumTestGroups() const {
     return numTestGroups_;
+  }
+
+  uint8_t getValueBits() const {
+    return valueBits_;
+  }
+
+  uint8_t getValueSquaredBits() const {
+    return valueSquaredBits_;
   }
 
   const std::vector<std::vector<bool>> getIndexShares() const {
@@ -108,6 +117,9 @@ class InputProcessor {
   // Share number of groups, including cohorts and publisher breakdowns.
   void shareNumGroupsStep();
 
+  // Share number of bits needed to store the input value and its square
+  void shareBitsForValuesStep();
+
   // Privately share popoulation
   void privatelySharePopulationStep();
 
@@ -138,6 +150,8 @@ class InputProcessor {
   uint32_t numPublisherBreakdowns_;
   uint32_t numGroups_;
   uint32_t numTestGroups_;
+  uint8_t valueBits_;
+  uint8_t valueSquaredBits_;
 
   SecTimestamp<schedulerId> opportunityTimestamps_;
   SecBit<schedulerId> isValidOpportunityTimestamp_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -79,6 +79,28 @@ void InputProcessor<schedulerId>::shareNumGroupsStep() {
 }
 
 template <int schedulerId>
+void InputProcessor<schedulerId>::shareBitsForValuesStep() {
+  XLOG(INFO) << "Set up number of bits needed for purchase value sharing";
+
+  auto valueBits = static_cast<uint64_t>(inputData_.getNumBitsForValue());
+  auto valueSquaredBits =
+      static_cast<uint64_t>(inputData_.getNumBitsForValueSquared());
+
+  valueBits_ = common::shareIntFrom<
+      schedulerId,
+      numBitsForValuesWidth,
+      common::PARTNER,
+      common::PUBLISHER>(myRole_, valueBits);
+  valueSquaredBits_ = common::shareIntFrom<
+      schedulerId,
+      numBitsForValuesWidth,
+      common::PARTNER,
+      common::PUBLISHER>(myRole_, valueSquaredBits);
+  XLOG(INFO) << "Num bits for values: " << valueBits_;
+  XLOG(INFO) << "Num bits for values squared: " << valueSquaredBits_;
+}
+
+template <int schedulerId>
 void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
   XLOG(INFO) << "Share cohort group ids";
   cohortGroupIds_ = common::privatelyShareArrayWithPaddingFrom<

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -91,6 +91,13 @@ TEST_F(InputProcessorTest, testNumRows) {
   EXPECT_EQ(partnerInputProcessor_.getNumRows(), 33);
 }
 
+TEST_F(InputProcessorTest, testBitsForValues) {
+  EXPECT_EQ(publisherInputProcessor_.getValueBits(), 10);
+  EXPECT_EQ(partnerInputProcessor_.getValueBits(), 10);
+  EXPECT_EQ(publisherInputProcessor_.getValueSquaredBits(), 15);
+  EXPECT_EQ(partnerInputProcessor_.getValueSquaredBits(), 15);
+}
+
 TEST_F(InputProcessorTest, testNumPartnerCohorts) {
   EXPECT_EQ(publisherInputProcessor_.getNumPartnerCohorts(), 3);
   EXPECT_EQ(partnerInputProcessor_.getNumPartnerCohorts(), 3);


### PR DESCRIPTION
Summary:
Added a method `shareBitsForValuesStep` in the `InputProcessor` that shares the number of bits needed for the values and the valueSquared, from the partner to the publisher.

* The variables being shared is of type `uint8_t` since we assume all value and valueSquared are of width at most 64 bit. Therefore we need only log_2(64) < 8 bit to store their width.
* The implementation follows the `OutputMetrics::initBitsForValues` method, but using PCF rather than EMP to share the value.

Differential Revision: D37628346

