### PR TITLE
Add simple metrics service

### DIFF
--- a/fbpcs/common/service/metric_service.py
+++ b/fbpcs/common/service/metric_service.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import logging
+
+
+class MetricService(abc.ABC):
+    def __init__(self, category: str = "default") -> None:
+        self.category = category
+        self.logger: logging.Logger = logging.getLogger(__name__)
+
+    @abc.abstractmethod
+    def bump_entity_key(self, entity: str, key: str, value: int = 1) -> None:
+        pass

--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+
+from fbpcs.common.service.metric_service import MetricService
+
+
+class SimpleMetricService(MetricService):
+    def bump_entity_key(self, entity: str, key: str, value: int = 1) -> None:
+        result = {
+            "operation": "bump_entity_key",
+            "entity": f"{self.category}.{entity}",
+            "key": key,
+            "value": value,
+        }
+        self.logger.info(json.dumps(result))

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import logging
+from unittest import mock, TestCase
+
+from fbpcs.common.service.simple_metric_service import SimpleMetricService
+
+
+class TestSimpleMetricService(TestCase):
+    def setUp(self) -> None:
+        self.logger = mock.create_autospec(logging.Logger)
+        self.svc = SimpleMetricService(category="default")
+        self.svc.logger = self.logger
+
+    def test_bump_entity_key_simple(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key",
+                "entity": "default.entity",
+                "key": "key",
+                "value": 1,
+            }
+        )
+
+        # Act
+        self.svc.bump_entity_key("entity", "key")
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)
+
+    def test_bump_entity_key_custom_value(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key",
+                "entity": "default.entity",
+                "key": "key",
+                "value": 123,
+            }
+        )
+
+        # Act
+        self.svc.bump_entity_key("entity", "key", 123)
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)


### PR DESCRIPTION
Summary: Define a metrics service (which will work in OSS) which simply JSON dumps the metrics and sends the string to a logger

Differential Revision: D38249478

