### PR TITLE
2/n Support resuming runs

### DIFF
--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -13,6 +13,9 @@ from typing import Optional, Type
 
 from dataclasses_json import config, DataClassJsonMixin
 from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
 
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
@@ -61,3 +64,15 @@ class BoltJob(DataClassJsonMixin):
             )
         if self.final_stage is None:
             self.final_stage = self.stage_flow.get_last_stage()
+
+    def is_finished(
+        self,
+        publisher_status: PrivateComputationInstanceStatus,
+        partner_status: PrivateComputationInstanceStatus,
+    ) -> bool:
+        final_status = (
+            self.final_stage.completed_status
+            if self.final_stage
+            else self.stage_flow.get_last_stage().completed_status
+        )
+        return publisher_status is final_status and partner_status is final_status

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -99,22 +99,6 @@ class BoltRunner:
     ) -> List[bool]:
         return list(await asyncio.gather(*[self.run_one(job=job) for job in jobs]))
 
-    async def is_finished(
-        self,
-        publisher_id: str,
-        partner_id: str,
-        final_stage: PrivateComputationBaseStageFlow,
-    ) -> bool:
-        publisher_status = (
-            await self.publisher_client.update_instance(publisher_id)
-        ).pc_instance_status
-        partner_status = (
-            await self.partner_client.update_instance(partner_id)
-        ).pc_instance_status
-        return (publisher_status is final_stage.completed_status) and (
-            partner_status is final_stage.completed_status
-        )
-
     async def run_one(self, job: BoltJob) -> bool:
         async with self.semaphore:
             try:
@@ -127,14 +111,7 @@ class BoltRunner:
                     while tries < max_tries:
                         tries += 1
                         try:
-                            final_stage = (
-                                job.final_stage or job.stage_flow.get_last_stage()
-                            )
-                            if await self.is_finished(
-                                publisher_id=publisher_id,
-                                partner_id=partner_id,
-                                final_stage=final_stage,
-                            ):
+                            if await self.job_is_finished(job=job):
                                 self.logger.info(
                                     # pyre-fixme: Undefined attribute [16]: `BoltCreateInstanceArgs` has no attribute `output_dir`
                                     f"Run for {job.job_name} completed. View results at {job.partner_bolt_args.create_instance_args.output_dir}"
@@ -373,3 +350,20 @@ class BoltRunner:
                     job.partner_bolt_args.create_instance_args
                 )
         return publisher_id, partner_id
+
+    async def job_is_finished(
+        self,
+        job: BoltJob,
+    ) -> bool:
+        publisher_id = job.publisher_bolt_args.create_instance_args.instance_id
+        partner_id = job.partner_bolt_args.create_instance_args.instance_id
+        publisher_status, partner_status = (
+            state.pc_instance_status
+            for state in await asyncio.gather(
+                self.publisher_client.update_instance(publisher_id),
+                self.partner_client.update_instance(partner_id),
+            )
+        )
+        return job.is_finished(
+            publisher_status=publisher_status, partner_status=partner_status
+        )

--- a/fbpcs/bolt/test/test_bolt_runner.py
+++ b/fbpcs/bolt/test/test_bolt_runner.py
@@ -39,7 +39,7 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
             partner_client=mock_partner_client,
             skip_publisher_creation=False,
         )
-        self.test_runner.is_finished = mock.AsyncMock(return_value=False)
+        self.test_runner.job_is_finished = mock.AsyncMock(return_value=False)
 
     @mock.patch("fbpcs.bolt.bolt_runner.asyncio.sleep")
     @mock.patch("fbpcs.bolt.bolt_job.BoltPlayerArgs")


### PR DESCRIPTION
Summary:
## What
* refactored the check to see if a job is finished into BoltJob

## Why
* can pass fewer arguments around
* it makes more sense for BoltJob to have this logic

Differential Revision: D37900895

