### PR TITLE
fix bolt config parsing bug

### DIFF
--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -80,7 +80,7 @@ def create_job_list(job_config_list: Dict[str, Any]) -> List[BoltJob]:
         partner_args["role"] = "PARTNER"
         shared_args = job_config["shared"]
         shared_args["job_name"] = job_name
-        job_specific_args = job_config.get("job_args", [])
+        job_specific_args = job_config.get("job_args", {})
 
         publisher_create_instance_args = BoltPCSCreateInstanceArgs.from_yml_dict(
             {**publisher_args, **shared_args}


### PR DESCRIPTION
Summary:
## What

* Fix a bug in bolt config parsing
    * if job_args isn't specified in the bolt_config, then the parsing doesn't work

> 104, in create_job_list
> poll_interval=job_specific_args.get(
AttributeError: 'list' object has no attribute 'get'

## Why

* job_args isn't specified in the github CI/CD bolt_config, so the bug is blocking the next release: https://github.com/facebookresearch/fbpcs/runs/7263335110?check_suite_focus=true

Differential Revision: D37738045

