### PR TITLE
Add Shard validator and Tests

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcs/emp_games/common/Constants.h>
+#include <fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h>
+
+namespace shard_combiner {
+
+enum class ShardSchemaType { kAdObjFormat, kGroupedLiftMetrics };
+
+template <
+    ShardSchemaType shardSchemaType,
+    int schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption>
+void validateShardSchema(
+    const AggMetrics<schedulerId, usingBatch, inputEncryption>& metrics);
+
+} // namespace shard_combiner

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardValidatorTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardValidatorTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <fbpcf/exception/exceptions.h>
+#include <fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h>
+#include <fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h>
+#include <fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h>
+
+namespace shard_combiner {
+
+class ShardValidatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Get full path of current source file
+    std::string filePath = __FILE__;
+    baseDir_ = filePath.substr(0, filePath.rfind("/")) +
+        "/test/shard_validation_test/";
+  }
+  std::string baseDir_;
+  static constexpr int schedulerId = 0;
+  static constexpr bool usingBatch = false;
+  static constexpr common::InputEncryption inputEncryption =
+      common::InputEncryption::Plaintext;
+};
+
+// Tests for ad object format validation
+TEST_F(ShardValidatorTest, AdObjectTestValidMeasurementInput) {
+  std::string inputFile = baseDir_ + "valid_measurement_shard.json";
+
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+
+  validateShardSchema<ShardSchemaType::kAdObjFormat>(*testMetricsObj);
+}
+
+// Tests for GroupedLiftMetrics format validation
+TEST_F(ShardValidatorTest, GroupedLiftMetricsTest) {
+  std::string inputFile = baseDir_ + "valid_lift_input.json";
+
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+
+  validateShardSchema<ShardSchemaType::kGroupedLiftMetrics>(*testMetricsObj);
+}
+
+// Tests if the validator emits exeception for wrong formats.
+TEST_F(ShardValidatorTest, AdObjectTestValidIncorrectMeasurementInput) {
+  std::string inputFile = baseDir_ + "valid_lift_input.json";
+
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+
+  EXPECT_THROW(
+      validateShardSchema<ShardSchemaType::kAdObjFormat>(*testMetricsObj),
+      common::exceptions::SchemaTraceError);
+}
+
+// Tests if the validator emits exeception for wrong formats.
+TEST_F(ShardValidatorTest, GroupedLiftMetricsIncorrectInput) {
+  std::string inputFile = baseDir_ + "valid_measurement_shard.json";
+
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+
+  EXPECT_THROW(
+      validateShardSchema<ShardSchemaType::kGroupedLiftMetrics>(
+          *testMetricsObj),
+      common::exceptions::SchemaTraceError);
+}
+
+TEST_F(ShardValidatorTest, AdObjectTestInvalidAggregationName) {
+  std::string inputFile = baseDir_ + "invalid_aggregation_name.json";
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+  EXPECT_THROW(
+      validateShardSchema<ShardSchemaType::kAdObjFormat>(*testMetricsObj),
+      common::exceptions::SchemaTraceError);
+}
+
+// Tests for lift format validation
+TEST_F(ShardValidatorTest, LiftTestValidLiftInput) {
+  std::string inputFile = baseDir_ + "valid_lift_input.json";
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+  validateShardSchema<ShardSchemaType::kGroupedLiftMetrics>(*testMetricsObj);
+}
+
+TEST_F(ShardValidatorTest, LiftTestInvalidAdObjectInput) {
+  std::string inputFile = baseDir_ + "valid_measurement_shard.json";
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+  EXPECT_THROW(
+      validateShardSchema<ShardSchemaType::kGroupedLiftMetrics>(
+          *testMetricsObj),
+      common::exceptions::SchemaTraceError);
+}
+
+TEST_F(ShardValidatorTest, LiftTestInvalidInputEmptyMap) {
+  std::string inputFile = baseDir_ + "invalid_empty_map_0.json";
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+  EXPECT_THROW(
+      validateShardSchema<ShardSchemaType::kGroupedLiftMetrics>(
+          *testMetricsObj),
+      common::exceptions::SchemaTraceError);
+}
+
+TEST_F(ShardValidatorTest, LiftTestValidInputEmptyCohortMetrics) {
+  std::string inputFile = baseDir_ + "valid_lift_no_cohort_metrics.json";
+  auto testMetricsObj =
+      AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(inputFile);
+
+  validateShardSchema<ShardSchemaType::kGroupedLiftMetrics>(*testMetricsObj);
+}
+
+} // namespace shard_combiner

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// checks if the `test_param` meets the `expected` based on the
+// `operator` otherwise throws a said expection `throw_` with a message
+// `msg`.
+#define VALIDATE_OR_THROW(test_param, operator, expected, throw_, msg) \
+  do {                                                                 \
+    if (test_param operator expected) {                                \
+    } else {                                                           \
+      throw throw_(msg);                                               \
+    }                                                                  \
+  } while (0)
+
+#include <fbpcf/exception/exceptions.h>
+#include <fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h>
+#include <fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h>
+
+namespace shard_combiner {
+
+template <
+    ShardSchemaType shardSchemaType,
+    int schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption>
+void validateShardSchema(
+    const AggMetrics<schedulerId, usingBatch, inputEncryption>& metrics) {
+  if constexpr (shardSchemaType == ShardSchemaType::kAdObjFormat) {
+    validateAdObjectFormatMetrics(metrics);
+  } else if constexpr (
+      shardSchemaType == ShardSchemaType::kGroupedLiftMetrics) {
+    validateGroupedLiftMetrics(metrics);
+  } else {
+    throw common::exceptions::SchemaTraceError(folly::sformat(
+        "This [{}] schema is currently not supported in pcf2_shard_combiner.",
+        shardSchemaType));
+  }
+}
+
+template <
+    int schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption>
+void validateAdObjectFormatMetrics(
+    const AggMetrics<schedulerId, usingBatch, inputEncryption>& metrics) {
+  VALIDATE_OR_THROW(
+      metrics.getAsDict().size(),
+      >,
+      0,
+      common::exceptions::SchemaTraceError,
+      "Metrics cannot have an empty dictionary.");
+  for (const auto& [rule, metricsEntry] : metrics.getAsDict()) {
+    VALIDATE_OR_THROW(
+        metricsEntry->getType(),
+        ==,
+        AggMetricType::kDict,
+        common::exceptions::SchemaTraceError,
+        folly::sformat("Metrics rule: {} should be a dictionary.", rule));
+
+    VALIDATE_OR_THROW(
+        metricsEntry->getAsDict().size(),
+        >,
+        0,
+        common::exceptions::SchemaTraceError,
+        folly::sformat(
+            "Metrics rule: {} should be a dictionary of size > 0.", rule));
+
+    for (const auto& [aggregationName, aggregationData] :
+         metricsEntry->getAsDict()) {
+      VALIDATE_OR_THROW(
+          aggregationName,
+          ==,
+          "measurement",
+          common::exceptions::SchemaTraceError,
+          folly::sformat(
+              "Unsupported aggregationName [{}] passed to Shard Aggregator",
+              aggregationName));
+      VALIDATE_OR_THROW(
+          aggregationData->getType(),
+          ==,
+          AggMetricType::kDict,
+          common::exceptions::SchemaTraceError,
+          folly::sformat(
+              "Aggregation should be a Dictionary({}), got: [{}]",
+              (int)AggMetricType::kDict,
+              (int)aggregationData->getType()));
+    }
+  }
+}
+
+template <
+    int schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption>
+void validateGroupedLiftMetrics(
+    const AggMetrics<schedulerId, usingBatch, inputEncryption>& metrics) {
+  VALIDATE_OR_THROW(
+      metrics.getType(),
+      ==,
+      AggMetricType::kDict,
+      common::exceptions::SchemaTraceError,
+      folly::sformat(
+          "GroupedLiftMetrics expects dictionary as input, got: [{}]",
+          (int)metrics.getType()));
+  VALIDATE_OR_THROW(
+      metrics.getAsDict().find("metrics"),
+      !=,
+      metrics.getAsDict().end(),
+      common::exceptions::SchemaTraceError,
+      "Dict does not have 'metrics' key");
+  VALIDATE_OR_THROW(
+      metrics.getAsDict().find("cohortMetrics"),
+      !=,
+      metrics.getAsDict().end(),
+      common::exceptions::SchemaTraceError,
+      "Dict does not have 'cohortMetrics' key, maybe SchemaType is wrong?");
+  VALIDATE_OR_THROW(
+      metrics.getAsDict().find("publisherBreakdowns"),
+      !=,
+      metrics.getAsDict().end(),
+      common::exceptions::SchemaTraceError,
+      "Dict does not have 'publisherBreakdowns' key");
+}
+} // namespace shard_combiner


### PR DESCRIPTION
Summary:
# Context
This diff adds the shard validator, basically, the purpose of this to check whether the Json Shards adhere to a said Schema. Since it templatized now, newer formats are easy to add. Also, code is more readable because we know which validator is used
```
ShardValidator<ShardSchemaType::GourpedLiftMetric> v;
v.validate(obj);
```
for instance is more readable than,
```
ShardValidator v;
v.validate(obj, "ad_object_fmt");
```
# Changes in this diff
1. Adds to new ShardValidator
 a. currently we support 2 formats AdObjectFormat and GroupedLiftMetric format.
 b. I added `VALIDATE_OR_THROW` macro, so that the code looks compact, readable. I'm not using glog checkers because we can't make them throw the exception that we like.
2. Adds ShadValidator tests.

Reviewed By: anthonyzhang25

Differential Revision: D37571697

