### PR TITLE
Make computing publisher breakdowns optional with a flag

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp.h
@@ -31,6 +31,7 @@ class CalculatorApp {
           fbpcf::engine::communication::IPartyCommunicationAgentFactory>
           communicationAgentFactory,
       const int numConversionsPerUser,
+      const bool computePublisherBreakdowns,
       const int epoch,
       const std::vector<std::string>& inputPaths,
       const std::vector<std::string>& outputPaths,
@@ -40,6 +41,7 @@ class CalculatorApp {
       : party_{party},
         communicationAgentFactory_{std::move(communicationAgentFactory)},
         numConversionsPerUser_(numConversionsPerUser),
+        computePublisherBreakdowns_(computePublisherBreakdowns),
         epoch_(epoch),
         inputPaths_(inputPaths),
         outputPaths_(outputPaths),
@@ -65,6 +67,7 @@ class CalculatorApp {
   std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
       communicationAgentFactory_;
   int numConversionsPerUser_;
+  bool computePublisherBreakdowns_;
   int epoch_;
   std::vector<std::string> inputPaths_;
   std::vector<std::string> outputPaths_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -70,6 +70,7 @@ CalculatorGameConfig CalculatorApp<schedulerId>::getInputData(
   InputData inputData{
       inputPath,
       InputData::LiftMPCType::Standard,
+      computePublisherBreakdowns_,
       epoch_,
       numConversionsPerUser_};
   CalculatorGameConfig config = {inputData, true, numConversionsPerUser_};

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.cpp
@@ -22,9 +22,11 @@ namespace private_lift {
 InputData::InputData(
     std::string filepath,
     LiftMPCType liftMpcType,
+    bool computePublisherBreakdowns,
     int64_t epoch,
     int32_t numConversionsPerUser)
     : liftMpcType_{liftMpcType},
+      computePublisherBreakdowns_{computePublisherBreakdowns},
       epoch_{epoch},
       numConversionsPerUser_{numConversionsPerUser} {
   auto readLine = [&](const std::vector<std::string>& header,
@@ -173,9 +175,12 @@ void InputData::addFromCSV(
       // We use parsed + 1 because cohorts are zero-indexed
       numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
     } else if (column == "breakdown_id") {
-      breakdownIds_.push_back(parsed);
-      // We use parsed + 1 because breakdowns are zero-indexed
-      numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+      if (computePublisherBreakdowns_) {
+        breakdownIds_.push_back(parsed);
+
+        // We use parsed + 1 because breakdowns are zero-indexed
+        numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+      }
     } else if (column == "event_timestamp") {
       // When event_timestamp column presents (in standard Converter Lift
       // input), parse it as arrays of size 1.

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputData.h
@@ -30,6 +30,7 @@ class InputData {
   explicit InputData(
       std::string filepath,
       LiftMPCType liftMpcType,
+      bool computePublisherBreakdowns,
       int64_t epoch = 0,
       int32_t numConversionsPerUser = INT32_MAX);
 
@@ -154,6 +155,7 @@ class InputData {
       const std::vector<std::string>& parts);
 
   LiftMPCType liftMpcType_;
+  bool computePublisherBreakdowns_;
   int64_t epoch_;
   std::vector<bool> testPopulation_;
   std::vector<bool> controlPopulation_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
@@ -69,6 +69,7 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
     std::vector<std::string>& inputFilepaths,
     std::vector<std::string>& outputFilepaths,
     int numConversionsPerUser,
+    bool computePublisherBreakdowns,
     int epoch,
     bool useXorEncryption) {
   // aggregate scheduler statistics across apps
@@ -104,6 +105,7 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
         PARTY,
         std::move(communicationAgentFactory),
         numConversionsPerUser,
+        computePublisherBreakdowns,
         epoch,
         inputFilepaths,
         outputFilepaths,
@@ -130,6 +132,7 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
                 inputFilepaths,
                 outputFilepaths,
                 numConversionsPerUser,
+                computePublisherBreakdowns,
                 epoch,
                 useXorEncryption);
         schedulerStatistics.add(remainingStats);
@@ -149,6 +152,7 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFiles(
     std::string serverIp,
     int port,
     int numConversionsPerUser,
+    bool computePublisherBreakdowns,
     int epoch,
     bool useXorEncryption) {
   // use only as many threads as the number of files
@@ -163,6 +167,7 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFiles(
       inputFilepaths,
       outputFilepaths,
       numConversionsPerUser,
+      computePublisherBreakdowns,
       epoch,
       useXorEncryption);
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -86,6 +86,10 @@ DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",
     "s3 regioni name");
+DEFINE_bool(
+    compute_publisher_breakdowns,
+    true,
+    "To enable or disable computing publisher breakdown for result validation");
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
@@ -155,6 +159,7 @@ int main(int argc, char** argv) {
             FLAGS_server_ip,
             FLAGS_port,
             FLAGS_num_conversions_per_user,
+            FLAGS_compute_publisher_breakdowns,
             FLAGS_epoch,
             FLAGS_use_xor_encryption);
   } else if (FLAGS_party == common::PARTNER) {
@@ -168,6 +173,7 @@ int main(int argc, char** argv) {
             FLAGS_server_ip,
             FLAGS_port,
             FLAGS_num_conversions_per_user,
+            FLAGS_compute_publisher_breakdowns,
             FLAGS_epoch,
             FLAGS_use_xor_encryption);
   } else {

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -59,11 +59,13 @@ class AggregatorTest : public ::testing::Test {
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
+        true,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
+        true,
         epoch,
         numConversionsPerUser);
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -51,11 +51,13 @@ class AttributorTest : public ::testing::Test {
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
+        true,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
+        true,
         epoch,
         numConversionsPerUser);
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -33,6 +33,7 @@ template <int schedulerId>
 void runCalculatorApp(
     int myId,
     const int numConversionsPerUser,
+    const bool computePublisherBreakdowns,
     const int epoch,
     const std::string& inputPath,
     const std::string& outputPath,
@@ -55,6 +56,7 @@ void runCalculatorApp(
       myId,
       std::move(communicationAgentFactory),
       numConversionsPerUser,
+      computePublisherBreakdowns,
       epoch,
       std::vector<std::string>{inputPath},
       std::vector<std::string>{outputPath},
@@ -107,6 +109,7 @@ class CalculatorAppTestFixture
       const std::string& publisherOutputPath,
       const std::string& partnerOutputPath,
       const int numConversionsPerUser,
+      const bool computePublisherBreakdowns,
       bool useTls,
       bool useXorEncryption) {
     int epoch = 1546300800;
@@ -114,6 +117,7 @@ class CalculatorAppTestFixture
         runCalculatorApp<0>,
         0,
         numConversionsPerUser,
+        computePublisherBreakdowns,
         epoch,
         publisherInputPath,
         publisherOutputPath,
@@ -127,6 +131,7 @@ class CalculatorAppTestFixture
         runCalculatorApp<1>,
         1,
         numConversionsPerUser,
+        computePublisherBreakdowns,
         epoch,
         partnerInputPath,
         partnerOutputPath,
@@ -166,6 +171,7 @@ TEST_P(CalculatorAppTestFixture, TestCorrectness) {
       publisherOutputPath_,
       partnerOutputPath_,
       numConversionsPerUser,
+      true,
       useTls,
       useXorEncryption);
 
@@ -199,6 +205,7 @@ TEST_P(CalculatorAppTestFixture, TestCorrectnessRandomInput) {
       publisherOutputPath_,
       partnerOutputPath_,
       numConversionsPerUser,
+      true,
       useTls,
       useXorEncryption);
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorGameTest.cpp
@@ -46,11 +46,13 @@ class CalculatorGameTestFixture
  public:
   CalculatorGameConfig getInputData(
       const std::filesystem::path& inputPath,
-      int numConversionsPerUser) {
+      int numConversionsPerUser,
+      bool computePublisherBreakdowns) {
     int64_t epoch = 1546300800;
     InputData inputData{
         inputPath,
         InputData::LiftMPCType::Standard,
+        computePublisherBreakdowns,
         epoch,
         numConversionsPerUser};
     CalculatorGameConfig config = {inputData, true, numConversionsPerUser};
@@ -106,10 +108,12 @@ TEST_P(CalculatorGameTestFixture, TestCorrectness) {
   CalculatorGameConfig publisherConfig =
       CalculatorGameTestFixture::getInputData(
           baseDir + "../sample_input/publisher_unittest3.csv",
-          numConversionsPerUser);
+          numConversionsPerUser,
+          true);
   CalculatorGameConfig partnerConfig = CalculatorGameTestFixture::getInputData(
       baseDir + "../sample_input/partner_2_convs_unittest.csv",
-      numConversionsPerUser);
+      numConversionsPerUser,
+      true);
   std::string expectedOutputFilename =
       baseDir + "../sample_input/correctness_output.json";
 
@@ -144,9 +148,9 @@ TEST_P(CalculatorGameTestFixture, TestCorrectnessRandomInput) {
   testDataGenerator.genFakePartnerInputFile(partnerInputFilename_, params);
   CalculatorGameConfig publisherConfig =
       CalculatorGameTestFixture::getInputData(
-          publisherInputFilename_, numConversionsPerUser);
+          publisherInputFilename_, numConversionsPerUser, true);
   CalculatorGameConfig partnerConfig = CalculatorGameTestFixture::getInputData(
-      partnerInputFilename_, numConversionsPerUser);
+      partnerInputFilename_, numConversionsPerUser, true);
 
   // Run calculator game with test input
   const bool unsafe = true;

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputDataTest.cpp
@@ -38,7 +38,11 @@ class InputDataTest : public ::testing::Test {
 
 TEST_F(InputDataTest, TestInputDataPublisher) {
   InputData inputData{
-      aliceInputFilename_, InputData::LiftMPCType::Standard, 1546300800, 4};
+      aliceInputFilename_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800,
+      4};
   std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
                                             0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
   std::vector<bool> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
@@ -58,7 +62,11 @@ TEST_F(InputDataTest, TestInputDataPublisher) {
 
 TEST_F(InputDataTest, TestInputDataPublisherOppColLast) {
   InputData inputData{
-      aliceInputFilename2_, InputData::LiftMPCType::Standard, 1546300800, 4};
+      aliceInputFilename2_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800,
+      4};
   std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
                                             0, 0, 0, 1, 1, 0, 0, 1, 0, 0};
   std::vector<bool> expectControlPopulation = {1, 0, 0, 0, 0, 0, 1, 1, 1, 1,
@@ -80,6 +88,7 @@ TEST_F(InputDataTest, TestInputDataPartner) {
   InputData inputData{
       bobInputFilename_,
       InputData::LiftMPCType::Standard,
+      true,
       1546300800, /* epoch */
       4 /* num_conversions_per_user */};
   std::vector<std::vector<uint32_t>> expectGetPurchaseTimestampArrays = {
@@ -125,6 +134,7 @@ TEST_F(InputDataTest, TestInputDataPartnerConverterLift) {
   InputData inputData{
       bobInputFilename2_,
       InputData::LiftMPCType::Standard,
+      true,
       0, /* epoch */
       1 /* num_conversions_per_user */};
   std::vector<std::vector<uint32_t>> expectGetPurchaseTimestamps = {
@@ -148,6 +158,7 @@ TEST_F(InputDataTest, TestGetBitmaskFor) {
   InputData inputData{
       bobInputFilename_,
       InputData::LiftMPCType::Standard,
+      true,
       1546300800, /* epoch */
       4 /* num_conversions_per_user */};
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -49,11 +49,13 @@ class InputProcessorTest : public ::testing::Test {
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
+        true,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
+        true,
         epoch,
         numConversionsPerUser);
 


### PR DESCRIPTION
Summary: Added a flag to allow enable/disable computing publisher breakdowns instead of always computing by default. A separated diff will be created for adding unittests for computePublisherBreakdowns=false case.

Reviewed By: chualynn

Differential Revision: D37835278

