### PR TITLE
Add new AttributionResult format in aggregation game

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
@@ -69,3 +69,4 @@ DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",
     "s3 region name");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
@@ -29,3 +29,4 @@ DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
 DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+#include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
+
+namespace pcf2_aggregation {
+
+struct AttributionReformattedResult {
+  uint64_t adId;
+  uint64_t convValue;
+  bool isAttributed;
+
+  static AttributionReformattedResult fromDynamic(const folly::dynamic& obj) {
+    AttributionReformattedResult out = AttributionReformattedResult{};
+
+    out.adId = obj["ad_id"].asInt();
+    out.convValue = obj["conv_value"].asInt();
+    out.isAttributed = obj["is_attributed"].asBool();
+    return out;
+  }
+};
+
+template <int schedulerId>
+struct PrivateAttributionReformattedResult {
+  explicit PrivateAttributionReformattedResult(
+      const AttributionReformattedResult& attributionReformattedResult) {
+    typename SecBit<schedulerId>::ExtractedBit extractedAttribution(
+        attributionReformattedResult.isAttributed);
+    this->isAttributed = SecBit<schedulerId>(std::move(extractedAttribution));
+
+    typename SecAdId<schedulerId>::ExtractedInt extractedAdId(
+        attributionReformattedResult.adId);
+    this->adId = SecAdId<schedulerId>(std::move(extractedAdId));
+
+    typename SecConvValue<schedulerId>::ExtractedInt extractedConvValue(
+        attributionReformattedResult.convValue);
+    this->convValue = SecConvValue<schedulerId>(std::move(extractedConvValue));
+  }
+
+  SecBit<schedulerId> isAttributed;
+  SecAdId<schedulerId> adId;
+  SecConvValue<schedulerId> convValue;
+};
+
+} // namespace pcf2_aggregation

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -140,6 +140,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="use_new_output_format", required=False),
         ],
     },
 }

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -177,6 +177,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
             "max_num_conversions": private_computation_instance.product_config.common.padding_size,
             "log_cost": self._log_cost_to_s3,
+            "use_new_output_format": False,
         }
 
         game_args = [

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -98,6 +98,7 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             "use_xor_encryption": True,
             "use_postfix": True,
             "log_cost": True,
+            "use_new_output_format": False,
         }
         test_game_args = [
             {


### PR DESCRIPTION
Summary:
# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
In this diff, modifying AggregationMetrics file with new output format.
# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Aggregation.
2. Modify PCS stage for aggregation with the new flag.
3. Modify AttributionMetrics format in aggregation game
4. **Modify AggregationMetrics file with new output format.**
5. Modify Aggregator and Aggregator_impl for Private Aggregation.
6. Modify AggregationGame and AggregationGame_impl file for Private Aggregation.
7. Update unit tests for Private Aggregation game.

Reviewed By: chualynn

Differential Revision: D37975433

