### PR TITLE
Set FBPCS_IMAGE_DIGEST sha in run_fbpcs.sh, add image digest in the log for easy troubleshooting

### DIFF
--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -35,3 +35,4 @@ PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 57600  # 8 hr instance sla, 2 tries per stage, total 16 hrs.
 
 FBPCS_GRAPH_API_TOKEN = "FBPCS_GRAPH_API_TOKEN"
+FBPCS_IMAGE_DIGEST = "FBPCS_IMAGE_DIGEST"

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -54,6 +54,7 @@ from docopt import docopt
 from fbpcs.bolt.read_config import parse_bolt_config
 from fbpcs.infra.logging_service.client.meta.client_manager import ClientManager
 from fbpcs.infra.logging_service.client.meta.data_model.lift_run_info import LiftRunInfo
+from fbpcs.pl_coordinator.constants import FBPCS_IMAGE_DIGEST
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
 from fbpcs.pl_coordinator.pl_study_runner import run_study
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
@@ -291,6 +292,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     logger = logging.getLogger(__name__)
     log_level = logging.DEBUG if arguments["--verbose"] else logging.INFO
     logger.setLevel(log_level)
+
+    logger.info(f"FBPCS_IMAGE_DIGEST: {os.getenv(FBPCS_IMAGE_DIGEST)}")
     # Concatenate all arguments to a string, with every argument wrapped by quotes.
     all_options = f"{sys.argv[1:]}"[1:-1].replace("', '", "' '")
     # E.g. Command line: private_computation_cli 'create_instance' 'partner_15464380' '--config=/tmp/tmp21ari0i6/config_local.yml' ...

--- a/fbpcs/scripts/run_fbpcs.sh
+++ b/fbpcs/scripts/run_fbpcs.sh
@@ -143,7 +143,8 @@ function run_fbpcs() {
     aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$FBPCS_CONTAINER_REPO_URL"
   fi
   docker pull "$docker_image"
-  docker run -e FBPCS_GRAPH_API_TOKEN --rm \
+  FBPCS_IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$docker_image")
+  docker run -e FBPCS_GRAPH_API_TOKEN -e FBPCS_IMAGE_DIGEST="$FBPCS_IMAGE_DIGEST" --rm \
     -v "$real_config_path":"$DOCKER_CONFIG_PATH" \
     -v "$REAL_INSTANCE_REPO":"$DOCKER_INSTANCE_REPO" \
     -v "$REAL_CREDENTIALS_PATH":"$DOCKER_CREDENTIALS_PATH" \


### PR DESCRIPTION
Summary:
## Why
During onboarding triage, it's hard to tell what's the version of the image bundle in the partner side's run.
for example, in previous posts https://fb.workplace.com/groups/331044242148818/permalink/525450086041565/
https://fb.workplace.com/groups/331044242148818/permalink/521810729738834/

It's a pain point for us to check whether partners are pulling the same docker image as publisher side tiers.

We want to see the image inspect in the log to help engineers to better troubleshooting
## What
Including image digest in the partner side log which helped us to narrow down the version of bundle caused the issues

* get image digest on shell script
** https://stackoverflow.com/questions/32046334/where-can-i-find-the-sha256-code-of-a-docker-image
* passing to docker run w/ `-e` to set env variable
* in CLI, get OS env, and print out in the log

Differential Revision: D37829033

