### PR TITLE
Adding quotes for target, var and backend-config key value

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
@@ -118,10 +118,10 @@ class TerraformDeploymentUtils:
         t.get_command_list("terraform apply")
 
         Returns:
-        => ['terraform', 'apply', '-backend-config region=us-west-2', '-backend-config access_key=fake_access_key']
+        => ['terraform', 'apply', '-backend-config "region=us-west-2"', '-backend-config "access_key=fake_access_key"']
         """
         commands_list: List[str] = []
-        commands_list.extend([f"-{key} {k}={v}" for k, v in value.items()])
+        commands_list.extend([f'-{key} "{k}={v}"' for k, v in value.items()])
         return commands_list
 
     def add_list_options(self, key: str, value: List[str]) -> List[str]:
@@ -132,11 +132,11 @@ class TerraformDeploymentUtils:
         t.get_command_list("terraform apply")
 
         Returns:
-        => ['terraform', 'apply', '-target=aws_s3_bucket_object.objects[2]', '-target=aws_s3_bucket_object.objects[3]']
+        => ['terraform', 'apply', '-target="aws_s3_bucket_object.objects[2]"', '-target="aws_s3_bucket_object.objects[3]"']
         """
         commands_list: List[str] = []
         for val in value:
-            commands_list.append(f"-{key}={val}")
+            commands_list.append(f'-{key}="{val}"')
         return commands_list
 
     def add_bool_options(self, key: str, value: bool) -> List[str]:
@@ -177,9 +177,9 @@ class TerraformDeploymentUtils:
         t.get_command_list("terraform init")
 
         Returns:
-        => ['terraform', 'init', '-target=aws_s3_bucket_object.objects[2]']
+        => ['terraform', 'init', '-target="aws_s3_bucket_object.objects[2]"']
         """
         commands_list: List[str] = []
         if value is not None:
-            commands_list.append(f"-{key}={value}")
+            commands_list.append(f'-{key}="{value}"')
         return commands_list

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
@@ -97,7 +97,7 @@ class TestTerraformDeployment(unittest.TestCase):
                 "region": "fake_region",
                 "access_key": "fake_access_key",
             }
-            expected_command = "terraform init -input=false -dry-run=true -backend-config region=fake_region -backend-config access_key=fake_access_key -reconfigure"
+            expected_command = 'terraform init -input=false -dry-run=true -backend-config "region=fake_region" -backend-config "access_key=fake_access_key" -reconfigure'
             expected_value = RunCommandResult(
                 return_code=0, output=f"Dry run command: {expected_command}", error=""
             )
@@ -111,7 +111,7 @@ class TestTerraformDeployment(unittest.TestCase):
                 "region": "fake_region ",
                 "access_key": "fake_access_key ",
             }
-            expected_command = "terraform init -input=false -dry-run=true -backend-config region=fake_region  -backend-config access_key=fake_access_key  -reconfigure"
+            expected_command = 'terraform init -input=false -dry-run=true -backend-config "region=fake_region " -backend-config "access_key=fake_access_key " -reconfigure'
             expected_value = RunCommandResult(
                 return_code=0, output=f"Dry run command: {expected_command}", error=""
             )


### PR DESCRIPTION
Summary:
**Context:**
These are series of diffs for terraform wrappers. Terraform is used by deploy.sh to bring up the AWS/GCP infrastructure.

**Change:**
Adding terraform CLI options backend-config. target and var values in quotes

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D38376283

