### PR TITLE
Remove libfb.py dependency from fbpcs unittest. unblock OSS repo test run

### DIFF
--- a/fbpcs/common/tests/test_stage_state_instance.py
+++ b/fbpcs/common/tests/test_stage_state_instance.py
@@ -5,14 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcs.common.entity.stage_state_instance import (
     StageStateInstance,
     StageStateInstanceStatus,
 )
-from libfb.py.testutil import data_provider, MagicMock
 
 
 class TestStageStateInstance(unittest.TestCase):
@@ -46,20 +45,27 @@ class TestStageStateInstance(unittest.TestCase):
     def test_elapsed_time(self) -> None:
         self.assertEqual(self.stage_state_instance.elapsed_time, 5)
 
-    @data_provider(
-        lambda: ({"container_stoppable": True}, {"container_stoppable": False})
-    )
     @patch("fbpcp.service.onedocker.OneDockerService")
-    def test_stop_containers(self, mock_onedocker_svc, container_stoppable) -> None:
-        mock_onedocker_svc.reset_mock()
-        if container_stoppable:
-            mock_onedocker_svc.stop_containers = MagicMock(return_value=[None, None])
-            self.stage_state_instance.stop_containers(mock_onedocker_svc)
-        else:
-            mock_onedocker_svc.stop_containers = MagicMock(return_value=[None, "Oops"])
-            with self.assertRaises(RuntimeError):
-                self.stage_state_instance.stop_containers(mock_onedocker_svc)
+    def test_stop_containers(self, mock_onedocker_svc) -> None:
+        for container_stoppable in (True, False):
+            with self.subTest(
+                "Subtest with container_stoppable: {container_stoppable}",
+                container_stoppable=container_stoppable,
+            ):
 
-        mock_onedocker_svc.stop_containers.assert_called_with(
-            ["test_container_instance_1", "test_container_instance_2"]
-        )
+                mock_onedocker_svc.reset_mock()
+                if container_stoppable:
+                    mock_onedocker_svc.stop_containers = MagicMock(
+                        return_value=[None, None]
+                    )
+                    self.stage_state_instance.stop_containers(mock_onedocker_svc)
+                else:
+                    mock_onedocker_svc.stop_containers = MagicMock(
+                        return_value=[None, "Oops"]
+                    )
+                    with self.assertRaises(RuntimeError):
+                        self.stage_state_instance.stop_containers(mock_onedocker_svc)
+
+                mock_onedocker_svc.stop_containers.assert_called_with(
+                    ["test_container_instance_1", "test_container_instance_2"]
+                )


### PR DESCRIPTION
Summary:
Remove libfb.py dependency from fbpcs
Code under fbpcs/ is open sourced. We have test code in the file mentioned in the title which references libfb.py. This is a problem because libfb.py is not open sourced (therefore, this test does not run in our OSS repo!).

Differential Revision: D37797458

