### PR TITLE
Hook up metric service to PCService

### DIFF
--- a/fbpcs/common/service/metric_service.py
+++ b/fbpcs/common/service/metric_service.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import logging
+
+
+class MetricService(abc.ABC):
+    def __init__(self, category: str = "default") -> None:
+        self.category = category
+        self.logger: logging.Logger = logging.getLogger(__name__)
+
+    @abc.abstractmethod
+    def bump_entity_key(self, entity: str, key: str, value: int = 1) -> None:
+        pass

--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+
+from fbpcs.common.service.metric_service import MetricService
+
+
+class SimpleMetricService(MetricService):
+    def bump_entity_key(self, entity: str, key: str, value: int = 1) -> None:
+        result = {
+            "operation": "bump_entity_key",
+            "entity": f"{self.category}.{entity}",
+            "key": key,
+            "value": value,
+        }
+        self.logger.info(json.dumps(result))

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import logging
+from unittest import mock, TestCase
+
+from fbpcs.common.service.simple_metric_service import SimpleMetricService
+
+
+class TestSimpleMetricService(TestCase):
+    def setUp(self) -> None:
+        self.logger = mock.create_autospec(logging.Logger)
+        self.svc = SimpleMetricService(category="default")
+        self.svc.logger = self.logger
+
+    def test_bump_entity_key_simple(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key",
+                "entity": "default.entity",
+                "key": "key",
+                "value": 1,
+            }
+        )
+
+        # Act
+        self.svc.bump_entity_key("entity", "key")
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)
+
+    def test_bump_entity_key_custom_value(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key",
+                "entity": "default.entity",
+                "key": "key",
+                "value": 123,
+            }
+        )
+
+        # Act
+        self.svc.bump_entity_key("entity", "key", 123)
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -17,8 +17,10 @@ from fbpcp.error.pcp import ThrottlingError
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
-from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 
+from fbpcs.common.service.metric_service import MetricService
+from fbpcs.common.service.simple_metric_service import SimpleMetricService
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
 from fbpcs.private_computation.entity.infra_config import (
@@ -97,6 +99,7 @@ class PrivateComputationService:
         post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
         pid_post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
         workflow_svc: Optional[WorkflowService] = None,
+        metric_svc: Optional[MetricService] = None,
     ) -> None:
         """Constructor of PrivateComputationService
         instance_repository -- repository to CRUD PrivateComputationInstance
@@ -107,6 +110,9 @@ class PrivateComputationService:
         self.onedocker_svc = onedocker_svc
         self.workflow_svc = workflow_svc
         self.onedocker_binary_config_map = onedocker_binary_config_map
+        # If a metric service isn't provided, just use a SimpleMetricService
+        # so a caller will never have to worry about this being None
+        self.metric_svc: MetricService = metric_svc or SimpleMetricService()
         self.post_processing_handlers: Dict[str, PostProcessingHandler] = (
             post_processing_handlers or {}
         )
@@ -123,6 +129,7 @@ class PrivateComputationService:
             self.onedocker_svc,
             self.pc_validator_config,
             self.workflow_svc,
+            self.metric_svc,
         )
         self.logger: logging.Logger = logging.getLogger(__name__)
 

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -13,6 +13,8 @@ from typing import DefaultDict, Dict, List, Optional
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
+
+from fbpcs.common.service.metric_service import MetricService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
@@ -38,6 +40,7 @@ class PrivateComputationStageServiceArgs:
     onedocker_svc: OneDockerService
     pc_validator_config: PCValidatorConfig
     workflow_svc: Optional[WorkflowService]
+    metric_svc: MetricService
 
 
 class PrivateComputationStageService(abc.ABC):


### PR DESCRIPTION
Summary: Now that we have a metric service definition, we can hook it into PCService to give all py code the ability to start logging metrics.

Differential Revision: D38251847

