### PR TITLE
Implementing terraform CLI `terraform destroy`

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
@@ -16,7 +16,7 @@ class DeployBase(ABC):
         pass
 
     @abstractmethod
-    def destroy(self) -> None:
+    def destroy(self) -> RunCommandResult:
         pass
 
     @abstractmethod

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -38,6 +38,7 @@ NOT_SUPPORTED_INIT_DEFAULT_OPTIONS: List[str] = [
 class TerraformCommand(str, Enum):
     INIT: str = "init"
     APPLY: str = "apply"
+    DESTROY: str = "destroy"
 
 
 class TerraformOptionFlag:

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment.py
@@ -87,8 +87,25 @@ class TerraformDeployment(DeployBase):
         options = self.utils.get_default_options(TerraformCommand.APPLY, options)
         return self.run_command("terraform apply", **options)
 
-    def destroy(self) -> None:
-        pass
+    def destroy(
+        self, auto_approve: bool = True, **kwargs: Dict[str, Any]
+    ) -> RunCommandResult:
+        """
+        Implements `terraform destroy` of terraform CLI.
+        `terraform destroy` destroys all remote objects managed by a particular Terraform configuration.
+
+        More information: https://www.terraform.io/docs/commands/destroy.html
+
+        auto_approve:
+            Skips interactive approval of plan before applying
+            More information: https://www.terraform.io/cli/commands/apply#apply-options
+
+        """
+        options: Dict[str, Any] = kwargs.copy()
+        options["auto-approve"] = auto_approve
+
+        options = self.utils.get_default_options(TerraformCommand.DESTROY, options)
+        return self.run_command("terraform destroy", **options)
 
     def terraform_init(
         self,


### PR DESCRIPTION
Summary:
**Context:**
These are series of diffs for terraform wrappers. Terraform is used by deploy.sh to bring up the AWS/GCP infrastructure.

**Change:**
This diff implements `terraform destroy` which is used to destroy resources listed in terraform files. More info about `terraform destroy` is added in the function docstring.

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37909068

