### PR TITLE
Add unit tests for Aggregation - test correctness

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/AggregationGame.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationGame.h
@@ -67,6 +67,11 @@ class AggregationGame : public fbpcf::frontend::MpcGame<schedulerId> {
   privatelyShareAttributionResults(
       const std::vector<std::vector<AttributionResult>>& attributionResults);
 
+  std::vector<std::vector<PrivateAttributionReformattedResult<schedulerId>>>
+  privatelyShareAttributionReformattedResults(
+      const std::vector<std::vector<AttributionReformattedResult>>&
+          attributionReformattedResults);
+
   /**
    * Both parties share and retrieve valid original ad ids.
    */
@@ -85,6 +90,10 @@ class AggregationGame : public fbpcf::frontend::MpcGame<schedulerId> {
       std::vector<uint64_t>& validOriginalAdIds);
 
   AggregationOutputMetrics computeAggregations(
+      const int myRole,
+      const AggregationInputMetrics& inputData);
+
+  AggregationOutputMetrics computeAggregationsReformatted(
       const int myRole,
       const AggregationInputMetrics& inputData);
 

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h
@@ -15,6 +15,7 @@
 #include "fbpcs/emp_games/common/Csv.h"
 
 #include "fbpcs/emp_games/pcf2_aggregation/Aggregator.h"
+#include "fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AttributionResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h"
 #include "fbpcs/emp_games/pcf2_aggregation/TouchpointMetadata.h"
@@ -26,9 +27,17 @@ struct AggregationMetrics {
       std::vector<std::map<int64_t, std::vector<AttributionResult>>>;
   using AttributionResultsList =
       std::vector<std::vector<std::vector<AttributionResult>>>;
+
+  using AttributionReformattedResultsMap =
+      std::vector<std::map<int64_t, std::vector<AttributionReformattedResult>>>;
+  using AttributionReformattedResultsList =
+      std::vector<std::vector<std::vector<AttributionReformattedResult>>>;
+
   AttributionResultsList attributionPidVector;
+  AttributionReformattedResultsList attributionReformattedPidVector;
 
   std::vector<std::string> attributionList;
+  std::vector<std::string> attributionReformattedList;
   std::unordered_map<std::string, AggregationOutput> formatToAggregation;
 
   folly::dynamic toDynamic() const {
@@ -98,6 +107,47 @@ struct AggregationMetrics {
 
     return attributionResultsList;
   }
+
+  static AggregationMetrics::AttributionReformattedResultsList
+  getAttributionsReformattedArrayfromDynamic(const folly::dynamic& obj) {
+    AttributionReformattedResultsMap attributionReformattedPidVectorMap;
+    // list of attribution rules
+    // For now, I am not using the rule name or formatter name in the logic as
+    // the aggregation behaviour is not affected by different attribution rules.
+    std::vector<std::string> attributionReformattedList;
+    AttributionReformattedResultsList attributionReformattedResultsList;
+    for (const auto& [rule, formatters] : obj.items()) {
+      attributionReformattedList.push_back(rule.asString());
+      for (const auto& [formatter, resultPerPID] : formatters.items()) {
+        std::map<int64_t, std::vector<AttributionReformattedResult>>
+            attributionsReformattedPerPidMap;
+        for (const auto& [pid, results] : resultPerPID.items()) {
+          std::vector<AttributionReformattedResult>
+              attributionReformattedResults;
+          for (const auto& result : results) {
+            attributionReformattedResults.push_back(
+                AttributionReformattedResult::fromDynamic(result));
+          }
+          attributionsReformattedPerPidMap.emplace(
+              pid.asInt(), attributionReformattedResults);
+        }
+        attributionReformattedPidVectorMap.push_back(
+            attributionsReformattedPerPidMap);
+      }
+
+      for (const auto& attributionsPerPidMap :
+           attributionReformattedPidVectorMap) {
+        std::vector<std::vector<AttributionReformattedResult>>
+            attributionPidVector;
+        for (const auto& attributionResults : attributionsPerPidMap) {
+          attributionPidVector.push_back(attributionResults.second);
+        }
+        attributionReformattedResultsList.push_back(attributionPidVector);
+      }
+    }
+
+    return attributionReformattedResultsList;
+  }
 };
 
 struct AggregationOutputMetrics {
@@ -159,12 +209,15 @@ class AggregationInputMetrics {
       std::vector<std::string> attributionRules,
       std::vector<std::string> aggregationFormats,
       AggregationMetrics::AttributionResultsList attributionSecretShare,
+      AggregationMetrics::AttributionReformattedResultsList
+          attributionReformattedSecretShare,
       std::vector<std::vector<TouchpointMetadata>> touchpointMetadataArrays,
       std::vector<std::vector<ConversionMetadata>> conversionMetadataArrays)
       : ids_{ids},
         attributionRules_{attributionRules},
         aggregationFormats_{aggregationFormats},
         attributionSecretShare_{attributionSecretShare},
+        attributionReformattedSecretShare_{attributionReformattedSecretShare},
         touchpointMetadataArrays_{touchpointMetadataArrays},
         conversionMetadataArrays_{conversionMetadataArrays} {}
 
@@ -179,6 +232,11 @@ class AggregationInputMetrics {
   const AggregationMetrics::AttributionResultsList& getAttributionSecretShares()
       const {
     return attributionSecretShare_;
+  }
+
+  const AggregationMetrics::AttributionReformattedResultsList&
+  getAttributionReformattedSecretShares() const {
+    return attributionReformattedSecretShare_;
   }
 
   const std::vector<std::vector<TouchpointMetadata>>& getTouchpointMetadata()
@@ -200,6 +258,8 @@ class AggregationInputMetrics {
   std::vector<std::string> attributionRules_;
   std::vector<std::string> aggregationFormats_;
   AggregationMetrics::AttributionResultsList attributionSecretShare_;
+  AggregationMetrics::AttributionReformattedResultsList
+      attributionReformattedSecretShare_;
   std::vector<std::vector<TouchpointMetadata>> touchpointMetadataArrays_;
   std::vector<std::vector<ConversionMetadata>> conversionMetadataArrays_;
 };
@@ -225,6 +285,15 @@ class PrivateAggregationMetrics {
       const PrivateAggregation<schedulerId>& privateAggregation) {
     for (const auto& [format, aggregator] : formatToAggregator) {
       aggregator->aggregateAttributions(privateAggregation);
+    }
+  }
+
+  void computeAggregationsReformattedPerFormat(
+      const PrivateAggregationReformatted<schedulerId>&
+          privateAggregationReformatted) {
+    for (const auto& [format, aggregator] : formatToAggregator) {
+      aggregator->aggregateReformattedAttributions(
+          privateAggregationReformatted);
     }
   }
 

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
@@ -69,3 +69,4 @@ DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",
     "s3 region name");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
@@ -29,3 +29,4 @@ DECLARE_int32(input_encryption);
 DECLARE_bool(log_cost);
 DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/pcf2_aggregation/Aggregator.h
+++ b/fbpcs/emp_games/pcf2_aggregation/Aggregator.h
@@ -16,6 +16,7 @@
 #include "fbpcf/mpc_std_lib/oram/IWriteOnlyOramFactory.h"
 #include "fbpcf/mpc_std_lib/util/util.h"
 #include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AttributionResult.h"
 #include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
 #include "fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h"
@@ -25,6 +26,8 @@ namespace pcf2_aggregation {
 
 using AttributionResultsList =
     std::vector<std::vector<std::vector<AttributionResult>>>;
+using AttributionReformattedResultsList =
+    std::vector<std::vector<std::vector<AttributionReformattedResult>>>;
 
 template <int schedulerId>
 using MeasurementTpmArrays =
@@ -42,6 +45,13 @@ struct PrivateAggregation {
       attributionResults;
   MeasurementTpmArrays<schedulerId> privateTpm;
   MeasurementCvmArrays<schedulerId> privateCvm;
+  // TODO: Add fields for additional aggregators to PrivateAggregation.
+};
+
+template <int schedulerId>
+struct PrivateAggregationReformatted {
+  std::vector<std::vector<PrivateAttributionReformattedResult<schedulerId>>>
+      attributionReformattedResults;
   // TODO: Add fields for additional aggregators to PrivateAggregation.
 };
 
@@ -70,6 +80,10 @@ class Aggregator {
 
   virtual void aggregateAttributions(
       const PrivateAggregation<schedulerId>& privateAggregation) = 0;
+
+  virtual void aggregateReformattedAttributions(
+      const PrivateAggregationReformatted<schedulerId>&
+          privateAggregationReformatted) = 0;
 
   virtual AggregationOutput reveal() const = 0;
 };

--- a/fbpcs/emp_games/pcf2_aggregation/Aggregator_impl.h
+++ b/fbpcs/emp_games/pcf2_aggregation/Aggregator_impl.h
@@ -7,15 +7,16 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
 #include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <memory>
 #include <string>
 #include <utility>
-#include "folly/dynamic.h"
 
 #include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h"
 #include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
 
 namespace pcf2_aggregation {
@@ -111,6 +112,37 @@ class MeasurementAggregator : public Aggregator<schedulerId> {
     aggregateUsingOram(touchpointConversionResults);
   }
 
+  virtual void aggregateReformattedAttributions(
+      const PrivateAggregationReformatted<schedulerId>&
+          privateAggregationReformatted) override {
+    XLOG(
+        INFO,
+        "Computing measurement aggregation based on reformatted attributions...");
+    const auto& privateAttributionReformattedArrays =
+        privateAggregationReformatted.attributionReformattedResults;
+    XLOGF(
+        DBG,
+        "For measurement aggregator, size of reformatted attribution: {}",
+        privateAttributionReformattedArrays.size());
+
+    std::vector<std::vector<typename MeasurementAggregation<
+        schedulerId>::PrivateMeasurementAggregationResult>>
+        touchpointConversionResults;
+    for (size_t i = 0; i < privateAttributionReformattedArrays.size(); ++i) {
+      // Retrieve the touchpoint-conversion metadata pairs based on
+      // attribution results.
+      auto touchpointConversionResultsPerId =
+          retrieveTouchpointForConversionPerIDReformatted(
+              privateAttributionReformattedArrays.at(i));
+      touchpointConversionResults.push_back(touchpointConversionResultsPerId);
+    }
+
+    XLOG(INFO, "Retrieved touchpoint-conversion metadata");
+
+    // Use ORAM for aggregation
+    aggregateUsingOram(touchpointConversionResults);
+  }
+
   const std::vector<typename MeasurementAggregation<
       schedulerId>::PrivateMeasurementAggregationResult>
   retrieveTouchpointForConversionPerID(
@@ -147,6 +179,39 @@ class MeasurementAggregator : public Aggregator<schedulerId> {
           schedulerId>::PrivateMeasurementAggregationResult aggregationResult{
           /* hasAttributedTouchpoint */ hasAttributedTouchpoint,
           /* conv */ privateCvmArray.at(convIndex),
+          /* tp */
+          PrivateMeasurementTouchpointMetadata<schedulerId>{attributedAdId}};
+
+      aggregationResults.push_back(aggregationResult);
+    }
+    return aggregationResults;
+  }
+
+  const std::vector<typename MeasurementAggregation<
+      schedulerId>::PrivateMeasurementAggregationResult>
+  retrieveTouchpointForConversionPerIDReformatted(
+      const std::vector<PrivateAttributionReformattedResult<schedulerId>>&
+          attributionReformattedResults) {
+    std::vector<typename MeasurementAggregation<
+        schedulerId>::PrivateMeasurementAggregationResult>
+        aggregationResults;
+
+    int numOfResults = attributionReformattedResults.size() - 1;
+
+    for (auto atIndex = numOfResults; atIndex >= 0; atIndex--) {
+      SecBit<schedulerId> hasAttributedTouchpoint;
+      SecConvValue<schedulerId> conversionValue;
+      SecAdId<schedulerId> attributedAdId;
+      hasAttributedTouchpoint =
+          attributionReformattedResults.at(atIndex).isAttributed;
+      attributedAdId = attributionReformattedResults.at(atIndex).adId;
+      conversionValue = attributionReformattedResults.at(atIndex).convValue;
+
+      typename MeasurementAggregation<
+          schedulerId>::PrivateMeasurementAggregationResult aggregationResult{
+          /* hasAttributedTouchpoint */ hasAttributedTouchpoint,
+          /* conv */
+          PrivateMeasurementConversionMetadata<schedulerId>{conversionValue},
           /* tp */
           PrivateMeasurementTouchpointMetadata<schedulerId>{attributedAdId}};
 

--- a/fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AttributionReformattedResult.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+#include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
+
+namespace pcf2_aggregation {
+
+struct AttributionReformattedResult {
+  uint64_t adId;
+  uint64_t convValue;
+  bool isAttributed;
+
+  static AttributionReformattedResult fromDynamic(const folly::dynamic& obj) {
+    AttributionReformattedResult out = AttributionReformattedResult{};
+
+    out.adId = obj["ad_id"].asInt();
+    out.convValue = obj["conv_value"].asInt();
+    out.isAttributed = obj["is_attributed"].asBool();
+    return out;
+  }
+};
+
+template <int schedulerId>
+struct PrivateAttributionReformattedResult {
+  explicit PrivateAttributionReformattedResult(
+      const AttributionReformattedResult& attributionReformattedResult) {
+    typename SecBit<schedulerId>::ExtractedBit extractedAttribution(
+        attributionReformattedResult.isAttributed);
+    this->isAttributed = SecBit<schedulerId>(std::move(extractedAttribution));
+
+    typename SecAdId<schedulerId>::ExtractedInt extractedAdId(
+        attributionReformattedResult.adId);
+    this->adId = SecAdId<schedulerId>(std::move(extractedAdId));
+
+    typename SecConvValue<schedulerId>::ExtractedInt extractedConvValue(
+        attributionReformattedResult.convValue);
+    this->convValue = SecConvValue<schedulerId>(std::move(extractedConvValue));
+  }
+
+  SecBit<schedulerId> isAttributed;
+  SecAdId<schedulerId> adId;
+  SecConvValue<schedulerId> convValue;
+};
+
+} // namespace pcf2_aggregation

--- a/fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h
+++ b/fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h
@@ -36,6 +36,9 @@ struct PrivateMeasurementConversionMetadata {
       convValue = SecConvValue<schedulerId>(std::move(extractedConvValue));
     }
   }
+  explicit PrivateMeasurementConversionMetadata(
+      const SecConvValue<schedulerId>& secConvValue)
+      : convValue(secConvValue) {}
 
   SecConvValue<schedulerId> convValue;
 };

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationGameTest.cpp
@@ -414,6 +414,20 @@ AggregationOutputMetrics computeAggregationsWithScheduler(
   return game->computeAggregations(myId, inputData);
 }
 
+template <int schedulerId>
+AggregationOutputMetrics computeAggregationsReformattedWithScheduler(
+    int myId,
+    AggregationInputMetrics inputData,
+    common::InputEncryption inputEncryption,
+    std::shared_ptr<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myId, *factory);
+  auto game = std::make_unique<AggregationGame<schedulerId>>(
+      std::move(scheduler), std::move(factory), inputEncryption);
+  return game->computeAggregationsReformatted(myId, inputData);
+}
+
 // Test cases are from https://fb.quip.com/IUHDApxKEAli
 void testCorrectnessWithScheduler(
     common::InputEncryption inputEncryption,
@@ -493,6 +507,87 @@ void testCorrectnessWithScheduler(
   }
 }
 
+void testCorrectnessReformattedWithScheduler(
+    common::InputEncryption inputEncryption,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  FLAGS_use_new_output_format = true;
+  std::string baseDir_ =
+      private_measurement::test_util::getBaseDirFromPath(__FILE__);
+  // Attribution rules to test
+  std::vector<std::string> attributionRules{
+      common::LAST_CLICK_1D,
+      common::LAST_TOUCH_1D,
+      common::LAST_CLICK_2_7D,
+      common::LAST_TOUCH_2_7D};
+  // Currently only one aggregation format - measurement.
+  std::vector<std::string> aggregationFormats{common::MEASUREMENT};
+
+  for (auto attributionRule : attributionRules) {
+    for (auto aggregationFormat : aggregationFormats) {
+      std::string filePrefix = baseDir_ + "test_correctness/" + attributionRule;
+      std::string outputJsonFileName =
+          filePrefix + "." + aggregationFormat + ".json";
+      std::string publisherSecretShareFileName =
+          filePrefix + "_reformatted.publisher.json";
+      std::string partnerSecretShareFileName =
+          filePrefix + "_reformatted.partner.json";
+      std::string clearTextFilePrefix = baseDir_ +
+          "../../pcf2_attribution/test/test_correctness/" + attributionRule +
+          ".";
+      if (inputEncryption == common::InputEncryption::PartnerXor) {
+        clearTextFilePrefix = clearTextFilePrefix + "partner_xor.";
+      } else if (inputEncryption == common::InputEncryption::Xor) {
+        clearTextFilePrefix = clearTextFilePrefix + "xor.";
+      }
+      std::string publisherClearTextFileName =
+          clearTextFilePrefix + "publisher.csv";
+      std::string partnerClearTextFileName =
+          clearTextFilePrefix + "partner.csv";
+
+      // read input files
+      AggregationInputMetrics publisherInputData{
+          common::PUBLISHER,
+          inputEncryption,
+          publisherSecretShareFileName,
+          publisherClearTextFileName,
+          aggregationFormat};
+      AggregationInputMetrics partnerInputData{
+          common::PARTNER,
+          inputEncryption,
+          partnerSecretShareFileName,
+          partnerClearTextFileName,
+          ""};
+
+      // compute aggregations
+      auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+      auto future0 = std::async(
+          computeAggregationsReformattedWithScheduler<0>,
+          0,
+          publisherInputData,
+          inputEncryption,
+          std::move(factories[0]),
+          schedulerCreator);
+
+      auto future1 = std::async(
+          computeAggregationsReformattedWithScheduler<1>,
+          1,
+          partnerInputData,
+          inputEncryption,
+          std::move(factories[1]),
+          schedulerCreator);
+
+      auto res0 = future0.get();
+      auto res1 = future1.get();
+
+      // check against expected output
+      auto output =
+          revealXORedResult(res0, res1, aggregationFormat, attributionRule);
+      verifyOutput(output, outputJsonFileName);
+    }
+  }
+}
+
 class AggregationGameTestFixture
     : public ::testing::TestWithParam<
           std::tuple<common::SchedulerType, common::InputEncryption>> {};
@@ -501,6 +596,13 @@ TEST_P(AggregationGameTestFixture, TestCorrectness) {
   auto [schedulerType, inputEncryption] = GetParam();
 
   testCorrectnessWithScheduler(
+      inputEncryption, fbpcf::getSchedulerCreator<unsafe>(schedulerType));
+}
+
+TEST_P(AggregationGameTestFixture, TestCorrectnessReformatted) {
+  auto [schedulerType, inputEncryption] = GetParam();
+
+  testCorrectnessReformattedWithScheduler(
       inputEncryption, fbpcf::getSchedulerCreator<unsafe>(schedulerType));
 }
 

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_1d_reformatted.partner.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_1d_reformatted.partner.json
@@ -1,0 +1,556 @@
+{
+    "last_click_1d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -2588157769154148858,
+                    "conv_value": 1122329313,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3796527911765538624,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1267899135228703729,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3325085780852887287,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 7330218875322131426,
+                    "conv_value": 3605659922,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1321292462444393675,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 231793653192258334,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5446551603315784138,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 2351136710312513312,
+                    "conv_value": 761833339,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4224821574004778730,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6231443153506603578,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6807923012558353222,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 8077263192534023574,
+                    "conv_value": 1595904763,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2102548637128793497,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2401745027623097537,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3757312674106393971,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 4764331049488962101,
+                    "conv_value": 2000760132,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1939117943603125282,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5586504610510750383,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6759942941574725683,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": -9090027699650930307,
+                    "conv_value": 1114584138,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1617094776854592235,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6675158747418204000,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3849529999472200046,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": -7616115081444455793,
+                    "conv_value": 3096377263,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6040358703495440470,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4761834371048166150,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7960963235521914812,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": -6333300161646249778,
+                    "conv_value": 3985795374,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5107396543947229299,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -71925750815001251,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4885419631636322582,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": -5936114408802953093,
+                    "conv_value": 2932428912,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7381722780427395114,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3329260064645734504,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3642584520490993242,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 7744130639386950534,
+                    "conv_value": 602831427,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 809116718779591292,
+                    "conv_value": 2523681432,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2696291648451566401,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 952995697436390567,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 7495213342461398651,
+                    "conv_value": 3983174594,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6108010113156343914,
+                    "conv_value": 3634233362,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3592515636460183783,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1316522377042001970,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 6643165389235507460,
+                    "conv_value": 3850034173,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1462768070108860597,
+                    "conv_value": 731859640,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4118371176171294649,
+                    "conv_value": 4207977172,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6424027693466887990,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 7799195211241231552,
+                    "conv_value": 1018535374,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4332586844306736981,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8558423500904241971,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2594197003344778291,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 5967599171625117376,
+                    "conv_value": 801011543,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7946477101360591857,
+                    "conv_value": 860414154,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4253751903923630678,
+                    "conv_value": 981504987,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4606026776242273502,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": -2196359191811367077,
+                    "conv_value": 696957123,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8615309021859466260,
+                    "conv_value": 3287796640,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8415897794783245424,
+                    "conv_value": 4112097635,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6696179369080320593,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 4053198496361184087,
+                    "conv_value": 323284747,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7298966842881737255,
+                    "conv_value": 1146262635,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5090944008231495717,
+                    "conv_value": 3139388461,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1306470050190816144,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": -6469176866206283115,
+                    "conv_value": 4209943514,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 57451021964804708,
+                    "conv_value": 2173585811,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4806213441953495657,
+                    "conv_value": 1714459742,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6706742730717859169,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": -922949480026733373,
+                    "conv_value": 2844162694,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3667865136597539038,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6215105129508029724,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2897474524155842368,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": -8493554428517080036,
+                    "conv_value": 3478425322,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2249183677437631511,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6666378619832221631,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8763280549674406552,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 4370468518142132012,
+                    "conv_value": 2899110732,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -107571477334236059,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5963202918540411205,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 207546557507839223,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": -8909080334011076688,
+                    "conv_value": 1328907997,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 19411747405504730,
+                    "conv_value": 3898369537,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7015474088043284739,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5748461440749666848,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 2242071173119875745,
+                    "conv_value": 1225452745,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2252246813006325486,
+                    "conv_value": 2851581372,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7538531343534727173,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5935415154144890330,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -7227304273369226946,
+                    "conv_value": 3463746071,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3640612003384132963,
+                    "conv_value": 4229629480,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5367944850316437018,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1892159309945576279,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -6033473397768035176,
+                    "conv_value": 1149554372,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7424678506920111743,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9035843003026763311,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8621951337793120546,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 8882359087916701158,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6272983194374292778,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3268025093210975654,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1762287170904914775,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_1d_reformatted.publisher.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_1d_reformatted.publisher.json
@@ -1,0 +1,556 @@
+{
+    "last_click_1d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -2588157769154148857,
+                    "conv_value": 1122328840,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3796527911765538624,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1267899135228703729,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3325085780852887287,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 7330218875322131426,
+                    "conv_value": 3605660408,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1321292462444393675,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 231793653192258334,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5446551603315784138,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": 2351136710312513314,
+                    "conv_value": 761832592,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4224821574004778730,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6231443153506603578,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6807923012558353222,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": 8077263192534023574,
+                    "conv_value": 1595904274,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2102548637128793497,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2401745027623097537,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3757312674106393971,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 4764331049488962103,
+                    "conv_value": 2000760497,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1939117943603125282,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5586504610510750383,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6759942941574725683,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": -9090027699650930307,
+                    "conv_value": 1114585020,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1617094776854592235,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6675158747418204000,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3849529999472200046,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": -7616115081444455793,
+                    "conv_value": 3096376408,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6040358703495440470,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4761834371048166150,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7960963235521914812,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": -6333300161646249777,
+                    "conv_value": 3985795798,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5107396543947229299,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -71925750815001251,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4885419631636322582,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": -5936114408802953093,
+                    "conv_value": 2932429705,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7381722780427395114,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3329260064645734504,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3642584520490993242,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 7744130639386950535,
+                    "conv_value": 602831289,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 809116718779591294,
+                    "conv_value": 2523682170,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2696291648451566401,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 952995697436390567,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 7495213342461398650,
+                    "conv_value": 3983173688,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6108010113156343915,
+                    "conv_value": 3634235376,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3592515636460183783,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1316522377042001970,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 6643165389235507460,
+                    "conv_value": 3850033153,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1462768070108860597,
+                    "conv_value": 731860316,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4118371176171294649,
+                    "conv_value": 4207978776,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6424027693466887990,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 7799195211241231554,
+                    "conv_value": 1018535461,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4332586844306736981,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8558423500904241971,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2594197003344778291,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 5967599171625117376,
+                    "conv_value": 801010858,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7946477101360591857,
+                    "conv_value": 860415791,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4253751903923630676,
+                    "conv_value": 981506070,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4606026776242273502,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": -2196359191811367079,
+                    "conv_value": 696957757,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8615309021859466263,
+                    "conv_value": 3287796806,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8415897794783245421,
+                    "conv_value": 4112100013,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6696179369080320593,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 4053198496361184087,
+                    "conv_value": 323284212,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7298966842881737256,
+                    "conv_value": 1146262412,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5090944008231495717,
+                    "conv_value": 3139391458,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1306470050190816144,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": -6469176866206283116,
+                    "conv_value": 4209944538,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 57451021964804709,
+                    "conv_value": 2173587067,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4806213441953495658,
+                    "conv_value": 1714462606,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6706742730717859169,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": -922949480026733374,
+                    "conv_value": 2844163719,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3667865136597539038,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6215105129508029724,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2897474524155842368,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": -8493554428517080035,
+                    "conv_value": 3478424838,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2249183677437631511,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6666378619832221631,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8763280549674406552,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 4370468518142132012,
+                    "conv_value": 2899110049,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -107571477334236059,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5963202918540411205,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 207546557507839223,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": -8909080334011076687,
+                    "conv_value": 1328907571,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 19411747405504731,
+                    "conv_value": 3898368471,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7015474088043284739,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5748461440749666848,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 2242071173119875745,
+                    "conv_value": 1225453350,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2252246813006325485,
+                    "conv_value": 2851580523,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7538531343534727173,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5935415154144890330,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -7227304273369226946,
+                    "conv_value": 3463746023,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3640612003384132963,
+                    "conv_value": 4229628400,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5367944850316437018,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1892159309945576279,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -6033473397768035176,
+                    "conv_value": 1149553973,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7424678506920111743,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9035843003026763311,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8621951337793120546,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": 8882359087916701158,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6272983194374292778,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3268025093210975654,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1762287170904914775,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_2_7d_reformatted.partner.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_2_7d_reformatted.partner.json
@@ -1,0 +1,688 @@
+{
+    "last_click_2_7d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -1814905076329526952,
+                    "conv_value": 4189450015,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 9097135842858179026,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9072474216109021899,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3657773979170650613,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": -3987396648043089668,
+                    "conv_value": 2585982300,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6033525866031926983,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1396149343159091114,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3462453472329470771,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": -3044822531569356450,
+                    "conv_value": 539993614,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2165511578941702715,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4772596791210478208,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7495659582956505819,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": -2232990378898320157,
+                    "conv_value": 2049078770,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7254488678954219913,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1329793280296964242,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3928249174913062039,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 3482918966821124526,
+                    "conv_value": 2623422741,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1902133267236188500,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3245567090271366283,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7102840944757857957,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 4978098882713350827,
+                    "conv_value": 2963532061,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3875749919098258811,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5868534938754692436,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8688339142650116731,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": -6034726449511536597,
+                    "conv_value": 2482668822,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6777408936369878518,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4662784362435949550,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4870052660184732637,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": -3966296656443681613,
+                    "conv_value": 4220613346,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1751432185789462632,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1444484117844739043,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6670628881724732142,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 3168833054340153032,
+                    "conv_value": 1273599766,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6789948601608238269,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7057032787162296021,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3267766171793647979,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 7406090321782693147,
+                    "conv_value": 3850775836,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8918487637435158787,
+                    "conv_value": 1149358125,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3079077702204223769,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5961780758563589498,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": -3175646852892826193,
+                    "conv_value": 3722881226,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5206662331868255725,
+                    "conv_value": 502776791,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2020796542268911288,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5800532750862561249,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 8638364236262241372,
+                    "conv_value": 554663439,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5838274697088549862,
+                    "conv_value": 2517501215,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1131386021934837039,
+                    "conv_value": 206841470,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2315047289409685618,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 5583933131119247457,
+                    "conv_value": 4084698989,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8129761091474002643,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4649357007997501747,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -746084580475079312,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": -3416072427051335923,
+                    "conv_value": 3031129509,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2291067519060421404,
+                    "conv_value": 3376161515,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -444820507306048895,
+                    "conv_value": 4195601687,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5896573517517426885,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 3998050411055664881,
+                    "conv_value": 981484194,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4631149895288110684,
+                    "conv_value": 1653712964,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2783409709249355839,
+                    "conv_value": 4031569782,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1349806822798741145,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 8137262485981576482,
+                    "conv_value": 2317664676,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4621900044990029174,
+                    "conv_value": 1226769402,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5815028751602263169,
+                    "conv_value": 4253843816,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6642372677753840129,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": -8963446607613619852,
+                    "conv_value": 1889717867,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7521709082063843407,
+                    "conv_value": 4240604229,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6986105083383168434,
+                    "conv_value": 3702249870,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -9011177761135265570,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": -3684641923200093269,
+                    "conv_value": 4117165758,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5494173367110556947,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6924435255633687000,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5932282446440203337,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": 4977269905470762047,
+                    "conv_value": 862834699,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8319285339915535701,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5351076848729883047,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 654519007017834633,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 8503961248858566299,
+                    "conv_value": 1920181186,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7426580420743065025,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2697887895447500610,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7895394421535946584,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 9090836787748159690,
+                    "conv_value": 1166598944,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8744743376374521827,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7858597624219434101,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2606937666519465036,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "28": [
+                {
+                    "ad_id": 4472662218865543112,
+                    "conv_value": 19465519,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6943258958610530151,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -766288554406062894,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6756526253715760343,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "29": [
+                {
+                    "ad_id": -946653046428848398,
+                    "conv_value": 1624026319,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6812820085714126529,
+                    "conv_value": 2741548056,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2076150719559171470,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3616844664017175866,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": -4101349142885238787,
+                    "conv_value": 1630638218,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2085036105874947487,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5675999441072082455,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8441813236919382579,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "30": [
+                {
+                    "ad_id": -5923759158084528642,
+                    "conv_value": 3742775559,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2322167659055284800,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7678762646763156225,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4697285317497784373,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": -8872304045331387968,
+                    "conv_value": 3379028778,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2696979071000200429,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2475684381993016235,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1755947583549836964,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": -9108369019942618740,
+                    "conv_value": 2395325795,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7917432600132418782,
+                    "conv_value": 923414517,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -715763977151879331,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4068439753061914237,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": -1723712678394947324,
+                    "conv_value": 379959105,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7397163477727192145,
+                    "conv_value": 738058475,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1758248442993419162,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8388315899206224860,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -7693088356476414781,
+                    "conv_value": 1625939918,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4224537907222423851,
+                    "conv_value": 2887909013,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8791297623398351839,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4157399865645290002,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -4142451857713641332,
+                    "conv_value": 3849669931,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7571439342161428838,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2592231573647464034,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3405124756919051926,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": -4763791690724693983,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8461502445518394231,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5923721166245085069,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8677818944855535611,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_2_7d_reformatted.publisher.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_click_2_7d_reformatted.publisher.json
@@ -1,0 +1,688 @@
+{
+    "last_click_2_7d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -1814905076329526951,
+                    "conv_value": 4189449462,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9097135842858179026,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9072474216109021899,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3657773979170650613,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": -3987396648043089668,
+                    "conv_value": 2585982646,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6033525866031926983,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1396149343159091114,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3462453472329470771,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": -3044822531569356452,
+                    "conv_value": 539993573,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2165511578941702715,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4772596791210478208,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7495659582956505819,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": -2232990378898320157,
+                    "conv_value": 2049078811,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7254488678954219913,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1329793280296964242,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3928249174913062039,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 3482918966821124524,
+                    "conv_value": 2623423200,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1902133267236188500,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3245567090271366283,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7102840944757857957,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 4978098882713350827,
+                    "conv_value": 2963532523,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3875749919098258811,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5868534938754692436,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8688339142650116731,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": -6034726449511536597,
+                    "conv_value": 2482669281,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6777408936369878518,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4662784362435949550,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4870052660184732637,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": -3966296656443681614,
+                    "conv_value": 4220612890,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1751432185789462632,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1444484117844739043,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6670628881724732142,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": 3168833054340153032,
+                    "conv_value": 1273599215,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6789948601608238269,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7057032787162296021,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3267766171793647979,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 7406090321782693146,
+                    "conv_value": 3850776294,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8918487637435158785,
+                    "conv_value": 1149360079,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3079077702204223769,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5961780758563589498,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": -3175646852892826194,
+                    "conv_value": 3722881840,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5206662331868255724,
+                    "conv_value": 502776885,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2020796542268911288,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5800532750862561249,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 8638364236262241372,
+                    "conv_value": 554663411,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5838274697088549862,
+                    "conv_value": 2517500667,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1131386021934837039,
+                    "conv_value": 206843314,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2315047289409685618,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 5583933131119247459,
+                    "conv_value": 4084698246,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8129761091474002643,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4649357007997501747,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -746084580475079312,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": -3416072427051335923,
+                    "conv_value": 3031129688,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2291067519060421404,
+                    "conv_value": 3376162062,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -444820507306048893,
+                    "conv_value": 4195600090,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5896573517517426885,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 3998050411055664883,
+                    "conv_value": 981483868,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4631149895288110687,
+                    "conv_value": 1653714850,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2783409709249355836,
+                    "conv_value": 4031567032,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1349806822798741145,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 8137262485981576482,
+                    "conv_value": 2317664859,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4621900044990029175,
+                    "conv_value": 1226769437,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5815028751602263169,
+                    "conv_value": 4253846183,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6642372677753840129,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": -8963446607613619851,
+                    "conv_value": 1889716843,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7521709082063843408,
+                    "conv_value": 4240604077,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6986105083383168435,
+                    "conv_value": 3702248030,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -9011177761135265570,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": -3684641923200093269,
+                    "conv_value": 4117165396,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5494173367110556947,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6924435255633687000,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5932282446440203337,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": 4977269905470762047,
+                    "conv_value": 862835681,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8319285339915535701,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5351076848729883047,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 654519007017834633,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 8503961248858566299,
+                    "conv_value": 1920180271,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7426580420743065025,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2697887895447500610,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7895394421535946584,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 9090836787748159690,
+                    "conv_value": 1166598349,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8744743376374521827,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7858597624219434101,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2606937666519465036,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "28": [
+                {
+                    "ad_id": 4472662218865543112,
+                    "conv_value": 19465922,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6943258958610530151,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -766288554406062894,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6756526253715760343,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "29": [
+                {
+                    "ad_id": -946653046428848398,
+                    "conv_value": 1624026943,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6812820085714126529,
+                    "conv_value": 2741547968,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2076150719559171470,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3616844664017175866,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": -4101349142885238788,
+                    "conv_value": 1630638950,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2085036105874947487,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5675999441072082455,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8441813236919382579,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "30": [
+                {
+                    "ad_id": -5923759158084528641,
+                    "conv_value": 3742776582,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2322167659055284800,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7678762646763156225,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4697285317497784373,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": -8872304045331387968,
+                    "conv_value": 3379028167,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2696979071000200429,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2475684381993016235,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1755947583549836964,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": -9108369019942618739,
+                    "conv_value": 2395326093,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7917432600132418783,
+                    "conv_value": 923412515,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -715763977151879331,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4068439753061914237,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": -1723712678394947324,
+                    "conv_value": 379958446,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7397163477727192144,
+                    "conv_value": 738060092,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1758248442993419162,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8388315899206224860,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -7693088356476414781,
+                    "conv_value": 1625939006,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4224537907222423851,
+                    "conv_value": 2887907661,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8791297623398351839,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4157399865645290002,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -4142451857713641332,
+                    "conv_value": 3849670362,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7571439342161428838,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2592231573647464034,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3405124756919051926,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": -4763791690724693983,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8461502445518394231,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5923721166245085069,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8677818944855535611,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_1d_reformatted.partner.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_1d_reformatted.partner.json
@@ -1,0 +1,622 @@
+{
+    "last_touch_1d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -8133128737136700780,
+                    "conv_value": 3464662019,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8032357747543029228,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6806476902408533558,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4240539606746669733,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": -5460975515179628998,
+                    "conv_value": 1456430592,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6021434073302145254,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1482456944673348846,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2959939944854892733,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": -563524435093975396,
+                    "conv_value": 2160570793,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4565354162425664008,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4407967855303851877,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1074211595057182277,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": -3236860506217810744,
+                    "conv_value": 1885688031,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 9051216864607370654,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8286201963356019292,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5115698200938484734,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 8566738414537330463,
+                    "conv_value": 154980265,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4848815505591319126,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1173377048650227191,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2734128385000472935,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 6638304416158956473,
+                    "conv_value": 3106747617,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 254973966533351559,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6527632523464941162,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6939784464977260014,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": -1217029847410179233,
+                    "conv_value": 3477569292,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3839653929895899526,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1122746207185082411,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1670497408247045464,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 4827349744502110899,
+                    "conv_value": 984192512,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1963802404493693692,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3468345239547997635,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2485619952135365503,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": -7249652190336902626,
+                    "conv_value": 1091687488,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8867872120046699997,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7908439429594698117,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6456116029598636639,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": -1394885806971720587,
+                    "conv_value": 4118305812,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3443848130856369142,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8175013098783743031,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7396428706892665683,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 2473062747340420859,
+                    "conv_value": 1093985639,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2659447761271699004,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4014418214133550727,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3852916197954535539,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 8946201446090503069,
+                    "conv_value": 803685942,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2265838111506969031,
+                    "conv_value": 2889614175,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6707457792754994240,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1776423351010989393,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 2874646131976494290,
+                    "conv_value": 1853821144,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5824170169714242241,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4441927038830331719,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2670611422102743271,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": -8356232143528926728,
+                    "conv_value": 878419150,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3504872281145996945,
+                    "conv_value": 2544599111,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3245318315143530145,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5611020753330342051,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 2590322900016918680,
+                    "conv_value": 2865628732,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8892572667808707631,
+                    "conv_value": 1447192073,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2688492282196405503,
+                    "conv_value": 1916860408,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8718916024644116854,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 8706333456792306927,
+                    "conv_value": 3914124009,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -9191341476273095664,
+                    "conv_value": 2657632667,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6546851444038512973,
+                    "conv_value": 2560144062,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1408602410317846864,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": 3602101202510492530,
+                    "conv_value": 4042885000,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7793827482048615611,
+                    "conv_value": 3405889000,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5748516889057532988,
+                    "conv_value": 1485555660,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4113240454818006131,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 2632481332434186270,
+                    "conv_value": 871945843,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3720591562738117090,
+                    "conv_value": 2821931361,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8693998687934367490,
+                    "conv_value": 403866749,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3704993694982928270,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": -8088542324932926488,
+                    "conv_value": 2968036948,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5990833440997237615,
+                    "conv_value": 2312389165,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2309774968285547510,
+                    "conv_value": 384344178,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4686292126910288203,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 4418561941397500290,
+                    "conv_value": 3089390623,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1263814786057655351,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4811497779619414746,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3134163606672618118,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 8541536961187610153,
+                    "conv_value": 68040829,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 424731926173690442,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2885709533297565189,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2569056342071486960,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": -5392421198185397426,
+                    "conv_value": 740984590,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3495860335552374920,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2661213894130713969,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6203300992078761623,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 4248951144665963512,
+                    "conv_value": 2825901664,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3896256886374025698,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1719543211045964645,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5959890338123626558,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": -9219819973264267584,
+                    "conv_value": 978663511,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8011631516938402782,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5178310218527337836,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1048576449337701080,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 5001779959874705081,
+                    "conv_value": 3240070939,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1808592642275444335,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3527781469132927786,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4738117598225983487,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -3891730298754569715,
+                    "conv_value": 2053912002,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7770738030067406104,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1256470782920403827,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4898389556570931848,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -8636017862619661893,
+                    "conv_value": 3673477156,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7039820923599465269,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1224674189418847489,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 174376187221295280,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": -8716348496010223354,
+                    "conv_value": 783303829,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7319892032054298133,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6350352188528554404,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8793678175356382119,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_1d_reformatted.publisher.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_1d_reformatted.publisher.json
@@ -1,0 +1,622 @@
+{
+    "last_touch_1d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -8133128737136700779,
+                    "conv_value": 3464663018,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8032357747543029228,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6806476902408533558,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4240539606746669733,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": -5460975515179628998,
+                    "conv_value": 1456430570,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6021434073302145254,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1482456944673348846,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2959939944854892733,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": -563524435093975394,
+                    "conv_value": 2160570970,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4565354162425664008,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4407967855303851877,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1074211595057182277,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": -3236860506217810742,
+                    "conv_value": 1885688619,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9051216864607370654,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8286201963356019292,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5115698200938484734,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 8566738414537330461,
+                    "conv_value": 154979420,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4848815505591319126,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1173377048650227191,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2734128385000472935,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": 6638304416158956475,
+                    "conv_value": 3106748183,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 254973966533351559,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6527632523464941162,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6939784464977260014,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": -1217029847410179235,
+                    "conv_value": 3477568763,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3839653929895899526,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1122746207185082411,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1670497408247045464,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": 4827349744502110899,
+                    "conv_value": 984192504,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1963802404493693692,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3468345239547997635,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2485619952135365503,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": -7249652190336902626,
+                    "conv_value": 1091688377,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8867872120046699997,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7908439429594698117,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6456116029598636639,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": -1394885806971720588,
+                    "conv_value": 4118306798,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3443848130856369142,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8175013098783743031,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7396428706892665683,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": 2473062747340420859,
+                    "conv_value": 1093985948,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2659447761271699004,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4014418214133550727,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3852916197954535539,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 8946201446090503068,
+                    "conv_value": 803685836,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2265838111506969029,
+                    "conv_value": 2889614525,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6707457792754994240,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1776423351010989393,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": 2874646131976494288,
+                    "conv_value": 1853821747,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5824170169714242241,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4441927038830331719,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2670611422102743271,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": -8356232143528926727,
+                    "conv_value": 878419764,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3504872281145996946,
+                    "conv_value": 2544600997,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3245318315143530145,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5611020753330342051,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 2590322900016918680,
+                    "conv_value": 2865628610,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8892572667808707631,
+                    "conv_value": 1447191023,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2688492282196405503,
+                    "conv_value": 1916861494,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8718916024644116854,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 8706333456792306927,
+                    "conv_value": 3914123542,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -9191341476273095664,
+                    "conv_value": 2657633916,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6546851444038512975,
+                    "conv_value": 2560145777,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1408602410317846864,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": 3602101202510492528,
+                    "conv_value": 4042883976,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7793827482048615610,
+                    "conv_value": 3405888000,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5748516889057532991,
+                    "conv_value": 1485556764,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4113240454818006131,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 2632481332434186270,
+                    "conv_value": 871944818,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3720591562738117091,
+                    "conv_value": 2821932680,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8693998687934367490,
+                    "conv_value": 403869612,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3704993694982928270,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": -8088542324932926487,
+                    "conv_value": 2968035926,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5990833440997237614,
+                    "conv_value": 2312390087,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2309774968285547511,
+                    "conv_value": 384347040,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4686292126910288203,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 4418561941397500291,
+                    "conv_value": 3089389596,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1263814786057655351,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4811497779619414746,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3134163606672618118,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 8541536961187610152,
+                    "conv_value": 68041849,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 424731926173690442,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2885709533297565189,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2569056342071486960,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": -5392421198185397425,
+                    "conv_value": 740984034,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3495860335552374920,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2661213894130713969,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6203300992078761623,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 4248951144665963512,
+                    "conv_value": 2825901453,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3896256886374025698,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1719543211045964645,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5959890338123626558,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": -9219819973264267583,
+                    "conv_value": 978664377,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8011631516938402782,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5178310218527337836,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1048576449337701080,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 5001779959874705081,
+                    "conv_value": 3240070388,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1808592642275444335,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3527781469132927786,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4738117598225983487,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -3891730298754569715,
+                    "conv_value": 2053912114,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7770738030067406104,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1256470782920403827,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4898389556570931848,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -8636017862619661894,
+                    "conv_value": 3673478101,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7039820923599465269,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1224674189418847489,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 174376187221295280,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": -8716348496010223353,
+                    "conv_value": 783304551,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7319892032054298133,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6350352188528554404,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8793678175356382119,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_2_7d_reformatted.partner.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_2_7d_reformatted.partner.json
@@ -1,0 +1,864 @@
+{
+    "last_touch_2_7d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -6190390937636831254,
+                    "conv_value": 4155338941,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8150345712875944988,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8992018324336903576,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5710861084732712476,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 1333792640801127575,
+                    "conv_value": 1455314046,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3592742550085523201,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2838253996036260702,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1391963782551952540,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": -6012091562499531844,
+                    "conv_value": 631064890,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2668572974321653377,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4464006890081059796,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3253503397427059027,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": -7504639399683563576,
+                    "conv_value": 692682361,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8795564330099487410,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7555784886583868928,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5107391652482781336,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 863485829736735063,
+                    "conv_value": 133777428,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1778174207337929044,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -733161806291663533,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 979792295330158107,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": -9078450409617942288,
+                    "conv_value": 2033936666,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4720067105702946025,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6199940105159701703,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4114895117923616436,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 6027923280196357075,
+                    "conv_value": 1862471304,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1227406233737116837,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4522634896085161116,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7001931513741305004,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": -5416266608054704094,
+                    "conv_value": 3585708915,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 411157494772096032,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -938826313737985698,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6989985274074124880,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": -67145287730774009,
+                    "conv_value": 3555635748,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2258175133829066246,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4719884397523721822,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -673308183793841973,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 5951458473298586477,
+                    "conv_value": 1852299662,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3548756178699466113,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 412864189446607556,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7459804906685708325,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": -8533548835412082725,
+                    "conv_value": 1920927141,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6188979969047454499,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2157408752295984585,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4596233405358573803,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 1124382964864299451,
+                    "conv_value": 1346092681,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6335022093873598859,
+                    "conv_value": 1994388615,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4598915712989484354,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8817397786556873625,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": -7520363025367078572,
+                    "conv_value": 4178272016,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1524161502910887541,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8134365393088448616,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2027554033640605579,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 6242573528651707185,
+                    "conv_value": 294923453,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3692867940480435972,
+                    "conv_value": 1752720262,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -343830297622987483,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7122382731842903093,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 550863969851670381,
+                    "conv_value": 2375352013,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5812114948392374471,
+                    "conv_value": 3484479530,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6158384216616309156,
+                    "conv_value": 386517786,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4189932381945311828,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 6484811169371529423,
+                    "conv_value": 4039591138,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6763445353958107947,
+                    "conv_value": 2341518414,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6517932533165090738,
+                    "conv_value": 1325197535,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3027711410441634627,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": -1650756172099708849,
+                    "conv_value": 1271231563,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6887250141632680688,
+                    "conv_value": 827707321,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -8866287514081236985,
+                    "conv_value": 4282040369,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 759983030644335043,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 8846031244765797253,
+                    "conv_value": 3181889221,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4943256644312734131,
+                    "conv_value": 439003878,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 234194101518787087,
+                    "conv_value": 2702600993,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4914663330276775332,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": -1268546348171372443,
+                    "conv_value": 2785801004,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4472134081835567080,
+                    "conv_value": 3728143247,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4239139193752869102,
+                    "conv_value": 3501791865,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 180816275687205441,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 2958503356719078112,
+                    "conv_value": 3899413028,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2653647875755043575,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7988875928646012011,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3483484374339246132,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 1015126928838461579,
+                    "conv_value": 1997701693,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 184752791702872970,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3979212855046301251,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5659761367185197154,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "28": [
+                {
+                    "ad_id": -2391520763407526398,
+                    "conv_value": 3006098444,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8410742902183025930,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7277769178127860486,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5044319690487717954,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "29": [
+                {
+                    "ad_id": -4658316406261032624,
+                    "conv_value": 1652623738,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7185714325371979040,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5291833224170807161,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -784041700352572261,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 8079353045951038903,
+                    "conv_value": 1963027106,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3998796300240712717,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1774049580768589877,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3376601989983498216,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "30": [
+                {
+                    "ad_id": 2850651601690590779,
+                    "conv_value": 3907127839,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3598470599126699089,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9014699232717062973,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1313454587627554199,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "31": [
+                {
+                    "ad_id": 1095598890541646569,
+                    "conv_value": 2630141073,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6057895292012622949,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6525143348630767397,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4739709426516178493,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "32": [
+                {
+                    "ad_id": 3416350191066393288,
+                    "conv_value": 3645581899,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3327464847192347013,
+                    "conv_value": 2521189588,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 261564209867764275,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5769708750771480936,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "33": [
+                {
+                    "ad_id": 1142800397047306767,
+                    "conv_value": 2425086818,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7572174068738587084,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3802190202915293254,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4507083517557384591,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "34": [
+                {
+                    "ad_id": -4806519776852603354,
+                    "conv_value": 2256457295,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 708754534642021214,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1593305829530821988,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2083136656207272610,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "35": [
+                {
+                    "ad_id": -1617356331918899692,
+                    "conv_value": 3365698607,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5627944234901142442,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1427267504254829326,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2605884094433666041,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "36": [
+                {
+                    "ad_id": 3452338450022894608,
+                    "conv_value": 2192978033,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2184722879428144234,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9138199464248294340,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1291229083690032002,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "37": [
+                {
+                    "ad_id": -4820112763494910251,
+                    "conv_value": 3334006338,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8097407637129379543,
+                    "conv_value": 2632499460,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2817180549646121996,
+                    "conv_value": 3807814813,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1753100521284164807,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "38": [
+                {
+                    "ad_id": 3539522575297572906,
+                    "conv_value": 210540093,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2399068208157050182,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7373613169109216763,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5589776731131538421,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 6298039807120940580,
+                    "conv_value": 402598181,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4314381985640743386,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2745608489609140172,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5068664929244641652,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 7697217966426229036,
+                    "conv_value": 572566560,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5112033711159110407,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5596715388057312538,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3624276036808716774,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 3701865920789194069,
+                    "conv_value": 4142051099,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7917223896351303397,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4012233070060848269,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8204564699355269479,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -3481273019752038158,
+                    "conv_value": 4060697471,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7033503046339697810,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2781738120383948825,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4821225503190555623,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -720486299094999393,
+                    "conv_value": 494079995,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8846923642454722506,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2840157383472102767,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7020816278473217125,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": -4685346819053082418,
+                    "conv_value": 2043331951,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1890802016160969848,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2708219979109736154,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4358564984694489465,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_2_7d_reformatted.publisher.json
+++ b/fbpcs/emp_games/pcf2_aggregation/test/test_correctness/last_touch_2_7d_reformatted.publisher.json
@@ -1,0 +1,864 @@
+{
+    "last_touch_2_7d": {
+        "default": {
+            "0": [
+                {
+                    "ad_id": -6190390937636831253,
+                    "conv_value": 4155339604,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8150345712875944988,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8992018324336903576,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5710861084732712476,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "1": [
+                {
+                    "ad_id": 1333792640801127575,
+                    "conv_value": 1455314836,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3592742550085523201,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2838253996036260702,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1391963782551952540,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "10": [
+                {
+                    "ad_id": -6012091562499531842,
+                    "conv_value": 631065289,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2668572974321653377,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4464006890081059796,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3253503397427059027,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "11": [
+                {
+                    "ad_id": -7504639399683563574,
+                    "conv_value": 692682125,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8795564330099487410,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7555784886583868928,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5107391652482781336,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "12": [
+                {
+                    "ad_id": 863485829736735061,
+                    "conv_value": 133778401,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1778174207337929044,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -733161806291663533,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 979792295330158107,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "13": [
+                {
+                    "ad_id": -9078450409617942286,
+                    "conv_value": 2033937132,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4720067105702946025,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6199940105159701703,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4114895117923616436,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "14": [
+                {
+                    "ad_id": 6027923280196357073,
+                    "conv_value": 1862471039,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1227406233737116837,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4522634896085161116,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7001931513741305004,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "15": [
+                {
+                    "ad_id": -5416266608054704094,
+                    "conv_value": 3585708171,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 411157494772096032,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -938826313737985698,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6989985274074124880,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "16": [
+                {
+                    "ad_id": -67145287730774009,
+                    "conv_value": 3555635677,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2258175133829066246,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4719884397523721822,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -673308183793841973,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "17": [
+                {
+                    "ad_id": 5951458473298586476,
+                    "conv_value": 1852299892,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3548756178699466113,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 412864189446607556,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7459804906685708325,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "18": [
+                {
+                    "ad_id": -8533548835412082725,
+                    "conv_value": 1920927326,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 6188979969047454499,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2157408752295984585,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4596233405358573803,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "19": [
+                {
+                    "ad_id": 1124382964864299450,
+                    "conv_value": 1346092403,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6335022093873598857,
+                    "conv_value": 1994388325,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 4598915712989484354,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8817397786556873625,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "2": [
+                {
+                    "ad_id": -7520363025367078570,
+                    "conv_value": 4178271483,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1524161502910887541,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8134365393088448616,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -2027554033640605579,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "20": [
+                {
+                    "ad_id": 6242573528651707184,
+                    "conv_value": 294924103,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3692867940480435971,
+                    "conv_value": 1752720484,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -343830297622987483,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7122382731842903093,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "21": [
+                {
+                    "ad_id": 550863969851670381,
+                    "conv_value": 2375351603,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 5812114948392374471,
+                    "conv_value": 3484481484,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6158384216616309156,
+                    "conv_value": 386515156,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4189932381945311828,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "22": [
+                {
+                    "ad_id": 6484811169371529423,
+                    "conv_value": 4039591709,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6763445353958107947,
+                    "conv_value": 2341518249,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -6517932533165090740,
+                    "conv_value": 1325196048,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3027711410441634627,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "23": [
+                {
+                    "ad_id": -1650756172099708851,
+                    "conv_value": 1271230539,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6887250141632680691,
+                    "conv_value": 827705425,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -8866287514081236988,
+                    "conv_value": 4282043361,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 759983030644335043,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "24": [
+                {
+                    "ad_id": 8846031244765797253,
+                    "conv_value": 3181888196,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4943256644312734132,
+                    "conv_value": 439004431,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 234194101518787087,
+                    "conv_value": 2702598384,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4914663330276775332,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "25": [
+                {
+                    "ad_id": -1268546348171372444,
+                    "conv_value": 2785802030,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4472134081835567079,
+                    "conv_value": 3728143461,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4239139193752869101,
+                    "conv_value": 3501789611,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 180816275687205441,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "26": [
+                {
+                    "ad_id": 2958503356719078113,
+                    "conv_value": 3899414055,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2653647875755043575,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7988875928646012011,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3483484374339246132,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "27": [
+                {
+                    "ad_id": 1015126928838461579,
+                    "conv_value": 1997701591,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 184752791702872970,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -3979212855046301251,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5659761367185197154,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "28": [
+                {
+                    "ad_id": -2391520763407526398,
+                    "conv_value": 3006099430,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8410742902183025930,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -7277769178127860486,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5044319690487717954,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "29": [
+                {
+                    "ad_id": -4658316406261032624,
+                    "conv_value": 1652624023,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -7185714325371979040,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5291833224170807161,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -784041700352572261,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "3": [
+                {
+                    "ad_id": 8079353045951038902,
+                    "conv_value": 1963026766,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3998796300240712717,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1774049580768589877,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3376601989983498216,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "30": [
+                {
+                    "ad_id": 2850651601690590779,
+                    "conv_value": 3907127794,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 3598470599126699089,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9014699232717062973,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 1313454587627554199,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "31": [
+                {
+                    "ad_id": 1095598890541646569,
+                    "conv_value": 2630141820,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -6057895292012622949,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 6525143348630767397,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4739709426516178493,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "32": [
+                {
+                    "ad_id": 3416350191066393288,
+                    "conv_value": 3645581755,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3327464847192347013,
+                    "conv_value": 2521189132,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 261564209867764275,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5769708750771480936,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "33": [
+                {
+                    "ad_id": 1142800397047306767,
+                    "conv_value": 2425086095,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7572174068738587084,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -3802190202915293254,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -4507083517557384591,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "34": [
+                {
+                    "ad_id": -4806519776852603354,
+                    "conv_value": 2256457122,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 708754534642021214,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1593305829530821988,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2083136656207272610,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "35": [
+                {
+                    "ad_id": -1617356331918899692,
+                    "conv_value": 3365699522,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5627944234901142442,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 1427267504254829326,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2605884094433666041,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "36": [
+                {
+                    "ad_id": 3452338450022894608,
+                    "conv_value": 2192978846,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2184722879428144234,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 9138199464248294340,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1291229083690032002,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "37": [
+                {
+                    "ad_id": -4820112763494910251,
+                    "conv_value": 3334006204,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8097407637129379543,
+                    "conv_value": 2632500962,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2817180549646121996,
+                    "conv_value": 3807817555,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -1753100521284164807,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "38": [
+                {
+                    "ad_id": 3539522575297572907,
+                    "conv_value": 210539070,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 2399068208157050182,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 7373613169109216763,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -5589776731131538421,
+                    "conv_value": 0,
+                    "is_attributed": true
+                }
+            ],
+            "4": [
+                {
+                    "ad_id": 6298039807120940580,
+                    "conv_value": 402598600,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 4314381985640743386,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2745608489609140172,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -5068664929244641652,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "5": [
+                {
+                    "ad_id": 7697217966426229037,
+                    "conv_value": 572567502,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5112033711159110407,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 5596715388057312538,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 3624276036808716774,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "6": [
+                {
+                    "ad_id": 3701865920789194069,
+                    "conv_value": 4142050548,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7917223896351303397,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4012233070060848269,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": 8204564699355269479,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "7": [
+                {
+                    "ad_id": -3481273019752038158,
+                    "conv_value": 4060696719,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7033503046339697810,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2781738120383948825,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4821225503190555623,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "8": [
+                {
+                    "ad_id": -720486299094999394,
+                    "conv_value": 494078986,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 8846923642454722506,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 2840157383472102767,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": 7020816278473217125,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ],
+            "9": [
+                {
+                    "ad_id": -4685346819053082417,
+                    "conv_value": 2043332253,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -1890802016160969848,
+                    "conv_value": 0,
+                    "is_attributed": false
+                },
+                {
+                    "ad_id": -2708219979109736154,
+                    "conv_value": 0,
+                    "is_attributed": true
+                },
+                {
+                    "ad_id": -4358564984694489465,
+                    "conv_value": 0,
+                    "is_attributed": false
+                }
+            ]
+        }
+    }
+}

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -140,6 +140,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="use_new_output_format", required=False),
         ],
     },
 }

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -177,6 +177,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
             "max_num_conversions": private_computation_instance.product_config.common.padding_size,
             "log_cost": self._log_cost_to_s3,
+            "use_new_output_format": False,
         }
 
         game_args = [

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -98,6 +98,7 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             "use_xor_encryption": True,
             "use_postfix": True,
             "log_cost": True,
+            "use_new_output_format": False,
         }
         test_game_args = [
             {


### PR DESCRIPTION
Summary:
# Reformat Attribution Output
We will apply performance improvements to private attribution product (game) by changing the format of attribution result. For this we will need to make changes to both private attribution and private aggregation stages.
The original format of attribution result is:
{
   "last_click_1d": {
     "default": {
       "0": [
         {
           "is_attributed": true
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         },
         {
           "is_attributed": false
         }
       ]
     }
   }
  }
Proposed format:
  [
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
      {ad_id, conversion_value, is_attributed},
  ]
The design plan: https://docs.google.com/document/d/1QyBtCkTeZA8IXAkok0n8EhfCZeLTU0SSN1VL57vjBCo/edit?usp=sharing

# This Diff
In this diff, adding unit tests for Private Aggregation - test correctness.
# This Stack
1. Add a flag to validate whether to use new vs old output format in Private Aggregation.
2. Modify PCS stage for aggregation with the new flag.
3. Modify AttributionMetrics format in aggregation game
4. Modify Aggregator and Aggregator_impl for Private Aggregation.
5. Modify AggregationMetrics files with new output format.
6. Modify computeAggregation logic - AggregationGame and AggregationGame_impl file for Private Aggregation.
7. Add unit tests for Private Aggregation game.
8. Add json test files for testing correctness for Aggregation.
9. **Add unit tests for Aggregation - test correctness**

Reviewed By: chualynn

Differential Revision: D38141508

