### PR TITLE
Use NetworkPlaintextScheduler in private aggregation

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -45,8 +45,11 @@ class AggregationApp {
         schedulerStatistics_{0, 0, 0, 0} {}
 
   void run() {
-    auto scheduler = fbpcf::scheduler::createLazySchedulerWithRealEngine(
-        MY_ROLE, *communicationAgentFactory_);
+    auto scheduler = outputVisibility_ == common::Visibility::Publisher
+        ? fbpcf::scheduler::createNetworkPlaintextScheduler<false>(
+              MY_ROLE, *communicationAgentFactory_)
+        : fbpcf::scheduler::createLazySchedulerWithRealEngine(
+              MY_ROLE, *communicationAgentFactory_);
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
 
     AggregationGame<schedulerId> game(
@@ -64,8 +67,7 @@ class AggregationApp {
           inputEncryption_,
           inputSecretShareFilePaths_.at(i),
           inputClearTextFilePaths_.at(i));
-      auto output =
-          game.computeAggregations(MY_ROLE, inputData, outputVisibility_);
+      auto output = game.computeAggregations(MY_ROLE, inputData);
       putOutputData(output, outputFilePaths_.at(i));
     }
 

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationGame.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationGame.h
@@ -86,8 +86,7 @@ class AggregationGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   AggregationOutputMetrics computeAggregations(
       const int myRole,
-      const AggregationInputMetrics& inputData,
-      common::Visibility outputVisibility);
+      const AggregationInputMetrics& inputData);
 
  private:
   std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationGame_impl.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationGame_impl.h
@@ -155,8 +155,7 @@ AggregationGame<schedulerId>::shareAggregationFormats(
 template <int schedulerId>
 AggregationOutputMetrics AggregationGame<schedulerId>::computeAggregations(
     const int myRole,
-    const AggregationInputMetrics& inputData,
-    common::Visibility outputVisibility) {
+    const AggregationInputMetrics& inputData) {
   XLOG(INFO, "Running private aggregation");
 
   auto ids = inputData.getIds();
@@ -205,7 +204,6 @@ AggregationOutputMetrics AggregationGame<schedulerId>::computeAggregations(
   PrivateAggregationMetrics<schedulerId> aggregationMetrics{
       aggregationFormats,
       AggregationContext{validOriginalAdIds},
-      outputVisibility,
       myRole,
       concurrency_,
       // linear ORAM will be less efficient theoretically if ORAM size is larger

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h
@@ -210,7 +210,6 @@ class PrivateAggregationMetrics {
   PrivateAggregationMetrics(
       std::vector<AggregationFormat<schedulerId>> aggregationFormats_,
       const AggregationContext& ctx,
-      const common::Visibility& outputVisibility,
       const int myRole,
       const int concurrency,
       std::unique_ptr<fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<
@@ -218,11 +217,7 @@ class PrivateAggregationMetrics {
     for (auto aggregationFormat : aggregationFormats_) {
       formatToAggregator[aggregationFormat.name] =
           aggregationFormat.newAggregator(
-              ctx,
-              outputVisibility,
-              myRole,
-              concurrency,
-              std::move(writeOnlyOramFactory));
+              ctx, myRole, concurrency, std::move(writeOnlyOramFactory));
     }
   }
 

--- a/fbpcs/emp_games/pcf2_aggregation/Aggregator.h
+++ b/fbpcs/emp_games/pcf2_aggregation/Aggregator.h
@@ -64,8 +64,7 @@ struct ConvMetrics {
 template <int schedulerId>
 class Aggregator {
  public:
-  explicit Aggregator(const common::Visibility& outputVisibility)
-      : outputVisibility_{outputVisibility} {}
+  explicit Aggregator() {}
 
   virtual ~Aggregator() {}
 
@@ -73,9 +72,6 @@ class Aggregator {
       const PrivateAggregation<schedulerId>& privateAggregation) = 0;
 
   virtual AggregationOutput reveal() const = 0;
-
- protected:
-  const common::Visibility outputVisibility_;
 };
 
 struct AggregationContext {
@@ -91,7 +87,6 @@ class AggregationFormat {
 
   std::function<std::unique_ptr<Aggregator<schedulerId>>(
       AggregationContext,
-      common::Visibility,
       int myRole,
       int concurrency,
       std::unique_ptr<fbpcf::mpc_std_lib::oram::IWriteOnlyOramFactory<


### PR DESCRIPTION
Summary:
This commit resolves the following issues.

1. In AggregationApp, use a NetworkPlaintextScheduler if the output visibility is set to the Publisher, otherwise use the current LazyScheduler.

2. Remove a loop in AggregationOutput reveal, where PublicRead is no longer needed.

3. Remove outputVisibility from AggregationGame, aggregationMetrics, Aggregator, and AggregationGameTest. Only keep it in the CalculatorApp.

Reviewed By: chualynn

Differential Revision: D37947658

