### PR TITLE
Update unit tests for PCF2 Attribution game per the new format

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
@@ -14,6 +14,7 @@
 #include "fbpcs/emp_games/common/Csv.h"
 
 #include "fbpcs/emp_games/pcf2_attribution/AttributionOutput.h"
+#include "fbpcs/emp_games/pcf2_attribution/AttributionReformattedOutput.h"
 #include "fbpcs/emp_games/pcf2_attribution/Conversion.h"
 #include "fbpcs/emp_games/pcf2_attribution/Touchpoint.h"
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionReformattedOutput.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionReformattedOutput.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/dynamic.h>
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Debug.h"
+#include "fbpcs/emp_games/pcf2_attribution/Constants.h"
+
+namespace pcf2_attribution {
+
+/**
+ * Store plaintext attribution result
+ */
+struct OutputMetricReformatted {
+  uint64_t ad_id;
+  uint64_t conv_value;
+  bool is_attributed;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic res = folly::dynamic::object();
+    res.insert("ad_id", ad_id);
+    res.insert("conv_value", conv_value);
+    res.insert("is_attributed", is_attributed);
+    return res;
+  }
+  static OutputMetricReformatted fromDynamic(const folly::dynamic& obj) {
+    OutputMetricReformatted out = OutputMetricReformatted{};
+    out.is_attributed = obj["is_attributed"].asBool();
+    out.ad_id = obj["ad_id"].asInt();
+    out.conv_value = obj["conv_value"].asInt();
+    return out;
+  }
+};
+
+/**
+ * Store map from uid to vector of attribution results
+ */
+struct AttributionReformattedFmt {
+  std::unordered_map<int64_t, std::vector<OutputMetricReformatted>> idToMetrics;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic res = folly::dynamic::object();
+
+    for (const auto& [k1, v1] : idToMetrics) {
+      auto uid = std::to_string(k1);
+      folly::dynamic metricList = folly::dynamic::array();
+      for (const auto& metric : v1) {
+        metricList.push_back(metric.toDynamic());
+      }
+      res.insert(uid, metricList);
+    }
+    return res;
+  }
+};
+
+using AttributionResult = folly::dynamic;
+
+template <int schedulerId, bool usingBatch>
+struct AttributionReformattedOutputFmt {
+  SecAdId<schedulerId, usingBatch> ad_id;
+  SecConvValue<schedulerId, usingBatch> conv_value;
+  SecBit<schedulerId, usingBatch> is_attributed;
+};
+
+template <int schedulerId, bool usingBatch = true>
+class AttributionReformattedOutput {
+ public:
+  AttributionReformattedOutput(
+      const std::vector<int64_t>& uids,
+      const std::vector<
+          AttributionReformattedOutputFmt<schedulerId, usingBatch>>&
+          attributionStruct)
+      : uids_{uids}, attributionStruct_{attributionStruct} {}
+
+  /**
+   * Reveal attribution result as XOR secret shares
+   */
+  AttributionResult reveal() {
+    AttributionReformattedFmt out;
+
+    std::vector<std::vector<uint64_t>> revealedAdId;
+    std::vector<std::vector<uint64_t>> revealedConvValue;
+    std::vector<std::vector<bool>> revealedAttribution;
+    for (const auto& attributionStructArray : attributionStruct_) {
+      if constexpr (usingBatch) {
+        IF_OMNISCIENT_MODE {
+          /* reveal ad_ids */
+          revealedAdId.push_back(
+              attributionStructArray.ad_id.openToParty(common::PUBLISHER)
+                  .getValue());
+          /* reveal conv_value */
+          revealedConvValue.push_back(
+              attributionStructArray.conv_value.openToParty(common::PUBLISHER)
+                  .getValue());
+          /* reveal is_attributed */
+          revealedAttribution.push_back(attributionStructArray.is_attributed
+                                            .openToParty(common::PUBLISHER)
+                                            .getValue());
+        }
+        else {
+          revealedAdId.push_back(
+              attributionStructArray.ad_id.extractIntShare().getValue());
+          revealedConvValue.push_back(
+              attributionStructArray.conv_value.extractIntShare().getValue());
+          revealedAttribution.push_back(
+              attributionStructArray.is_attributed.extractBit().getValue());
+        }
+      } else {
+        std::vector<uint64_t> revealedAdIdArray;
+        std::vector<uint64_t> revealedConvValueArray;
+        std::vector<bool> revealedAttributionArray;
+
+        for (const auto& attribution : attributionStructArray) {
+          IF_OMNISCIENT_MODE {
+            revealedAdIdArray.push_back(
+                attribution.ad_id.openToParty(common::PUBLISHER).getValue());
+
+            revealedConvValueArray.push_back(
+                attribution.conv_value.openToParty(common::PUBLISHER)
+                    .getValue());
+
+            revealedAttributionArray.push_back(
+                attribution.is_attributed.openToParty(common::PUBLISHER)
+                    .getValue());
+          }
+          else {
+            revealedAdIdArray.push_back(
+                attribution.ad_id.extractIntShare().getValue());
+
+            revealedConvValueArray.push_back(
+                attribution.conv_value.extractIntShare().getValue());
+
+            revealedAttributionArray.push_back(
+                attribution.is_attributed.extractBit().getValue());
+          }
+        }
+        revealedAdId.push_back(std::move(revealedAdIdArray));
+        revealedConvValue.push_back(std::move(revealedConvValueArray));
+        revealedAttribution.push_back(std::move(revealedAttributionArray));
+      }
+    }
+
+    // Count number of attributions for debugging
+    uint32_t adIdCountOmniscient = 0;
+    uint32_t convValueSumOmniscient = 0;
+    uint32_t attributionCountOmniscient = 0;
+
+    for (size_t i = 0; i < uids_.size(); ++i) {
+      std::vector<OutputMetricReformatted> revealedMetric;
+      if constexpr (usingBatch) {
+        for (size_t j = 0; j < revealedAdId.size(); ++j) {
+          revealedMetric.emplace_back(
+              revealedAdId.at(j).at(i),
+              revealedConvValue.at(j).at(i),
+              revealedAttribution.at(j).at(i));
+          IF_OMNISCIENT_MODE {
+            if (revealedAdId.at(j).at(i)) {
+              adIdCountOmniscient++;
+            }
+            convValueSumOmniscient += revealedConvValue.at(j).at(i);
+            if (revealedAttribution.at(j).at(i)) {
+              attributionCountOmniscient++;
+            }
+          }
+        }
+      } else {
+        // revealedAttribution for non-batch is related to batch by transposing
+        for (size_t j = 0; j < revealedAdId.at(i).size(); ++j) {
+          revealedMetric.emplace_back(
+              revealedAdId.at(i).at(j),
+              revealedConvValue.at(i).at(j),
+              revealedAttribution.at(i).at(j));
+
+          IF_OMNISCIENT_MODE {
+            if (revealedAdId.at(i).at(j)) {
+              adIdCountOmniscient++;
+            }
+            convValueSumOmniscient += revealedConvValue.at(i).at(j);
+            if (revealedAttribution.at(i).at(j)) {
+              attributionCountOmniscient++;
+            }
+          }
+        }
+      }
+      out.idToMetrics.emplace(uids_.at(i), revealedMetric);
+    }
+
+    OMNISCIENT_ONLY_XLOGF(DBG, "Ad_id count: {}", adIdCountOmniscient);
+    OMNISCIENT_ONLY_XLOGF(
+        DBG, "Conversion_values sum: {}", convValueSumOmniscient);
+    OMNISCIENT_ONLY_XLOGF(
+        DBG, "Attribution count: {}", attributionCountOmniscient);
+
+    return out.toDynamic();
+  }
+
+ private:
+  std::vector<int64_t> uids_;
+  std::vector<AttributionReformattedOutputFmt<schedulerId, usingBatch>>
+      attributionStruct_;
+};
+} // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/Constants.h
+++ b/fbpcs/emp_games/pcf2_attribution/Constants.h
@@ -15,6 +15,8 @@ const int kMaxConcurrency = 16;
 const size_t timeStampWidth = 32;
 const size_t targetIdWidth = 64;
 const size_t actionTypeWidth = 16;
+const size_t adIdWidth = 64;
+const size_t convValueWidth = 32;
 
 template <int schedulerId, bool usingBatch = true>
 using PubBit =
@@ -44,6 +46,20 @@ template <int schedulerId, bool usingBatch = true>
 using SecActionType = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<actionTypeWidth, usingBatch>;
 
+template <int schedulerId, bool usingBatch = true>
+using PubAdId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<adIdWidth, usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecAdId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<adIdWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
+using PubConvValue = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<convValueWidth, usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecConvValue = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<convValueWidth, usingBatch>;
+
 template <typename T, bool useVector>
 using ConditionalVector =
     typename std::conditional<useVector, std::vector<T>, T>::type;
@@ -59,5 +75,11 @@ using SecTargetIdT =
 template <int schedulerId, bool usingBatch = true>
 using SecActionTypeT =
     ConditionalVector<SecActionType<schedulerId, usingBatch>, !usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecAdIdT =
+    ConditionalVector<SecAdId<schedulerId, usingBatch>, !usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecConvValueT =
+    ConditionalVector<SecConvValue<schedulerId, usingBatch>, !usingBatch>;
 
 } // namespace pcf2_attribution

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -17,6 +17,7 @@ struct Conversion {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
+  ConditionalVector<uint64_t, usingBatch> convValue;
 };
 
 template <bool usingBatch>
@@ -30,6 +31,7 @@ struct PrivateConversion {
   SecTimestamp<schedulerId, usingBatch> ts;
   SecTargetId<schedulerId, usingBatch> targetId;
   SecActionType<schedulerId, usingBatch> actionType;
+  SecConvValue<schedulerId, usingBatch> convValue;
 
   explicit PrivateConversion(const Conversion<usingBatch>& conversion) {
     if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
@@ -39,6 +41,8 @@ struct PrivateConversion {
           conversion.targetId, common::PARTNER);
       actionType = SecActionType<schedulerId, usingBatch>(
           conversion.actionType, common::PARTNER);
+      convValue = SecConvValue<schedulerId, usingBatch>(
+          conversion.convValue, common::PARTNER);
     } else {
       typename SecTimestamp<schedulerId, usingBatch>::ExtractedInt extractedTs(
           conversion.ts);
@@ -50,6 +54,9 @@ struct PrivateConversion {
           extractedAids(conversion.actionType);
       actionType =
           SecActionType<schedulerId, usingBatch>(std::move(extractedAids));
+      typename SecConvValue<schedulerId, usingBatch>::ExtractedInt extractedVs(
+          conversion.convValue);
+      convValue = SecConvValue<schedulerId, usingBatch>(std::move(extractedVs));
     }
   }
 };
@@ -59,6 +66,7 @@ struct ParsedConversion {
   uint64_t ts = 0U;
   uint64_t targetId = 0U;
   uint64_t actionType = 0U;
+  uint64_t convValue = 0U;
 
   bool operator<(const ParsedConversion& conv) const {
     return (ts < conv.ts);

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -19,6 +19,7 @@ struct Touchpoint {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
+  ConditionalVector<uint64_t, usingBatch> adId;
 };
 
 template <bool usingBatch>
@@ -33,6 +34,7 @@ struct PrivateTouchpoint {
   SecTimestamp<schedulerId, usingBatch> ts;
   SecTargetId<schedulerId, usingBatch> targetId;
   SecActionType<schedulerId, usingBatch> actionType;
+  SecAdId<schedulerId, usingBatch> adId;
 
   explicit PrivateTouchpoint(const Touchpoint<usingBatch>& touchpoint)
       : id{touchpoint.id} {
@@ -47,6 +49,10 @@ struct PrivateTouchpoint {
           extractedAids(touchpoint.actionType);
       actionType =
           SecActionType<schedulerId, usingBatch>(std::move(extractedAids));
+      typename SecAdId<schedulerId, usingBatch>::ExtractedInt extractedAdIds(
+          touchpoint.adId);
+      adId = SecAdId<schedulerId, usingBatch>(std::move(extractedAdIds));
+
     } else {
       ts = SecTimestamp<schedulerId, usingBatch>(
           touchpoint.ts, common::PUBLISHER);
@@ -54,6 +60,8 @@ struct PrivateTouchpoint {
           touchpoint.targetId, common::PUBLISHER);
       actionType = SecActionType<schedulerId, usingBatch>(
           touchpoint.actionType, common::PUBLISHER);
+      adId =
+          SecAdId<schedulerId, usingBatch>(touchpoint.adId, common::PUBLISHER);
     }
   }
 };
@@ -85,6 +93,7 @@ struct ParsedTouchpoint {
   uint64_t ts = 0U;
   uint64_t targetId = 0U;
   uint64_t actionType = 0U;
+  uint64_t adId = 0U;
 
   /**
    * If both are clicks, or both are views, the earliest one comes first.

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -122,6 +122,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="use_new_output_format", required=False),
         ],
     },
     GameNames.PCF2_AGGREGATION.value: {

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -184,6 +184,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             "attribution_rules": attribution_rule.value,
             "use_xor_encryption": True,
             "use_postfix": True,
+            "use_new_output_format": False,
         }
 
         game_args = [

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -92,6 +92,7 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             "use_xor_encryption": True,
             "use_postfix": True,
             "log_cost": True,
+            "use_new_output_format": False,
         }
         test_game_args = [
             {


### PR DESCRIPTION
Summary:
# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
In this diff, adding a flag to validate whether to use new vs old output format in Private Attribution.
# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Attribution.
2. Modify PCS stage for attribution with the new flag.
3. Parse the input for new output format.
4. Add a new output format file in attribution game.
5. **Update unit tests for PCF2 Attribution game per the new format.**
6. Add a flag to validate whether to use new vs old input format of attribution in Private Aggregation.
7. Modify PCS stage for aggregation with the new flag.
8. Modify Input parsing logic in Aggregation game and update unit tests.
9. Create end to end tests to test the new attribution format.

Differential Revision: D37722578

