### PR TITLE
Adding terraform init implementation for terraform CLI init

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
@@ -20,10 +20,6 @@ class DeployBase(ABC):
         pass
 
     @abstractmethod
-    def init(self) -> None:
-        pass
-
-    @abstractmethod
     def plan(self) -> None:
         pass
 

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 
 @dataclass
@@ -14,3 +14,26 @@ class RunCommandReturn:
     return_code: int
     output: Optional[str]
     error: Optional[str]
+
+
+@dataclass
+class TerraformCliOptions:
+    state: str = "state"
+    target: str = "target"
+    var: str = "var"
+    var_file: str = "var_file"
+    parallelism: str = "parallelism"
+    terraform_input: str = "input"
+    backend_config: str = "backend_config"
+    reconfigure: str = "reconfigure"
+
+
+NOT_SUPPORTED_INIT_DEFAULT_OPTIONS: List[str] = [
+    TerraformCliOptions.state,
+    TerraformCliOptions.parallelism,
+]
+
+
+@dataclass
+class TerraformCommands:
+    init: str = "init"

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform.py
@@ -8,13 +8,17 @@
 import logging
 import sys
 from subprocess import PIPE, Popen
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from fbpcs.infra.pce_deployment_library.deploy_library.deploy_base.deploy_base import (
     DeployBase,
 )
 
-from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandReturn
+from fbpcs.infra.pce_deployment_library.deploy_library.models import (
+    RunCommandReturn,
+    TerraformCliOptions,
+    TerraformCommands,
+)
 from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_utils import (
     TerraformUtils,
 )
@@ -60,20 +64,49 @@ class Terraform(DeployBase):
     def destroy(self) -> None:
         pass
 
-    def init(self) -> None:
-        pass
+    def terraform_init(
+        self,
+        backend_config: Optional[Dict[str, str]] = None,
+        reconfigure: bool = False,
+        **kwargs: Dict[str, Any],
+    ) -> RunCommandReturn:
+        """
+        Implements `terraform init` of terraform CLI.
+        `terraform init` command is used to initialize a working directory containing Terraform configuration files.
+
+        More information: https://www.terraform.io/cli/commands/init
+
+        backend_config:
+            Provides backend config information using key-value pairs.
+            Usage:
+                terraform = Terraform()
+                terraform.terraform_init(backend_config = {"bucket": s3_bucket,"region": region})
+            More info: https://www.terraform.io/language/settings/backends/configuration#command-line-key-value-pairs
+
+        reconfigure:
+            in `terraform init` reconfigure disregards any existing configuration, preventing migration of any existing state.
+            More info: https://www.terraform.io/cli/commands/init#backend-initialization
+        """
+        options: Dict[str, Any] = kwargs.copy()
+        options.update(
+            {
+                TerraformCliOptions.backend_config: backend_config,
+                TerraformCliOptions.reconfigure: reconfigure,
+            }
+        )
+        options = self.utils.get_default_options(TerraformCommands.init, options)
+        return self.run_command("terraform init", **options)
 
     def plan(self) -> None:
         pass
 
     def run_command(
-        self,
-        command: str,
-        capture_output: bool = True,
+        self, command: str, capture_output: bool = True, **kwargs: Any
     ) -> RunCommandReturn:
         """
         Executes Terraform CLIs apply/destroy/init/plan
         """
+        options: Dict[str, Any] = kwargs.copy()
 
         if capture_output:
             stderr = PIPE
@@ -82,7 +115,7 @@ class Terraform(DeployBase):
             stderr = sys.stderr
             stdout = sys.stdout
 
-        command_list = self.utils.get_command_list(command)
+        command_list = self.utils.get_command_list(command, **options)
         command_str = " ".join(command_list)
         self.log.info(f"Command: {command_str}")
         out, err = None, None

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform.py
@@ -90,3 +90,6 @@ class TestTerraform(unittest.TestCase):
             self.assertEqual(test_command_return.return_code, func_ret.return_code)
             self.assertEqual(test_command_return.output, func_ret.output)
             self.assertEqual(test_command_return.error, func_ret.error)
+
+    def test_terraform_init(self) -> None:
+        pass


### PR DESCRIPTION
Summary:
**Context:**
These are series of diffs for terraform wrappers. Terraform is used by deploy.sh to bring up the AWS/GCP infrastructure.

**Change:**
This diff implements `terraform init` which is used to initialize the directory that has terraform files. More info about `terraform init` is added in the function docstring.

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37635866

