### PR TITLE
Solve the linking issue when building the fbpcs image

### DIFF
--- a/docker/data_processing/CMakeLists.txt
+++ b/docker/data_processing/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   fbpcf
   ${AWSSDK_LINK_LIBRARIES}
   ${EMP-OT_LIBRARIES}
+  google-cloud-cpp::storage
   Folly::folly
   re2)
 


### PR DESCRIPTION
Summary:
The "Publish Docker image" action for fbpcf has been failing since diff D37727313 landed. The error is:

https://pxl.cl/28pLP

Turns out we're missing the "google-cloud-cpp::storage" for one of the component in CMakeLists.txt.

Differential Revision: D38097834

