### PR TITLE
Modify AggretationMetrics files for Private Aggregation

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h
@@ -15,6 +15,7 @@
 #include "fbpcs/emp_games/common/Csv.h"
 
 #include "fbpcs/emp_games/pcf2_aggregation/Aggregator.h"
+#include "fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AttributionResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h"
 #include "fbpcs/emp_games/pcf2_aggregation/TouchpointMetadata.h"
@@ -26,9 +27,17 @@ struct AggregationMetrics {
       std::vector<std::map<int64_t, std::vector<AttributionResult>>>;
   using AttributionResultsList =
       std::vector<std::vector<std::vector<AttributionResult>>>;
+
+  using AttributionReformattedResultsMap =
+      std::vector<std::map<int64_t, std::vector<AttributionReformattedResult>>>;
+  using AttributionReformattedResultsList =
+      std::vector<std::vector<std::vector<AttributionReformattedResult>>>;
+
   AttributionResultsList attributionPidVector;
+  AttributionReformattedResultsList attributionReformattedPidVector;
 
   std::vector<std::string> attributionList;
+  std::vector<std::string> attributionReformattedList;
   std::unordered_map<std::string, AggregationOutput> formatToAggregation;
 
   folly::dynamic toDynamic() const {
@@ -98,6 +107,47 @@ struct AggregationMetrics {
 
     return attributionResultsList;
   }
+
+  static AggregationMetrics::AttributionReformattedResultsList
+  getAttributionsReformattedArrayfromDynamic(const folly::dynamic& obj) {
+    AttributionReformattedResultsMap attributionReformattedPidVectorMap;
+    // list of attribution rules
+    // For now, I am not using the rule name or formatter name in the logic as
+    // the aggregation behaviour is not affected by different attribution rules.
+    std::vector<std::string> attributionReformattedList;
+    AttributionReformattedResultsList attributionReformattedResultsList;
+    for (const auto& [rule, formatters] : obj.items()) {
+      attributionReformattedList.push_back(rule.asString());
+      for (const auto& [formatter, resultPerPID] : formatters.items()) {
+        std::map<int64_t, std::vector<AttributionReformattedResult>>
+            attributionsReformattedPerPidMap;
+        for (const auto& [pid, results] : resultPerPID.items()) {
+          std::vector<AttributionReformattedResult>
+              attributionReformattedResults;
+          for (const auto& result : results) {
+            attributionReformattedResults.push_back(
+                AttributionReformattedResult::fromDynamic(result));
+          }
+          attributionsReformattedPerPidMap.emplace(
+              pid.asInt(), attributionReformattedResults);
+        }
+        attributionReformattedPidVectorMap.push_back(
+            attributionsReformattedPerPidMap);
+      }
+
+      for (const auto& attributionsPerPidMap :
+           attributionReformattedPidVectorMap) {
+        std::vector<std::vector<AttributionReformattedResult>>
+            attributionPidVector;
+        for (const auto& attributionResults : attributionsPerPidMap) {
+          attributionPidVector.push_back(attributionResults.second);
+        }
+        attributionReformattedResultsList.push_back(attributionPidVector);
+      }
+    }
+
+    return attributionReformattedResultsList;
+  }
 };
 
 struct AggregationOutputMetrics {
@@ -159,12 +209,15 @@ class AggregationInputMetrics {
       std::vector<std::string> attributionRules,
       std::vector<std::string> aggregationFormats,
       AggregationMetrics::AttributionResultsList attributionSecretShare,
+      AggregationMetrics::AttributionReformattedResultsList
+          attributionReformattedSecretShare,
       std::vector<std::vector<TouchpointMetadata>> touchpointMetadataArrays,
       std::vector<std::vector<ConversionMetadata>> conversionMetadataArrays)
       : ids_{ids},
         attributionRules_{attributionRules},
         aggregationFormats_{aggregationFormats},
         attributionSecretShare_{attributionSecretShare},
+        attributionReformattedSecretShare_{attributionReformattedSecretShare},
         touchpointMetadataArrays_{touchpointMetadataArrays},
         conversionMetadataArrays_{conversionMetadataArrays} {}
 
@@ -179,6 +232,11 @@ class AggregationInputMetrics {
   const AggregationMetrics::AttributionResultsList& getAttributionSecretShares()
       const {
     return attributionSecretShare_;
+  }
+
+  const AggregationMetrics::AttributionReformattedResultsList&
+  getAttributionReformattedSecretShares() const {
+    return attributionReformattedSecretShare_;
   }
 
   const std::vector<std::vector<TouchpointMetadata>>& getTouchpointMetadata()
@@ -200,6 +258,8 @@ class AggregationInputMetrics {
   std::vector<std::string> attributionRules_;
   std::vector<std::string> aggregationFormats_;
   AggregationMetrics::AttributionResultsList attributionSecretShare_;
+  AggregationMetrics::AttributionReformattedResultsList
+      attributionReformattedSecretShare_;
   std::vector<std::vector<TouchpointMetadata>> touchpointMetadataArrays_;
   std::vector<std::vector<ConversionMetadata>> conversionMetadataArrays_;
 };
@@ -225,6 +285,15 @@ class PrivateAggregationMetrics {
       const PrivateAggregation<schedulerId>& privateAggregation) {
     for (const auto& [format, aggregator] : formatToAggregator) {
       aggregator->aggregateAttributions(privateAggregation);
+    }
+  }
+
+  void computeAggregationsReformattedPerFormat(
+      const PrivateAggregationReformatted<schedulerId>&
+          privateAggregationReformatted) {
+    for (const auto& [format, aggregator] : formatToAggregator) {
+      aggregator->aggregateReformattedAttributions(
+          privateAggregationReformatted);
     }
   }
 

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
@@ -69,3 +69,4 @@ DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",
     "s3 region name");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
@@ -29,3 +29,4 @@ DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
 DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/pcf2_aggregation/Aggregator.h
+++ b/fbpcs/emp_games/pcf2_aggregation/Aggregator.h
@@ -16,6 +16,7 @@
 #include "fbpcf/mpc_std_lib/oram/IWriteOnlyOramFactory.h"
 #include "fbpcf/mpc_std_lib/util/util.h"
 #include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AttributionResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
 #include "fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h"
@@ -25,6 +26,8 @@ namespace pcf2_aggregation {
 
 using AttributionResultsList =
     std::vector<std::vector<std::vector<AttributionResult>>>;
+using AttributionReformattedResultsList =
+    std::vector<std::vector<std::vector<AttributionReformattedResult>>>;
 
 template <int schedulerId>
 using MeasurementTpmArrays =
@@ -42,6 +45,13 @@ struct PrivateAggregation {
       attributionResults;
   MeasurementTpmArrays<schedulerId> privateTpm;
   MeasurementCvmArrays<schedulerId> privateCvm;
+  // TODO: Add fields for additional aggregators to PrivateAggregation.
+};
+
+template <int schedulerId>
+struct PrivateAggregationReformatted {
+  std::vector<std::vector<PrivateAttributionReformattedResult<schedulerId>>>
+      attributionReformattedResults;
   // TODO: Add fields for additional aggregators to PrivateAggregation.
 };
 
@@ -70,6 +80,10 @@ class Aggregator {
 
   virtual void aggregateAttributions(
       const PrivateAggregation<schedulerId>& privateAggregation) = 0;
+
+  virtual void aggregateReformattedAttributions(
+      const PrivateAggregationReformatted<schedulerId>&
+          privateAggregationReformatted) = 0;
 
   virtual AggregationOutput reveal() const = 0;
 };

--- a/fbpcs/emp_games/pcf2_aggregation/Aggregator_impl.h
+++ b/fbpcs/emp_games/pcf2_aggregation/Aggregator_impl.h
@@ -7,15 +7,16 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
 #include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
-#include "folly/dynamic.h"
 
 #include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h"
 #include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
 
 namespace pcf2_aggregation {
@@ -111,6 +112,37 @@ class MeasurementAggregator : public Aggregator<schedulerId> {
     aggregateUsingOram(touchpointConversionResults);
   }
 
+  virtual void aggregateReformattedAttributions(
+      const PrivateAggregationReformatted<schedulerId>&
+          privateAggregationReformatted) override {
+    XLOG(
+        INFO,
+        "Computing measurement aggregation based on reformatted attributions...");
+    const auto& privateAttributionReformattedArrays =
+        privateAggregationReformatted.attributionReformattedResults;
+    XLOGF(
+        DBG,
+        "For measurement aggregator, size of reformatted attribution: {}",
+        privateAttributionReformattedArrays.size());
+
+    std::vector<std::vector<typename MeasurementAggregation<
+        schedulerId>::PrivateMeasurementAggregationResult>>
+        touchpointConversionResults;
+    for (size_t i = 0; i < privateAttributionReformattedArrays.size(); ++i) {
+      // Retrieve the touchpoint-conversion metadata pairs based on
+      // attribution results.
+      auto touchpointConversionResultsPerId =
+          retrieveTouchpointForConversionPerIDReformatted(
+              privateAttributionReformattedArrays.at(i));
+      touchpointConversionResults.push_back(touchpointConversionResultsPerId);
+    }
+
+    XLOG(INFO, "Retrieved touchpoint-conversion metadata");
+
+    // Use ORAM for aggregation
+    aggregateUsingOram(touchpointConversionResults);
+  }
+
   const std::vector<typename MeasurementAggregation<
       schedulerId>::PrivateMeasurementAggregationResult>
   retrieveTouchpointForConversionPerID(
@@ -147,6 +179,39 @@ class MeasurementAggregator : public Aggregator<schedulerId> {
           schedulerId>::PrivateMeasurementAggregationResult aggregationResult{
           /* hasAttributedTouchpoint */ hasAttributedTouchpoint,
           /* conv */ privateCvmArray.at(convIndex),
+          /* tp */
+          PrivateMeasurementTouchpointMetadata<schedulerId>{attributedAdId}};
+
+      aggregationResults.push_back(aggregationResult);
+    }
+    return aggregationResults;
+  }
+
+  const std::vector<typename MeasurementAggregation<
+      schedulerId>::PrivateMeasurementAggregationResult>
+  retrieveTouchpointForConversionPerIDReformatted(
+      const std::vector<PrivateAttributionReformattedResult<schedulerId>>&
+          attributionReformattedResults) {
+    std::vector<typename MeasurementAggregation<
+        schedulerId>::PrivateMeasurementAggregationResult>
+        aggregationResults;
+
+    int numOfResults = attributionReformattedResults.size() - 1;
+
+    for (auto atIndex = numOfResults; atIndex >= 0; atIndex--) {
+      SecBit<schedulerId> hasAttributedTouchpoint;
+      SecConvValue<schedulerId> conversionValue;
+      SecAdId<schedulerId> attributedAdId;
+      hasAttributedTouchpoint =
+          attributionReformattedResults.at(atIndex).isAttributed;
+      attributedAdId = attributionReformattedResults.at(atIndex).adId;
+      conversionValue = attributionReformattedResults.at(atIndex).convValue;
+
+      typename MeasurementAggregation<
+          schedulerId>::PrivateMeasurementAggregationResult aggregationResult{
+          /* hasAttributedTouchpoint */ hasAttributedTouchpoint,
+          /* conv */
+          PrivateMeasurementConversionMetadata<schedulerId>{conversionValue},
           /* tp */
           PrivateMeasurementTouchpointMetadata<schedulerId>{attributedAdId}};
 

--- a/fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+#include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
+
+namespace pcf2_aggregation {
+
+struct AttributionReformattedResult {
+  uint64_t adId;
+  uint64_t convValue;
+  bool isAttributed;
+
+  static AttributionReformattedResult fromDynamic(const folly::dynamic& obj) {
+    AttributionReformattedResult out = AttributionReformattedResult{};
+
+    out.adId = obj["ad_id"].asInt();
+    out.convValue = obj["conv_value"].asInt();
+    out.isAttributed = obj["is_attributed"].asBool();
+    return out;
+  }
+};
+
+template <int schedulerId>
+struct PrivateAttributionReformattedResult {
+  explicit PrivateAttributionReformattedResult(
+      const AttributionReformattedResult& attributionReformattedResult) {
+    typename SecBit<schedulerId>::ExtractedBit extractedAttribution(
+        attributionReformattedResult.isAttributed);
+    this->isAttributed = SecBit<schedulerId>(std::move(extractedAttribution));
+
+    typename SecAdId<schedulerId>::ExtractedInt extractedAdId(
+        attributionReformattedResult.adId);
+    this->adId = SecAdId<schedulerId>(std::move(extractedAdId));
+
+    typename SecConvValue<schedulerId>::ExtractedInt extractedConvValue(
+        attributionReformattedResult.convValue);
+    this->convValue = SecConvValue<schedulerId>(std::move(extractedConvValue));
+  }
+
+  SecBit<schedulerId> isAttributed;
+  SecAdId<schedulerId> adId;
+  SecConvValue<schedulerId> convValue;
+};
+
+} // namespace pcf2_aggregation

--- a/fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h
+++ b/fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h
@@ -36,6 +36,9 @@ struct PrivateMeasurementConversionMetadata {
       convValue = SecConvValue<schedulerId>(std::move(extractedConvValue));
     }
   }
+  explicit PrivateMeasurementConversionMetadata(
+      const SecConvValue<schedulerId>& secConvValue)
+      : convValue(secConvValue) {}
 
   SecConvValue<schedulerId> convValue;
 };

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -140,6 +140,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="use_new_output_format", required=False),
         ],
     },
 }

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -177,6 +177,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
             "max_num_conversions": private_computation_instance.product_config.common.padding_size,
             "log_cost": self._log_cost_to_s3,
+            "use_new_output_format": False,
         }
 
         game_args = [

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -98,6 +98,7 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             "use_xor_encryption": True,
             "use_postfix": True,
             "log_cost": True,
+            "use_new_output_format": False,
         }
         test_game_args = [
             {


### PR DESCRIPTION
Summary:
# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
In this diff, modifying AggregationMetrics files with new output format.
# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Aggregation.
2. Modify PCS stage for aggregation with the new flag.
3. Modify AttributionMetrics format in aggregation game
4. Modify Aggregator and Aggregator_impl for Private Aggregation.
5. **Modify AggregationMetrics files with new output format.**
6. Modify computeAggregation logic - AggregationGame and AggregationGame_impl file for Private Aggregation.
7. Update unit tests for Private Aggregation game.
8. Add json test files for testing correctness for Aggregation.
9. Add unit tests for Aggregation - test correctness

Reviewed By: ajinkya-ghonge

Differential Revision: D38091978

