### PR TITLE
refatoring LoggerAdapter to util

### DIFF
--- a/fbpcs/pl_coordinator/pl_instance_runner.py
+++ b/fbpcs/pl_coordinator/pl_instance_runner.py
@@ -44,16 +44,8 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
+from fbpcs.utils.logger_adapter import LoggerAdapter
 from termcolor import colored
-
-
-class LoggerAdapter(logging.LoggerAdapter):
-    def __init__(self, logger: logging.Logger, prefix: str) -> None:
-        super(LoggerAdapter, self).__init__(logger, {})
-        self.prefix = prefix
-
-    def process(self, msg, kwargs):
-        return "[%s] %s" % (self.prefix, msg), kwargs
 
 
 def run_instance(

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -40,15 +40,7 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     _build_private_computation_service,
     get_tier,
 )
-
-
-class LoggerAdapter(logging.LoggerAdapter):
-    def __init__(self, logger: logging.Logger, prefix: str) -> None:
-        super(LoggerAdapter, self).__init__(logger, {})
-        self.prefix = prefix
-
-    def process(self, msg, kwargs):
-        return "[%s] %s" % (self.prefix, msg), kwargs
+from fbpcs.utils.logger_adapter import LoggerAdapter
 
 
 # dataset information fields
@@ -245,7 +237,7 @@ def run_attribution(
             "num_mpc_containers": num_mpc_containers,
             "num_pid_containers": num_pid_containers,
             "stage_flow": stage_flow,
-            "logger": logger,
+            "logger": LoggerAdapter(logger=logger, prefix=instance_id),
             "game_type": PrivateComputationGameType.ATTRIBUTION,
             "attribution_rule": attribution_rule,
             "aggregation_type": AggregationType.MEASUREMENT,

--- a/fbpcs/utils/logger_adapter.py
+++ b/fbpcs/utils/logger_adapter.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    def __init__(self, logger: logging.Logger, prefix: str) -> None:
+        super(LoggerAdapter, self).__init__(logger, {})
+        self.prefix = prefix
+
+    def process(self, msg, kwargs):
+        return "[%s] %s" % (self.prefix, msg), kwargs


### PR DESCRIPTION
Summary:
## Why
LoggerAdapter should be reused not only in pl runner but also be used in bolt/PA runner, handler
## What
* Move LoggerAdapter to Util
* Adding LoggerAdapter to old PA runner
## Next
* Adding LogAdaptor to bolt runner

Reviewed By: ztlbells, gitfish77

Differential Revision: D38359871

