### PR TITLE
Fix build issue

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -64,7 +64,7 @@ COPY deployment_helper /terraform_deployment/fbpcs/infra/cloud_bridge/deployment
 # #########################################
 # Spring Boot
 # #########################################
-ARG JAR_FILE=server/build/libs/*.jar
-COPY ${JAR_FILE} /server/server.jar
+ARG JAR_FILE_PATH
+COPY ${JAR_FILE_PATH}  /server/server.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/server/server.jar"]

--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -7,6 +7,8 @@ IMAGE_NAME?=cloudbridge-private_lift-server
 
 SERVER_VERSION?=0.0.1
 SERVER_JAR=server/build/libs/server-$(SERVER_VERSION).jar
+SERVER_JAR_VERSION=`grep 'version = ' server/build.gradle | sed s"/^version = //" | sed s"/'*//g"`
+JAR_FILE_PATH="server/build/libs/server-${SERVER_JAR_VERSION}.jar"
 
 SOURCE_FILES=$(wildcard server/src/main/java/com/facebook/business/cloudbridge/pl/server/*.java)
 
@@ -32,7 +34,7 @@ local-run:
 
 
 image-build: $(SERVER_JAR) external_deps
-	docker build -t $(CONTAINER_IMAGE) .
+	docker build --build-arg JAR_FILE_PATH=$(JAR_FILE_PATH) -t $(CONTAINER_IMAGE) .
 	docker tag $(CONTAINER_IMAGE) $(LOCAL_IMAGE)
 
 	# Cleanup copied resources


### PR DESCRIPTION
Summary:
When upgrading the spring version, it started outputting an extra jar file that
messed up the COPY command in the Dockerfile. To resolve the issue, fetch the
version from the build.gradle file and copy just that 1 jar file during the
build.

Differential Revision: D37759268

