### PR TITLE
Uniform time assignment for status_update_ts and end_ts

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -5,7 +5,6 @@
 
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional, Set, Type, TYPE_CHECKING, Union
 
@@ -70,8 +69,7 @@ class StatusUpdate:
 # called in post_status_hook
 # happens whenever status is updated
 def post_update_status(obj: "InfraConfig") -> None:
-    # TODO:T126122461 uniform time assignment for `status_update_ts` and `end_ts`
-    obj.status_update_ts = int(datetime.now(tz=timezone.utc).timestamp())
+    obj.status_update_ts = int(time.time())
     append_status_updates(obj)
     if obj.is_stage_flow_completed():
         obj.end_ts = int(time.time())

--- a/fbpcs/private_computation/test/entity/test_infra_config.py
+++ b/fbpcs/private_computation/test/entity/test_infra_config.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    post_update_status,
+    PrivateComputationGameType,
+    PrivateComputationRole,
+    StatusUpdate,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstanceStatus,
+)
+
+
+class TestInfraConfig(unittest.TestCase):
+    def test_stage_flow(self) -> None:
+        pass
+
+    def test_is_stage_flow_completed(self) -> None:
+        pass
+
+
+class TestInfraConfigFreeFunctions(unittest.TestCase):
+    @patch("time.time", return_value=444)
+    def test_post_update_status_stage_flow_incomplete(
+        self, mock_time: MagicMock
+    ) -> None:
+        # Arrange
+        config = InfraConfig(
+            instance_id="test_instance_123",
+            role=PrivateComputationRole.PARTNER,
+            status=PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+            status_update_ts=123,
+            instances=[],
+            game_type=PrivateComputationGameType.ATTRIBUTION,
+            num_pid_containers=10,
+            num_mpc_containers=20,
+            num_files_per_mpc_container=100,
+            status_updates=[],
+        )
+        original_end_ts = config.end_ts
+        expected_status_updates = [StatusUpdate(config.status, 444)]
+
+        # Act
+        post_update_status(config)
+
+        # Assert
+        self.assertEqual(expected_status_updates, config.status_updates)
+        # Check that the end_ts wasn't updated
+        self.assertEqual(original_end_ts, config.end_ts)
+
+    @patch("time.time", return_value=555)
+    def test_post_update_status_stage_flow_complete(self, mock_time: MagicMock) -> None:
+        # Arrange
+        config = InfraConfig(
+            instance_id="test_instance_123",
+            role=PrivateComputationRole.PARTNER,
+            status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED,
+            status_update_ts=123,
+            instances=[],
+            game_type=PrivateComputationGameType.ATTRIBUTION,
+            num_pid_containers=10,
+            num_mpc_containers=20,
+            num_files_per_mpc_container=100,
+            status_updates=[],
+        )
+        expected_status_updates = [StatusUpdate(config.status, 555)]
+
+        # Act
+        post_update_status(config)
+
+        # Assert
+        self.assertEqual(expected_status_updates, config.status_updates)
+        # Check that the end_ts was updated
+        self.assertEqual(555, config.end_ts)
+
+    def test_append_status_updates(self) -> None:
+        pass
+
+    def test_raise_containers_error(self) -> None:
+        pass
+
+    def test_not_valid_containers(self) -> None:
+        pass

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -394,13 +394,21 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             private_computation_instance.elapsed_time,
         )
 
-        expected_end_ts = time.time() + 1
+        before_end_time = time.time()
         private_computation_instance.update_status(
             private_computation_instance.stage_flow.get_last_stage().completed_status,
             logging.getLogger(),
         )
-        self.assertEqual(
-            expected_end_ts, private_computation_instance.infra_config.end_ts
+        after_end_time = time.time()
+        # We have this somewhat complicated assert because `time.time` will be called
+        # multiple times inside the `update_status` statement and don't want any
+        # *really* specific testing like "end_ts = time.time() + 2" since that would
+        # be testing a side-effect rather than actual usage. Instead, we just check
+        # that the end time happened in between the time before and after the call.
+        self.assertTrue(
+            before_end_time
+            < private_computation_instance.infra_config.end_ts
+            < after_end_time
         )
         expected_elapsed_time = (
             private_computation_instance.infra_config.end_ts


### PR DESCRIPTION
Summary:
# What
  * Change instances of `datetime.datetime` to `time.time`

# Why
  * to be consistent throughout instance, we want to use the same method for time assignment in all locations
  * NOTE: the other uses of datetime in `fbpcs/` correspond to uses which need `timedelta`, so they are not relevant to change

Differential Revision: D38128606

