### PR TITLE
Adding bootcamp tasks to add unittests for `create`, `destroy` and `plan` functions of class `terraform_deployment`

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment.py
@@ -19,6 +19,7 @@ from fbpcs.infra.pce_deployment_library.deploy_library.models import (
     RunCommandResult,
     TerraformCliOptions,
     TerraformCommand,
+    TerraformOptionFlag,
 )
 from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_deployment_utils import (
     TerraformDeploymentUtils,
@@ -111,7 +112,7 @@ class TerraformDeployment(DeployBase):
     def terraform_init(
         self,
         backend_config: Optional[Dict[str, str]] = None,
-        reconfigure: Type[FlaggedOption] = FlaggedOption,
+        reconfigure: Type[TerraformOptionFlag] = FlaggedOption,
         **kwargs: Dict[str, Any],
     ) -> RunCommandResult:
         """
@@ -182,8 +183,12 @@ class TerraformDeployment(DeployBase):
     ) -> RunCommandResult:
         """
         Executes Terraform CLIs apply/destroy/init/plan
+
+        Set `dry_run` flag in `kwargs` to test the function.
+        `dry_run` returns the command that will be run in shell for a given input
         """
         options: Dict[str, Any] = kwargs.copy()
+        dry_run: bool = options.get("dry_run", False)
 
         capture_output: bool = options.get("capture_output", True)
 
@@ -198,6 +203,12 @@ class TerraformDeployment(DeployBase):
         command_str = " ".join(command_list)
         self.log.info(f"Command: {command_str}")
         out, err = None, None
+
+        if dry_run:
+            # Adding dryrun flag for tests. It returns the command that will be executed for given input
+            return RunCommandResult(
+                return_code=0, output=f"Dry run command: {command_str}", error=""
+            )
 
         with Popen(command_list, stdout=stdout, stderr=stderr) as p:
             out, err = p.communicate()

--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
@@ -59,7 +59,9 @@ class TerraformDeploymentUtils:
         """
         self.input = False
 
-    def get_command_list(self, command: str, *args: Any, **kwargs: str) -> List[str]:
+    def get_command_list(
+        self, command: str, *args: Any, **kwargs: Dict[str, Any]
+    ) -> List[str]:
         """
         Converts command string to list and updates commands with terraform options provided through kwargs and args.
         """
@@ -77,7 +79,6 @@ class TerraformDeploymentUtils:
             # terraform CLI accepts options with "-" using "_" will results in error
             key = key.replace("_", "-")
 
-            # pyre-fixme
             func = type_to_func_dict.get(type(value), self.add_other_options)
 
             # pyre-fixme

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
@@ -129,4 +129,13 @@ class TestTerraformDeployment(unittest.TestCase):
             self.assertEquals(expected_value, return_value)
 
     def test_create(self) -> None:
+        # T126572515
+        pass
+
+    def test_destory(self) -> None:
+        # T126573127
+        pass
+
+    def test_plan(self) -> None:
+        # T126574725
         pass

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
@@ -6,6 +6,9 @@
 # pyre-strict
 
 import unittest
+from typing import Any, Dict
+
+from fbpcs.infra.pce_deployment_library.deploy_library.models import FlaggedOption
 
 from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_deployment_utils import (
     TerraformDeploymentUtils,
@@ -21,8 +24,73 @@ class TestTerraformDeploymentUtils(unittest.TestCase):
         pass
 
     def test_get_command_list(self) -> None:
-        # T125643785
-        pass
+        command: str = "terraform apply"
+        with self.subTest("OptionTypeDict"):
+            kwargs: Dict[str, Any] = {
+                "backend-config": {
+                    "region": "fake_region",
+                    "access_key": "fake_access_key",
+                }
+            }
+            expected_value = [
+                "terraform",
+                "apply",
+                "-backend-config region=fake_region",
+                "-backend-config access_key=fake_access_key",
+            ]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEquals(expected_value, return_value)
+
+        with self.subTest("OptionTypeList"):
+            kwargs: Dict[str, Any] = {"target": ["fake_region", "fake_access_key"]}
+            expected_value = [
+                "terraform",
+                "apply",
+                "-target=fake_region",
+                "-target=fake_access_key",
+            ]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEquals(expected_value, return_value)
+
+        with self.subTest("OptionTypeBool"):
+            kwargs: Dict[str, Any] = {"input": "false"}
+            expected_value = ["terraform", "apply", "-input=false"]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEquals(expected_value, return_value)
+
+        with self.subTest("OptionTypeFlaggedOption"):
+            kwargs: Dict[str, Any] = {"reconfigure": FlaggedOption}
+            expected_value = ["terraform", "apply", "-reconfigure"]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEquals(expected_value, return_value)
+
+        with self.subTest("OptionTypeDictWithArgs"):
+            kwargs: Dict[str, Any] = {
+                "backend-config": {
+                    "region": "fake_region",
+                    "access_key": "fake_access_key",
+                }
+            }
+            args = ("test_test",)
+            expected_value = [
+                "terraform",
+                "apply",
+                "-backend-config region=fake_region",
+                "-backend-config access_key=fake_access_key",
+                "test_test",
+            ]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, *args, **kwargs
+            )
+            self.assertEquals(expected_value, return_value)
 
     def test_add_dict_options(self) -> None:
         pass


### PR DESCRIPTION
Summary: Adding bootcamp tasks to add unittests for `create`, `destroy` and `plan` functions of class `terraform_deployment`

Differential Revision: D37978472

