### PR TITLE
delete inner-implement, apply mutability mixin

### DIFF
--- a/fbpcs/common/entity/dataclasses_mutability.py
+++ b/fbpcs/common/entity/dataclasses_mutability.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import partial
+from typing import Any, TypeVar
+
+from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin
+from fbpcs.common.entity.exceptions import InstanceFrozenFieldError
+
+
+T = TypeVar("T")
+
+IS_FROZEN_FIELD: str = "mutability"
+
+
+class MutabilityMetadata(Enum):
+    MUTABLE = {IS_FROZEN_FIELD: False}
+    IMMUTABLE = {IS_FROZEN_FIELD: True}
+
+
+mutable_field = partial(field, metadata=MutabilityMetadata.MUTABLE.value)
+immutable_field = partial(field, metadata=MutabilityMetadata.IMMUTABLE.value)
+
+
+@dataclass
+class DataclassMutabilityMixin(DataclassHookMixin):
+    """
+    You also get hooks if inherits this mutability mixin
+    """
+
+    # this boolean will be set to True after an obj initialization
+    initialized: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        self.initialized = True
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # if setattr is called after initialization
+        if self.initialized:
+            # if we cannot find it, this field has not been initialized yet
+            try:
+                self.__getattribute__(name)
+            except AttributeError:
+                DataclassHookMixin.__setattr__(self, name, value)
+            else:
+                # if this field has been initialized and it is immutable
+                # pyre-fixme Undefined attribute [16]: InstanceBase has no attribute __dataclass_fields__
+                if self.__dataclass_fields__[name].metadata.get(IS_FROZEN_FIELD, False):
+                    raise InstanceFrozenFieldError(name)
+                else:
+                    DataclassHookMixin.__setattr__(self, name, value)
+        else:
+            # if setattr is called during initialization
+            DataclassHookMixin.__setattr__(self, name, value)

--- a/fbpcs/common/entity/frozen_field_hook.py
+++ b/fbpcs/common/entity/frozen_field_hook.py
@@ -12,9 +12,9 @@ from fbpcs.common.entity.dataclasses_hooks import (
     DataclassHookMixin,
     HookEventType,
 )
-from fbpcs.common.entity.instance_base_config import (
-    InstanceBaseMetadata,
+from fbpcs.common.entity.dataclasses_mutability import (
     IS_FROZEN_FIELD,
+    MutabilityMetadata,
 )
 
 T = TypeVar("T")
@@ -64,13 +64,13 @@ class FrozenFieldHook(DataclassHook[T]):
 
             if hooks is None:
                 # No hooks, so just set the metadata as immutable
-                field_obj.metadata = InstanceBaseMetadata.IMMUTABLE.value
+                field_obj.metadata = MutabilityMetadata.IMMUTABLE.value
             else:
                 # if this field has hooks
                 # We want to set the metadata as immutable and keep a record
                 # of the existing hooks (field metadata can't be updated because
                 # it is a "mappingproxy" object, not a real dict)
                 field_obj.metadata = {
-                    **InstanceBaseMetadata.IMMUTABLE.value,
+                    **MutabilityMetadata.IMMUTABLE.value,
                     **DataclassHookMixin.get_metadata(hooks),
                 }

--- a/fbpcs/common/entity/instance_base.py
+++ b/fbpcs/common/entity/instance_base.py
@@ -7,34 +7,17 @@
 # pyre-strict
 
 import abc
-from dataclasses import dataclass, field
-from functools import partial
-from typing import Any, Type, TypeVar
+from dataclasses import dataclass
+from typing import Type, TypeVar
 
 from dataclasses_json import DataClassJsonMixin
-from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin
-from fbpcs.common.entity.exceptions import InstanceFrozenFieldError
-from fbpcs.common.entity.instance_base_config import (
-    InstanceBaseMetadata,
-    IS_FROZEN_FIELD,
-)
+from fbpcs.common.entity.dataclasses_mutability import DataclassMutabilityMixin
 
 T = TypeVar("T", bound="InstanceBase")
 
-# pyre-ignore Missing parameter annotation [4]
-mutable_field = partial(field, metadata=InstanceBaseMetadata.MUTABLE.value)
-# pyre-ignore Missing parameter annotation [4]
-immutable_field = partial(field, metadata=InstanceBaseMetadata.IMMUTABLE.value)
-
 
 @dataclass
-class InstanceBase(DataClassJsonMixin, DataclassHookMixin):
-    # this boolean will be set to True after an obj initialization
-    initialized: bool = field(default=False, init=False)
-
-    def __post_init__(self) -> None:
-        self.initialized = True
-
+class InstanceBase(DataClassJsonMixin, DataclassMutabilityMixin):
     @abc.abstractmethod
     def get_instance_id(self) -> str:
         pass
@@ -48,23 +31,3 @@ class InstanceBase(DataClassJsonMixin, DataclassHookMixin):
     @classmethod
     def loads_schema(cls: Type[T], json_schema_str: str) -> T:
         return cls.schema().loads(json_schema_str, many=None)
-
-    # pyre-ignore Missing parameter annotation [2]
-    def __setattr__(self, name: str, value: Any) -> None:
-        # if setattr is called after initialization
-        if self.initialized:
-            # if we cannot find it, this field has not been initialized yet
-            try:
-                self.__getattribute__(name)
-            except AttributeError:
-                DataclassHookMixin.__setattr__(self, name, value)
-            else:
-                # if this field has been initialized and it is immutable
-                # pyre-fixme Undefined attribute [16]: InstanceBase has no attribute __dataclass_fields__
-                if self.__dataclass_fields__[name].metadata.get(IS_FROZEN_FIELD, False):
-                    raise InstanceFrozenFieldError(name)
-                else:
-                    DataclassHookMixin.__setattr__(self, name, value)
-        else:
-            # if setattr is called during initialization
-            DataclassHookMixin.__setattr__(self, name, value)

--- a/fbpcs/common/tests/entity/test_comprehensive_hooks_and_mutability.py
+++ b/fbpcs/common/tests/entity/test_comprehensive_hooks_and_mutability.py
@@ -6,19 +6,21 @@
 # pyer-strict
 
 import unittest
+
 from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin, HookEventType
+from fbpcs.common.entity.dataclasses_mutability import (
+    immutable_field,
+    MutabilityMetadata,
+    mutable_field,
+)
 from fbpcs.common.entity.exceptions import InstanceFrozenFieldError, OutOfRangeHookError
 from fbpcs.common.entity.frozen_field_hook import FrozenFieldHook
 from fbpcs.common.entity.generic_hook import GenericHook
-from fbpcs.common.entity.instance_base import (
-    immutable_field,
-    InstanceBase,
-    mutable_field,
-)
-from fbpcs.common.entity.instance_base_config import InstanceBaseMetadata
+from fbpcs.common.entity.instance_base import InstanceBase
+
 from fbpcs.common.entity.range_hook import RangeHook
 
 from fbpcs.common.entity.update_other_field_hook import UpdateOtherFieldHook
@@ -158,27 +160,27 @@ class DummyInstance(InstanceBase):
     instance_id: str = field(
         metadata={
             **DataclassHookMixin.get_metadata(name_init_hook),
-            **InstanceBaseMetadata.IMMUTABLE.value,
+            **MutabilityMetadata.IMMUTABLE.value,
         }
     )
 
     input_path: str = field(
         metadata={
             **DataclassHookMixin.get_metadata(ouput_update_hook, storage_update_hook),
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
         }
     )
 
     user: str = field(
         metadata={
-            **InstanceBaseMetadata.IMMUTABLE.value,
+            **MutabilityMetadata.IMMUTABLE.value,
             **DataclassHookMixin.get_metadata(org_init_hook),
         }
     )
     owner: Optional[str] = immutable_field()
     region: Optional[str] = field(
         metadata={
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
             **DataclassHookMixin.get_metadata(frozen_location_hook),
         },
     )
@@ -189,14 +191,14 @@ class DummyInstance(InstanceBase):
 
     counter: int = field(
         metadata={
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
             **DataclassHookMixin.get_metadata(counter_range_hook),
         }
     )
 
     pressure: int = field(
         metadata={
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
             **DataclassHookMixin.get_metadata(
                 pressure_range_hook, highest_pressure_hook
             ),
@@ -206,7 +208,7 @@ class DummyInstance(InstanceBase):
     priority: int = field(
         default=1,
         metadata={
-            **InstanceBaseMetadata.IMMUTABLE.value,
+            **MutabilityMetadata.IMMUTABLE.value,
             **DataclassHookMixin.get_metadata(priority_range_hook),
         },
     )
@@ -215,7 +217,7 @@ class DummyInstance(InstanceBase):
         default="start",
         metadata={
             **DataclassHookMixin.get_metadata(frozen_input_hook, frozen_output_hook),
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
         },
     )
 

--- a/fbpcs/common/tests/entity/test_frozen_field_hook.py
+++ b/fbpcs/common/tests/entity/test_frozen_field_hook.py
@@ -9,10 +9,10 @@ import unittest
 from dataclasses import dataclass, field
 
 from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin
+from fbpcs.common.entity.dataclasses_mutability import MutabilityMetadata, mutable_field
 from fbpcs.common.entity.exceptions import InstanceFrozenFieldError
 from fbpcs.common.entity.frozen_field_hook import FrozenFieldHook
-from fbpcs.common.entity.instance_base import InstanceBase, mutable_field
-from fbpcs.common.entity.instance_base_config import InstanceBaseMetadata
+from fbpcs.common.entity.instance_base import InstanceBase
 
 # create a hook obj
 # frozen input when status is complete
@@ -49,7 +49,7 @@ class DummyInstance(InstanceBase):
     user: str = field(
         metadata={
             **DataclassHookMixin.get_metadata(frozen_location_hook),
-            **InstanceBaseMetadata.IMMUTABLE.value,
+            **MutabilityMetadata.IMMUTABLE.value,
         },
     )
     location: str = mutable_field()
@@ -58,7 +58,7 @@ class DummyInstance(InstanceBase):
         default="start",
         metadata={
             **DataclassHookMixin.get_metadata(frozen_input_hook, frozen_output_hook),
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
         },
     )
 

--- a/fbpcs/common/tests/entity/test_instance_base_mutability.py
+++ b/fbpcs/common/tests/entity/test_instance_base_mutability.py
@@ -7,13 +7,11 @@ import unittest
 from dataclasses import dataclass
 from typing import Generic, List, Optional, TypeVar
 
+from fbpcs.common.entity.dataclasses_mutability import immutable_field, mutable_field
+
 from fbpcs.common.entity.exceptions import InstanceFrozenFieldError
 
-from fbpcs.common.entity.instance_base import (
-    immutable_field,
-    InstanceBase,
-    mutable_field,
-)
+from fbpcs.common.entity.instance_base import InstanceBase
 
 
 def create_new_num_list() -> List[int]:

--- a/fbpcs/common/tests/entity/test_range_hook.py
+++ b/fbpcs/common/tests/entity/test_range_hook.py
@@ -9,9 +9,9 @@ import unittest
 from dataclasses import dataclass, field
 
 from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin
+from fbpcs.common.entity.dataclasses_mutability import MutabilityMetadata
 from fbpcs.common.entity.exceptions import MissingRangeHookError, OutOfRangeHookError
 from fbpcs.common.entity.instance_base import InstanceBase
-from fbpcs.common.entity.instance_base_config import InstanceBaseMetadata
 from fbpcs.common.entity.range_hook import RangeHook
 
 # create a hook obj
@@ -43,14 +43,14 @@ class DummyInstance(InstanceBase):
     # each field will be mutable as default
     counter: int = field(
         metadata={
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
             **DataclassHookMixin.get_metadata(counter_range_hook),
         }
     )
 
     pressure: int = field(
         metadata={
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
             **DataclassHookMixin.get_metadata(pressure_range_hook),
         }
     )

--- a/fbpcs/common/tests/entity/test_update_other_field_hook.py
+++ b/fbpcs/common/tests/entity/test_update_other_field_hook.py
@@ -9,8 +9,8 @@ import unittest
 from dataclasses import dataclass, field
 
 from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin
-from fbpcs.common.entity.instance_base import InstanceBase, mutable_field
-from fbpcs.common.entity.instance_base_config import InstanceBaseMetadata
+from fbpcs.common.entity.dataclasses_mutability import MutabilityMetadata, mutable_field
+from fbpcs.common.entity.instance_base import InstanceBase
 
 from fbpcs.common.entity.update_other_field_hook import UpdateOtherFieldHook
 
@@ -47,14 +47,14 @@ class DummyInstance(InstanceBase):
     instance_id: str = field(
         metadata={
             **DataclassHookMixin.get_metadata(name_update_hook),
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
         }
     )
 
     input_path: str = field(
         metadata={
             **DataclassHookMixin.get_metadata(ouput_update_hook, storage_update_hook),
-            **InstanceBaseMetadata.MUTABLE.value,
+            **MutabilityMetadata.MUTABLE.value,
         }
     )
 


### PR DESCRIPTION
Summary:
Since we have a mutability mixin now (early diff), we do not need to maintain the inner-implement of mutability anymore. We can apply mutability mixin in InstanceBase. I also make this modification for all test files.
Now, any class can inherit this mixin to get individual frozen fields.

Differential Revision: D37618916

