### PR TITLE
Fix GitHub OneDocker image build-up failure

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -4,6 +4,7 @@ cython==0.29.30 # required by thriftpy2 setup
 dataclasses-json==0.5.2 # fbpcp requires this version, so we must as well
 docopt>=0.6.2
 fbpcp>=0.2.2 # depending on: boto3, botocore
+marshmallow==3.5.1
 networkx>=2.6.3
 requests>=2.26.0
 schema==0.7.0 # fbpcp requires this version, so we must as well

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -85,7 +85,7 @@ class PrivateComputationInstance(InstanceBase):
         # create infra config
         infra_config: InfraConfig = InfraConfig.schema().loads(
             json.dumps(json_object["infra_config"]),
-            unknown="EXCLUDE",
+            unknown=marshmallow.utils.EXCLUDE,
             many=None,
         )
 
@@ -100,7 +100,7 @@ class PrivateComputationInstance(InstanceBase):
             try:
                 product_config = cls._product_map(json_object).loads(
                     json.dumps(product_json),
-                    unknown="EXCLUDE",
+                    unknown=marshmallow.utils.EXCLUDE,
                     many=None,
                 )
                 product_cleaned_json = True


### PR DESCRIPTION
Summary:
# What:
Fix this failure for GitHub: https://github.com/facebookresearch/fbpcs/runs/7403058331?check_suite_focus=true

# Why:
Which version of third party library will be used?
For internal use: buck is reading TARGET (you can check `Third Party Code` webpage to see all the third-party library versions)
For external use: GitHub building image w/ pip_requirements.txt we listed, otherwise the newest version

In our case, OneDocker is not using the same version of marshmallow as we do.
The marshmallow internal Facebook is 3.5.1 right now.
However, since we never specify this in pip_requirement.txt, the external will just use the newest version of marshmallow which is 3.17

I made two changes here:
 1. Changed the code used in my functions, so both new and old version of marshmallow can recognize it.
2. Added the required version of marshmallow we should use in pip_requirement.txt

Differential Revision: D37964236

