### PR TITLE
Migrate Test File to use FileIOWrappers:io:readFile

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.cpp
@@ -17,7 +17,7 @@
 #include <utility>
 
 #include <fbpcf/common/FunctionalUtil.h>
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <vector>
 #include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/common/PrivateData.h"
@@ -241,8 +241,8 @@ AggregationInputMetrics::AggregationInputMetrics(
       inputSecretShareFilePath.string());
   // Reading the attribution results received from private attribution game in
   // an unordered_map.
-  auto attributionResultJson =
-      folly::parseJson(fbpcf::io::read(inputSecretShareFilePath));
+  auto attributionResultJson = folly::parseJson(
+      fbpcf::io::FileIOWrappers::readFile(inputSecretShareFilePath));
 
   for (const auto& [rule, formatters] : attributionResultJson.items()) {
     attributionRules_.push_back(rule.asString());

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/test/AggregationTestUtils.h
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/test/AggregationTestUtils.h
@@ -23,6 +23,7 @@
 #include "folly/logging/xlog.h"
 #include "folly/test/JsonTestUtil.h"
 
+#include "fbpcf/io/api/FileIOWrappers.h"
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/AggregationApp.h"
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/AggregationMetrics.h"
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/Constants.h"
@@ -82,10 +83,10 @@ runGameAndGenOutput(
   futureAlice.wait();
   futureBob.wait();
 
-  auto resAlice =
-      AggregationOutputMetrics::fromJson(fbpcf::io::read(outputPathAlice));
-  auto resBob =
-      AggregationOutputMetrics::fromJson(fbpcf::io::read(outputPathBob));
+  auto resAlice = AggregationOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathAlice));
+  auto resBob = AggregationOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathBob));
 
   return std::make_pair(resAlice, resBob);
 }
@@ -96,7 +97,7 @@ inline void verifyOutput(
     AggregationOutputMetrics resBob,
     std::string ouputJsonFileName) {
   folly::dynamic expectedOutput =
-      folly::parseJson(fbpcf::io::read(ouputJsonFileName));
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(ouputJsonFileName));
 
   FOLLY_EXPECT_JSON_EQ(
       folly::toJson(resAlice.toDynamic()), folly::toJson(expectedOutput));

--- a/fbpcs/emp_games/attribution/decoupled_attribution/test/AttributionTestUtils.h
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/test/AttributionTestUtils.h
@@ -28,7 +28,7 @@
 #include "fbpcs/emp_games/attribution/decoupled_attribution/AttributionOutput.h"
 #include "fbpcs/emp_games/attribution/decoupled_attribution/Constants.h"
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include "fbpcf/io/api/FileIOWrappers.h"
 
 namespace aggregation::private_attribution {
 
@@ -77,10 +77,10 @@ runGameAndGenOutputPUBLIC(
   futureAlice.wait();
   futureBob.wait();
 
-  auto resAlice =
-      AttributionOutputMetrics::fromJson(fbpcf::io::read(outputPathAlice));
-  auto resBob =
-      AttributionOutputMetrics::fromJson(fbpcf::io::read(outputPathBob));
+  auto resAlice = AttributionOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathAlice));
+  auto resBob = AttributionOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathBob));
 
   return std::make_pair(resAlice, resBob);
 }
@@ -115,10 +115,10 @@ runGameAndGenOutputXOR(
   futureAlice.wait();
   futureBob.wait();
 
-  auto resAlice =
-      AttributionOutputMetrics::fromJson(fbpcf::io::read(outputPathAlice));
-  auto resBob =
-      AttributionOutputMetrics::fromJson(fbpcf::io::read(outputPathBob));
+  auto resAlice = AttributionOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathAlice));
+  auto resBob = AttributionOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathBob));
 
   return std::make_pair(resAlice, resBob);
 }
@@ -130,7 +130,7 @@ inline void verifyOutput(
     AttributionOutputMetrics resBob,
     std::string ouputJsonFileName) {
   folly::dynamic expectedOutput =
-      folly::parseJson(fbpcf::io::read(ouputJsonFileName));
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(ouputJsonFileName));
 
   FOLLY_EXPECT_JSON_EQ(
       folly::toJson(resAlice.toDynamic()), folly::toJson(expectedOutput));

--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
@@ -18,7 +18,7 @@
 #include <folly/logging/xlog.h>
 #include <folly/test/JsonTestUtil.h>
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 
 namespace measurement::private_attribution {
 
@@ -35,7 +35,8 @@ class AggMetricsTest : public ::testing::Test {
 
 TEST_F(AggMetricsTest, TestParseSimpleMap) {
   auto inputPath = baseDir_ + "test_new_parser/simple_map.json";
-  auto parsedInput = folly::parseJson(fbpcf::io::read(inputPath));
+  auto parsedInput =
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(inputPath));
   auto metrics = private_measurement::AggMetrics::fromDynamic(parsedInput);
   XLOG(INFO) << metrics;
   EXPECT_EQ(metrics.getAtKey("measurement")->getIntValue(), 339959610281870460);
@@ -45,7 +46,8 @@ TEST_F(AggMetricsTest, TestParseSimpleMap) {
 TEST_F(AggMetricsTest, TestParseAttribution) {
   auto inputPath =
       baseDir_ + "shard_validation_test/valid_measurement_shard.json";
-  auto parsedInput = folly::parseJson(fbpcf::io::read(inputPath));
+  auto parsedInput =
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(inputPath));
   auto metrics = private_measurement::AggMetrics::fromDynamic(parsedInput);
   XLOG(INFO) << metrics;
   EXPECT_EQ(
@@ -81,7 +83,8 @@ TEST_F(AggMetricsTest, TestParseAttribution) {
 
 TEST_F(AggMetricsTest, TestParseLift) {
   auto inputPath = baseDir_ + "shard_validation_test/valid_lift_input.json";
-  auto parsedInput = folly::parseJson(fbpcf::io::read(inputPath));
+  auto parsedInput =
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(inputPath));
   auto metrics = private_measurement::AggMetrics::fromDynamic(parsedInput);
   XLOG(INFO) << metrics;
 
@@ -150,7 +153,7 @@ TEST_F(AggMetricsTest, TestParseInvalidMap) {
   auto inputPath = baseDir_ + "test_new_parser/invalid_map.json";
   EXPECT_DEATH(
       private_measurement::AggMetrics::fromDynamic(
-          folly::parseJson(fbpcf::io::read(inputPath))),
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(inputPath))),
       "Metric values should be integers");
 }
 } // namespace measurement::private_attribution

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include <emp-sh2pc/emp-sh2pc.h>
-
 #include <folly/Format.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
@@ -20,6 +19,7 @@
 
 #include <fbpcf/common/FunctionalUtil.h>
 #include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpGame.h>
 #include "AggMetrics.h"
 #include "ShardAggregatorGame.h"
@@ -82,8 +82,9 @@ std::vector<std::shared_ptr<AggMetrics>> ShardAggregatorApp::getInputData() {
       fbpcf::functional::map<std::string, std::shared_ptr<AggMetrics>>(
           inputPaths, [](const auto& inputPath) {
             XLOG(INFO) << "Opening file at <" << inputPath << ">";
-            return std::make_shared<AggMetrics>(AggMetrics::fromDynamic(
-                folly::parseJson(fbpcf::io::read(inputPath))));
+            return std::make_shared<AggMetrics>(
+                AggMetrics::fromDynamic(folly::parseJson(
+                    fbpcf::io::FileIOWrappers::readFile(inputPath))));
           });
   validateInputDataAggMetrics(inputData, metricsFormatType_);
   return inputData;
@@ -92,7 +93,8 @@ std::vector<std::shared_ptr<AggMetrics>> ShardAggregatorApp::getInputData() {
 void ShardAggregatorApp::putOutputData(
     const std::shared_ptr<AggMetrics>& metrics) {
   XLOG(INFO) << "putting out data ...";
-  fbpcf::io::write(outputPath_, folly::toJson(metrics->toDynamic()));
+  fbpcf::io::FileIOWrappers::writeFile(
+      outputPath_, folly::toJson(metrics->toDynamic()));
 }
 
 std::shared_ptr<AggMetrics> ShardAggregatorApp::revealMetrics(

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorAppTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorAppTest.cpp
@@ -14,7 +14,7 @@
 #include <folly/test/JsonTestUtil.h>
 #include <gtest/gtest.h>
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpGame.h>
 #include "../../common/TestUtil.h"
 #include "AggMetrics.h"
@@ -103,13 +103,15 @@ class ShardAggregatorAppTest : public ::testing::Test {
     futureAlice.wait();
     futureBob.wait();
 
-    auto resAlice = folly::parseJson(fbpcf::io::read(outputPathAlice_));
-    auto resBob = folly::parseJson(fbpcf::io::read(outputPathBob_));
+    auto resAlice =
+        folly::parseJson(fbpcf::io::FileIOWrappers::readFile(outputPathAlice_));
+    auto resBob =
+        folly::parseJson(fbpcf::io::FileIOWrappers::readFile(outputPathBob_));
 
-    folly::dynamic expectedOutAlice =
-        folly::parseJson(fbpcf::io::read(expectedAliceOutPath));
-    folly::dynamic expectedOutBob =
-        folly::parseJson(fbpcf::io::read(expectedBobOutPath));
+    folly::dynamic expectedOutAlice = folly::parseJson(
+        fbpcf::io::FileIOWrappers::readFile(expectedAliceOutPath));
+    folly::dynamic expectedOutBob = folly::parseJson(
+        fbpcf::io::FileIOWrappers::readFile(expectedBobOutPath));
 
     FOLLY_EXPECT_JSON_EQ(
         folly::toJson(resAlice), folly::toJson(expectedOutAlice));

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorGameTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorGameTest.cpp
@@ -18,7 +18,7 @@
 #include <folly/test/JsonTestUtil.h>
 #include <gtest/gtest.h>
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpGame.h>
 #include <fbpcf/mpc/EmpTestUtil.h>
 #include <fbpcf/mpc/QueueIO.h>
@@ -33,13 +33,15 @@ using AggMetricsTag = private_measurement::AggMetricsTag;
 class ShardAggregatorGameTest : public ::testing::Test {
  protected:
   folly::dynamic outputMetricsObjFromPath(const std::string& path) {
-    return folly::parseJson(fbpcf::io::read(baseDir_ + path));
+    return folly::parseJson(
+        fbpcf::io::FileIOWrappers::readFile(baseDir_ + path));
   }
 
   std::shared_ptr<AggMetrics> outputAggMetricsObjFromPath(
       const std::string& path) {
-    return std::make_shared<AggMetrics>(AggMetrics::fromDynamic(
-        folly::parseJson(fbpcf::io::read(baseDir_ + path))));
+    return std::make_shared<AggMetrics>(
+        AggMetrics::fromDynamic(folly::parseJson(
+            fbpcf::io::FileIOWrappers::readFile(baseDir_ + path))));
   }
 
   // asserts that actual and expected structures, but not inner values, are

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidationTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidationTest.cpp
@@ -13,7 +13,7 @@
 #include "folly/logging/xlog.h"
 
 #include <fbpcf/common/FunctionalUtil.h>
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 
 #include <gtest/gtest.h>
 
@@ -36,8 +36,9 @@ class ShardAggregatorValidationTest : public ::testing::Test {
 // Tests for ad object format validation
 TEST_F(ShardAggregatorValidationTest, AdObjectTestValidMeasurementInput) {
   auto validMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "valid_measurement_shard.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "valid_measurement_shard.json"))));
   auto validData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>({validMap});
   validateInputDataAggMetrics(validData, "ad_object");
@@ -45,8 +46,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestValidMeasurementInput) {
 
 TEST_F(ShardAggregatorValidationTest, AdObjectTestValidPCMInput) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "invalid_pcm_shard.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "invalid_pcm_shard.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -57,8 +59,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestValidPCMInput) {
 
 TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputLift) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "valid_lift_input.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "valid_lift_input.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -70,8 +73,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputLift) {
 
 TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputBadStructure) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "invalid_bad_structure.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "invalid_bad_structure.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -83,8 +87,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputBadStructure) {
 
 TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputEmptyMap0) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "invalid_empty_map_0.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "invalid_empty_map_0.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -96,8 +101,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputEmptyMap0) {
 
 TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputEmptyMap1) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "invalid_empty_map_1.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "invalid_empty_map_1.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -109,8 +115,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidInputEmptyMap1) {
 
 TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidAggregationName) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "invalid_aggregation_name.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "invalid_aggregation_name.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -123,8 +130,9 @@ TEST_F(ShardAggregatorValidationTest, AdObjectTestInvalidAggregationName) {
 // Tests for lift format validation
 TEST_F(ShardAggregatorValidationTest, LiftTestValidLiftInput) {
   auto validMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "valid_lift_input.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "valid_lift_input.json"))));
   auto validData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>({validMap});
   validateInputDataAggMetrics(validData, "lift");
@@ -132,8 +140,9 @@ TEST_F(ShardAggregatorValidationTest, LiftTestValidLiftInput) {
 
 TEST_F(ShardAggregatorValidationTest, LiftTestInvalidAdObjectInput) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "valid_measurement_shard.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "valid_measurement_shard.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -144,8 +153,9 @@ TEST_F(ShardAggregatorValidationTest, LiftTestInvalidAdObjectInput) {
 
 TEST_F(ShardAggregatorValidationTest, LiftTestInvalidInputEmptyMap) {
   auto invalidMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "invalid_empty_map_0.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "invalid_empty_map_0.json"))));
   auto invalidData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>(
           {invalidMap});
@@ -156,8 +166,9 @@ TEST_F(ShardAggregatorValidationTest, LiftTestInvalidInputEmptyMap) {
 
 TEST_F(ShardAggregatorValidationTest, LiftTestValidInputEmptyCohortMetrics) {
   auto validMap = std::make_shared<private_measurement::AggMetrics>(
-      private_measurement::AggMetrics::fromDynamic(folly::parseJson(
-          fbpcf::io::read(baseDir_ + "valid_lift_no_cohort_metrics.json"))));
+      private_measurement::AggMetrics::fromDynamic(
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              baseDir_ + "valid_lift_no_cohort_metrics.json"))));
   auto validData =
       std::vector<std::shared_ptr<private_measurement::AggMetrics>>({validMap});
 

--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -16,6 +16,7 @@
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/exception/ExceptionBase.h>
 #include <fbpcs/performance_tools/CostEstimation.h>
+#include <signal.h>
 #include "MainUtil.h"
 #include "ShardAggregatorApp.h"
 
@@ -51,6 +52,7 @@ int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   fbpcf::AwsSdk::aquire();
+  signal(SIGPIPE, SIG_IGN);
 
   XLOGF(INFO, "Party: {}", FLAGS_party);
   XLOGF(INFO, "Visibility: {}", FLAGS_visibility);

--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
@@ -10,7 +10,7 @@
 #include <gflags/gflags.h>
 #include "folly/logging/xlog.h"
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpApp.h>
 #include <fbpcf/mpc/EmpGame.h>
 
@@ -69,6 +69,6 @@ CalculatorGameConfig CalculatorApp::getInputData() {
 
 void CalculatorApp::putOutputData(const std::string& output) {
   XLOG(INFO) << "putting out data...";
-  fbpcf::io::write(outputPath_, output);
+  fbpcf::io::FileIOWrappers::writeFile(outputPath_, output);
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/CalculatorAppTest.cpp
@@ -14,7 +14,7 @@
 #include "folly/Format.h"
 #include "folly/Random.h"
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/mpc/EmpGame.h>
 #include "../../../common/Csv.h"
 #include "../CalculatorApp.h"
@@ -122,9 +122,11 @@ TEST_F(CalculatorAppTest, RandomInputTestVisibilityPublic) {
   GroupedLiftMetrics expectedRes;
   expectedRes.metrics = computedResult.toLiftMetrics();
 
-  auto resAlice =
-      GroupedLiftMetrics::fromJson(fbpcf::io::read(outputPathAlice_));
-  auto resBob = GroupedLiftMetrics::fromJson(fbpcf::io::read(outputPathBob_));
+  auto resAlice = GroupedLiftMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathAlice_));
+  auto resBob = GroupedLiftMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathBob_));
+
   EXPECT_EQ(expectedRes, resAlice);
   EXPECT_EQ(expectedRes, resBob);
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
@@ -80,7 +81,7 @@ void CalculatorApp<schedulerId>::putOutputData(
     const std::string& output,
     const std::string& outputPath) {
   XLOG(INFO) << "putting out data...";
-  fbpcf::io::write(outputPath, output);
+  fbpcf::io::FileIOWrappers::writeFile(outputPath, output);
 }
 
 template <int schedulerId>

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -15,11 +15,11 @@
 #include <gtest/gtest.h>
 #include "folly/Random.h"
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
-#include "fbpcf/io/FileManagerUtil.h"
 #include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/common/TestUtil.h"
 #include "fbpcs/emp_games/common/test/TestUtils.h"
@@ -138,10 +138,10 @@ class CalculatorAppTestFixture
 
     future0.get();
     future1.get();
-    auto publisherResult =
-        GroupedLiftMetrics::fromJson(fbpcf::io::read(publisherOutputPath));
-    auto partnerResult =
-        GroupedLiftMetrics::fromJson(fbpcf::io::read(partnerOutputPath));
+    auto publisherResult = GroupedLiftMetrics::fromJson(
+        fbpcf::io::FileIOWrappers::readFile(publisherOutputPath));
+    auto partnerResult = GroupedLiftMetrics::fromJson(
+        fbpcf::io::FileIOWrappers::readFile(partnerOutputPath));
 
     return useXorEncryption ? publisherResult ^ partnerResult : publisherResult;
   }
@@ -169,8 +169,9 @@ TEST_P(CalculatorAppTestFixture, TestCorrectness) {
       useTls,
       useXorEncryption);
 
-  auto expectedResult =
-      GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputPath));
+  auto expectedResult = GroupedLiftMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(expectedOutputPath));
+
   EXPECT_EQ(expectedResult, result);
 }
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
@@ -14,9 +14,9 @@
 #include <gtest/gtest.h>
 #include "folly/Random.h"
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/io/FileManagerUtil.h"
 #include "fbpcf/test/TestHelper.h"
 #include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/common/TestUtil.h"
@@ -122,8 +122,9 @@ TEST_P(CalculatorGameTestFixture, TestCorrectness) {
       schedulerCreator, std::move(publisherConfig), std::move(partnerConfig));
 
   // Read expected output from file
-  auto expectedRes =
-      GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputFilename));
+  auto expectedRes = GroupedLiftMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(expectedOutputFilename));
+
   EXPECT_EQ(expectedRes, res);
 }
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftCalculatorLocalTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftCalculatorLocalTest.cpp
@@ -18,7 +18,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <sys/types.h>
 #include "fbpcs/emp_games/common/TestUtil.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h"
@@ -240,8 +240,8 @@ TEST(LiftCalculatorLocalTest, JsonCorrectnessTest) {
       private_measurement::test_util::getBaseDirFromPath(__FILE__);
   std::string expectedOutputPath =
       baseDir + "../../../sample_input/correctness_output.json";
-  GroupedLiftMetrics expectedResult =
-      GroupedLiftMetrics::fromJson(fbpcf::io::read(expectedOutputPath));
+  GroupedLiftMetrics expectedResult = GroupedLiftMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(expectedOutputPath));
 
   auto result = getLiftMetrics();
   EXPECT_EQ(result, expectedResult);

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <fbpcf/io/FileManagerUtil.h>
-
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -117,7 +117,8 @@ class AggregationApp {
   void putOutputData(
       const AggregationOutputMetrics& aggregationOutput,
       std::string outputPath) {
-    fbpcf::io::write(outputPath, aggregationOutput.toJson());
+    fbpcf::io::FileIOWrappers::writeFile(
+        outputPath, aggregationOutput.toJson());
   }
 
  private:

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.cpp
@@ -18,8 +18,8 @@
 #include <utility>
 #include <vector>
 
-#include <fbpcf/common/FunctionalUtil.h>
 #include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "folly/json.h"
 #include "folly/logging/xlog.h"
 
@@ -225,8 +225,8 @@ AggregationInputMetrics::AggregationInputMetrics(
       inputSecretShareFilePath.string());
   // Reading the attribution results received from private attribution game in
   // an unordered_map.
-  auto attributionResultJson =
-      folly::parseJson(fbpcf::io::read(inputSecretShareFilePath));
+  auto attributionResultJson = folly::parseJson(
+      fbpcf::io::FileIOWrappers::readFile(inputSecretShareFilePath));
 
   for (const auto& [rule, formatters] : attributionResultJson.items()) {
     attributionRules_.push_back(rule.asString());

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
@@ -14,6 +14,7 @@
 #include "folly/Random.h"
 #include "folly/logging/xlog.h"
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
@@ -107,9 +108,9 @@ inline void testCorrectnessAggregationAppHelper(
   futureBob.get();
 
   auto resAlice = AggregationOutputMetrics::fromJson(
-      fbpcf::io::read(outputPathAlice.at(id)));
-  auto resBob =
-      AggregationOutputMetrics::fromJson(fbpcf::io::read(outputPathBob.at(id)));
+      fbpcf::io::FileIOWrappers::readFile(outputPathAlice.at(id)));
+  auto resBob = AggregationOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathBob.at(id)));
 
   if constexpr (outputVisibility == common::Visibility::Xor) {
     auto result = revealXORedResult(

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationTestUtils.h
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationTestUtils.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <gtest/gtest.h>
 
 #include "folly/dynamic.h"
@@ -23,7 +23,7 @@ inline void verifyOutput(
     AggregationOutputMetrics output,
     std::string outputJsonFileName) {
   folly::dynamic expectedOutput =
-      folly::parseJson(fbpcf::io::read(outputJsonFileName));
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(outputJsonFileName));
 
   FOLLY_EXPECT_JSON_EQ(
       folly::toJson(output.toDynamic()), folly::toJson(expectedOutput));

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -9,6 +9,8 @@
 
 #include <fbpcf/io/FileManagerUtil.h>
 
+#include <fbpcf/io/api/FileIOWrappers.h>
+#include <string>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -98,7 +100,8 @@ class AttributionApp {
   void putOutputData(
       const AttributionOutputMetrics& attributions,
       std::string outputPath) {
-    fbpcf::io::write(outputPath, attributions.toJson());
+    std::string content = attributions.toJson();
+    fbpcf::io::FileIOWrappers::writeFile(outputPath, content);
   }
 
  private:

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
@@ -14,6 +14,7 @@
 #include "folly/Random.h"
 #include "folly/logging/xlog.h"
 
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
@@ -92,9 +93,9 @@ inline void testCorrectnessAttributionAppHelper(
   futureBob.wait();
 
   auto resAlice = AttributionOutputMetrics::fromJson(
-      fbpcf::io::read(outputPathAlice.at(id)));
-  auto resBob =
-      AttributionOutputMetrics::fromJson(fbpcf::io::read(outputPathBob.at(id)));
+      fbpcf::io::FileIOWrappers::readFile(outputPathAlice.at(id)));
+  auto resBob = AttributionOutputMetrics::fromJson(
+      fbpcf::io::FileIOWrappers::readFile(outputPathBob.at(id)));
 
   auto result = revealXORedResult(resAlice, resBob, attributionRule.at(id));
 

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionTestUtils.h
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionTestUtils.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <fbpcf/io/FileManagerUtil.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
 #include <gtest/gtest.h>
 
 #include "folly/dynamic.h"
@@ -26,7 +26,7 @@ inline void verifyOutput(
     AttributionOutputMetrics output,
     std::string outputJsonFileName) {
   folly::dynamic expectedOutput =
-      folly::parseJson(fbpcf::io::read(outputJsonFileName));
+      folly::parseJson(fbpcf::io::FileIOWrappers::readFile(outputJsonFileName));
 
   FOLLY_EXPECT_JSON_EQ(
       folly::toJson(output.toDynamic()), folly::toJson(expectedOutput));


### PR DESCRIPTION
Summary: Migrate Test File to use FileIOWrappers:io:readFile

Differential Revision: D37401418

