### PR TITLE
Centralize PID Related Variables

### DIFF
--- a/fbpcs/pid/service/pid_service/utils.py
+++ b/fbpcs/pid/service/pid_service/utils.py
@@ -24,3 +24,12 @@ def get_pid_protocol_from_num_shards(
     if num_pid_containers == 1 and multikey_enabled:
         return PIDProtocol.UNION_PID_MULTIKEY
     return DEFAULT_PID_PROTOCOL
+
+
+def pid_should_use_row_numbers(
+    pid_use_row_numbers: bool, pid_protocol: PIDProtocol
+) -> bool:
+    if pid_use_row_numbers and pid_protocol is not PIDProtocol.UNION_PID_MULTIKEY:
+        return True
+    else:
+        return False

--- a/fbpcs/private_computation/entity/product_config.py
+++ b/fbpcs/private_computation/entity/product_config.py
@@ -8,8 +8,10 @@ from enum import Enum, IntEnum
 from typing import Any, Dict, Optional
 
 from dataclasses_json import dataclass_json, DataClassJsonMixin
+from fbpcs.pid.entity.pid_instance import PIDProtocol
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
 from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
+from fbpcs.private_computation.service.constants import DEFAULT_PID_PROTOCOL
 
 # This is the visibility defined in https://fburl.com/code/i1itu32l
 class ResultVisibility(IntEnum):
@@ -33,8 +35,11 @@ class CommonProductConfig:
                         because the lift id spine combiner uses a hard-coded value of 25.
                         TODO T104391012: pass padding size to lift id spine combiner.
         result_visibility: an enum indicating the visibility of results.
-        pid_use_row_numbers: his is used by Private ID protocol to indicate whether we should enable
+        pid_use_row_numbers: this is used by Private ID protocol to indicate whether we should enable
                                 'use-row-numbers' argument.
+        multikey_enabled: if it is true, then multiple identifier is used for PID matching; otherwise, only 1 key is used for PID matching.
+        pid_protocol: the PIDProtocol that is used for PID matching.
+        pid_max_column_count: this specifies how many indentifiers are used for PID matching.
         pid_configs: whether this should be in infra or product is controversial.
         post_processing_data: fields to be sent to the post processing tier.
     """
@@ -50,6 +55,9 @@ class CommonProductConfig:
     result_visibility: ResultVisibility = ResultVisibility.PUBLIC
 
     pid_use_row_numbers: bool = True
+    multikey_enabled: bool = False
+    pid_protocol: PIDProtocol = DEFAULT_PID_PROTOCOL
+    pid_max_column_count: int = 1
     pid_configs: Optional[Dict[str, Any]] = None
 
     post_processing_data: Optional[PostProcessingData] = None

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -14,10 +14,6 @@ from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.pid.service.pid_service.pid import PIDService
-from fbpcs.pid.service.pid_service.utils import (
-    get_max_id_column_cnt,
-    get_pid_protocol_from_num_shards,
-)
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -76,11 +72,6 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
 
         self._logger.info(f"[{self}] Starting id spine combiner service")
 
-        pid_protocol = get_pid_protocol_from_num_shards(
-            pc_instance.infra_config.num_pid_containers,
-            False if self._pid_svc is None else self._pid_svc.multikey_enabled,
-        )
-
         # TODO: we will write log_cost_to_s3 to the instance, so this function interface
         #   will get simplified
         container_instances = await start_combiner_service(
@@ -89,7 +80,7 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
             self._onedocker_binary_config_map,
             combine_output_path,
             log_cost_to_s3=self._log_cost_to_s3,
-            max_id_column_count=get_max_id_column_cnt(pid_protocol),
+            max_id_column_count=pc_instance.product_config.common.pid_max_column_count,
         )
         self._logger.info("Finished running CombinerService")
 

--- a/fbpcs/private_computation/stage_flows/private_computation_pid_migration_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pid_migration_test_stage_flow.py
@@ -138,14 +138,12 @@ class PrivateComputationPIDMigrationTestStageFlow(PrivateComputationBaseStageFlo
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
-                args.pid_svc.multikey_enabled,
             )
         elif self is self.PID_PREPARE:
             return PIDPrepareStageService(
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
-                args.pid_svc.multikey_enabled,
             )
         elif self is self.COMPUTE:
             return ComputeMetricsStageService(

--- a/fbpcs/private_computation/stage_flows/private_computation_pid_pa_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pid_pa_test_stage_flow.py
@@ -157,14 +157,12 @@ class PrivateComputationPIDPATestStageFlow(PrivateComputationBaseStageFlow):
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
-                args.pid_svc.multikey_enabled,
             )
         elif self is self.ID_MATCH:
             return PIDRunProtocolStageService(
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
-                args.pid_svc.multikey_enabled,
             )
         else:
             return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/stage_selector.py
+++ b/fbpcs/private_computation/stage_flows/stage_selector.py
@@ -67,14 +67,12 @@ class StageSelector:
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
-                args.pid_svc.multikey_enabled,
             )
         elif stage_flow.name == "ID_MATCH":
             return PIDRunProtocolStageService(
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
-                args.pid_svc.multikey_enabled,
             )
         elif stage_flow.name == "ID_MATCH_POST_PROCESS":
             return PostProcessingStageService(

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -84,12 +84,16 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             if pid_protocol is PIDProtocol.UNION_PID_MULTIKEY
             else 1
         )
-        pc_instance = self.create_sample_pc_instance(pc_role, test_num_containers)
+        pc_instance = self.create_sample_pc_instance(
+            pc_role=pc_role,
+            test_num_containers=test_num_containers,
+            multikey_enabled=multikey_enabled,
+            pid_max_column_count=max_col_cnt_expect,
+        )
         stage_svc = PIDPrepareStageService(
             storage_svc=self.mock_storage_svc,
             onedocker_svc=self.mock_onedocker_svc,
             onedocker_binary_config_map=self.onedocker_binary_config_map,
-            multikey_enabled=multikey_enabled,
         )
         containers = [
             self.create_container_instance(i) for i in range(test_num_containers)
@@ -135,6 +139,8 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         self,
         pc_role: PrivateComputationRole = PrivateComputationRole.PUBLISHER,
         test_num_containers: int = 1,
+        pid_max_column_count: int = 1,
+        multikey_enabled: bool = False,
         status: PrivateComputationInstanceStatus = PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
     ) -> PrivateComputationInstance:
         infra_config: InfraConfig = InfraConfig(
@@ -152,6 +158,8 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             input_path=self.input_path,
             output_dir=self.output_path,
             pid_use_row_numbers=True,
+            pid_max_column_count=pid_max_column_count,
+            multikey_enabled=multikey_enabled,
         )
         product_config: ProductConfig = LiftConfig(
             common=common,


### PR DESCRIPTION
Summary:
Why?
Currently, those variables are fragmented in different places. For example, mltikey_enabled is an attribute of PIDService which will be deprecated soon. And pid_use_row_number, and pid_config are attributes within pc_instance. What’s more, the PID protocol and max_col_cnt are not stored as attributes and we have to calculate them repeatedly in different PID stages.
So before deleting the PIDService, we centralized those variables in one place to increase code maintenance and decrease redundancy.

Detail:
In this diff, we instantiate the following variables when instantiating PrivateComputationInstance:
multikey_enabled
pid_protocol
max_column_count

Differential Revision: D37699936

