### PR TITLE
Adding local stage flow to fix automated e2e tests.

### DIFF
--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -102,7 +102,10 @@ class AggregateShardsStageService(PrivateComputationStageService):
             "PrivateComputationPIDPATestStageFlow",
         ]:
             input_stage_path = pc_instance.pcf2_aggregation_stage_output_base_path
-        elif pc_instance.get_flow_cls_name == "PrivateComputationPCF2LiftStageFlow":
+        elif pc_instance.get_flow_cls_name in [
+            "PrivateComputationPCF2LiftStageFlow",
+            "PrivateComputationPCF2LiftLocalTestStageFlow",
+        ]:
             input_stage_path = pc_instance.pcf2_lift_stage_output_base_path
         else:
             input_stage_path = pc_instance.compute_stage_output_base_path

--- a/fbpcs/private_computation/stage_flows/__init__.py
+++ b/fbpcs/private_computation/stage_flows/__init__.py
@@ -17,6 +17,7 @@ __all__ = [  # noqa: ignore=F405
     "private_computation_decoupled_local_test_stage_flow",
     "private_computation_decoupled_stage_flow",
     "private_computation_local_test_stage_flow",
+    "private_computation_pcf2_lift_local_test_stage_flow",
     "private_computation_pcf2_lift_stage_flow",
     "private_computation_pcf2_local_test_stage_flow",
     "private_computation_pcf2_stage_flow",

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -38,7 +38,7 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = "CREATED ID_SPINE_COMBINER RESHARD DECOUPLED_ATTRIBUTION DECOUPLED_AGGREGATION AGGREGATE"
+    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS ID_SPINE_COMBINER RESHARD DECOUPLED_ATTRIBUTION DECOUPLED_AGGREGATION AGGREGATE"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -46,6 +46,31 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
         PrivateComputationInstanceStatus.CREATION_STARTED,
         PrivateComputationInstanceStatus.CREATED,
         PrivateComputationInstanceStatus.CREATION_FAILED,
+        False,
+    )
+    PID_SHARD = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_SHARD_STARTED,
+        PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+        PrivateComputationInstanceStatus.PID_SHARD_FAILED,
+        False,
+    )
+    PID_PREPARE = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_PREPARE_STARTED,
+        PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+        PrivateComputationInstanceStatus.PID_PREPARE_FAILED,
+        False,
+    )
+    ID_MATCH = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+        True,
+        is_retryable=False,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
         False,
     )
     ID_SPINE_COMBINER = PrivateComputationStageFlowData(

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -32,9 +32,7 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = (
-        "CREATED ID_SPINE_COMBINER RESHARD COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
-    )
+    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS ID_SPINE_COMBINER RESHARD COMPUTE AGGREGATE POST_PROCESSING_HANDLERS"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -42,6 +40,31 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.CREATION_STARTED,
         PrivateComputationInstanceStatus.CREATED,
         PrivateComputationInstanceStatus.CREATION_FAILED,
+        False,
+    )
+    PID_SHARD = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_SHARD_STARTED,
+        PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+        PrivateComputationInstanceStatus.PID_SHARD_FAILED,
+        False,
+    )
+    PID_PREPARE = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_PREPARE_STARTED,
+        PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+        PrivateComputationInstanceStatus.PID_PREPARE_FAILED,
+        False,
+    )
+    ID_MATCH = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+        True,
+        is_retryable=False,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
         False,
     )
     ID_SPINE_COMBINER = PrivateComputationStageFlowData(

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_local_test_stage_flow.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.pcf2_lift_stage_service import (
+    PCF2LiftStageService,
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+    PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
+)
+
+
+class PrivateComputationPCF2LiftLocalTestStageFlow(PrivateComputationBaseStageFlow):
+    """
+    - Private Lift Stage Flow -
+    This enum lists all of the supported stage types and maps to their possible statuses.
+    It also provides methods to get information about the next or previous stage.
+
+    NOTE: The order in which the enum members appear is the order in which the stages are intended
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    An exception is raised at runtime if _order_ is inconsistent with the actual member order.
+    """
+
+    # Specifies the order of the stages. Don't change this unless you know what you are doing.
+    # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
+    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS ID_SPINE_COMBINER RESHARD PCF2_LIFT AGGREGATE POST_PROCESSING_HANDLERS"
+    # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
+    # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
+
+    CREATED = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.CREATION_STARTED,
+        PrivateComputationInstanceStatus.CREATED,
+        PrivateComputationInstanceStatus.CREATION_FAILED,
+        False,
+    )
+    PID_SHARD = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_SHARD_STARTED,
+        PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+        PrivateComputationInstanceStatus.PID_SHARD_FAILED,
+        False,
+    )
+    PID_PREPARE = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_PREPARE_STARTED,
+        PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+        PrivateComputationInstanceStatus.PID_PREPARE_FAILED,
+        False,
+    )
+    ID_MATCH = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+        True,
+        is_retryable=False,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
+        False,
+    )
+    ID_SPINE_COMBINER = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_SPINE_COMBINER_STARTED,
+        PrivateComputationInstanceStatus.ID_SPINE_COMBINER_COMPLETED,
+        PrivateComputationInstanceStatus.ID_SPINE_COMBINER_FAILED,
+        False,
+    )
+    RESHARD = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.RESHARD_STARTED,
+        PrivateComputationInstanceStatus.RESHARD_COMPLETED,
+        PrivateComputationInstanceStatus.RESHARD_FAILED,
+        False,
+    )
+    PCF2_LIFT = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PCF2_LIFT_STARTED,
+        PrivateComputationInstanceStatus.PCF2_LIFT_COMPLETED,
+        PrivateComputationInstanceStatus.PCF2_LIFT_FAILED,
+        True,
+        timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,  # setting the timeout here to 12 hours, as lift stage can sometime take more time.
+    )
+    AGGREGATE = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.AGGREGATION_STARTED,
+        PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
+        PrivateComputationInstanceStatus.AGGREGATION_FAILED,
+        True,
+    )
+    POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,
+        PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED,
+        PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
+        False,
+    )
+
+    def get_stage_service(
+        self, args: PrivateComputationStageServiceArgs
+    ) -> PrivateComputationStageService:
+        """
+        Maps PrivateComputationStageFlow instances to StageService instances
+
+        Arguments:
+            args: Common arguments initialized in PrivateComputationService that are consumed by stage services
+
+        Returns:
+            An instantiated StageService object corresponding to the StageFlow enum member caller.
+
+        Raises:
+            NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
+        """
+        if self is self.PCF2_LIFT:
+            return PCF2LiftStageService(
+                args.onedocker_binary_config_map,
+                args.mpc_svc,
+            )
+        else:
+            return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
@@ -38,9 +38,7 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
 
     # Specifies the order of the stages. Don't change this unless you know what you are doing.
     # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
-    _order_ = (
-        "CREATED ID_SPINE_COMBINER RESHARD PCF2_ATTRIBUTION PCF2_AGGREGATION AGGREGATE"
-    )
+    _order_ = "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_MATCH_POST_PROCESS ID_SPINE_COMBINER RESHARD PCF2_ATTRIBUTION PCF2_AGGREGATION AGGREGATE"
     # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
@@ -48,6 +46,31 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
         PrivateComputationInstanceStatus.CREATION_STARTED,
         PrivateComputationInstanceStatus.CREATED,
         PrivateComputationInstanceStatus.CREATION_FAILED,
+        False,
+    )
+    PID_SHARD = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_SHARD_STARTED,
+        PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+        PrivateComputationInstanceStatus.PID_SHARD_FAILED,
+        False,
+    )
+    PID_PREPARE = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.PID_PREPARE_STARTED,
+        PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+        PrivateComputationInstanceStatus.PID_PREPARE_FAILED,
+        False,
+    )
+    ID_MATCH = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+        True,
+        is_retryable=False,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
         False,
     )
     ID_SPINE_COMBINER = PrivateComputationStageFlowData(


### PR DESCRIPTION
Summary:
# Context
Caleb is working on adding the automated test for pcf2 lift, however we are facing an issue where the test times out due to an underlying error in aggregation stage.

# Error
Aggregation stage is looking for input in compute stage i.e. in PCF 1.0 lift, while we are running with PCF2.0 lift and the files are places in pcf2_lift_stage.

# Fix
Added PCF2LiftLocalStageFlow to aggregation service, so that it picks up the right input path for the local tests.

Differential Revision: D38213046

