### PR TITLE
Refactor dummy permuter to use MPC adapters (#259)

### DIFF
--- a/fbpcs/data_processing/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcs/data_processing/unified_data_process/adapter/test/AdapterTest.cpp
@@ -148,9 +148,9 @@ TEST(AdapterTest, testAdapterWithPermuteBasedShufflerAndDummyPermuter) {
               fbpcf::frontend::BitString<true, 0, true>>>(
           0,
           1,
-          std::make_unique<
-              fbpcf::mpc_std_lib::permuter::insecure::DummyPermuterFactory<
-                  fbpcf::frontend::BitString<true, 0, true>>>(0, 1),
+          std::make_unique<fbpcf::mpc_std_lib::permuter::insecure::
+                               DummyPermuterFactory<std::vector<bool>, 0>>(
+              0, 1),
           std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
 
   AdapterFactory<1> factory1(
@@ -162,9 +162,9 @@ TEST(AdapterTest, testAdapterWithPermuteBasedShufflerAndDummyPermuter) {
               fbpcf::frontend::BitString<true, 1, true>>>(
           1,
           0,
-          std::make_unique<
-              fbpcf::mpc_std_lib::permuter::insecure::DummyPermuterFactory<
-                  fbpcf::frontend::BitString<true, 1, true>>>(1, 0),
+          std::make_unique<fbpcf::mpc_std_lib::permuter::insecure::
+                               DummyPermuterFactory<std::vector<bool>, 1>>(
+              1, 0),
           std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
 
   adapterTest(factory0.create(), factory1.create());


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcf/pull/259

Use MPC adapters when opening and processing secret values in dummy permuter implementation.

Details: In the current implementation of dummy permuter, a template type ```T``` is limited to Bit, Int and BitString as it has a dependency on the method ```OpenToParty``` and the constructor for processing secret inputs. Thus, to make ```T``` more general, we use MPC adapters as proxies to call those functions.

- We make small changes to all existing dependent unit tests to reflect the modifications to the dummy permuter.

Reviewed By: chualynn

Differential Revision: D37687008

