### PR TITLE
Adding PL PCF2 GK to pcs_feature enum

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -11,18 +11,18 @@ from enum import Enum
 
 
 class PCSFeature(Enum):
-    UNKNOWN = "unknown"
-    PCS_DUMMY = "pcs_dummy_feature"
+
     BOLT_RUNNER = "bolt_runner"
+    PCS_DUMMY = "pcs_dummy_feature"
+    PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
+    UNKNOWN = "unknown"
 
     @staticmethod
     def from_str(feature_str: str) -> "PCSFeature":
         """maps str (possibly feature name defined in SV) to a PCSFeature."""
         feature_str = feature_str.casefold()
-        if feature_str == PCSFeature.PCS_DUMMY.value:
-            return PCSFeature.PCS_DUMMY
-        elif feature_str == PCSFeature.BOLT_RUNNER.value:
-            return PCSFeature.BOLT_RUNNER
-        else:
+        try:
+            return PCSFeature(feature_str)
+        except ValueError:
             logging.warning(f"can't map {feature_str} to pre-defined PCSFeature")
             return PCSFeature.UNKNOWN

--- a/fbpcs/private_computation/test/entity/test_pcs_feature.py
+++ b/fbpcs/private_computation/test/entity/test_pcs_feature.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
+
+
+class TestPcsFeatureEnum(unittest.TestCase):
+    def test_pcs_feature_enum(self) -> None:
+        for test_pcs_feature in PCSFeature:
+            with self.subTest(test_pcs_feature=test_pcs_feature):
+                feature = PCSFeature.from_str(test_pcs_feature.value)
+
+                # Test to make sure  from_str is case insensitive.
+                uppercase_feature = PCSFeature.from_str(test_pcs_feature.value.upper())
+
+                self.assertEquals(feature, test_pcs_feature)
+                self.assertEquals(uppercase_feature, test_pcs_feature)
+
+    def test_pcs_feature_enum_unkown(self) -> None:
+        feature = PCSFeature.from_str("unknown_feature")
+        self.assertEquals(feature, PCSFeature.UNKNOWN)


### PR DESCRIPTION
Summary: Adding PL PCF2 GK entry to pcs_feature enum.

Differential Revision: D38230003

