### PR TITLE
Removed VPC check from undeploy flow

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeployController.java
@@ -57,7 +57,7 @@ public class DeployController {
   private APIReturn runDeployment(boolean shouldDeploy, DeploymentParams deployment) {
     try {
       deployment.validate();
-      Validator.ValidatorResult preValidationResult = validator.validate(deployment);
+      Validator.ValidatorResult preValidationResult = validator.validate(deployment, shouldDeploy);
       if (!preValidationResult.isSuccessful) {
         return new APIReturn(APIReturn.Status.STATUS_FAIL, preValidationResult.message);
       }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
@@ -129,15 +129,17 @@ public class Validator {
     return new ValidatorResult(true, "credentials provides are valid");
   }
 
-  public ValidatorResult validate(DeploymentParams deploymentParams) {
+  public ValidatorResult validate(DeploymentParams deploymentParams, boolean deploy) {
     final ValidatorResult credentialsValidationResult = validateCredentials(deploymentParams);
     if (!credentialsValidationResult.isSuccessful) {
       return credentialsValidationResult;
     }
 
-    final ValidatorResult vpcValidationResult = validateVpcQuotaPerRegion(deploymentParams);
-    if (!vpcValidationResult.isSuccessful) {
-      return vpcValidationResult;
+    if (deploy) {
+      final ValidatorResult vpcValidationResult = validateVpcQuotaPerRegion(deploymentParams);
+      if (!vpcValidationResult.isSuccessful) {
+        return vpcValidationResult;
+      }
     }
     // TODO S3 bucket limit validation T119080329
     return new ValidatorResult(true, "No pre validation issues found so far!");


### PR DESCRIPTION
Summary:
Below image shows the issues that happened during undeploy.
{F749940901}

Basically, the AWS region hit the vpc limit which is 5, and the validation checks were part of undeployment workflow as well.

This diff:

1. Removes VPC related validation checks which were part of undeploy workflow earlier.

Differential Revision: D37669960

