### PR TITLE
Create SimpleTraceLoggingService for OSS

### DIFF
--- a/fbpcs/common/service/simple_trace_logging_service.py
+++ b/fbpcs/common/service/simple_trace_logging_service.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+from typing import Dict, Optional
+
+from fbpcs.common.service.trace_logging_service import (
+    CheckpointStatus,
+    TraceLoggingService,
+)
+
+
+class SimpleTraceLoggingService(TraceLoggingService):
+    def write_checkpoint(
+        self,
+        run_id: str,
+        instance_id: str,
+        checkpoint_name: str,
+        status: CheckpointStatus,
+        checkpoint_data: Optional[Dict[str, str]] = None,
+    ) -> None:
+        result = {
+            "operation": "write_checkpoint",
+            "run_id": run_id,
+            "instance_id": instance_id,
+            "checkpoint_name": checkpoint_name,
+            "status": str(status),
+        }
+        if checkpoint_data:
+            result["checkpoint_data"] = json.dumps(checkpoint_data)
+        self.logger.info(json.dumps(result))

--- a/fbpcs/common/service/test/test_simple_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_simple_trace_logging_service.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import logging
+from unittest import mock, TestCase
+
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+
+from fbpcs.common.service.trace_logging_service import CheckpointStatus
+
+
+class TestSimpleTraceLoggingService(TestCase):
+    def setUp(self) -> None:
+        self.logger = mock.create_autospec(logging.Logger)
+        self.svc = SimpleTraceLoggingService()
+        self.svc.logger = self.logger
+
+    def test_write_checkpoint_simple(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+            }
+        )
+
+        # Act
+        self.svc.write_checkpoint(
+            run_id="run123",
+            instance_id="instance456",
+            checkpoint_name="foo",
+            status=CheckpointStatus.STARTED,
+        )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)
+
+    def test_write_checkpoint_custom_data(self) -> None:
+        # Arrange
+        data = {"bar": "baz", "quux": "quuz"}
+        expected_dump = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+                "checkpoint_data": json.dumps(data),
+            }
+        )
+
+        # Act
+        self.svc.write_checkpoint(
+            run_id="run123",
+            instance_id="instance456",
+            checkpoint_name="foo",
+            status=CheckpointStatus.STARTED,
+            checkpoint_data=data,
+        )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/common/service/trace_logging_service.py
+++ b/fbpcs/common/service/trace_logging_service.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import logging
+from enum import auto, Enum
+from typing import Dict, Optional
+
+
+class CheckpointStatus(Enum):
+    STARTED = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class TraceLoggingService(abc.ABC):
+    def __init__(self) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
+
+    @abc.abstractmethod
+    def write_checkpoint(
+        self,
+        run_id: str,
+        instance_id: str,
+        checkpoint_name: str,
+        status: CheckpointStatus,
+        checkpoint_data: Optional[Dict[str, str]] = None,
+    ) -> None:
+        pass


### PR DESCRIPTION
Summary:
# What
* Title
# Why
* The low bar for OSS code is that trace logging just writes messages out via the logger. This mimics the behavior we implemented for the metric service in diff 2 of this stack

Differential Revision: D38266949

