### PR TITLE
fix typo in bolt runner validation

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -116,7 +116,7 @@ class BoltRunner:
                     *[
                         self.publisher_client.validate_results(
                             instance_id=publisher_id,
-                            expected_result_path=job.partner_bolt_args.expected_result_path,
+                            expected_result_path=job.publisher_bolt_args.expected_result_path,
                         ),
                         self.partner_client.validate_results(
                             instance_id=partner_id,


### PR DESCRIPTION
Summary:
## What

* fix typo

## Why

* Bolt is using the wrong publisher input file for result validation
* I fixed this issue in D37633860 (https://github.com/facebookresearch/fbpcs/commit/fb1ef17f8e354adbc6cc1e4d1f639b83e46e7c6e) when adding a test to our CI/CD, but it was improperly overwritten (presumably when resolving a merge conflict) in D37630393 (https://github.com/facebookresearch/fbpcs/commit/9a591c6bcc57f3f107209aff6ae05080ce82b96e)

Differential Revision: D37734651

