### PR TITLE
We need to increase the timeout of compute stage in lift, to avoid timeout in CM.

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.pcf2_lift_stage_service import (
     PCF2LiftStageService,
 )
@@ -91,6 +92,7 @@ class PrivateComputationPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.PCF2_LIFT_COMPLETED,
         PrivateComputationInstanceStatus.PCF2_LIFT_FAILED,
         True,
+        timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,  # setting the timeout here to 12 hours, as lift stage can sometime take more time.
     )
     AGGREGATE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -10,6 +10,7 @@ from fbpcs.private_computation.entity.private_computation_status import (
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
@@ -91,6 +92,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.COMPUTATION_COMPLETED,
         PrivateComputationInstanceStatus.COMPUTATION_FAILED,
         True,
+        timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,  # setting the timeout here to 12 hours, as lift stage can sometime take more time.
     )
     AGGREGATE = PrivateComputationStageFlowData(
         PrivateComputationInstanceStatus.AGGREGATION_STARTED,


### PR DESCRIPTION
Summary:
# Context
After onboarding EP to bolt, we are getting timeouts in EP continuous measurement PL runs. This is because we have a default timeout of 1 hour for each MPC stage and for lift the EP CM runs takes 3 -5 hours approx.

# Fix
Thus in this diff, increasing the timeout for Compute stage in PCF 1.0 and PCF 2.0 PL stage flow.

Differential Revision: D37807126

