### PR TITLE
Cohort ID support in data processing stage for partner data

### DIFF
--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineFileCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineFileCombiner.cpp
@@ -114,6 +114,14 @@ void LiftIdSpineFileCombiner::combineFile() {
     std::vector<std::string> aggregatedCols = idSwapOutFileHeader;
     aggregatedCols.erase(
         std::find(aggregatedCols.begin(), aggregatedCols.end(), "id_"));
+    // cohort_id is an optional field that may be provided in the partner data.
+    // If used, the following compute stage expects that only one cohort id is
+    // provided per user. Thus, remove this column from being aggregated on if
+    // present. In theory, a user should only belong to one cohort, so grabbing
+    // a random cohort per user should be sufficient.
+    aggregatedCols.erase(
+        std::remove(aggregatedCols.begin(), aggregatedCols.end(), "cohort_id"),
+        aggregatedCols.end());
 
     std::stringstream groupByOutFile;
     std::stringstream groupByUnsortedOutFile;


### PR DESCRIPTION
Summary:
In Private Lift, the partner may want to include an identifier for each event in the partner data to identify which cohort a user belongs to. This is simply an integer and is useful for the advertiser to calculate cohort lift. `cohort_id` had been briefly supported in the past, but due to problems in how it was handled in the PL flow, it has since been removed. We now want to permanently add back support for this field. This is a requested feature from multiple advertisers, and is currently a blocker in onboarding for those who need it.

In adding back support, the main thing is ensuring compatibility between the data processing stage and the following compute stage. The data processing stage prepares the input for the compute stage by aggregating the conversion entries for a single user into one entry. In combining the events for a single user into one row, it aggregates various fields into arrays. By default, the data processing stage will aggregate all columns provided that are not the `id_` column. This works perfectly for all expected fields except for `cohort_id`, since the PL compute stage expects only one cohort id to be provided for each entry. The PL run will fail.

In theory, a user should only belong to one cohort across all events. This means that we can dedupe the cohort ids gathered for one user into just one value to comply with the expectations of the compute stage. Thus, we can explicitly remove `cohort_id` from the columns to aggregate and just return back one `cohort_id` per user. Everything should flow smoothly from there.

More context here: https://fburl.com/gdoc/1fe9htyj

Reviewed By: chualynn, anthonyzhang25

Differential Revision: D38013630

