### PR TITLE
Add tests for lift with cohorts and breakdowns

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.h
@@ -25,9 +25,9 @@ class GenFakeData {
  private:
   struct LiftInputColumns {
     // publisher header:
-    //   id_,opportunity,test_flag,opportunity_timestamp,num_impressions,num_clicks,total_spend
+    //   id_,opportunity,test_flag,opportunity_timestamp,num_impressions,num_clicks,total_spend,breakdown_id
 
-    // partner header: id_,event_timestamps,values
+    // partner header: id_,event_timestamps,values,cohort_id
     std::string id;
     bool opportunity;
     bool test_flag;
@@ -35,6 +35,8 @@ class GenFakeData {
     int32_t num_impressions;
     int32_t num_clicks;
     int32_t total_spend;
+    int32_t breakdown_id;
+    int32_t cohort_id;
     std::vector<int32_t> event_timestamps;
     std::vector<int32_t> values;
   };

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftFakeDataParams.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftFakeDataParams.cpp
@@ -53,4 +53,15 @@ LiftFakeDataParams& LiftFakeDataParams::setOmitValuesColumn(
   return *this;
 }
 
+LiftFakeDataParams& LiftFakeDataParams::setNumBreakdowns(
+    int32_t numBreakdowns) {
+  numBreakdowns_ = numBreakdowns;
+  return *this;
+}
+
+LiftFakeDataParams& LiftFakeDataParams::setNumCohorts(int32_t numCohorts) {
+  numCohorts_ = numCohorts;
+  return *this;
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftFakeDataParams.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftFakeDataParams.h
@@ -21,6 +21,8 @@ class LiftFakeDataParams {
   int32_t epoch_ = 0;
   int32_t numConversions_ = 4;
   bool omitValuesColumn_ = false;
+  int32_t numBreakdowns_ = 0;
+  int32_t numCohorts_ = 0;
 
   LiftFakeDataParams& setNumRows(size_t numRows);
   LiftFakeDataParams& setOpportunityRate(double opportunityRate);
@@ -30,6 +32,8 @@ class LiftFakeDataParams {
   LiftFakeDataParams& setEpoch(int32_t epoch);
   LiftFakeDataParams& setNumConversions(int32_t numConversions);
   LiftFakeDataParams& setOmitValuesColumn(bool omitValuesColumn);
+  LiftFakeDataParams& setNumBreakdowns(int32_t numBreakdowns);
+  LiftFakeDataParams& setNumCohorts(int32_t numCohorts);
 };
 
 } // namespace private_lift


### PR DESCRIPTION
Summary:
[PCF][PL] Add tests for lift with cohorts and breakdowns to verify the correctness of the implementation using framework, against a plaintext implementation that does not use any cryptography.
We currently already have tests against a fixed set of correctness cases as well as random test inputs, and for this task we will add tests for missing functionalities for the random test inputs. In particular, the input data generator for the random test inputs does not include partner cohorts or publisher breakdowns, so we will first add that, then add tests to verify correctness.

Differential Revision: D38078384

