### PR TITLE
stop_service() in PIDShardStageService

### DIFF
--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -27,6 +27,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     get_pc_status_from_stage_state,
+    stop_stage_service,
 )
 
 
@@ -124,3 +125,9 @@ class PIDShardStageService(PrivateComputationStageService):
             timeout=self._container_timeout,
             env_vars=env_vars,
         )
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        stop_stage_service(pc_instance, self._onedocker_svc)


### PR DESCRIPTION
Summary: In this diff, we implemented stop_service() in PIDShardStageService, which overides stop_service() in PrivateComputationStageService and will be called by cancel_current_stage() in private_computation.py

Reviewed By: joe1234wu

Differential Revision: D37432012

