### PR TITLE
Set FBPCS_BUNDLE_ID ENV in Dockefile, passing bundle id when building image

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -f ./fbpcs/Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ github.event.inputs.new_tag }} .
+          docker build --build-arg FBPCS_BUNDLE_ID=${{ github.event.inputs.new_tag }} -f ./fbpcs/Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ github.event.inputs.new_tag }} .
 
       # Tests will be added here
 

--- a/fbpcs/Dockerfile
+++ b/fbpcs/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.8-slim
 
+# Set BUNDLE_ID ENV
+ARG FBPCS_BUNDLE_ID
+ENV FBPCS_BUNDLE_ID=${FBPCS_BUNDLE_ID:-0}
+RUN echo FBPCS_BUNDLE_ID=$FBPCS_BUNDLE_ID
+
 # Install Dependencies
 RUN apt-get update
 RUN apt-get install -y software-properties-common

--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -35,3 +35,4 @@ PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 57600  # 8 hr instance sla, 2 tries per stage, total 16 hrs.
 
 FBPCS_GRAPH_API_TOKEN = "FBPCS_GRAPH_API_TOKEN"
+FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -54,6 +54,7 @@ from docopt import docopt
 from fbpcs.bolt.read_config import parse_bolt_config
 from fbpcs.infra.logging_service.client.meta.client_manager import ClientManager
 from fbpcs.infra.logging_service.client.meta.data_model.lift_run_info import LiftRunInfo
+from fbpcs.pl_coordinator.constants import FBPCS_BUNDLE_ID
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
 from fbpcs.pl_coordinator.pl_study_runner import run_study
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
@@ -291,6 +292,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     logger = logging.getLogger(__name__)
     log_level = logging.DEBUG if arguments["--verbose"] else logging.INFO
     logger.setLevel(log_level)
+
+    logger.info(f"FBPCS_BUNDLE_ID: {os.getenv(FBPCS_BUNDLE_ID)}")
     # Concatenate all arguments to a string, with every argument wrapped by quotes.
     all_options = f"{sys.argv[1:]}"[1:-1].replace("', '", "' '")
     # E.g. Command line: private_computation_cli 'create_instance' 'partner_15464380' '--config=/tmp/tmp21ari0i6/config_local.yml' ...


### PR DESCRIPTION
Summary:
## Why
During onboarding triage, it's hard to tell what's the version of the image bundle in the partner side's run.
for example, in previous posts
https://fb.workplace.com/groups/331044242148818/permalink/525450086041565/
https://fb.workplace.com/groups/331044242148818/permalink/521810729738834/
It's a pain point for us to check whether partners are pulling the same docker image as publisher side tiers.
We want to see the image inspect in the log to help engineers to better troubleshooting

## What
* Add FBPCS_BUNDLE_ID ARG in docker file, make ENV FBPCS_BUNDLE_ID default 0 if no `--build-arg` pass in for backward compatible
* Add `--build-arg` in Github CI/CD, no deploement depency
* in CLI, get OS env, and print out in the log

## Next
* store bundle id into pcinstance as version

Differential Revision: D37861394

