### PR TITLE
5/n Support resuming runs

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional, Type
+
+from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
+
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+
+
+@dataclass
+class BoltState:
+    pc_instance_status: PrivateComputationInstanceStatus
+    server_ips: Optional[List[str]] = None
+
+
+class BoltClient(ABC):
+    """
+    Exposes async methods for creating instances, running stages, updating instances, and validating the correctness of a computation
+    """
+
+    @abstractmethod
+    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
+        pass
+
+    @abstractmethod
+    async def run_stage(
+        self,
+        instance_id: str,
+        stage: PrivateComputationBaseStageFlow,
+        server_ips: Optional[List[str]] = None,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    async def update_instance(self, instance_id: str) -> BoltState:
+        pass
+
+    @abstractmethod
+    async def validate_results(
+        self, instance_id: str, expected_result_path: Optional[str] = None
+    ) -> bool:
+        pass
+
+    async def cancel_current_stage(self, instance_id: str) -> None:
+        pass
+
+    def ready_for_stage(
+        self,
+        status: PrivateComputationInstanceStatus,
+        stage: PrivateComputationBaseStageFlow,
+    ) -> bool:
+        previous_stage = stage.previous_stage
+        return status in [
+            previous_stage.completed_status if previous_stage else None,
+            stage.started_status,
+            stage.failed_status,
+        ]
+
+    async def get_valid_stage(
+        self, instance_id: str, stage_flow: Type[PrivateComputationBaseStageFlow]
+    ) -> Optional[PrivateComputationBaseStageFlow]:
+        status = (
+            await self.update_instance(instance_id=instance_id)
+        ).pc_instance_status
+        for stage in list(stage_flow):
+            if self.ready_for_stage(status, stage):
+                return stage
+        return None

--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -40,7 +40,7 @@ class BoltClient(ABC):
     async def run_stage(
         self,
         instance_id: str,
-        stage: PrivateComputationBaseStageFlow,
+        stage: Optional[PrivateComputationBaseStageFlow] = None,
         server_ips: Optional[List[str]] = None,
     ) -> None:
         pass

--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -75,4 +75,4 @@ class BoltJob(DataClassJsonMixin):
             if self.final_stage
             else self.stage_flow.get_last_stage().completed_status
         )
-        return publisher_status is final_status and partner_status is final_status
+        return (publisher_status is final_status) and (partner_status is final_status)

--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -13,6 +13,9 @@ from typing import Optional, Type
 
 from dataclasses_json import config, DataClassJsonMixin
 from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
 
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
@@ -61,3 +64,15 @@ class BoltJob(DataClassJsonMixin):
             )
         if self.final_stage is None:
             self.final_stage = self.stage_flow.get_last_stage()
+
+    def is_finished(
+        self,
+        publisher_status: PrivateComputationInstanceStatus,
+        partner_status: PrivateComputationInstanceStatus,
+    ) -> bool:
+        final_status = (
+            self.final_stage.completed_status
+            if self.final_stage
+            else self.stage_flow.get_last_stage().completed_status
+        )
+        return publisher_status is final_status and partner_status is final_status

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -8,12 +8,12 @@
 
 import asyncio
 import logging
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from time import time
 from typing import List, Optional, Tuple
 
-from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs, BoltJob
+from fbpcs.bolt.bolt_client import BoltClient
+
+from fbpcs.bolt.bolt_job import BoltJob
 from fbpcs.bolt.constants import (
     DEFAULT_MAX_PARALLEL_RUNS,
     DEFAULT_NUM_TRIES,
@@ -32,44 +32,6 @@ from fbpcs.private_computation.entity.private_computation_status import (
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
-
-
-@dataclass
-class BoltState:
-    pc_instance_status: PrivateComputationInstanceStatus
-    server_ips: Optional[List[str]] = None
-
-
-class BoltClient(ABC):
-    """
-    Exposes async methods for creating instances, running stages, updating instances, and validating the correctness of a computation
-    """
-
-    @abstractmethod
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
-        pass
-
-    @abstractmethod
-    async def run_stage(
-        self,
-        instance_id: str,
-        stage: PrivateComputationBaseStageFlow,
-        server_ips: Optional[List[str]] = None,
-    ) -> None:
-        pass
-
-    @abstractmethod
-    async def update_instance(self, instance_id: str) -> BoltState:
-        pass
-
-    @abstractmethod
-    async def validate_results(
-        self, instance_id: str, expected_result_path: Optional[str] = None
-    ) -> bool:
-        pass
-
-    async def cancel_current_stage(self, instance_id: str) -> None:
-        pass
 
 
 class BoltRunner:

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -99,22 +99,6 @@ class BoltRunner:
     ) -> List[bool]:
         return list(await asyncio.gather(*[self.run_one(job=job) for job in jobs]))
 
-    async def is_finished(
-        self,
-        publisher_id: str,
-        partner_id: str,
-        final_stage: PrivateComputationBaseStageFlow,
-    ) -> bool:
-        publisher_status = (
-            await self.publisher_client.update_instance(publisher_id)
-        ).pc_instance_status
-        partner_status = (
-            await self.partner_client.update_instance(partner_id)
-        ).pc_instance_status
-        return (publisher_status is final_stage.completed_status) and (
-            partner_status is final_stage.completed_status
-        )
-
     async def run_one(self, job: BoltJob) -> bool:
         async with self.semaphore:
             try:
@@ -127,14 +111,7 @@ class BoltRunner:
                     while tries < max_tries:
                         tries += 1
                         try:
-                            final_stage = (
-                                job.final_stage or job.stage_flow.get_last_stage()
-                            )
-                            if await self.is_finished(
-                                publisher_id=publisher_id,
-                                partner_id=partner_id,
-                                final_stage=final_stage,
-                            ):
+                            if await self.job_is_finished(job=job):
                                 self.logger.info(
                                     # pyre-fixme: Undefined attribute [16]: `BoltCreateInstanceArgs` has no attribute `output_dir`
                                     f"Run for {job.job_name} completed. View results at {job.partner_bolt_args.create_instance_args.output_dir}"
@@ -373,3 +350,20 @@ class BoltRunner:
                     job.partner_bolt_args.create_instance_args
                 )
         return publisher_id, partner_id
+
+    async def job_is_finished(
+        self,
+        job: BoltJob,
+    ) -> bool:
+        publisher_id = job.publisher_bolt_args.create_instance_args.instance_id
+        partner_id = job.partner_bolt_args.create_instance_args.instance_id
+        publisher_status, partner_status = (
+            state.pc_instance_status
+            for state in await asyncio.gather(
+                self.publisher_client.update_instance(publisher_id),
+                self.partner_client.update_instance(partner_id),
+            )
+        )
+        return job.is_finished(
+            publisher_status=publisher_status, partner_status=partner_status
+        )

--- a/fbpcs/bolt/constants.py
+++ b/fbpcs/bolt/constants.py
@@ -6,6 +6,11 @@
 
 # pyre-strict
 
+from typing import List
+
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
 from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
     PrivateComputationPCF2StageFlow,
 )
@@ -20,3 +25,9 @@ DEFAULT_MAX_PARALLEL_RUNS = 10
 DEFAULT_NUM_TRIES = 2
 TIMEOUT_SEC = 1200
 RETRY_INTERVAL = 60
+INVALID_STATUS_LIST: List[PrivateComputationInstanceStatus] = [
+    PrivateComputationInstanceStatus.TIMEOUT,
+    PrivateComputationInstanceStatus.UNKNOWN,
+    PrivateComputationInstanceStatus.PROCESSING_REQUEST,
+]
+WAIT_VALID_STATUS_TIMEOUT = 600

--- a/fbpcs/bolt/exceptions.py
+++ b/fbpcs/bolt/exceptions.py
@@ -14,6 +14,10 @@ class StageTimeoutException(RuntimeError):
     pass
 
 
+class WaitValidStatusTimeout(RuntimeError):
+    pass
+
+
 class NoServerIpsException(ValueError):
     pass
 

--- a/fbpcs/bolt/exceptions.py
+++ b/fbpcs/bolt/exceptions.py
@@ -16,3 +16,7 @@ class StageTimeoutException(RuntimeError):
 
 class NoServerIpsException(ValueError):
     pass
+
+
+class IncompatibleStageError(RuntimeError):
+    pass

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -142,12 +142,19 @@ class BoltPCSClient(BoltClient):
     async def run_stage(
         self,
         instance_id: str,
-        stage: PrivateComputationBaseStageFlow,
+        stage: Optional[PrivateComputationBaseStageFlow] = None,
         server_ips: Optional[List[str]] = None,
     ) -> None:
-        await self.pcs.run_stage_async(
-            instance_id=instance_id, stage=stage, server_ips=server_ips
-        )
+        if stage:
+            self.logger.info(f"Running stage {stage.name}")
+            await self.pcs.run_stage_async(
+                instance_id=instance_id, stage=stage, server_ips=server_ips
+            )
+        else:
+            self.logger.info("Running next stage")
+            await self.pcs.run_next_async(
+                instance_id=instance_id, server_ips=server_ips
+            )
 
     async def update_instance(self, instance_id: str) -> BoltState:
         loop = asyncio.get_running_loop()

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -14,8 +14,8 @@ from typing import Any, Dict, List, Optional, Type
 
 from dataclasses_json import config, DataClassJsonMixin
 
+from fbpcs.bolt.bolt_client import BoltClient, BoltState
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
-from fbpcs.bolt.bolt_runner import BoltClient, BoltState
 from fbpcs.bolt.constants import DEFAULT_ATTRIBUTION_STAGE_FLOW, DEFAULT_LIFT_STAGE_FLOW
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
 from fbpcs.private_computation.entity.infra_config import (

--- a/fbpcs/bolt/test/test_bolt_runner.py
+++ b/fbpcs/bolt/test/test_bolt_runner.py
@@ -39,7 +39,7 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
             partner_client=mock_partner_client,
             skip_publisher_creation=False,
         )
-        self.test_runner.is_finished = mock.AsyncMock(return_value=False)
+        self.test_runner.job_is_finished = mock.AsyncMock(return_value=False)
 
     @mock.patch("fbpcs.bolt.bolt_runner.asyncio.sleep")
     @mock.patch("fbpcs.bolt.bolt_job.BoltPlayerArgs")

--- a/fbpcs/bolt/test/test_bolt_runner.py
+++ b/fbpcs/bolt/test/test_bolt_runner.py
@@ -9,8 +9,9 @@ import unittest
 from typing import List, Optional, Tuple
 from unittest import mock
 
+from fbpcs.bolt.bolt_client import BoltState
 from fbpcs.bolt.bolt_job import BoltJob
-from fbpcs.bolt.bolt_runner import BoltRunner, BoltState
+from fbpcs.bolt.bolt_runner import BoltRunner
 from fbpcs.bolt.constants import DEFAULT_NUM_TRIES
 from fbpcs.bolt.exceptions import StageFailedException
 from fbpcs.private_computation.entity.infra_config import PrivateComputationRole
@@ -205,7 +206,7 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
                     )
                     self.test_runner.partner_client.cancel_current_stage.assert_not_called()
 
-    @mock.patch("fbpcs.bolt.bolt_runner.BoltState")
+    @mock.patch("fbpcs.bolt.bolt_client.BoltState")
     async def test_is_existing_instance(self, mock_state) -> None:
         for role in (PrivateComputationRole.PUBLISHER, PrivateComputationRole.PARTNER):
             self.test_runner.publisher_client.update_instance = mock.AsyncMock(

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -8,8 +8,8 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+from fbpcs.bolt.bolt_client import BoltClient, BoltState
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
-from fbpcs.bolt.bolt_runner import BoltClient, BoltState
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -43,7 +43,7 @@ class BoltGraphAPIClient(BoltClient):
     async def run_stage(
         self,
         instance_id: str,
-        stage: PrivateComputationBaseStageFlow,
+        stage: Optional[PrivateComputationBaseStageFlow] = None,
         server_ips: Optional[List[str]] = None,
     ) -> None:
         pass


### PR DESCRIPTION
Summary:
## What
* Integrate resuming runs into BoltRunner
* Runner restarts from the next valid stage in both creation/resume cases
* wait for publisher status to become valid before resuming
* stage argument made optional in BoltClient as the GraphAPI client doesn't use it and no stage is available to pass as an argument in the case where publisher status is TIMEOUT

## Why
* matching production runner features

Differential Revision: D37946489

