### PR TITLE
Migration of PID Stage Services

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -18,6 +18,9 @@ Types of changes
 ### Added
 - Added optional new argument --padding_size which is passed as multi_conversion_limit to the lift id spine combiner and as num_conversions_per_user to the pcf2 private lift stage
 
+### Changed
+- change StageSelector to select PIDShardStageService, PIDPrepareStageService and PIDRunProtocolStageService for PID_SHARD, PID_PREPARE and ID_MATCH stages respectively
+
 ## [1.7.0] - 2022-06-23
 
 ### Changed

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -18,7 +18,6 @@ from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
-from fbpcs.pid.entity.pid_instance import PIDInstance
 from fbpcs.pid.service.pid_service.pid import PIDService
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
@@ -475,11 +474,9 @@ class PrivateComputationService:
         self.logger.info(
             f"Canceling the current stage {stage} of instance {instance_id}"
         )
-        # TODO: T124324848 move MPCInstance/PIDInstance stop instance to StageService.stop_service()
+        # TODO: T124324848 move MPCInstance stop instance to StageService.stop_service()
         if isinstance(last_instance, MPCInstance):
             self.mpc_svc.stop_instance(instance_id=last_instance.instance_id)
-        elif isinstance(last_instance, PIDInstance):
-            self.pid_svc.stop_instance(instance_id=last_instance.instance_id)
         else:
             stage_svc = stage.get_stage_service(self.stage_service_args)
             # TODO: T124322832 make stop service as abstract method and enforce all stage service to implement

--- a/fbpcs/private_computation/stage_flows/stage_selector.py
+++ b/fbpcs/private_computation/stage_flows/stage_selector.py
@@ -5,7 +5,6 @@
 
 from typing import Optional, TYPE_CHECKING
 
-from fbpcs.pid.entity.pid_stages import UnionPIDStage
 from fbpcs.private_computation.service.aggregate_shards_stage_service import (
     AggregateShardsStageService,
 )
@@ -16,7 +15,15 @@ from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
 from fbpcs.private_computation.service.pc_pre_validation_stage_service import (
     PCPreValidationStageService,
 )
-from fbpcs.private_computation.service.pid_stage_service import PIDStageService
+from fbpcs.private_computation.service.pid_prepare_stage_service import (
+    PIDPrepareStageService,
+)
+from fbpcs.private_computation.service.pid_run_protocol_stage_service import (
+    PIDRunProtocolStageService,
+)
+from fbpcs.private_computation.service.pid_shard_stage_service import (
+    PIDShardStageService,
+)
 from fbpcs.private_computation.service.post_processing_stage_service import (
     PostProcessingStageService,
 )
@@ -50,22 +57,24 @@ class StageSelector:
                 args.onedocker_binary_config_map,
             )
         elif stage_flow.name == "PID_SHARD":
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_SHARD,
-                UnionPIDStage.ADV_SHARD,
+            return PIDShardStageService(
+                args.storage_svc,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
             )
         elif stage_flow.name == "PID_PREPARE":
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_PREPARE,
-                UnionPIDStage.ADV_PREPARE,
+            return PIDPrepareStageService(
+                args.storage_svc,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+                args.pid_svc.multikey_enabled,
             )
         elif stage_flow.name == "ID_MATCH":
-            return PIDStageService(
-                args.pid_svc,
-                UnionPIDStage.PUBLISHER_RUN_PID,
-                UnionPIDStage.ADV_RUN_PID,
+            return PIDRunProtocolStageService(
+                args.storage_svc,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+                args.pid_svc.multikey_enabled,
             )
         elif stage_flow.name == "ID_MATCH_POST_PROCESS":
             return PostProcessingStageService(


### PR DESCRIPTION
Summary:
Private Identity match (PID) involves 3 stages: PID_SHARD, PID_PREPARE and ID_MATCH. And in order to integrate with the re-architectured private computation service (PCS), we built PIDShardStageService, PIDPrepareStageService and PIDRunProtocolStageService for PID_SHARD, PID_PREPARE and ID_MATCH respectively. To prepare for this migration, we created test stage flows with those 3 PID stage services and run e2e tests for PL and PA, and also tested retry logic and the Github test (see detail: https://docs.google.com/document/d/1vSdqlyZ3rW4SgOF6tzAmU_FpV_lbcH1DmRdpgz0dskM/edit?usp=sharing).

In this diff, we finally replaced PIDStageService with PID PIDShardStageService, PIDPrepareStageService and PIDRunProtocolStageService for PID_SHARD, PID_PREPARE and ID_MATCH.

## changelog
[Changed] - change StageSelector to select PIDShardStageService, PIDPrepareStageService and PIDRunProtocolStageService for PID_SHARD, PID_PREPARE and ID_MATCH stages respectively

Reviewed By: jrodal98, yuyashiraki

Differential Revision: D37619253

