### PR TITLE
Fix build issue by upgrading the gradle version

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/gradle/wrapper/gradle-wrapper.properties
+++ b/fbpcs/infra/cloud_bridge/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Summary:
Upgrade the gradle version to match the version used in CAPI-G, this resolves
the make error.

Differential Revision: D38429562

