### PR TITLE
Passing pcs_features from graph API response to runner

### DIFF
--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -58,6 +58,7 @@ class PrivateComputationPartnerInstance(PrivateComputationCalcInstance):
         num_files_per_mpc_container: Optional[int] = None,
         k_anonymity_threshold: Optional[int] = None,
         result_visibility: Optional[ResultVisibility] = None,
+        pcs_features: Optional[List[str]] = None,
     ) -> None:
         super().__init__(instance_id, logger, PrivateComputationRole.PARTNER)
         self.config: Dict[str, Any] = config
@@ -86,6 +87,7 @@ class PrivateComputationPartnerInstance(PrivateComputationCalcInstance):
                 num_files_per_mpc_container=num_files_per_mpc_container,
                 k_anonymity_threshold=k_anonymity_threshold,
                 result_visibility=result_visibility,
+                pcs_features=pcs_features,
             )
 
         self.status = pc_instance.infra_config.status

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -74,6 +74,7 @@ def run_instance(
     num_tries: Optional[int] = 2,  # this is number of tries per stage
     dry_run: Optional[bool] = False,
     result_visibility: Optional[ResultVisibility] = None,
+    pcs_features: Optional[List[str]] = None,
 ) -> None:
     num_tries = num_tries if num_tries is not None else MAX_TRIES
     if num_tries < MIN_TRIES or num_tries > MAX_TRIES:
@@ -83,23 +84,24 @@ def run_instance(
         )
     client = PCGraphAPIClient(config, logger)
     instance_runner = PLInstanceRunner(
-        config,
-        instance_id,
-        input_path,
-        num_mpc_containers,
-        num_pid_containers,
-        logger,
-        client,
-        num_tries,
-        game_type,
-        dry_run,
-        stage_flow,
-        attribution_rule,
-        aggregation_type,
-        concurrency,
-        num_files_per_mpc_container,
-        k_anonymity_threshold,
-        result_visibility,
+        config=config,
+        instance_id=instance_id,
+        input_path=input_path,
+        num_mpc_containers=num_mpc_containers,
+        num_pid_containers=num_pid_containers,
+        logger=logger,
+        client=client,
+        num_tries=num_tries,
+        game_type=game_type,
+        dry_run=dry_run,
+        stage_flow=stage_flow,
+        attribution_rule=attribution_rule,
+        aggregation_type=aggregation_type,
+        concurrency=concurrency,
+        num_files_per_mpc_container=num_files_per_mpc_container,
+        k_anonymity_threshold=k_anonymity_threshold,
+        result_visibility=result_visibility,
+        pcs_features=pcs_features,
     )
     logger.info(f"Running private {game_type.name.lower()} for instance {instance_id}")
     instance_runner.run()
@@ -115,6 +117,7 @@ def run_instances(
     num_tries: Optional[int] = 2,  # this is number of tries per stage
     dry_run: Optional[bool] = False,
     result_visibility: Optional[ResultVisibility] = None,
+    pcs_features: Optional[List[str]] = None,
 ) -> None:
     if len(instance_ids) is not len(input_paths):
         raise PCStudyValidationException(
@@ -147,6 +150,7 @@ def run_instances(
                     "num_tries": num_tries,
                     "dry_run": dry_run,
                     "result_visibility": result_visibility,
+                    "pcs_features": pcs_features,
                 },
             ),
             instance_ids,
@@ -186,6 +190,7 @@ class PLInstanceRunner:
         num_files_per_mpc_container: Optional[int] = None,
         k_anonymity_threshold: Optional[int] = None,
         result_visibility: Optional[ResultVisibility] = None,
+        pcs_features: Optional[List[str]] = None,
     ) -> None:
         self.logger = logger
         self.instance_id = instance_id
@@ -207,6 +212,7 @@ class PLInstanceRunner:
             num_pid_containers=num_pid_containers,
             logger=logger,
             result_visibility=result_visibility,
+            pcs_features=pcs_features,
         )
         self.num_tries = num_tries
         self.dry_run = dry_run

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -8,7 +8,7 @@
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 import dateutil.parser
 import pytz
@@ -48,6 +48,7 @@ ATTRIBUTION_RULE = "attribution_rule"
 STATUS = "status"
 CREATED_TIME = "created_time"
 TIER = "tier"
+FEATURE_LIST = "feature_list"
 
 TERMINAL_STATUSES = [
     "POST_PROCESSING_HANDLERS_COMPLETED",
@@ -146,6 +147,10 @@ def run_attribution(
         )
     instance_data = _get_pa_instance_info(client, instance_id, logger)
     _check_version(instance_data, config)
+    # get the enabled features
+    pcs_features = _get_pcs_features(instance_data)
+    if pcs_features:
+        logger.info(f"Enabled features: {pcs_features}")
     num_pid_containers = instance_data[NUM_SHARDS]
     num_mpc_containers = instance_data[NUM_CONTAINERS]
 
@@ -166,6 +171,7 @@ def run_attribution(
         "num_files_per_mpc_container": num_files_per_mpc_container,
         "k_anonymity_threshold": k_anonymity_threshold,
         "num_tries": num_tries,
+        "pcs_features": pcs_features,
     }
     run_instance(**instance_parameters)
     logger.info(f"Finished running instances {instance_id}.")
@@ -218,6 +224,10 @@ def _check_version(
         raise IncorrectVersionError.make_error(
             instance["id"], expected_tier, config_tier
         )
+
+
+def _get_pcs_features(instance: Dict[str, Any]) -> Optional[List[str]]:
+    return instance.get(FEATURE_LIST)
 
 
 def get_attribution_dataset_info(

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -70,6 +70,7 @@ def create_instance(
     k_anonymity_threshold: Optional[int] = None,
     stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
     result_visibility: Optional[ResultVisibility] = None,
+    pcs_features: Optional[List[str]] = None,
 ) -> PrivateComputationInstance:
     pc_service = _build_private_computation_service(
         config["private_computation"],
@@ -101,6 +102,7 @@ def create_instance(
         stage_flow_cls=stage_flow_cls,
         pid_configs=config["pid"],
         result_visibility=result_visibility,
+        pcs_features=pcs_features,
     )
 
     logger.info(instance)

--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import random
+from typing import Any, List
+from unittest import TestCase
+from unittest.mock import patch, PropertyMock
+
+import requests
+
+from fbpcs.pl_coordinator import pl_study_runner
+
+
+class TestPlStudyRunner(TestCase):
+    @patch("logging.Logger")
+    @patch("fbpcs.pl_coordinator.pc_graphapi_utils.PCGraphAPIClient")
+    def setUp(
+        self,
+        mock_graph_api_client,
+        mock_logger,
+    ) -> None:
+        self.mock_graph_api_client = mock_graph_api_client
+        self.mock_logger = mock_logger
+        self.num_shards = 2
+        self.cell_id = str(random.randint(100, 200))
+        self.objective_id = str(random.randint(100, 200))
+        self.instance_id = str(random.randint(100, 200))
+        self.cell_obj_instances = {
+            self.cell_id: {
+                self.objective_id: {
+                    "latest_data_ts": 1645039053,
+                    "input_path": "https://input/path/to/input.csv",
+                    "num_shards": self.num_shards,
+                    "instance_id": self.instance_id,
+                    "status": "CREATED",
+                }
+            }
+        }
+
+    def test_get_pcs_features(self) -> None:
+        expected_features = ["dummy_feature1", "dummy_feature2"]
+        self.mock_graph_api_client.get_instance.return_value = (
+            self._get_graph_api_output("CREATED", expected_features)
+        )
+        tested_features = pl_study_runner._get_pcs_features(
+            self.cell_obj_instances, self.mock_graph_api_client
+        )
+        self.assertEqual(tested_features, expected_features)
+
+    def _get_graph_api_output(
+        self, status: str, feature_list: List[str]
+    ) -> requests.Response:
+        data = {"status": status, "feature_list": feature_list}
+        r = requests.Response()
+        r.status_code = 200
+        # pyre-ignore
+        type(r).text = PropertyMock(return_value=json.dumps(data))
+
+        def json_func(**kwargs) -> Any:
+            return data
+
+        r.json = json_func
+        return r

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -165,6 +165,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
             stage_flow_cls=None,
             pid_configs={"dependency": {"PIDInstanceRepository": None}},
             result_visibility=None,
+            pcs_features=None,
         )
 
     @patch(


### PR DESCRIPTION
Summary:
## Why
In previous Diff stack, we added `pcs_features` returned via graph API, this diff is to read the enabled features and pass into PC runner when create instance
## What
* Reading `pcs_features` from graph API returned
* Passing `pcs_features` into PL runner

Differential Revision: D37625194

