### PR TITLE
Adding pcs_features argument when create instance (#1265)

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -6,7 +6,7 @@
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Union
 
 from dataclasses_json import DataClassJsonMixin
 from fbpcs.common.entity.dataclasses_hooks import DataclassHookMixin, HookEventType
@@ -18,6 +18,7 @@ from fbpcs.post_processing_handler.post_processing_instance import (
     PostProcessingInstance,
 )
 from fbpcs.private_computation.entity.pce_config import PCEConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -102,6 +103,7 @@ class InfraConfig(DataClassJsonMixin, DataclassHookMixin):
     num_files_per_mpc_container: int
 
     tier: Optional[str] = None
+    pcs_features: Set[PCSFeature] = field(default_factory=set)
     pce_config: Optional[PCEConfig] = None
 
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     )
 
 import json
+import logging
 from datetime import datetime, timezone
-from logging import Logger
 
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcs.common.entity.instance_base import InstanceBase
@@ -41,6 +41,7 @@ from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
     PrivateComputationRole,
 )
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -234,7 +235,7 @@ class PrivateComputationInstance(InstanceBase):
         )
 
     def update_status(
-        self, new_status: PrivateComputationInstanceStatus, logger: Logger
+        self, new_status: PrivateComputationInstanceStatus, logger: logging.Logger
     ) -> None:
         old_status = self.infra_config.status
         self.infra_config.status = new_status
@@ -257,3 +258,12 @@ class PrivateComputationInstance(InstanceBase):
         if isinstance(last_instance, (PIDInstance, PCSMPCInstance, StageStateInstance)):
             server_ips_list = last_instance.server_ips or []
         return server_ips_list
+
+    def has_feature(self, feature: PCSFeature) -> bool:
+        if feature is PCSFeature.UNKNOWN:
+            logging.warning(
+                f"checking Unknown feature on instance {self.infra_config.instance_id}"
+            )
+            return False
+
+        return feature in self.infra_config.pcs_features

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -32,6 +32,7 @@ from fbpcs.private_computation.entity.infra_config import (
 )
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.pce_config import PCEConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
@@ -153,6 +154,7 @@ class PrivateComputationService:
         pid_use_row_numbers: bool = True,
         post_processing_data_optional: Optional[PostProcessingData] = None,
         pid_configs: Optional[Dict[str, Any]] = None,
+        pcs_features: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -172,6 +174,10 @@ class PrivateComputationService:
             instances=[],
             game_type=game_type,
             tier=tier,
+            pcs_features={
+                PCSFeature.from_str(feature)
+                for feature in unwrap_or_default(optional=pcs_features, default=[])
+            },
             pce_config=pce_config,
             _stage_flow_cls_name=unwrap_or_default(
                 optional=stage_flow_cls,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -29,6 +29,7 @@ from fbpcs.private_computation.entity.infra_config import (
     UnionedPCInstance,
 )
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -215,6 +216,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     hmac_key=self.test_hmac_key,
                     attribution_rule=AttributionRule.LAST_CLICK_1D,
                     aggregation_type=AggregationType.MEASUREMENT,
+                    pcs_features=[PCSFeature.PCS_DUMMY.value],
                 )
                 # check instance_repository.create is called with the correct arguments
                 # pyre-fixme[16]: Callable `create` has no attribute `assert_called`.
@@ -244,6 +246,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     int(yesterday_timestamp),
                     args.product_config.common.post_processing_data.dataset_timestamp,
                 )
+                self.assertTrue(args.has_feature(PCSFeature.PCS_DUMMY))
 
     @mock.patch("time.time", new=mock.MagicMock(return_value=1))
     def test_create_instance_mr_workflow(self) -> None:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/1265

## Why
* we need to have instance update to store feature list

## What
* adding feature sets in pc_instance.infra_config
* implement `has_feature` api

Reviewed By: gorel

Differential Revision: D37569964

