### PR TITLE
Migrate `AggregationMetrics.cpp` to use FileIOWrappers:io:readFile

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 
 #include <fbpcf/common/FunctionalUtil.h>
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <vector>
 #include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/common/PrivateData.h"
@@ -241,8 +241,8 @@ AggregationInputMetrics::AggregationInputMetrics(
       inputSecretShareFilePath.string());
   // Reading the attribution results received from private attribution game in
   // an unordered_map.
-  auto attributionResultJson =
-      folly::parseJson(fbpcf::io::read(inputSecretShareFilePath));
+  auto attributionResultJson = folly::parseJson(
+      fbpcf::io::FileIOWrappers::readFile(inputSecretShareFilePath));
 
   for (const auto& [rule, formatters] : attributionResultJson.items()) {
     attributionRules_.push_back(rule.asString());

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include <emp-sh2pc/emp-sh2pc.h>
-
 #include <folly/Format.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
@@ -20,6 +19,7 @@
 
 #include <fbpcf/common/FunctionalUtil.h>
 #include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpGame.h>
 #include "AggMetrics.h"
 #include "ShardAggregatorGame.h"
@@ -82,8 +82,9 @@ std::vector<std::shared_ptr<AggMetrics>> ShardAggregatorApp::getInputData() {
       fbpcf::functional::map<std::string, std::shared_ptr<AggMetrics>>(
           inputPaths, [](const auto& inputPath) {
             XLOG(INFO) << "Opening file at <" << inputPath << ">";
-            return std::make_shared<AggMetrics>(AggMetrics::fromDynamic(
-                folly::parseJson(fbpcf::io::read(inputPath))));
+            return std::make_shared<AggMetrics>(
+                AggMetrics::fromDynamic(folly::parseJson(
+                    fbpcf::io::FileIOWrappers::readFile(inputPath))));
           });
   validateInputDataAggMetrics(inputData, metricsFormatType_);
   return inputData;
@@ -92,7 +93,8 @@ std::vector<std::shared_ptr<AggMetrics>> ShardAggregatorApp::getInputData() {
 void ShardAggregatorApp::putOutputData(
     const std::shared_ptr<AggMetrics>& metrics) {
   XLOG(INFO) << "putting out data ...";
-  fbpcf::io::write(outputPath_, folly::toJson(metrics->toDynamic()));
+  fbpcf::io::FileIOWrappers::writeFile(
+      outputPath_, folly::toJson(metrics->toDynamic()));
 }
 
 std::shared_ptr<AggMetrics> ShardAggregatorApp::revealMetrics(

--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -16,6 +16,7 @@
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/exception/ExceptionBase.h>
 #include <fbpcs/performance_tools/CostEstimation.h>
+#include <signal.h>
 #include "MainUtil.h"
 #include "ShardAggregatorApp.h"
 
@@ -51,6 +52,7 @@ int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+  signal(SIGPIPE, SIG_IGN);
 
   XLOGF(INFO, "Party: {}", FLAGS_party);
   XLOGF(INFO, "Visibility: {}", FLAGS_visibility);

--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
@@ -10,7 +10,7 @@
 #include <gflags/gflags.h>
 #include "folly/logging/xlog.h"
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpApp.h>
 #include <fbpcf/mpc/EmpGame.h>
 
@@ -69,6 +69,6 @@ CalculatorGameConfig CalculatorApp::getInputData() {
 
 void CalculatorApp::putOutputData(const std::string& output) {
   XLOG(INFO) << "putting out data...";
-  fbpcf::io::write(outputPath_, output);
+  fbpcf::io::FileIOWrappers::writeFile(outputPath_, output);
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
@@ -80,7 +81,7 @@ void CalculatorApp<schedulerId>::putOutputData(
     const std::string& output,
     const std::string& outputPath) {
   XLOG(INFO) << "putting out data...";
-  fbpcf::io::write(outputPath, output);
+  fbpcf::io::FileIOWrappers::writeFile(outputPath, output);
 }
 
 template <int schedulerId>

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <fbpcf/io/FileManagerUtil.h>
-
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -117,7 +117,8 @@ class AggregationApp {
   void putOutputData(
       const AggregationOutputMetrics& aggregationOutput,
       std::string outputPath) {
-    fbpcf::io::write(outputPath, aggregationOutput.toJson());
+    fbpcf::io::FileIOWrappers::writeFile(
+        outputPath, aggregationOutput.toJson());
   }
 
  private:

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.cpp
@@ -18,8 +18,8 @@
 #include <utility>
 #include <vector>
 
-#include <fbpcf/common/FunctionalUtil.h>
 #include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "folly/json.h"
 #include "folly/logging/xlog.h"
 
@@ -225,8 +225,8 @@ AggregationInputMetrics::AggregationInputMetrics(
       inputSecretShareFilePath.string());
   // Reading the attribution results received from private attribution game in
   // an unordered_map.
-  auto attributionResultJson =
-      folly::parseJson(fbpcf::io::read(inputSecretShareFilePath));
+  auto attributionResultJson = folly::parseJson(
+      fbpcf::io::FileIOWrappers::readFile(inputSecretShareFilePath));
 
   for (const auto& [rule, formatters] : attributionResultJson.items()) {
     attributionRules_.push_back(rule.asString());

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -9,6 +9,8 @@
 
 #include <fbpcf/io/FileManagerUtil.h>
 
+#include <fbpcf/io/api/FileIOWrappers.h>
+#include <string>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -98,7 +100,8 @@ class AttributionApp {
   void putOutputData(
       const AttributionOutputMetrics& attributions,
       std::string outputPath) {
-    fbpcf::io::write(outputPath, attributions.toJson());
+    std::string content = attributions.toJson();
+    fbpcf::io::FileIOWrappers::writeFile(outputPath, content);
   }
 
  private:


### PR DESCRIPTION
Summary: Migrate `AggregationMetrics.cpp` to use FileIOWrappers:io:readFile for future GCS support

Differential Revision: D37401395

