### PR TITLE
Add runId to PA instance creation in PCS

### DIFF
--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -82,6 +82,7 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
     post_processing_data_optional: Optional[PostProcessingData] = None
     pid_configs: Optional[Dict[str, Any]] = None
     pcs_features: Optional[List[str]] = None
+    run_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.stage_flow_cls is PrivateComputationBaseStageFlow:
@@ -142,6 +143,7 @@ class BoltPCSClient(BoltClient):
             post_processing_data_optional=instance_args.post_processing_data_optional,
             pid_configs=instance_args.pid_configs,
             pcs_features=instance_args.pcs_features,
+            run_id=instance_args.run_id,
         )
         return instance.infra_config.instance_id
 

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -93,6 +93,7 @@ class BoltPLGraphAPICreateInstanceArgs(BoltCreateInstanceArgs):
     instance_id: str  # used for temporary resuming solution
     study_id: str
     breakdown_key: Dict[str, str]
+    run_id: str
 
 
 @dataclass
@@ -124,6 +125,7 @@ class BoltGraphAPIClient(BoltClient):
         params = self.params.copy()
         if isinstance(instance_args, BoltPLGraphAPICreateInstanceArgs):
             params["breakdown_key"] = json.dumps(instance_args.breakdown_key)
+            params["run_id"] = instance_args.run_id
             r = requests.post(
                 f"{URL}/{instance_args.study_id}/instances", params=params
             )

--- a/fbpcs/pl_coordinator/pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pc_graphapi_utils.py
@@ -133,10 +133,14 @@ class PCGraphAPIClient:
 
     # TODO rename to create_pl_instance since we now have a create_pa_instance function
     def create_instance(
-        self, study_id: str, breakdown_key: Dict[str, str]
+        self,
+        study_id: str,
+        breakdown_key: Dict[str, str],
+        run_id: str,
     ) -> requests.Response:
         params = self.params.copy()
         params["breakdown_key"] = json.dumps(breakdown_key)
+        params["run_id"] = run_id
         r = requests.post(f"{URL}/{study_id}/instances", params=params)
         self._check_err(r, "creating fb instance")
         return r

--- a/fbpcs/pl_coordinator/pc_partner_instance.py
+++ b/fbpcs/pl_coordinator/pc_partner_instance.py
@@ -59,6 +59,7 @@ class PrivateComputationPartnerInstance(PrivateComputationCalcInstance):
         k_anonymity_threshold: Optional[int] = None,
         result_visibility: Optional[ResultVisibility] = None,
         pcs_features: Optional[List[str]] = None,
+        run_id: Optional[str] = None,
     ) -> None:
         super().__init__(instance_id, logger, PrivateComputationRole.PARTNER)
         self.config: Dict[str, Any] = config
@@ -88,6 +89,7 @@ class PrivateComputationPartnerInstance(PrivateComputationCalcInstance):
                 k_anonymity_threshold=k_anonymity_threshold,
                 result_visibility=result_visibility,
                 pcs_features=pcs_features,
+                run_id=run_id,
             )
 
         self.status = pc_instance.infra_config.status

--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -75,6 +75,7 @@ def run_instance(
     dry_run: Optional[bool] = False,
     result_visibility: Optional[ResultVisibility] = None,
     pcs_features: Optional[List[str]] = None,
+    run_id: Optional[str] = None,
 ) -> None:
     num_tries = num_tries if num_tries is not None else MAX_TRIES
     if num_tries < MIN_TRIES or num_tries > MAX_TRIES:
@@ -102,6 +103,7 @@ def run_instance(
         k_anonymity_threshold=k_anonymity_threshold,
         result_visibility=result_visibility,
         pcs_features=pcs_features,
+        run_id=run_id,
     )
     logger.info(f"Running private {game_type.name.lower()} for instance {instance_id}")
     instance_runner.run()
@@ -191,6 +193,7 @@ class PLInstanceRunner:
         k_anonymity_threshold: Optional[int] = None,
         result_visibility: Optional[ResultVisibility] = None,
         pcs_features: Optional[List[str]] = None,
+        run_id: Optional[str] = None,
     ) -> None:
         self.logger = logger
         self.instance_id = instance_id
@@ -213,6 +216,7 @@ class PLInstanceRunner:
             logger=logger,
             result_visibility=result_visibility,
             pcs_features=pcs_features,
+            run_id=run_id,
         )
         self.num_tries = num_tries
         self.dry_run = dry_run

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -56,6 +56,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
 # study information fields
 TYPE = "type"
 STATUS = "status"
+RUN_ID = "run_id"
 START_TIME = "start_time"
 OBSERVATION_END_TIME = "observation_end_time"
 OBJECTIVES = "objectives"
@@ -88,6 +89,7 @@ def run_study(
     dry_run: Optional[bool] = False,  # if set to true, it will only run one stage
     result_visibility: Optional[ResultVisibility] = None,
     final_stage: Optional[PrivateComputationBaseStageFlow] = None,
+    run_id: Optional[str] = None,
 ) -> None:
 
     ## Step 1: Validation. Function arguments and study metadata must be valid for private lift run.
@@ -117,6 +119,7 @@ def run_study(
         study_data,
         objective_ids,
         input_paths,
+        run_id or "",
     )
     _print_json(
         "Existing valid instances for cell-obj pairs", cell_obj_instance, logger
@@ -156,6 +159,7 @@ def run_study(
             num_shards = data["num_shards"]
             cell_id = data["cell_id"]
             obj_id = data["objective_id"]
+            run_id = data["run_id"]
             publisher_args = BoltPlayerArgs(
                 create_instance_args=BoltPLGraphAPICreateInstanceArgs(
                     instance_id=instance_id,
@@ -164,6 +168,7 @@ def run_study(
                         "cell_id": cell_id,
                         "objective_id": obj_id,
                     },
+                    run_id=run_id,
                 )
             )
             partner_args = BoltPlayerArgs(
@@ -177,6 +182,7 @@ def run_study(
                     stage_flow_cls=stage_flow,
                     result_visibility=result_visibility or ResultVisibility.PUBLIC,
                     pcs_features=pcs_features,
+                    run_id=run_id,
                 )
             )
             job = BoltJob(
@@ -236,7 +242,10 @@ def run_study(
 
     ## Step 4: Print out the initial and end states
     new_cell_obj_instances = _get_cell_obj_instance(
-        _get_study_data(study_id, client), objective_ids, input_paths
+        _get_study_data(study_id, client),
+        objective_ids,
+        input_paths,
+        run_id or "",
     )
     _print_json(
         "Pre-run statuses for instance of each cell-objective pair",
@@ -367,6 +376,7 @@ def _get_cell_obj_instance(
     study_data: Dict[str, Any],
     objective_ids: List[str],
     input_paths: List[str],
+    run_id: str,
 ) -> Dict[str, Dict[str, Dict[str, Any]]]:
     # only consider cells in OPP_DATA_INFORMATION (opportunity datasets available).
     cells_data: List[str] = study_data[OPP_DATA_INFORMATION]
@@ -396,6 +406,7 @@ def _get_cell_obj_instance(
         breakdown_key = json.loads(instance_data["breakdown_key"])
         cell_id = str(breakdown_key["cell_id"])
         objective_id = str(breakdown_key["objective_id"])
+
         # If to-be-calculated cell-obj pairs does not include this instance's
         # cell-obj pair, skip.
         if (
@@ -415,6 +426,9 @@ def _get_cell_obj_instance(
                 "id"
             ]
             cell_obj_instance[cell_id][objective_id][STATUS] = status.value
+            # Same run_id needs to be present in all instances of the PL run.
+            # Thus adding run_id to each cell_id*object_id pair.
+            cell_obj_instance[cell_id][objective_id][RUN_ID] = run_id
 
     return cell_obj_instance
 
@@ -429,10 +443,11 @@ def _create_new_instances(
         for objective_id in cell_obj_instances[cell_id]:
             # Create new instance for cell_obj pairs which has no valid instance.
             if "instance_id" not in cell_obj_instances[cell_id][objective_id]:
+                run_id = cell_obj_instances[cell_id][objective_id][RUN_ID]
                 cell_obj_instances[cell_id][objective_id][
                     "instance_id"
                 ] = _create_instance_retry(
-                    client, study_id, cell_id, objective_id, logger
+                    client, study_id, cell_id, objective_id, run_id, logger
                 )
                 cell_obj_instances[cell_id][objective_id][
                     STATUS
@@ -444,6 +459,7 @@ def _create_instance_retry(
     study_id: str,
     cell_id: str,
     objective_id: str,
+    run_id: str,
     logger: logging.Logger,
 ) -> str:
     tries = 0
@@ -452,7 +468,9 @@ def _create_instance_retry(
         try:
             instance_id = json.loads(
                 client.create_instance(
-                    study_id, {"cell_id": cell_id, "objective_id": objective_id}
+                    study_id,
+                    {"cell_id": cell_id, "objective_id": objective_id},
+                    run_id,
                 ).text
             )["id"]
             logger.info(

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -92,7 +92,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             params={
                 "access_token": ACCESS_TOKEN,
                 "breakdown_key": json.dumps(test_pl_args.breakdown_key),
-                "run_id": "run_id",
+                "run_id": test_pl_args.run_id,
             },
         )
 

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -84,6 +84,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
                 "cell_id": "cell_id",
                 "objective_id": "obj_id",
             },
+            run_id="run_id",
         )
         await self.test_client.create_instance(test_pl_args)
         mock_post.assert_called_once_with(
@@ -91,6 +92,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             params={
                 "access_token": ACCESS_TOKEN,
                 "breakdown_key": json.dumps(test_pl_args.breakdown_key),
+                "run_id": "run_id",
             },
         )
 

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -143,6 +143,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
         creation_ts: the time of the creation of this PrivateComputationInstance
         end_ts: the time of the the end when finishing a computation run
         mpc_compute_concurrency: number of threads to run per container at the MPC compute metrics stage
+        run_id: field that can be used to identify all the logs for a run.
 
     Private attributes:
         _stage_flow_cls_name: the name of a PrivateComputationBaseStageFlow subclass (cls.__name__)
@@ -180,6 +181,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
         },
     )
     pce_config: Optional[PCEConfig] = None
+    run_id: Optional[str] = immutable_field(default=None)
 
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name

--- a/fbpcs/private_computation/entity/product_config.py
+++ b/fbpcs/private_computation/entity/product_config.py
@@ -65,7 +65,6 @@ class CommonProductConfig(DataclassMutabilityMixin):
     result_visibility: ResultVisibility = immutable_field(
         default=ResultVisibility.PUBLIC
     )
-
     pid_use_row_numbers: bool = immutable_field(default=True)
     multikey_enabled: bool = immutable_field(default=True)
     pid_protocol: PIDProtocol = immutable_field(default=DEFAULT_PID_PROTOCOL)

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -95,6 +95,7 @@ def run_attribution(
     logger: logging.Logger,
     num_tries: Optional[int] = 2,  # this is number of tries per stage
     final_stage: Optional[PrivateComputationBaseStageFlow] = None,
+    run_id: Optional[str] = None,
 ) -> None:
 
     ## Step 1: Validation. Function arguments and  for private attribution run.
@@ -200,6 +201,7 @@ def run_attribution(
                 num_files_per_mpc_container=num_files_per_mpc_container,
                 k_anonymity_threshold=k_anonymity_threshold,
                 pcs_features=pcs_features,
+                run_id=run_id,
             )
         )
         job = BoltJob(
@@ -254,6 +256,7 @@ def run_attribution(
             "k_anonymity_threshold": k_anonymity_threshold,
             "num_tries": num_tries,
             "pcs_features": pcs_features,
+            "run_id": run_id,
         }
         run_instance(**instance_parameters)
         logger.info(f"Finished running instances {instance_id}.")

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -159,6 +159,7 @@ class PrivateComputationService:
         post_processing_data_optional: Optional[PostProcessingData] = None,
         pid_configs: Optional[Dict[str, Any]] = None,
         pcs_features: Optional[List[str]] = None,
+        run_id: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -198,6 +199,7 @@ class PrivateComputationService:
             ),
             mpc_compute_concurrency=concurrency or DEFAULT_CONCURRENCY,
             status_updates=[],
+            run_id=run_id,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -26,7 +26,7 @@ Usage:
     pc-cli print_current_status <instance_id> --config=<config_file> [options]
     pc-cli print_log_urls <instance_id> --config=<config_file> [options]
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
-    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [options]
+    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [--run_id=<run_id>] [options]
     pc-cli pre_validate --config=<config_file> [--dataset_id=<dataset_id>] --input_path=<input_path> [--timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>] [options]
     pc-cli bolt_e2e --bolt_config=<bolt_config_file>
     pc-cli secret_scrubber <secret_input_path> <scrubbed_output_path>
@@ -445,6 +445,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             stage_flow=stage_flow,
             num_tries=2,
             final_stage=PrivateComputationPCF2StageFlow.AGGREGATE,
+            run_id=arguments["--run_id"],
         )
 
     elif arguments["cancel_current_stage"]:

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -10,7 +10,7 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pc-cli create_instance <instance_id> --config=<config_file> --role=<pl_role> --game_type=<game_type> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --padding_size=<padding_size> --k_anonymity_threshold=<k_anonymity_threshold> --hmac_key=<base64_key> --stage_flow=<stage_flow> --result_visibility=<result_visibility>] [options]
+    pc-cli create_instance <instance_id> --config=<config_file> --role=<pl_role> --game_type=<game_type> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --padding_size=<padding_size> --k_anonymity_threshold=<k_anonymity_threshold> --hmac_key=<base64_key> --stage_flow=<stage_flow> --result_visibility=<result_visibility> --run_id=<run_id>] [options]
     pc-cli validate <instance_id> --config=<config_file> --expected_result_path=<expected_result_path> [--aggregated_result_path=<aggregated_result_path>] [options]
     pc-cli run_next <instance_id> --config=<config_file> [--server_ips=<server_ips>] [options]
     pc-cli run_stage <instance_id> --stage=<stage> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
@@ -19,7 +19,7 @@ Usage:
     pc-cli get_mpc <instance_id> --config=<config_file> [options]
     pc-cli run_instance <instance_id> --config=<config_file> --input_path=<input_path> --num_shards=<num_shards> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli run_instances <instance_ids> --config=<config_file> --input_paths=<input_paths> --num_shards_list=<num_shards_list> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
-    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --dry_run] [options]
+    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --dry_run] [options]
     pc-cli pre_validate [<study_id>] --config=<config_file> [--objective_ids=<objective_ids>] --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
@@ -268,6 +268,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 None,
                 schema.Use(lambda arg: ResultVisibility[arg.upper()]),
             ),
+            "--run_id": schema.Or(None, str),
             "--stage": schema.Or(None, str),
             "--verbose": bool,
             "--help": bool,
@@ -345,6 +346,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             k_anonymity_threshold=arguments["--k_anonymity_threshold"],
             stage_flow_cls=arguments["--stage_flow"],
             result_visibility=arguments["--result_visibility"],
+            run_id=arguments["--run_id"],
         )
     elif arguments["run_next"]:
         logger.info(f"run_next instance: {instance_id}")
@@ -424,6 +426,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             num_tries=arguments["--tries_per_stage"],
             dry_run=arguments["--dry_run"],
             result_visibility=arguments["--result_visibility"],
+            run_id=arguments["--run_id"],
             final_stage=PrivateComputationStageFlow.AGGREGATE,
         )
     elif arguments["run_attribution"]:

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -73,6 +73,7 @@ def create_instance(
     stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
     result_visibility: Optional[ResultVisibility] = None,
     pcs_features: Optional[List[str]] = None,
+    run_id: Optional[str] = None,
 ) -> PrivateComputationInstance:
     pc_service = _build_private_computation_service(
         config["private_computation"],
@@ -105,6 +106,7 @@ def create_instance(
         pid_configs=config["pid"],
         result_visibility=result_visibility,
         pcs_features=pcs_features,
+        run_id=run_id,
     )
 
     logger.info(instance)

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -343,6 +343,7 @@ class TestPrivateComputationCli(TestCase):
             "12345",
             f"--config={self.temp_filename}",
             "--objective_ids=12,34,56,78,90",
+            "--run_id=2621fda2-0eca-11ed-861d-0242ac120003",
             f"--input_paths={','.join(self.temp_files_paths)},",
         ]
         pc_cli.main(argv)

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -201,6 +201,7 @@ class TestPrivateComputationCli(TestCase):
             f"--config={self.temp_filename}",
             "--timestamp=1646870400",
             "--k_anonymity_threshold=0",
+            "--run_id=123",
         ]
         pc_cli.main(argv)
         create_mock.assert_called_once()

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -140,6 +140,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
             output_dir="output_path",
             num_pid_containers=1,
             num_mpc_containers=1,
+            run_id="2621fda2-0eca-11ed-861d-0242ac120003",
         )
         self.mock_pcs.create_instance.assert_called_once_with(
             instance_id=self.test_instance_id,
@@ -161,6 +162,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
             pid_configs={"dependency": {}},
             result_visibility=None,
             pcs_features=None,
+            run_id="2621fda2-0eca-11ed-861d-0242ac120003",
         )
 
     @patch(


### PR DESCRIPTION
Summary:
# Context
For Centralized Logging, we will use a unique run_id to identify a PL/PA run, this run_id will be generated on the partner side and will be consumed by publisher side during instance creation. This run_id will be included in all the multiple ENT instances involved in the run and will also be shared with all the backend components (thrift, PCS, PCA binaries).
# Design Doc
https://docs.google.com/document/d/1vZNOq8GUT1D_7-MjSh2yNpUKVEsvpsYeFx1PjceyelQ/edit?usp=sharing
RunID Format
RunId will be in UUID format. Ex - 2621fda2-0eca-11ed-861d-0242ac120002
# This Stack
Add field run_id to private computation instance pattern.
Add field run_id to PL instance creation endpoint.
Add field run_id to PA instance creation endpoint.
Add logic in PCS to get run_id using private computation cli for PL run.
Add logic in PCS to pass run_id to PL creation API.
Add logic in PCS to get run_id using private computation cli for PA run.
Add logic in PCS to pass run_id to PA creation API.
Add logic to pass run_id from www to thrift tier and save it in thrift entity.
Add logic to pass run_id from thrift tier to PID/PCA binaries.
# This diff
Add logic in PCS to get run_id using private computation cli for PA run
Add logic in PCS to pass run_id to PA creation API.

Differential Revision: D38304718

