### PR TITLE
BE for loads_schema

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -41,6 +41,20 @@ class InfraConfig(DataClassJsonMixin):
     """Stores metadata of infra config in a private computation instance
 
     Public attributes:
+        instance_id: this is unique for each PrivateComputationInstance.
+                        It is used to find and generate PCInstance in json repo.
+        role: an Enum indicating if this PrivateComputationInstance is a publisher object or partner object
+        status: an Enum indecating what stage and status the PCInstance is currently in
+        status_update_ts: the time of last status update
+        instances: during the whole computation run, all the instances created will be sotred here.
+        game_type: an Enum indicating if this PrivateComputationInstance is for private lift or private attribution
+        num_pid_containers: the number of containers used in pid
+        num_mpc_containers: the number of containers used in mpc
+        num_files_per_mpc_container: the number of files for each container
+        tier: an string indicating the release binary tier to run (rc, canary, latest)
+        retry_counter: the number times a stage has been retried
+        creation_ts: the time of the creation of this PrivateComputationInstance
+        end_ts: the time of the the end when finishing a computation run
         mpc_compute_concurrency: number of threads to run per container at the MPC compute metrics stage
 
     Private attributes:

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -105,7 +105,9 @@ class PrivateComputationInstance(InstanceBase):
         """
         if json_object["infra_config"]["game_type"] == "ATTRIBUTION":
             return AttributionConfig.schema()
-        return LiftConfig.schema()
+        elif json_object["infra_config"]["game_type"] == "LIFT":
+            return LiftConfig.schema()
+        raise RuntimeError(f"Invalid product config: {json_object}")
 
     def get_instance_id(self) -> str:
         return self.infra_config.instance_id

--- a/fbpcs/private_computation/entity/product_config.py
+++ b/fbpcs/private_computation/entity/product_config.py
@@ -24,11 +24,18 @@ class CommonProductConfig:
     """Stores metadata of common product config used both by attribution config and lift config
 
     Public attributes:
+        input_path: the input path of PrivateComputationInstance
+        output_dir: the output path of PrivateComputationInstance
+        hmac_key: key value of hmac
         padding_size: the id spine combiner would pad each partner row to have this number of conversions.
                         This is required by MPC compute metrics to support multiple conversions per id while
                         at the same time maintaining privacy. It is currently only used when game_type=attribution
                         because the lift id spine combiner uses a hard-coded value of 25.
                         TODO T104391012: pass padding size to lift id spine combiner.
+        result_visibility: an enum indicating the visibility of results.
+        pid_use_row_numbers: his is used by Private ID protocol to indicate whether we should enable
+                                'use-row-numbers' argument.
+        pid_configs: whether this should be in infra or product is controversial.
         post_processing_data: fields to be sent to the post processing tier.
     """
 
@@ -39,13 +46,12 @@ class CommonProductConfig:
     # because at the time the instance is created, pl might not provide any or all of them.
     hmac_key: Optional[str] = None
     padding_size: Optional[int] = None
+
     result_visibility: ResultVisibility = ResultVisibility.PUBLIC
 
-    # this is used by Private ID protocol to indicate whether we should
-    # enable 'use-row-numbers' argument.
     pid_use_row_numbers: bool = True
-
     pid_configs: Optional[Dict[str, Any]] = None
+
     post_processing_data: Optional[PostProcessingData] = None
 
 
@@ -95,7 +101,13 @@ class LiftConfig(ProductConfig):
     """Stores metadata of lift config in product config in a private computation instance
 
     Public attributes:
-
+        k_anonymity_threshold: Threshold for matched conversions to make results viewable
+                                For PA: K-Anon threshold strategy is five clicks per day for an Ad Id.
+                                But it will not get the value from PCInstance. Only lift run will use
+                                it from PCInstance. So this is a "lift unique" field here.
+                                For PL: K-Anon threshold is 100
+        breakdown_key: When PL service is running, CreateInstance accepts the breakdown key struct so
+                        that the instance can be aware of what cell-objective pair it belongs to at any stage.
     """
 
     k_anonymity_threshold: int = 0


### PR DESCRIPTION
Summary:
# This Stack: T119253842
This stack will decouple product and infra instance data in private_computation_instance.py.
We will ship the whole stack after each diff is accepted.

## 4nd Part: Clean-up

# This Diff
use `elif` so we can raise an error if the game type is unexpected

Reviewed By: gorel

Differential Revision: D37573930

