### PR TITLE
Onboard one command runner to Bolt

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -108,8 +108,9 @@ class BoltRunner:
                             if tries >= max_tries:
                                 self.logger.exception(e)
                                 return False
-                            self.logger.error(
-                                f"Error: type: {type(e)}, message: {e}. Retries left: {self.num_tries - tries}."
+                            self.logger.error(f"Error: type: {type(e)}, message: {e}")
+                            self.logger.info(
+                                f"Retrying stage {stage}, Retries left: {self.num_tries - tries}."
                             )
                             await asyncio.sleep(RETRY_INTERVAL)
                     # update stage

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -81,6 +81,7 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
     pid_use_row_numbers: bool = True
     post_processing_data_optional: Optional[PostProcessingData] = None
     pid_configs: Optional[Dict[str, Any]] = None
+    pcs_features: Optional[List[str]] = None
 
     def __post_init__(self) -> None:
         if self.stage_flow_cls is PrivateComputationBaseStageFlow:
@@ -105,9 +106,13 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
 
 
 class BoltPCSClient(BoltClient):
-    def __init__(self, pcs: PrivateComputationService) -> None:
+    def __init__(
+        self, pcs: PrivateComputationService, logger: Optional[logging.Logger] = None
+    ) -> None:
         self.pcs = pcs
-        self.logger: logging.Logger = logging.getLogger(__name__)
+        self.logger: logging.Logger = (
+            logging.getLogger(__name__) if logger is None else logger
+        )
 
     async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
         assert isinstance(
@@ -136,6 +141,7 @@ class BoltPCSClient(BoltClient):
             pid_use_row_numbers=instance_args.pid_use_row_numbers,
             post_processing_data_optional=instance_args.post_processing_data_optional,
             pid_configs=instance_args.pid_configs,
+            pcs_features=instance_args.pcs_features,
         )
         return instance.infra_config.instance_id
 

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -13,6 +13,7 @@ from enum import Enum
 class PCSFeature(Enum):
     UNKNOWN = "unknown"
     PCS_DUMMY = "pcs_dummy_feature"
+    BOLT_RUNNER = "bolt_runner"
 
     @staticmethod
     def from_str(feature_str: str) -> "PCSFeature":
@@ -20,6 +21,8 @@ class PCSFeature(Enum):
         feature_str = feature_str.casefold()
         if feature_str == PCSFeature.PCS_DUMMY.value:
             return PCSFeature.PCS_DUMMY
+        elif feature_str == PCSFeature.BOLT_RUNNER.value:
+            return PCSFeature.BOLT_RUNNER
         else:
             logging.warning(f"can't map {feature_str} to pre-defined PCSFeature")
             return PCSFeature.UNKNOWN

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -424,6 +424,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             num_tries=arguments["--tries_per_stage"],
             dry_run=arguments["--dry_run"],
             result_visibility=arguments["--result_visibility"],
+            final_stage=PrivateComputationStageFlow.AGGREGATE,
         )
     elif arguments["run_attribution"]:
         stage_flow = PrivateComputationPCF2StageFlow


### PR DESCRIPTION
Summary:
## What
* use BoltRunner instead of PLInstanceRunner
* all relevant setup and execution is in the same place

## Why
* using Bolt makes runners easy to maintain since new features only need to be added to Bolt

Differential Revision: D38021363

