### PR TITLE
set _stage_flow_cls_name immutable

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -163,8 +163,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
 
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name
-    # TODO: _stage_flow_cls_name should be immutable
-    _stage_flow_cls_name: str = "PrivateComputationStageFlow"
+    _stage_flow_cls_name: str = immutable_field(default="PrivateComputationStageFlow")
 
     retry_counter: int = 0
     creation_ts: int = immutable_field(default_factory=lambda: int(time.time()))

--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -39,6 +39,7 @@ from fbpcs.service.workflow_sfn import SfnWorkflowService
 class TestPIDMRStageService(IsolatedAsyncioTestCase):
     @patch("fbpcs.private_computation.service.pid_mr_stage_service.PIDMRStageService")
     async def test_run_async(self, pid_mr_svc_mock) -> None:
+        flow = PrivateComputationMRStageFlow
         infra_config: InfraConfig = InfraConfig(
             instance_id="publisher_123",
             role=PrivateComputationRole.PUBLISHER,
@@ -50,6 +51,7 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=1,
             num_files_per_mpc_container=1,
             status_updates=[],
+            _stage_flow_cls_name=flow.get_cls_name(),
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/input.csv",
@@ -70,8 +72,6 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
             infra_config=infra_config,
             product_config=product_config,
         )
-        flow = PrivateComputationMRStageFlow
-        pc_instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         service = SfnWorkflowService("us-west-2", "access_key", "access_data")
         service.start_workflow = MagicMock(return_value="execution_arn")

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -466,7 +466,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         status = flow.ID_MATCH.previous_stage.completed_status
 
         instance = self.create_sample_instance(status)
-        instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         self.assertEqual(flow.ID_MATCH, instance.get_next_runnable_stage())
 
@@ -475,7 +474,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         status = flow.ID_MATCH.failed_status
 
         instance = self.create_sample_instance(status)
-        instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         self.assertEqual(flow.ID_MATCH, instance.get_next_runnable_stage())
 
@@ -484,7 +482,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         status = flow.ID_MATCH.started_status
 
         instance = self.create_sample_instance(status)
-        instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         self.assertEqual(None, instance.get_next_runnable_stage())
 
@@ -493,7 +490,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         status = flow.get_last_stage().completed_status
 
         instance = self.create_sample_instance(status)
-        instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         self.assertEqual(None, instance.get_next_runnable_stage())
 
@@ -506,7 +502,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         status = flow.ID_MATCH.previous_stage.completed_status
 
         instance = self.create_sample_instance(status)
-        instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         self.private_computation_service.instance_repository.read = MagicMock(
             return_value=instance
@@ -524,7 +519,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         status = flow.get_last_stage().completed_status
 
         instance = self.create_sample_instance(status)
-        instance.infra_config._stage_flow_cls_name = flow.get_cls_name()
 
         with self.assertRaises(PrivateComputationServiceInvalidStageError):
             self.private_computation_service.run_next(instance.infra_config.instance_id)


### PR DESCRIPTION
Summary:
# What:
Setting  _stage_flow_cls_name as immutable.

Some re-assignments of `_stage_flow_cls_name` after creating `PCInstance` are deleted. Since ` _stage_flow_cls_name` now is immutable, we can only assign it when creation.

Reviewed By: gorel

Differential Revision: D37811631

