### PR TITLE
create update_generic_hook for status_update_ts

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 import json
 import logging
-from datetime import datetime, timezone
 
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcs.common.entity.instance_base import InstanceBase
@@ -238,11 +237,8 @@ class PrivateComputationInstance(InstanceBase):
         self, new_status: PrivateComputationInstanceStatus, logger: logging.Logger
     ) -> None:
         old_status = self.infra_config.status
-        self.infra_config.status = new_status
         if old_status is not new_status:
-            self.infra_config.status_update_ts = int(
-                datetime.now(tz=timezone.utc).timestamp()
-            )
+            self.infra_config.status = new_status
             logger.info(
                 f"Updating status of {self.infra_config.instance_id} from {old_status} to {self.infra_config.status} at time {self.infra_config.status_update_ts}"
             )


### PR DESCRIPTION
Summary:
# Why:
The logic is: `status_update_ts` will record the time when status is updated. This was in `update_status` function in `PraviteComputationInstance.py`, After we have officially decoupled infra and product attributes, it will be much better to apply this in `InfraConfig` since both `status` and `status_update_ts` are in `InfraConfig` now.

# What:
create a `UpdateGenericHook` for `status`. Whenever `status` is updated, update `status_update_ts`. I am not using `UpdateOtherFieldHook` (Updates some *other* field in this instance whenever this field gets updated) here, because there are more to add in `post_update_status` function.

Reviewed By: gorel

Differential Revision: D37620672

