### PR TITLE
Implementing terraform CLI `terraform output`

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/deploy_base/deploy_base.py
@@ -20,9 +20,5 @@ class DeployBase(ABC):
         pass
 
     @abstractmethod
-    def plan(self) -> None:
-        pass
-
-    @abstractmethod
     def run_command(self) -> RunCommandResult:
         pass

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -39,6 +39,7 @@ class TerraformCommand(str, Enum):
     INIT: str = "init"
     APPLY: str = "apply"
     DESTROY: str = "destroy"
+    PLAN: str = "plan"
 
 
 class TerraformOptionFlag:
@@ -46,8 +47,33 @@ class TerraformOptionFlag:
 
 
 class FlaggedOption(TerraformOptionFlag):
+    """
+    Used to set flag options, eg, `terraform init -reconfigure`
+    `-reconfigure` is a flagged option here.
+
+    This should not be confused with the options that accept bool values.
+    In case of options that accept bool values, explicit bool value is passed.
+    Eg of bool option: `terraform apply -input=false`
+
+    Usage of FlaggedOption:
+        t = TerraformDeployment()
+        t.terraform_init(reconfigure=FlaggedOption)
+
+        Results in : `terraform init -reconfigure`
+    """
+
     pass
 
 
 class NotFlaggedOption(TerraformOptionFlag):
+    """
+    Is opposite of the FlaggedOption and is used to unset flag options.
+
+    Usage:
+        t = TerraformDeployment()
+        t.terraform_init(reconfigure=NotFlaggedOption)
+
+        Results in : `terraform init`
+    """
+
     pass

--- a/fbpcs/infra/pce_deployment_library/deploy_library/models.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/models.py
@@ -40,6 +40,7 @@ class TerraformCommand(str, Enum):
     APPLY: str = "apply"
     DESTROY: str = "destroy"
     PLAN: str = "plan"
+    OUTPUT: str = "output"
 
 
 class TerraformOptionFlag:

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
@@ -23,7 +23,7 @@ class TerraformDeploymentUtils:
         self,
         state_file_path: Optional[str] = None,
         terraform_variables: Optional[Dict[str, str]] = None,
-        parallelism: int = TERRAFORM_DEFAULT_PARALLELISM,
+        parallelism: Optional[int] = None,
         resource_targets: Optional[List[str]] = None,
         var_definition_file: Optional[str] = None,
     ) -> None:

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
@@ -8,6 +8,7 @@
 
 import unittest
 from subprocess import PIPE, Popen
+from typing import Any, Dict
 
 from fbpcs.infra.pce_deployment_library.deploy_library.models import RunCommandResult
 
@@ -32,9 +33,7 @@ class TestTerraformDeployment(unittest.TestCase):
                 output=test_stdout.decode("utf-8"),
                 error=test_error if test_error else "",
             )
-            func_ret = self.terraform.run_command(
-                command=command, capture_output=capture_output
-            )
+            func_ret = self.terraform.run_command(command=command)
             self.assertEqual(test_command_return.return_code, func_ret.return_code)
             self.assertEqual(test_command_return.output, func_ret.output)
             self.assertEqual(test_command_return.error, func_ret.error)
@@ -51,10 +50,8 @@ class TestTerraformDeployment(unittest.TestCase):
                 output=test_stdout,
                 error=test_stdout,
             )
-
-            func_ret = self.terraform.run_command(
-                command=command, capture_output=capture_output
-            )
+            kwargs: Dict[str, Any] = {"capture_output": capture_output}
+            func_ret = self.terraform.run_command(command=command, **kwargs)
             self.assertEqual(test_command_return.return_code, func_ret.return_code)
             self.assertEqual(test_command_return.output, func_ret.output)
             self.assertEqual(test_command_return.error, func_ret.error)
@@ -63,9 +60,7 @@ class TestTerraformDeployment(unittest.TestCase):
             command = "cp"
             capture_output = True
 
-            func_ret = self.terraform.run_command(
-                command=command, capture_output=capture_output
-            )
+            func_ret = self.terraform.run_command(command=command)
             test_command_return = RunCommandResult(
                 return_code=1,
                 output="",
@@ -78,10 +73,9 @@ class TestTerraformDeployment(unittest.TestCase):
         with self.subTest("TestStdErrWithoutCaptureOutput"):
             command = "cp"
             capture_output = False
+            kwargs: Dict[str, Any] = {"capture_output": capture_output}
 
-            func_ret = self.terraform.run_command(
-                command=command, capture_output=capture_output
-            )
+            func_ret = self.terraform.run_command(command=command, **kwargs)
             test_command_return = RunCommandResult(
                 return_code=1,
                 output=None,


### PR DESCRIPTION
Summary:
**Context:**
These are series of diffs for terraform wrappers. Terraform is used by deploy.sh to bring up the AWS/GCP infrastructure.

**Change:**
This diff implements `terraform output` which is used to get terraform variable output. This is useful to get the information about the resources after resource creation. Eg VPC ID, EC2 instance IP address etc. More info about `terraform output` is added in the function docstring.

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D37926920

