### PR TITLE
Adding supporting functions to AggMetrics to support missing keys in AdObjFmt

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <ostream>
 #include <string>
-#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -52,7 +52,7 @@ class AggMetrics {
   using MetricsValue = int64_t;
   using MetricsList = std::vector<
       std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>>;
-  using MetricsDict = std::unordered_map<
+  using MetricsDict = std::map<
       std::string,
       std::shared_ptr<AggMetrics<schedulerId, usingBatch, inputEncryption>>>;
   using MetricsVariant = std::variant<MetricsValue, MetricsList, MetricsDict>;
@@ -112,7 +112,11 @@ class AggMetrics {
     secVal_ = std::move(v);
   }
 
+  // inits secretValue holding data structure SecMetricVariant.
   void updateSecValueFromRawInt();
+
+  // Traverses through all children and calls updateSecValueFromRawInt.
+  void updateAllSecVals();
 
   // Value is moved to val_.
   void setList(MetricsList& v);
@@ -158,6 +162,9 @@ class AggMetrics {
 
   // Emits dynamic object which can be converted to json
   folly::dynamic toDynamic() const;
+
+  // Emits dynamic object which can be converted to json.
+  // Note: use this method reveal final output metric.
   folly::dynamic toRevealedDynamic(int party) const;
 
   // writes object with indentation to the ostream obj.


### PR DESCRIPTION
Summary:
# Context
This commit makes some implementation tweaks to AggMetrics.

# Changes in this diff
a. After looking at test files (shard_0)[https://www.internalfb.com/code/fbsource/fbcode/fbpcs/emp_games/attribution/shard_aggregator/test/ad_object_format/publisher_attribution_out.json_0] and (shar_1)[https://www.internalfb.com/code/fbsource/fbcode/fbpcs/emp_games/attribution/shard_aggregator/test/ad_object_format/publisher_attribution_out.json_1], realized that certain shards may have smaller outputs, we need to support grouping of keys.
 - ::accumulate() now just moves missing keys in lhs from rhs to lhs, that way we don't have to run any mpc-adds(saves time).

b. Rename object names inside accumulate function so that is more readable.
c. previously we used to run `updateSecValueFromRawInt()` while constructing the AggMetrics. This turned out be *not* a good idea.
 - Reason: AggMetrics is formed by traversing through folly::dynamic which is formed form folly::parseJson(), it appears that it uses unordered_map internally to store dictionaries. Hence, there is no guaranteed order in the keys. Also, what I noticed was the order changed from one thread to another (i.e. publisher thread to partner thread).
 - Fix: Inorder to fix this, we need order while traversal of the dictionary, switched to std::map internally in AggMetrics and we call updateSecValueRawInt() after AggMetrics is done building by calling a wrapper function updateAllSecVals().

Reviewed By: chualynn

Differential Revision: D38065429

