### PR TITLE
adding fbpcs_bundle_id in infra config

### DIFF
--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -35,4 +35,3 @@ PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 57600  # 8 hr instance sla, 2 tries per stage, total 16 hrs.
 
 FBPCS_GRAPH_API_TOKEN = "FBPCS_GRAPH_API_TOKEN"
-FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -6,12 +6,7 @@
 
 # pyre-strict
 
-from typing import List
-
 from fbpcs.pid.entity.pid_instance import PIDProtocol
-from fbpcs.private_computation.entity.private_computation_status import (
-    PrivateComputationInstanceStatus,
-)
 
 """
 43200 s = 12 hrs
@@ -42,3 +37,5 @@ ATTRIBUTION_DEFAULT_PADDING_SIZE = 4
 DEFAULT_LOG_COST_TO_S3 = True
 DEFAULT_SORT_STRATEGY = "sort"
 DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT = 6
+
+FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
+import random
 import time
 import unittest
 from collections import defaultdict
@@ -50,6 +52,7 @@ from fbpcs.private_computation.service.constants import (
     DEFAULT_K_ANONYMITY_THRESHOLD_PA,
     DEFAULT_K_ANONYMITY_THRESHOLD_PL,
     DEFAULT_LOG_COST_TO_S3,
+    FBPCS_BUNDLE_ID,
     NUM_NEW_SHARDS_PER_FILE,
 )
 from fbpcs.private_computation.service.errors import (
@@ -991,6 +994,14 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             instances=[stage_state_instance],
         )
         self.assertEqual(non_empty_instance.server_ips, ["1.1.1.1"])
+
+    def test_fbpcs_bundle_id(self) -> None:
+        TEST_BUNDLE_ID = str(random.randint(100, 200))
+        with patch.dict(os.environ, {FBPCS_BUNDLE_ID: TEST_BUNDLE_ID}):
+            test_instance = self.create_sample_instance(
+                status=PrivateComputationInstanceStatus.CREATED
+            )
+            self.assertEqual(test_instance.infra_config.fbpcs_bundle_id, TEST_BUNDLE_ID)
 
     def create_sample_instance(
         self,

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -53,7 +53,6 @@ from docopt import docopt
 from fbpcs.bolt.read_config import parse_bolt_config
 from fbpcs.infra.logging_service.client.meta.client_manager import ClientManager
 from fbpcs.infra.logging_service.client.meta.data_model.lift_run_info import LiftRunInfo
-from fbpcs.pl_coordinator.constants import FBPCS_BUNDLE_ID
 from fbpcs.pl_coordinator.pl_instance_runner import run_instance, run_instances
 from fbpcs.pl_coordinator.pl_study_runner import run_study
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
@@ -69,6 +68,7 @@ from fbpcs.private_computation.pc_attribution_runner import (
     get_attribution_dataset_info,
     run_attribution,
 )
+from fbpcs.private_computation.service.constants import FBPCS_BUNDLE_ID
 from fbpcs.private_computation.service.pre_validate_service import PreValidateService
 from fbpcs.private_computation.service.utils import transform_file_path
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (


### PR DESCRIPTION
Summary:
## Why
In previous diff D37861394 (https://github.com/facebookresearch/fbpcs/commit/b4c52b2e11d9cadfc017f3e5e6af7bc684c5f819), we add bundle id in DockerFile to inject into OS env.
This diff is to store bundle id to pc instance
## What
* Move `FBPCS_BUNDLE_ID` from CLI constant to service constant
* Adding  `fbpcs_bundle_id` into InfraConfig
* set `fbpcs_bundle_id` as `init=False`, read os env from `__post__init__` to read os env during init time not static time

Differential Revision: D37931131

