### PR TITLE
2/n Remove need for skip_publisher_creation flag

### DIFF
--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -241,3 +241,16 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
                     "test_id", PrivateComputationStageFlow
                 )
                 self.assertEqual(valid_stage, expected_stage)
+
+    @mock.patch("fbpcs.bolt.bolt_job.BoltCreateInstanceArgs")
+    @mock.patch("fbpcs.bolt.bolt_client.BoltState")
+    async def test_is_existing_instance(self, mock_state, mock_instance_args) -> None:
+        self.bolt_pcs_client.update_instance = mock.AsyncMock(
+            side_effect=[mock_state, Exception()]
+        )
+        for expected_result in (True, False):
+            with self.subTest(expected_result=expected_result):
+                actual_result = await self.bolt_pcs_client.is_existing_instance(
+                    instance_args=mock_instance_args
+                )
+                self.assertEqual(actual_result, expected_result)

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -181,6 +181,21 @@ class BoltGraphAPIClient(BoltClient):
                 "This method should not be called with expected results"
             )
 
+    async def is_existing_instance(self, instance_args: BoltCreateInstanceArgs) -> bool:
+        instance_id = instance_args.instance_id
+        self.logger.info(f"Checking if {instance_id} exists...")
+        if instance_id:
+            try:
+                await self.update_instance(instance_id)
+                self.logger.info(f"{instance_id} found.")
+                return True
+            except Exception:
+                self.logger.info(f"{instance_id} not found.")
+                return False
+        else:
+            self.logger.info("instance_id is empty, fetching a valid one")
+            return False
+
     async def get_instance(self, instance_id: str) -> requests.Response:
         r = requests.get(f"{URL}/{instance_id}", self.params)
         self._check_err(r, "getting fb instance")

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -212,9 +212,7 @@ def run_attribution(
             poll_interval=60,
         )
         runner = BoltRunner(
-            publisher_client=BoltGraphAPIClient(
-                config=config["graphapi"], logger=logger
-            ),
+            publisher_client=BoltGraphAPIClient(config=config, logger=logger),
             partner_client=BoltPCSClient(
                 _build_private_computation_service(
                     config["private_computation"],


### PR DESCRIPTION
Summary:
## What
* graphAPI client create_instance now checks for existing instances and creates one if none exist
* version check is moved into create instance
* init config argument reverted back to full config dict rather than just the "graphapi" section

## Why
* the GraphAPI client cannot check if an instance exists in is_existing_instance as mentioned in D38089091, so all the work must be done in create_instance. It either finds an existing instance and returns its ID or creates a new one and returns the new ID.

Differential Revision: D38217914

