### PR TITLE
Migrate Calculator/Aggregation/Attribution to use new FileIOWrappers

### DIFF
--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
@@ -10,7 +10,7 @@
 #include <gflags/gflags.h>
 #include "folly/logging/xlog.h"
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpApp.h>
 #include <fbpcf/mpc/EmpGame.h>
 
@@ -69,6 +69,6 @@ CalculatorGameConfig CalculatorApp::getInputData() {
 
 void CalculatorApp::putOutputData(const std::string& output) {
   XLOG(INFO) << "putting out data...";
-  fbpcf::io::write(outputPath_, output);
+  fbpcf::io::FileIOWrappers::writeFile(outputPath_, output);
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
@@ -80,7 +81,7 @@ void CalculatorApp<schedulerId>::putOutputData(
     const std::string& output,
     const std::string& outputPath) {
   XLOG(INFO) << "putting out data...";
-  fbpcf::io::write(outputPath, output);
+  fbpcf::io::FileIOWrappers::writeFile(outputPath, output);
 }
 
 template <int schedulerId>

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <fbpcf/io/FileManagerUtil.h>
-
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -117,7 +117,8 @@ class AggregationApp {
   void putOutputData(
       const AggregationOutputMetrics& aggregationOutput,
       std::string outputPath) {
-    fbpcf::io::write(outputPath, aggregationOutput.toJson());
+    fbpcf::io::FileIOWrappers::writeFile(
+        outputPath, aggregationOutput.toJson());
   }
 
  private:

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -9,6 +9,8 @@
 
 #include <fbpcf/io/FileManagerUtil.h>
 
+#include <fbpcf/io/api/FileIOWrappers.h>
+#include <string>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -98,7 +100,8 @@ class AttributionApp {
   void putOutputData(
       const AttributionOutputMetrics& attributions,
       std::string outputPath) {
-    fbpcf::io::write(outputPath, attributions.toJson());
+    std::string content = attributions.toJson();
+    fbpcf::io::FileIOWrappers::writeFile(outputPath, content);
   }
 
  private:


### PR DESCRIPTION
Summary: Migrate to use FileIOWrappers::writeFile for future GCS support

Differential Revision: D37401993

