### PR TITLE
Implement validate_results

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -175,7 +175,15 @@ class BoltGraphAPIClient(BoltClient):
     async def validate_results(
         self, instance_id: str, expected_result_path: Optional[str] = None
     ) -> bool:
-        pass
+        if not expected_result_path:
+            self.logger.info(
+                "No expected result path was given, so result validation was skipped."
+            )
+            return True
+        else:
+            raise NotImplementedError(
+                "This method should not be called with expected results"
+            )
 
     async def get_instance(self, instance_id: str) -> requests.Response:
         r = requests.get(f"{URL}/{instance_id}", self.params)

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -6,7 +6,7 @@
 
 import json
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcs.bolt.constants import FBPCS_GRAPH_API_TOKEN
 
@@ -16,6 +16,9 @@ from fbpcs.pl_coordinator.bolt_graphapi_client import (
     BoltPLGraphAPICreateInstanceArgs,
 )
 from fbpcs.pl_coordinator.exceptions import GraphAPITokenNotFound
+from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
+)
 
 ACCESS_TOKEN = "access_token"
 URL = "https://graph.facebook.com/v13.0"
@@ -104,8 +107,17 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_run_stage(self) -> None:
-        pass
+    @patch("fbpcs.pl_coordinator.bolt_graphapi_client.requests.post")
+    async def test_bolt_run_stage(self, mock_post) -> None:
+        expected_params = {
+            "access_token": ACCESS_TOKEN,
+            "operation": "NEXT",
+        }
+        self.test_client.should_invoke_stage = AsyncMock(return_value=True)
+        for stage in PrivateComputationStageFlow.ID_MATCH, None:
+            mock_post.reset_mock()
+            await self.test_client.run_stage(instance_id="id", stage=stage)
+            mock_post.assert_called_once_with(f"{URL}/id", params=expected_params)
 
     async def test_update_instance(self) -> None:
         pass

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -140,8 +140,14 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(state.server_ips, "1.1.1.1")
 
-    async def test_validate_results(self) -> None:
-        pass
+    async def test_validate_results_without_path(self) -> None:
+        valid = await self.test_client.validate_results("id")
+        self.assertEqual(valid, True)
+
+    async def test_validate_results_with_path(self) -> None:
+        expected_result_path = "test/path"
+        with self.assertRaises(NotImplementedError):
+            await self.test_client.validate_results("id", expected_result_path)
 
     def _get_graph_api_output(self, text: Any) -> requests.Response:
         r = requests.Response()


### PR DESCRIPTION
Summary:
## What
* all BoltClients must implement validate_results, but the graphapi client should never call this function

## Why
* there will be no expected results in actual lift/attribution runs

Differential Revision: D38124030

