### PR TITLE
Implementing terraform CLI `terraform plan`

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
@@ -20,9 +20,5 @@ class DeployBase(ABC):
         pass
 
     @abstractmethod
-    def plan(self) -> None:
-        pass
-
-    @abstractmethod
     def run_command(self) -> RunCommandResult:
         pass

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -39,6 +39,7 @@ class TerraformCommand(str, Enum):
     INIT: str = "init"
     APPLY: str = "apply"
     DESTROY: str = "destroy"
+    PLAN: str = "plan"
 
 
 class TerraformOptionFlag:
@@ -46,8 +47,33 @@ class TerraformOptionFlag:
 
 
 class FlaggedOption(TerraformOptionFlag):
+    """
+    Used to set flag options, eg, `terraform init -reconfigure`
+    `-reconfigure` is a flagged option here.
+
+    This should not be confused with the options that accept bool values.
+    In case of options that accept bool values, explicit bool value is passed.
+    Eg of bool option: `terraform apply -input=false`
+
+    Usage of FlaggedOption:
+        t = TerraformDeployment()
+        t.terraform_init(reconfigure=FlaggedOption)
+
+        Results in : `terraform init -reconfigure`
+    """
+
     pass
 
 
 class NotFlaggedOption(TerraformOptionFlag):
+    """
+    Is opposite of the FlaggedOption and is used to unset flag options.
+
+    Usage:
+        t = TerraformDeployment()
+        t.terraform_init(reconfigure=NotFlaggedOption)
+
+        Results in : `terraform init`
+    """
+
     pass


### PR DESCRIPTION
Summary:
**Context:**
These are series of diffs for terraform wrappers. Terraform is used by deploy.sh to bring up the AWS/GCP infrastructure.

**Change:**
This diff implements `terraform plan` which is used to list all the resources which will be create/destroyed if apply/destroy commands are run subsequently.. More info about `terraform plan` is added in the function docstring.

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37909386

