### PR TITLE
Remove if-else block from `get_command_list` function in class `TerraformDeploymentUtils` and replace with a factory

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -38,3 +38,15 @@ NOT_SUPPORTED_INIT_DEFAULT_OPTIONS: List[str] = [
 class TerraformCommands(str, Enum):
     INIT: str = "init"
     APPLY: str = "apply"
+
+
+class TerraformOptionFlag:
+    pass
+
+
+class FlaggedOption(TerraformOptionFlag):
+    pass
+
+
+class NotFlaggedOption(TerraformOptionFlag):
+    pass

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
@@ -23,3 +23,18 @@ class TestTerraformDeploymentUtils(unittest.TestCase):
     def test_get_command_list(self) -> None:
         # T125643785
         pass
+
+    def test_add_dict_options(self) -> None:
+        pass
+
+    def test_add_list_options(self) -> None:
+        pass
+
+    def test_add_bool_options(self) -> None:
+        pass
+
+    def test_add_flagged_option(self) -> None:
+        pass
+
+    def test_add_other_options(self) -> None:
+        pass


### PR DESCRIPTION
Summary:
**Context:**
These are series of diffs for terraform wrappers. Terraform is used by deploy.sh to bring up the AWS/GCP infrastructure.

**Change:**
For terraform supports terraform CLIs which helps in create/destroy cloud resources. To execute terraform we use python subprocess, which executes commands in a shell and returns the output back to the calling function. Subprocess accepts input command in list of string format. This diff creates this list.

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37845112

