### PR TITLE
Get access token from config or environment variable

### DIFF
--- a/fbpcs/bolt/constants.py
+++ b/fbpcs/bolt/constants.py
@@ -31,3 +31,5 @@ INVALID_STATUS_LIST: List[PrivateComputationInstanceStatus] = [
     PrivateComputationInstanceStatus.PROCESSING_REQUEST,
 ]
 WAIT_VALID_STATUS_TIMEOUT = 600
+
+FBPCS_GRAPH_API_TOKEN = "FBPCS_GRAPH_API_TOKEN"

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -5,13 +5,57 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest.mock import patch
+
+from fbpcs.bolt.constants import FBPCS_GRAPH_API_TOKEN
 
 from fbpcs.pl_coordinator.bolt_graphapi_client import BoltGraphAPIClient
+from fbpcs.pl_coordinator.exceptions import GraphAPITokenNotFound
+
+ACCESS_TOKEN = "access_token"
 
 
 class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
-    def setUp(self) -> None:
-        pass
+    @patch("logging.Logger")
+    def setUp(self, mock_logger) -> None:
+        self.mock_logger = mock_logger
+
+    def test_get_graph_api_token_from_dict(self) -> None:
+        expected_token = "from_dict"
+        config = {"access_token": expected_token}
+        actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+        self.assertEqual(expected_token, actual_token)
+
+    def test_get_graph_api_token_from_env_config_todo(self) -> None:
+        expected_token = "from_env"
+        with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: expected_token}):
+            config = {"access_token": "TODO"}
+            actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+            self.assertEqual(expected_token, actual_token)
+
+    def test_get_graph_api_token_from_env_config_no_field(self) -> None:
+        expected_token = "from_env"
+        with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: expected_token}):
+            config = {"random_field": "not_a_token"}
+            actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+            self.assertEqual(expected_token, actual_token)
+
+    def test_get_graph_api_token_dict_and_env(self) -> None:
+        expected_token = "from_dict"
+        with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: "from_env"}):
+            config = {"access_token": expected_token}
+            actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+            self.assertEqual(expected_token, actual_token)
+
+    def test_get_graph_api_token_no_token_todo(self) -> None:
+        config = {"access_token": "TODO"}
+        with self.assertRaises(GraphAPITokenNotFound):
+            BoltGraphAPIClient(config, self.mock_logger).access_token
+
+    def test_get_graph_api_token_no_field(self) -> None:
+        config = {"random_field": "not_a_token"}
+        with self.assertRaises(GraphAPITokenNotFound):
+            BoltGraphAPIClient(config, self.mock_logger).access_token
 
     async def test_create_instance(self) -> None:
         pass


### PR DESCRIPTION
Summary:
## What
* get access token from the graphapi section of config

## Why
* no need to pass in all of the config, but does the same thing as current graphapi client

Differential Revision: D38007396

