### PR TITLE
Add unit tests for new output format - testCorrectness

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_click_1d_reformatted.json
+++ b/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_click_1d_reformatted.json
@@ -1,0 +1,556 @@
+{
+    "last_click_1d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1003,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1004,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1007,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2007,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1009,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1003,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1013,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1014,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1015,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1016,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1017,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1020,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2020,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3020,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1021,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2021,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 3021,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 2022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 3022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2023,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 3024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1025,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_click_1d_targetid_reformatted.json
+++ b/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_click_1d_targetid_reformatted.json
@@ -1,0 +1,424 @@
+{
+    "last_click_1d_targetid": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 200,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 88,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 88,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 88,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 88,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1021,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2021,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 3021,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 2022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 5,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 5,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_click_2_7d_reformatted.json
+++ b/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_click_2_7d_reformatted.json
@@ -1,0 +1,688 @@
+{
+    "last_click_2_7d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1003,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1004,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1007,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2007,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1009,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1003,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1001,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1013,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1014,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1015,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1016,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1017,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1020,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2020,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3020,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1021,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2021,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 3021,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 2022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 3022,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2023,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 3024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "28": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "29": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "30": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1025,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_touch_1d_reformatted.json
+++ b/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_touch_1d_reformatted.json
@@ -1,0 +1,622 @@
+{
+    "last_touch_1d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1003,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1004,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1007,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1009,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1010,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1011,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1012,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1013,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1014,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1015,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1016,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1017,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1019,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 3023,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 2024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 3024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1025,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2025,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3025,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1026,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2026,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 3026,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1027,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1028,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_touch_2_7d_reformatted.json
+++ b/fbpcs/emp_games/pcf2_attribution/test/test_correctness/last_touch_2_7d_reformatted.json
@@ -1,0 +1,864 @@
+{
+    "last_touch_2_7d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1001,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1003,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1004,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1007,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1009,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1010,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1011,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1012,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1013,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1014,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1015,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1016,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1017,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1019,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2018,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2,
+                    "conv_value": 3023,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": 2,
+                    "conv_value": 1024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 2024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3,
+                    "conv_value": 3024,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1025,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2025,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3025,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1026,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 2026,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1,
+                    "conv_value": 3026,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1027,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "28": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1002,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "29": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "30": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "31": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "32": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2008,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "33": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "34": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "35": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1005,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "36": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1007,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "37": [
+                {
+                    "ad_id": 0,
+                    "conv_value": 1022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 2022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 3022,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "38": [
+                {
+                    "ad_id": 1,
+                    "conv_value": 1027,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 0,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Summary:
# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
Add unit tests for new output format - testCorrectness.

# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Attribution.
2. Modify PCS stage for attribution with the new flag.
3. Parse the input for new output format.
4. Add a new output format file in attribution game.
5. Add ComputAttributionHelper function for new output format.
6. Update computeAttributions function.
7. Update unit tests for PCF2 Attribution logic.
8. Add json test files for new output format.
9. Modify revealXORedResult method for new output.
10. **Add unit tests for new output format - testCorrectness.**

Reviewed By: chualynn, ajinkya-ghonge

Differential Revision: D37929917

