### PR TITLE
make update_other_field_hook inherits update_generic_hook

### DIFF
--- a/fbpcs/common/entity/update_other_field_hook.py
+++ b/fbpcs/common/entity/update_other_field_hook.py
@@ -6,12 +6,13 @@
 
 from typing import Any, Callable, Iterable, Optional, TypeVar
 
-from fbpcs.common.entity.dataclasses_hooks import DataclassHook, HookEventType
+from fbpcs.common.entity.dataclasses_hooks import HookEventType
+from fbpcs.common.entity.update_generic_hook import UpdateGenericHook
 
 T = TypeVar("T")
 
 
-class UpdateOtherFieldHook(DataclassHook[T]):
+class UpdateOtherFieldHook(UpdateGenericHook):
     def __init__(
         self,
         other_field: str,
@@ -20,28 +21,9 @@ class UpdateOtherFieldHook(DataclassHook[T]):
         only_trigger_on_change: bool = True,
         triggers: Optional[Iterable[HookEventType]] = None,
     ) -> None:
-        self.other_field = other_field
-        self.update_function = update_function
-        self.update_condition = update_condition or (lambda _: True)
-        self.only_trigger_on_change = only_trigger_on_change
-        self._triggers = triggers or [
-            HookEventType.POST_INIT,
-            HookEventType.POST_UPDATE,
-        ]
-
-    def run(
-        self,
-        instance: T,
-        field_name: str,
-        previous_field_value: Any,
-        new_field_value: Any,
-        hook_event: HookEventType,
-    ) -> None:
-        if (
-            previous_field_value != new_field_value or not self.only_trigger_on_change
-        ) and self.update_condition(instance):
-            setattr(instance, self.other_field, self.update_function(instance))
-
-    @property
-    def triggers(self) -> Iterable[HookEventType]:
-        return self._triggers
+        super().__init__(
+            update_function=lambda obj: setattr(obj, other_field, update_function(obj)),
+            update_condition=update_condition,
+            only_trigger_on_change=only_trigger_on_change,
+            triggers=triggers,
+        )


### PR DESCRIPTION
Summary: This is BE for `update_other_field_hook`. We had this `update_other_field_hook` first, then we created `update_generic_hook` for more generic use.

Differential Revision: D37876543

