### PR TITLE
Renaming `RunCommandReturn` to `RunCommandResult` and `TerraformCommands` to `TerraformCommand`

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
@@ -7,12 +7,12 @@
 
 from abc import ABC, abstractmethod
 
-from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandReturn
+from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandResult
 
 
 class DeployBase(ABC):
     @abstractmethod
-    def create(self) -> RunCommandReturn:
+    def create(self) -> RunCommandResult:
         pass
 
     @abstractmethod
@@ -24,5 +24,5 @@ class DeployBase(ABC):
         pass
 
     @abstractmethod
-    def run_command(self) -> RunCommandReturn:
+    def run_command(self) -> RunCommandResult:
         pass

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 
 @dataclass
-class RunCommandReturn:
+class RunCommandResult:
     return_code: int
     output: Optional[str]
     error: Optional[str]
@@ -35,7 +35,7 @@ NOT_SUPPORTED_INIT_DEFAULT_OPTIONS: List[str] = [
 ]
 
 
-class TerraformCommands(str, Enum):
+class TerraformCommand(str, Enum):
     INIT: str = "init"
     APPLY: str = "apply"
 

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -38,3 +38,15 @@ NOT_SUPPORTED_INIT_DEFAULT_OPTIONS: List[str] = [
 class TerraformCommands(str, Enum):
     INIT: str = "init"
     APPLY: str = "apply"
+
+
+class TerraformOptionFlag:
+    pass
+
+
+class FlaggedOption(TerraformOptionFlag):
+    pass
+
+
+class NotFlaggedOption(TerraformOptionFlag):
+    pass

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment.py
@@ -15,9 +15,9 @@ from fbpcs.infra.pce_deployment_library.deploy_library.deploy_base.deploy_base i
 )
 
 from fbpcs.infra.pce_deployment_library.deploy_library.models import (
-    RunCommandReturn,
+    RunCommandResult,
     TerraformCliOptions,
-    TerraformCommands,
+    TerraformCommand,
 )
 from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_deployment_utils import (
     TerraformDeploymentUtils,
@@ -66,7 +66,7 @@ class TerraformDeployment(DeployBase):
         terraform_input: bool = False,
         auto_approve: bool = True,
         **kwargs: Dict[str, Any],
-    ) -> RunCommandReturn:
+    ) -> RunCommandResult:
         """
         Implements `terraform apply` of terraform CLI.
         `terraform apply` command executes the actions proposed in a `terraform plan`.
@@ -84,7 +84,7 @@ class TerraformDeployment(DeployBase):
         options: Dict[str, Any] = kwargs.copy()
         options["input"] = terraform_input
         options["auto-approve"] = auto_approve  # a False value will require an input
-        options = self.utils.get_default_options(TerraformCommands.APPLY, options)
+        options = self.utils.get_default_options(TerraformCommand.APPLY, options)
         return self.run_command("terraform apply", **options)
 
     def destroy(self) -> None:
@@ -95,7 +95,7 @@ class TerraformDeployment(DeployBase):
         backend_config: Optional[Dict[str, str]] = None,
         reconfigure: bool = False,
         **kwargs: Dict[str, Any],
-    ) -> RunCommandReturn:
+    ) -> RunCommandResult:
         """
         Implements `terraform init` of terraform CLI.
         `terraform init` command is used to initialize a working directory containing Terraform configuration files.
@@ -120,7 +120,7 @@ class TerraformDeployment(DeployBase):
                 TerraformCliOptions.reconfigure: reconfigure,
             }
         )
-        options = self.utils.get_default_options(TerraformCommands.INIT, options)
+        options = self.utils.get_default_options(TerraformCommand.INIT, options)
         return self.run_command("terraform init", **options)
 
     def plan(self) -> None:
@@ -128,7 +128,7 @@ class TerraformDeployment(DeployBase):
 
     def run_command(
         self, command: str, capture_output: bool = True, **kwargs: Any
-    ) -> RunCommandReturn:
+    ) -> RunCommandResult:
         """
         Executes Terraform CLIs apply/destroy/init/plan
         """
@@ -158,4 +158,4 @@ class TerraformDeployment(DeployBase):
                 out = None
                 err = None
 
-        return RunCommandReturn(return_code=ret_code, output=out, error=err)
+        return RunCommandResult(return_code=ret_code, output=out, error=err)

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
@@ -8,8 +8,10 @@
 from typing import Any, Dict, List, Optional
 
 from fbpcs.infra.pce_deployment_library.deploy_library.models import (
+    FlaggedOption,
     NOT_SUPPORTED_INIT_DEFAULT_OPTIONS,
     TerraformCliOptions,
+    TerraformOptionFlag,
 )
 
 
@@ -64,24 +66,22 @@ class TerraformDeploymentUtils:
 
         commands_list = command.split()
 
+        type_to_func_dict = {
+            type({}): self.add_dict_options,
+            type([]): self.add_list_options,
+            type(True): self.add_bool_options,
+            type(TerraformOptionFlag): self.add_flagged_option,
+        }
+
         for key, value in kwargs.items():
             # terraform CLI accepts options with "-" using "_" will results in error
             key = key.replace("_", "-")
 
-            if isinstance(value, list):
-                for inner_value in value:
-                    commands_list.append(f"-{key}={inner_value}")
-            elif isinstance(value, dict):
-                if "backend-config" in key:
-                    commands_list.extend(
-                        [f"-backend-config {k}={v}" for k, v in value.items()]
-                    )
-                # TODO: read var in kwargs and update commands
-            elif isinstance(value, bool):
-                value = "true" if value else "false"
-                commands_list.append(f"-{key}={value}")
-            elif value is not None:
-                commands_list.append(f"-{key}={value}")
+            # pyre-fixme
+            func = type_to_func_dict.get(type(value), self.add_other_options)
+
+            # pyre-fixme
+            commands_list.extend(func(key, value))
 
         # Add args to commands list
         commands_list.extend(args)
@@ -109,3 +109,80 @@ class TerraformDeploymentUtils:
                 return_dict.pop(default_option, None)
 
         return return_dict
+
+    def add_dict_options(self, key: str, value: Dict[str, Any]) -> List[str]:
+        """
+        Adds dict options in Terraform CLI:
+        Eg: t = TerraformDeploymentUtils()
+        options = {"backend_config": {"region": "us-west-2", "access_key":"fake_access_key"}}
+        t.get_command_list("terraform apply")
+
+        Returns:
+        => ['terraform', 'apply', '-backend-config region=us-west-2', '-backend-config access_key=fake_access_key']
+        """
+        commands_list: List[str] = []
+        if "backend-config" in key:
+            commands_list.extend([f"-backend-config {k}={v}" for k, v in value.items()])
+        elif "var" in key:
+            commands_list.extend([f"-var {k}={v}" for k, v in value.items()])
+        return commands_list
+
+    def add_list_options(self, key: str, value: List[str]) -> List[str]:
+        """
+        Adds list options in Terraform CLI:
+        Eg: t = TerraformDeploymentUtils()
+        options = {"target": ["aws_s3_bucket_object.objects[2]", "aws_s3_bucket_object.objects[3]"]}
+        t.get_command_list("terraform apply")
+
+        Returns:
+        => ['terraform', 'apply', '-target=aws_s3_bucket_object.objects[2]', '-target=aws_s3_bucket_object.objects[3]']
+        """
+        commands_list: List[str] = []
+        for val in value:
+            commands_list.append(f"-{key}={val}")
+        return commands_list
+
+    def add_bool_options(self, key: str, value: bool) -> List[str]:
+        """
+        Adds bool options in Terraform CLI:
+        Eg: t = TerraformDeploymentUtils()
+        options = {"input": False}
+        t.get_command_list("terraform apply")
+
+        Returns:
+        => ['terraform', 'apply', '-input false']
+        """
+        commands_list: List[str] = []
+        ret_value: str = "true" if value else "false"
+        commands_list.append(f"-{key}={ret_value}")
+        return commands_list
+
+    def add_flagged_option(self, key: str, value: TerraformOptionFlag) -> List[str]:
+        """
+        Adds flag options in Terraform CLI:
+        Eg: t = TerraformDeploymentUtils()
+        options = {"reconfigure": FlaggedOption}
+        t.get_command_list("terraform init")
+
+        Returns:
+        => ['terraform', 'init', '-reconfigure']
+        """
+        commands_list: List[str] = []
+        if value == FlaggedOption:
+            commands_list.append(f"-{key}")
+        return commands_list
+
+    def add_other_options(self, key: str, value: str) -> List[str]:
+        """
+        Adds default options in Terraform CLI:
+        Eg: t = TerraformDeploymentUtils()
+        options = {"target": "aws_s3_bucket_object.objects[2]"}
+        t.get_command_list("terraform init")
+
+        Returns:
+        => ['terraform', 'init', '-target=aws_s3_bucket_object.objects[2]']
+        """
+        commands_list: List[str] = []
+        if value is not None:
+            commands_list.append(f"-{key}={value}")
+        return commands_list

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
@@ -9,7 +9,7 @@
 import unittest
 from subprocess import PIPE, Popen
 
-from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandReturn
+from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandResult
 
 from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_deployment import (
     TerraformDeployment,
@@ -27,7 +27,7 @@ class TestTerraformDeployment(unittest.TestCase):
             test_obj = Popen(["echo", "Hello World!"], stdout=PIPE)
             test_stdout, test_error = test_obj.communicate()
             test_return_code = test_obj.returncode
-            test_command_return = RunCommandReturn(
+            test_command_return = RunCommandResult(
                 return_code=test_return_code,
                 output=test_stdout.decode("utf-8"),
                 error=test_error if test_error else "",
@@ -46,7 +46,7 @@ class TestTerraformDeployment(unittest.TestCase):
             test_obj = Popen(["echo", "Hello World!"])
             test_stdout, test_error = test_obj.communicate()
             test_return_code = test_obj.returncode
-            test_command_return = RunCommandReturn(
+            test_command_return = RunCommandResult(
                 return_code=test_return_code,
                 output=test_stdout,
                 error=test_stdout,
@@ -66,7 +66,7 @@ class TestTerraformDeployment(unittest.TestCase):
             func_ret = self.terraform.run_command(
                 command=command, capture_output=capture_output
             )
-            test_command_return = RunCommandReturn(
+            test_command_return = RunCommandResult(
                 return_code=1,
                 output="",
                 error="cp: missing file operand\nTry 'cp --help' for more information.\n",
@@ -82,7 +82,7 @@ class TestTerraformDeployment(unittest.TestCase):
             func_ret = self.terraform.run_command(
                 command=command, capture_output=capture_output
             )
-            test_command_return = RunCommandReturn(
+            test_command_return = RunCommandResult(
                 return_code=1,
                 output=None,
                 error=None,

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
@@ -23,3 +23,18 @@ class TestTerraformDeploymentUtils(unittest.TestCase):
     def test_get_command_list(self) -> None:
         # T125643785
         pass
+
+    def test_add_dict_options(self) -> None:
+        pass
+
+    def test_add_list_options(self) -> None:
+        pass
+
+    def test_add_bool_options(self) -> None:
+        pass
+
+    def test_add_flagged_option(self) -> None:
+        pass
+
+    def test_add_other_options(self) -> None:
+        pass


### PR DESCRIPTION
Summary:
**Change:**
Renaming the dataclass and enum classes based on the review comments on diff D37774333 (https://github.com/facebookresearch/fbpcs/commit/53b1442356f5be2e007219bf818229361d7f1a1f)

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37872404

