### PR TITLE
Swallow update instance exception when checking for existing instance

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -266,8 +266,7 @@ class BoltRunner:
                 await self.partner_client.update_instance(instance_id)
             self.logger.info(f"{instance_id} found.")
             return True
-        except Exception as e:
-            self.logger.exception(e)
+        except Exception:
             self.logger.info(f"{instance_id} not found.")
             return False
 


### PR DESCRIPTION
Summary:
## What
* swallow exception when instance is not found at the beginning of a new run

## Why
* it's confusing in the logs

Reviewed By: jrodal98, joe1234wu

Differential Revision: D38130322

