### PR TITLE
Hook up trace logging service to PCService

### DIFF
--- a/fbpcs/common/service/simple_trace_logging_service.py
+++ b/fbpcs/common/service/simple_trace_logging_service.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+from typing import Dict, Optional
+
+from fbpcs.common.service.trace_logging_service import (
+    CheckpointStatus,
+    TraceLoggingService,
+)
+
+
+class SimpleTraceLoggingService(TraceLoggingService):
+    def write_checkpoint(
+        self,
+        run_id: str,
+        instance_id: str,
+        checkpoint_name: str,
+        status: CheckpointStatus,
+        checkpoint_data: Optional[Dict[str, str]] = None,
+    ) -> None:
+        result = {
+            "operation": "write_checkpoint",
+            "run_id": run_id,
+            "instance_id": instance_id,
+            "checkpoint_name": checkpoint_name,
+            "status": str(status),
+        }
+        if checkpoint_data:
+            result["checkpoint_data"] = checkpoint_data
+        self.logger.info(json.dumps(result))

--- a/fbpcs/common/service/test/test_simple_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_simple_trace_logging_service.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import logging
+from unittest import mock, TestCase
+
+from fbpcs.common.service.trace_logging_service import CheckpointStatus
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+
+
+class TestSimpleTraceLoggingService(TestCase):
+    def setUp(self) -> None:
+        self.logger = mock.create_autospec(logging.Logger)
+        self.svc = SimpleTraceLoggingService()
+        self.svc.logger = self.logger
+
+    def test_write_checkpoint_simple(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+            }
+        )
+
+        # Act
+        self.svc.write_checkpoint(
+            run_id="run123",
+            instance_id="instance456",
+            checkpoint_name="foo",
+            status=CheckpointStatus.STARTED,
+        )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)
+
+    def test_write_checkpoint_custom_data(self) -> None:
+        # Arrange
+        data = {"bar": "baz", "quux": "quuz"}
+        expected_dump = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+                "checkpoint_data": data,
+            }
+        )
+
+        # Act
+        self.svc.write_checkpoint(
+            run_id="run123",
+            instance_id="instance456",
+            checkpoint_name="foo",
+            status=CheckpointStatus.STARTED,
+            checkpoint_data=data,
+        )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/common/service/test/test_simple_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_simple_trace_logging_service.py
@@ -10,8 +10,9 @@ import json
 import logging
 from unittest import mock, TestCase
 
-from fbpcs.common.service.trace_logging_service import CheckpointStatus
 from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+
+from fbpcs.common.service.trace_logging_service import CheckpointStatus
 
 
 class TestSimpleTraceLoggingService(TestCase):

--- a/fbpcs/common/service/trace_logging_service.py
+++ b/fbpcs/common/service/trace_logging_service.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+import logging
+from enum import auto, Enum
+from typing import Dict, Optional
+
+
+class CheckpointStatus(Enum):
+    STARTED = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class TraceLoggingService(abc.ABC):
+    def __init__(self) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
+
+    @abc.abstractmethod
+    def write_checkpoint(
+        self,
+        run_id: str,
+        instance_id: str,
+        checkpoint_name: str,
+        status: CheckpointStatus,
+        checkpoint_data: Optional[Dict[str, str]] = None,
+    ) -> None:
+        pass

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -20,6 +20,8 @@ from fbpcp.service.storage import StorageService
 
 from fbpcs.common.service.metric_service import MetricService
 from fbpcs.common.service.simple_metric_service import SimpleMetricService
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
@@ -100,6 +102,7 @@ class PrivateComputationService:
         pid_post_processing_handlers: Optional[Dict[str, PostProcessingHandler]] = None,
         workflow_svc: Optional[WorkflowService] = None,
         metric_svc: Optional[MetricService] = None,
+        trace_logging_svc: Optional[TraceLoggingService] = None,
     ) -> None:
         """Constructor of PrivateComputationService
         instance_repository -- repository to CRUD PrivateComputationInstance
@@ -113,6 +116,10 @@ class PrivateComputationService:
         # If a metric service isn't provided, just use a SimpleMetricService
         # so a caller will never have to worry about this being None
         self.metric_svc: MetricService = metric_svc or SimpleMetricService()
+        # Same deal with trace_logging_svc
+        self.trace_logging_svc: TraceLoggingService = (
+            trace_logging_svc or SimpleTraceLoggingService()
+        )
         self.post_processing_handlers: Dict[str, PostProcessingHandler] = (
             post_processing_handlers or {}
         )
@@ -130,6 +137,7 @@ class PrivateComputationService:
             self.pc_validator_config,
             self.workflow_svc,
             self.metric_svc,
+            self.trace_logging_svc,
         )
         self.logger: logging.Logger = logging.getLogger(__name__)
 

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -15,6 +15,7 @@ from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 
 from fbpcs.common.service.metric_service import MetricService
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
@@ -41,6 +42,7 @@ class PrivateComputationStageServiceArgs:
     pc_validator_config: PCValidatorConfig
     workflow_svc: Optional[WorkflowService]
     metric_svc: MetricService
+    trace_logging_svc: TraceLoggingService
 
 
 class PrivateComputationStageService(abc.ABC):

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -21,6 +21,8 @@ from fbpcp.service.storage import StorageService
 from fbpcs.common.service.metric_service import MetricService
 from fbpcs.common.service.pcs_container_service import PCSContainerService
 from fbpcs.common.service.simple_metric_service import SimpleMetricService
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_service_config import OneDockerServiceConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
@@ -413,6 +415,14 @@ def _build_metric_service(config: Optional[Dict[str, Any]]) -> MetricService:
     return reflect.get_instance(config, MetricService)
 
 
+def _build_trace_logging_service(
+    config: Optional[Dict[str, Any]]
+) -> TraceLoggingService:
+    if config is None:
+        return SimpleTraceLoggingService()
+    return reflect.get_instance(config, TraceLoggingService)
+
+
 def _build_private_computation_service(
     pc_config: Dict[str, Any],
     mpc_config: Dict[str, Any],
@@ -447,6 +457,9 @@ def _build_private_computation_service(
         workflow_service = None
 
     metric_svc = _build_metric_service(pc_config["dependency"].get("MetricService"))
+    trace_logging_svc = _build_trace_logging_service(
+        pc_config["dependency"].get("TraceLoggingService")
+    )
 
     return PrivateComputationService(
         instance_repository=repository_service,
@@ -461,6 +474,7 @@ def _build_private_computation_service(
         pid_post_processing_handlers=_get_post_processing_handlers(pid_pph_config),
         workflow_svc=workflow_service,
         metric_svc=metric_svc,
+        trace_logging_svc=trace_logging_svc,
     )
 
 


### PR DESCRIPTION
Summary:
# What
* Title
# Why
* Now that the interface is defined, we plumb it through PCService. I'll talk with a couple people on making a slightly more convenient interface that can auto-populate run_id and instance_id later.

Differential Revision: D38267684

