### PR TITLE
Add new aggregateMetric for shard combiner

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <folly/logging/xlog.h>
+
+#include <fbpcf/exception/exceptions.h>
+#include <fbpcf/frontend/mpcGame.h>
+#include <fbpcs/emp_games/common/Constants.h>
+#include <fbpcs/emp_games/common/Util.h>
+
+namespace shard_combiner {
+
+// Enum used to define the type of AggMetrics object,
+// We need this information to parse folly::dynamic objects to
+// AggMetrics object.
+enum class AggMetricType {
+  kValue, // used to define a metric type that holds the value defined by the
+          // type common::InputEncryption.
+
+  kList, // used to define a container that holds a list of AggMetrics object
+
+  kDict // used to define a container that holds a Dictionary of AggMetrics type
+};
+
+const size_t kMetricBitWidth = 64;
+
+template <int schedulerId, bool usingBatch = true>
+using SecInt = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecSignedInt<kMetricBitWidth, usingBatch>;
+
+template <
+    int schedulerId = 0,
+    bool usingBatch = false,
+    common::InputEncryption inputEncryption =
+        common::InputEncryption::Plaintext>
+class AggMetrics {
+ public:
+  using MetricsValue = int64_t;
+  using MetricsList = std::vector<
+      std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>>;
+  using MetricsDict = std::unordered_map<
+      std::string,
+      std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>>;
+  using MetricsVariant = std::variant<MetricsValue, MetricsList, MetricsDict>;
+  // add more types if necessary, like arithmetic secret share, constructor will
+  // assign as needed.
+  using SecMetricVariant = std::variant<SecInt<schedulerId, usingBatch>>;
+
+  explicit AggMetrics(MetricsValue val)
+      : type_{AggMetricType::kValue}, val_{val} {}
+
+  explicit AggMetrics(MetricsList& valList)
+      : type_{AggMetricType::kList}, val_(std::move(valList)) {}
+  explicit AggMetrics(MetricsDict& valDict)
+      : type_{AggMetricType::kDict}, val_(std::move(valDict)) {}
+
+  explicit AggMetrics(AggMetricType type) : type_{type} {
+    if (type_ == AggMetricType::kDict) {
+      val_ = MetricsDict{};
+    } else if (type_ == AggMetricType::kList) {
+      val_ = MetricsList{};
+    } else if (type_ == AggMetricType::kValue) {
+      val_ = MetricsValue{0};
+    } else {
+      std::string errMsg = folly::sformat(
+          "Construction not supported for: [{}], should be one of kValue(0), kList(1), or kDict(2)",
+          static_cast<std::underlying_type<AggMetricType>::type>(type));
+      XLOG(ERR) << errMsg;
+      throw common::exceptions::ConstructionError(errMsg);
+    }
+  }
+
+  // Adds rhs to self. this is the main function that performs the job of
+  // combining. Also, see `accumulateFinal()` for the complete understanding.
+  void accumulate(const std::shared_ptr<
+                  AggMetrics<schedulerId, usingBatch, inputEncryption>>& rhs);
+
+  AggMetricType getType() const {
+    return type_;
+  }
+
+  MetricsValue getValue() const;
+  SecInt<schedulerId, usingBatch> getSecValueXor() const {
+    return std::get<SecInt<schedulerId, usingBatch>>(secVal_);
+  }
+  const MetricsList& getAsList() const;
+  const MetricsDict& getAsDict() const;
+
+  void setValue(MetricsValue v);
+
+  // setter for XorSecretShareValue
+  void setSecValueXor(SecInt<schedulerId, usingBatch> v) {
+    secVal_ = std::move(v);
+  }
+
+  // Value is moved to val_.
+  void setList(MetricsList& v);
+
+  void pushBack(
+      std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>&
+          val);
+
+  // Value is moved to val_.
+  void setDict(MetricsDict& v);
+
+  // inserts a new/replace Metric at key
+  void insert(
+      std::pair<
+          std::string,
+          std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>>
+          kv);
+
+  // append metric to a list at key.
+  // creates a new entry if not exists.
+  void appendAtKey(
+      std::string key,
+      std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+          value);
+
+  // if dict looks up the key and returns the Metric shared pointer.
+  std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+      getAtKey(std::string) const;
+
+  // if list returns AggMetric shared pointer.
+  std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+  getAtIndex(size_t i) const;
+
+  // returns copy of a AggMetric. Does a deep copy.
+  static std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+  copy(const std::shared_ptr<
+       AggMetrics<schedulerId, usingBatch, inputEncryption>>& rhs);
+
+  // creates a Metrics blob with 0 initialized values following the schema
+  // of rhs.
+  static std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+  newLike(const std::shared_ptr<
+          AggMetrics<schedulerId, usingBatch, inputEncryption>>& rhs);
+
+  // Parses the Json into AggMetrics object.
+  static std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+  fromJson(std::string filePath);
+
+  // Emits dynamic object which can be converted to json
+  folly::dynamic toDynamic() const;
+
+  // writes object with indentation to the ostream obj.
+  void print(std::ostream& os, int32_t tabstop) const;
+
+  friend std::ostream& operator<<(
+      std::ostream& os,
+      const AggMetrics<schedulerId, usingBatch, inputEncryption>& metrics) {
+    metrics.print(os, 0);
+    return os;
+  }
+
+  friend std::ostream& operator<<(
+      std::ostream& os,
+      std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>
+          metrics) {
+    metrics->print(os, 0);
+    return os;
+  }
+
+ private:
+  // This is the actual accumulate operation that gets called on the leaf node.
+  // Reason for writing this function separately is that, newer backends
+  // can be easily configured. (like Arithemetic-SS for instance).
+  void accumulateFinal(
+      const std::shared_ptr<
+          AggMetrics<schedulerId, usingBatch, inputEncryption>>& rhs);
+
+  // helper for print
+  void printSpaces(std::ostream& os, int32_t n) const;
+
+  // Every metric should bear a type, can be either of List, Dict, Value.
+  AggMetricType type_;
+  // Holds the final value or another metric blob.
+  MetricsVariant val_;
+  // this is a std::variant because we'd like to support many frontend/backend
+  // interface like XOR-SS, Arithmetic, etc.
+  SecMetricVariant secVal_;
+};
+
+} // namespace shard_combiner


### PR DESCRIPTION
Summary:
# context
Contains the AggMetric header to support PCF2.0 computations.
This is version of the AggMetric.h is intended to be more generic to support XOR-SS, Arithmetic-SS or anything else. I have added comment to reflect this.
# Note
Splitting the diff. I'm not including this file in the targets file, will add later.

# Changes in this diff
1. Add new AggMetric header file.

Reviewed By: chualynn, ajinkya-ghonge

Differential Revision: D37618435

