### PR TITLE
Add unittests for without computing publisher breakdowns

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -56,16 +56,17 @@ class AggregatorTest : public ::testing::Test {
         baseDir + "../sample_input/partner_2_convs_unittest.csv";
     int numConversionsPerUser = 2;
     int epoch = 1546300800;
+    bool computePublisherBreakdowns = true;
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
-        true,
+        computePublisherBreakdowns,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
-        true,
+        computePublisherBreakdowns,
         epoch,
         numConversionsPerUser);
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -48,16 +48,17 @@ class AttributorTest : public ::testing::Test {
         baseDir + "../sample_input/partner_2_convs_unittest.csv";
     int numConversionsPerUser = 2;
     int epoch = 1546300800;
+    bool computePublisherBreakdowns = true;
     auto publisherInputData = InputData(
         publisherInputFilename,
         InputData::LiftMPCType::Standard,
-        true,
+        computePublisherBreakdowns,
         epoch,
         numConversionsPerUser);
     auto partnerInputData = InputData(
         partnerInputFilename,
         InputData::LiftMPCType::Standard,
-        true,
+        computePublisherBreakdowns,
         epoch,
         numConversionsPerUser);
 


### PR DESCRIPTION
Summary: Added unittests for testing computePublisherBreakdowns=false case.

Reviewed By: chualynn

Differential Revision: D37891170

