### PR TITLE
remove duplicate constant import of DEFAULT_BINARY_REPOSITORY ONEDOCKER_REPOSITORY_PATH

### DIFF
--- a/fbpcs/pc_pre_validation/binary_file_validator.py
+++ b/fbpcs/pc_pre_validation/binary_file_validator.py
@@ -9,6 +9,10 @@ from typing import Dict, List, Optional
 
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.storage_s3 import S3StorageService
+from fbpcs.onedocker_binary_config import (
+    DEFAULT_BINARY_REPOSITORY,
+    ONEDOCKER_REPOSITORY_PATH,
+)
 from fbpcs.pc_pre_validation.binary_path import (
     BinaryInfo,
     LocalBinaryPath,
@@ -17,11 +21,9 @@ from fbpcs.pc_pre_validation.binary_path import (
 from fbpcs.pc_pre_validation.constants import (
     BINARY_FILE_VALIDATOR_NAME,
     BINARY_INFOS,
-    DEFAULT_BINARY_REPOSITORY,
     DEFAULT_BINARY_VERSION,
     DEFAULT_EXE_FOLDER,
     ONEDOCKER_EXE_PATH,
-    ONEDOCKER_REPOSITORY_PATH,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.validation_report import ValidationReport

--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -9,11 +9,6 @@
 import re
 from typing import Dict, List, Pattern
 
-from fbpcs.onedocker_binary_config import (
-    DEFAULT_BINARY_REPOSITORY,
-    ONEDOCKER_REPOSITORY_PATH,
-)
-
 from fbpcs.pc_pre_validation.binary_path import BinaryInfo
 
 INPUT_DATA_VALIDATOR_NAME = "Input Data Validator"
@@ -72,7 +67,6 @@ VALIDATION_REGEXES: Dict[str, Pattern[str]] = {
 
 VALID_LINE_ENDING_REGEX: Pattern[str] = re.compile(r".*(\S|\S\n)$")
 
-DEFAULT_BINARY_REPOSITORY = DEFAULT_BINARY_REPOSITORY
 DEFAULT_BINARY_VERSION = "latest"
 DEFAULT_EXE_FOLDER = "/root/onedocker/package/"
 BINARY_INFOS: List[BinaryInfo] = [
@@ -90,5 +84,4 @@ BINARY_INFOS: List[BinaryInfo] = [
     BinaryInfo("private_attribution/shard-aggregator"),
     BinaryInfo("private_lift/lift"),
 ]
-ONEDOCKER_REPOSITORY_PATH = ONEDOCKER_REPOSITORY_PATH
 ONEDOCKER_EXE_PATH = "ONEDOCKER_EXE_PATH"

--- a/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/binary_file_validator_test.py
@@ -9,15 +9,17 @@ from unittest import TestCase
 from unittest.mock import call, Mock, patch
 
 from fbpcp.error.pcp import PcpError
+from fbpcs.onedocker_binary_config import (
+    DEFAULT_BINARY_REPOSITORY,
+    ONEDOCKER_REPOSITORY_PATH,
+)
 from fbpcs.pc_pre_validation.binary_file_validator import BinaryFileValidator
 from fbpcs.pc_pre_validation.binary_path import BinaryInfo
 from fbpcs.pc_pre_validation.constants import (
     BINARY_FILE_VALIDATOR_NAME,
-    DEFAULT_BINARY_REPOSITORY,
     DEFAULT_BINARY_VERSION,
     DEFAULT_EXE_FOLDER,
     ONEDOCKER_EXE_PATH,
-    ONEDOCKER_REPOSITORY_PATH,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.validation_report import ValidationReport


### PR DESCRIPTION
Summary:
## Why
in Previous Diff D38392439 (https://github.com/facebookresearch/fbpcs/commit/e1c367ce6c63f77da8517b505d6bcbcaa13e66dd) we consolidate DEFAULT_BINARY_REPOSITORY ONEDOCKER_REPOSITORY_PATH in `onedocker_binary_config`
This is kinda weird to have duplicate constant imports.
## What
* remove DEFAULT_BINARY_REPOSITORY ONEDOCKER_REPOSITORY_PATH from pc_pre_validataion.constant.py
* import those constant from `onedocker_binary_config`

Differential Revision: D38434295

