### PR TITLE
Pass run_id to PL instance creation API from pcs.

### DIFF
--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -82,6 +82,7 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
     post_processing_data_optional: Optional[PostProcessingData] = None
     pid_configs: Optional[Dict[str, Any]] = None
     pcs_features: Optional[List[str]] = None
+    run_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.stage_flow_cls is PrivateComputationBaseStageFlow:
@@ -142,6 +143,7 @@ class BoltPCSClient(BoltClient):
             post_processing_data_optional=instance_args.post_processing_data_optional,
             pid_configs=instance_args.pid_configs,
             pcs_features=instance_args.pcs_features,
+            run_id=instance_args.run_id,
         )
         return instance.infra_config.instance_id
 

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -93,6 +93,7 @@ class BoltPLGraphAPICreateInstanceArgs(BoltCreateInstanceArgs):
     instance_id: str  # used for temporary resuming solution
     study_id: str
     breakdown_key: Dict[str, str]
+    run_id: Optional[str]
 
 
 @dataclass
@@ -124,6 +125,8 @@ class BoltGraphAPIClient(BoltClient):
         params = self.params.copy()
         if isinstance(instance_args, BoltPLGraphAPICreateInstanceArgs):
             params["breakdown_key"] = json.dumps(instance_args.breakdown_key)
+            if instance_args.run_id is not None:
+                params["run_id"] = instance_args.run_id
             r = requests.post(
                 f"{URL}/{instance_args.study_id}/instances", params=params
             )

--- a/fbpcs/pl_coordinator/pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pc_graphapi_utils.py
@@ -7,7 +7,7 @@
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 from fbpcs.pl_coordinator.constants import FBPCS_GRAPH_API_TOKEN
@@ -133,10 +133,15 @@ class PCGraphAPIClient:
 
     # TODO rename to create_pl_instance since we now have a create_pa_instance function
     def create_instance(
-        self, study_id: str, breakdown_key: Dict[str, str]
+        self,
+        study_id: str,
+        breakdown_key: Dict[str, str],
+        run_id: Optional[str],
     ) -> requests.Response:
         params = self.params.copy()
         params["breakdown_key"] = json.dumps(breakdown_key)
+        if run_id is not None:
+            params["run_id"] = run_id
         r = requests.post(f"{URL}/{study_id}/instances", params=params)
         self._check_err(r, "creating fb instance")
         return r

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -84,6 +84,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
                 "cell_id": "cell_id",
                 "objective_id": "obj_id",
             },
+            run_id="run_id",
         )
         await self.test_client.create_instance(test_pl_args)
         mock_post.assert_called_once_with(
@@ -91,6 +92,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             params={
                 "access_token": ACCESS_TOKEN,
                 "breakdown_key": json.dumps(test_pl_args.breakdown_key),
+                "run_id": "run_id",
             },
         )
 

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -143,6 +143,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
         creation_ts: the time of the creation of this PrivateComputationInstance
         end_ts: the time of the the end when finishing a computation run
         mpc_compute_concurrency: number of threads to run per container at the MPC compute metrics stage
+        run_id: field that can be used to identify all the logs for a run.
 
     Private attributes:
         _stage_flow_cls_name: the name of a PrivateComputationBaseStageFlow subclass (cls.__name__)
@@ -180,6 +181,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
         },
     )
     pce_config: Optional[PCEConfig] = None
+    run_id: Optional[str] = immutable_field(default=None)
 
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name

--- a/fbpcs/private_computation/entity/product_config.py
+++ b/fbpcs/private_computation/entity/product_config.py
@@ -65,7 +65,6 @@ class CommonProductConfig(DataclassMutabilityMixin):
     result_visibility: ResultVisibility = immutable_field(
         default=ResultVisibility.PUBLIC
     )
-
     pid_use_row_numbers: bool = immutable_field(default=True)
     multikey_enabled: bool = immutable_field(default=True)
     pid_protocol: PIDProtocol = immutable_field(default=DEFAULT_PID_PROTOCOL)

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -167,6 +167,7 @@ class PrivateComputationService:
         post_processing_data_optional: Optional[PostProcessingData] = None,
         pid_configs: Optional[Dict[str, Any]] = None,
         pcs_features: Optional[List[str]] = None,
+        run_id: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
 
@@ -206,6 +207,7 @@ class PrivateComputationService:
             ),
             mpc_compute_concurrency=concurrency or DEFAULT_CONCURRENCY,
             status_updates=[],
+            run_id=run_id,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -10,7 +10,7 @@ CLI for running a Private Lift study
 
 
 Usage:
-    pc-cli create_instance <instance_id> --config=<config_file> --role=<pl_role> --game_type=<game_type> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --padding_size=<padding_size> --k_anonymity_threshold=<k_anonymity_threshold> --hmac_key=<base64_key> --stage_flow=<stage_flow> --result_visibility=<result_visibility>] [options]
+    pc-cli create_instance <instance_id> --config=<config_file> --role=<pl_role> --game_type=<game_type> --input_path=<input_path> --output_dir=<output_dir> --num_pid_containers=<num_pid_containers> --num_mpc_containers=<num_mpc_containers> [--attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --padding_size=<padding_size> --k_anonymity_threshold=<k_anonymity_threshold> --hmac_key=<base64_key> --stage_flow=<stage_flow> --result_visibility=<result_visibility> --run_id=<run_id>] [options]
     pc-cli validate <instance_id> --config=<config_file> --expected_result_path=<expected_result_path> [--aggregated_result_path=<aggregated_result_path>] [options]
     pc-cli run_next <instance_id> --config=<config_file> [--server_ips=<server_ips>] [options]
     pc-cli run_stage <instance_id> --stage=<stage> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
@@ -19,7 +19,7 @@ Usage:
     pc-cli get_mpc <instance_id> --config=<config_file> [options]
     pc-cli run_instance <instance_id> --config=<config_file> --input_path=<input_path> --num_shards=<num_shards> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli run_instances <instance_ids> --config=<config_file> --input_paths=<input_paths> --num_shards_list=<num_shards_list> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
-    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --dry_run] [options]
+    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --dry_run] [options]
     pc-cli pre_validate [<study_id>] --config=<config_file> [--objective_ids=<objective_ids>] --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
@@ -268,6 +268,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 None,
                 schema.Use(lambda arg: ResultVisibility[arg.upper()]),
             ),
+            "--run_id": schema.Or(None, str),
             "--stage": schema.Or(None, str),
             "--verbose": bool,
             "--help": bool,
@@ -345,6 +346,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             k_anonymity_threshold=arguments["--k_anonymity_threshold"],
             stage_flow_cls=arguments["--stage_flow"],
             result_visibility=arguments["--result_visibility"],
+            run_id=arguments["--run_id"],
         )
     elif arguments["run_next"]:
         logger.info(f"run_next instance: {instance_id}")
@@ -424,6 +426,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             num_tries=arguments["--tries_per_stage"],
             dry_run=arguments["--dry_run"],
             result_visibility=arguments["--result_visibility"],
+            run_id=arguments["--run_id"],
             final_stage=PrivateComputationStageFlow.AGGREGATE,
         )
     elif arguments["run_attribution"]:

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -75,6 +75,7 @@ def create_instance(
     stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
     result_visibility: Optional[ResultVisibility] = None,
     pcs_features: Optional[List[str]] = None,
+    run_id: Optional[str] = None,
 ) -> PrivateComputationInstance:
     pc_service = _build_private_computation_service(
         config["private_computation"],
@@ -107,6 +108,7 @@ def create_instance(
         pid_configs=config["pid"],
         result_visibility=result_visibility,
         pcs_features=pcs_features,
+        run_id=run_id,
     )
 
     logger.info(instance)

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -343,6 +343,7 @@ class TestPrivateComputationCli(TestCase):
             "12345",
             f"--config={self.temp_filename}",
             "--objective_ids=12,34,56,78,90",
+            "--run_id=2621fda2-0eca-11ed-861d-0242ac120003",
             f"--input_paths={','.join(self.temp_files_paths)},",
         ]
         pc_cli.main(argv)

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -140,6 +140,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
             output_dir="output_path",
             num_pid_containers=1,
             num_mpc_containers=1,
+            run_id="2621fda2-0eca-11ed-861d-0242ac120003",
         )
         self.mock_pcs.create_instance.assert_called_once_with(
             instance_id=self.test_instance_id,
@@ -161,6 +162,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
             pid_configs={"dependency": {}},
             result_visibility=None,
             pcs_features=None,
+            run_id="2621fda2-0eca-11ed-861d-0242ac120003",
         )
 
     @patch(


### PR DESCRIPTION
Summary:
# Context
For Centralized Logging, we will use a unique run_id to identify a PL/PA run, this run_id will be generated on the partner side and will be consumed by publisher side during instance creation. This run_id will be included in all the multiple ENT instances involved in the run and will also be shared with all the backend components (thrift, PCS, PCA binaries).
# Design Doc
https://docs.google.com/document/d/1vZNOq8GUT1D_7-MjSh2yNpUKVEsvpsYeFx1PjceyelQ/edit?usp=sharing
RunID Format
RunId will be in UUID format. Ex - 2621fda2-0eca-11ed-861d-0242ac120002
# This Stack
Add field run_id to private computation instance pattern.
Add field run_id to PL instance creation endpoint.
Add field run_id to PA instance creation endpoint.
Add logic in PCS to get run_id using private computation cli for PL run.
Add logic in PCS to pass run_id to PL creation API.
Add logic in PCS to get run_id using private computation cli for PA run.
Add logic in PCS to pass run_id to PA creation API.
Add logic to pass run_id from www to thrift tier and save it in thrift entity.
Add logic to pass run_id from thrift tier to PID/PCA binaries.
# This diff
Add logic in PCS to pass run_id to PL creation API.

Differential Revision: D38304611

