### PR TITLE
adding test to threshold checker in ShardCombinerGame

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGame.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGame.h
@@ -23,6 +23,7 @@
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/util/AggMetricsThresholdCheckers.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/util/AggMetricsThresholdCheckers_impl.h"
 
@@ -107,6 +108,7 @@ class ShardCombinerGame : public fbpcf::frontend::MpcGame<schedulerId> {
       auto shard =
           AggMetrics<schedulerId, usingBatch, inputEncryption>::fromJson(
               fullPath);
+      validateShardSchema<shardSchemaType>(*shard);
       shard->updateAllSecVals();
       shards_.push_back(shard);
     }

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h
@@ -14,13 +14,16 @@
   do {                                                                 \
     if (test_param operator expected) {                                \
     } else {                                                           \
+      XLOG(ERR) << msg;                                                \
       throw throw_(msg);                                               \
     }                                                                  \
   } while (0)
 
 #include <fbpcf/exception/exceptions.h>
-#include <fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h>
-#include <fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h>
+
+#include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics_impl.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h"
 
 namespace shard_combiner {
 
@@ -36,6 +39,8 @@ void validateShardSchema(
   } else if constexpr (
       shardSchemaType == ShardSchemaType::kGroupedLiftMetrics) {
     validateGroupedLiftMetrics(metrics);
+  } else if constexpr (shardSchemaType == ShardSchemaType::kTest) {
+    /* Do nothing for test shards */
   } else {
     throw common::exceptions::SchemaTraceError(folly::sformat(
         "This [{}] schema is currently not supported in pcf2_shard_combiner.",


### PR DESCRIPTION
Summary:
This test verifies if the threshold checker works or not, tests on odd and even number of shards.
# Changes in the diff
- Tests for ThresholdChecking
- integrates validator to the shardRead logic
- added a logging statement at throw for VALIDATA_OR_TROW macro.

Reviewed By: anthonyzhang25

Differential Revision: D38178871

