### PR TITLE
create update_generic_hook.py

### DIFF
--- a/fbpcs/common/entity/update_generic_hook.py
+++ b/fbpcs/common/entity/update_generic_hook.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Any, Callable, Iterable, Optional, TypeVar
+
+from fbpcs.common.entity.dataclasses_hooks import DataclassHook, HookEventType
+
+T = TypeVar("T")
+
+
+class UpdateGenericHook(DataclassHook[T]):
+    def __init__(
+        self,
+        update_function: Callable[[T], Any],
+        update_condition: Optional[Callable[[T], bool]] = None,
+        only_trigger_on_change: bool = True,
+        triggers: Optional[Iterable[HookEventType]] = None,
+    ) -> None:
+        pass
+
+    def run(
+        self,
+        instance: T,
+        field_name: str,
+        previous_field_value: Any,
+        new_field_value: Any,
+        hook_event: HookEventType,
+    ) -> None:
+        pass
+
+    @property
+    def triggers(self) -> Iterable[HookEventType]:
+        return self._triggers

--- a/fbpcs/common/tests/entity/test_update_generic_hook.py
+++ b/fbpcs/common/tests/entity/test_update_generic_hook.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyer-strict
+
+import unittest
+from dataclasses import dataclass
+
+from fbpcs.common.entity.instance_base import InstanceBase
+
+
+@dataclass
+class DummyInstance(InstanceBase):
+    """
+    Dummy instance class to be used in unit tests.
+
+    """
+
+
+class TestUpdateGenericHook(unittest.TestCase):
+    def test_init_event_update_generic_hook(self) -> None:
+        pass
+
+    def test_update_event_update_generic_hook(self) -> None:
+        pass


### PR DESCRIPTION
Summary:
# What & Why:
Right now, we have update_other_field_hook, frozen_field_hook, range_hook and generic_hook. I am adding 5th hook here in the hooks family.
This update_generic_hook is more powerful than update_other_field_hook.
update_other_field_hook: update some *other* field in this instance whenever this field gets updated.
update_generic_hook: do whatever you want in this instance whenever this field gets updated.

# Use case:
This hook will be used for status in InfraConfig class.

Reviewed By: jrodal98

Differential Revision: D37618879

