### PR TITLE
Adding main.cpp to ShardCombiner

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <folly/Format.h>
+#include <folly/Random.h>
+#include <folly/json.h>
+
+#include <fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h>
+#include <fbpcf/engine/communication/test/SocketInTestHelper.h>
+#include <fbpcf/engine/communication/test/TlsCommunicationUtils.h>
+#include <fbpcf/io/api/FileIOWrappers.h>
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h"
+
+namespace shard_combiner {
+class ShardCombinerAppTestFixture
+    : public ::testing::TestWithParam<std::tuple<bool, bool>> {
+ protected:
+  void SetUp() override {
+    // When running tests in parallel there could be contention for ports
+    // to run the game. To be on the safer side we set different ports
+    // for each test.
+    initialPort_ =
+        fbpcf::engine::communication::SocketInTestHelper::findNextOpenPort(
+            5500);
+    std::string filePath = __FILE__;
+    baseDir_ = filePath.substr(0, filePath.rfind("/")) + "/test/";
+    tempDir_ = std::filesystem::temp_directory_path();
+
+    tlsDir_ = fbpcf::engine::communication::setUpTlsFiles();
+  }
+
+  void TearDown() override {
+    fbpcf::engine::communication::deleteTlsFiles(tlsDir_);
+  }
+
+  template <
+      ShardSchemaType shardSchemaType,
+      bool usingBatch,
+      common::InputEncryption inputEncryption>
+  void runGame(
+      int32_t firstShardIndex,
+      int32_t numShards,
+      int64_t threshold,
+      const std::string& baseDir,
+      const std::string& inputFilePrefixPartner,
+      const std::string& inputFilePrefixPublisher,
+      const std::string& expectedOutputFile,
+      bool useTls,
+      const std::string& tlsDir,
+      uint16_t portNo,
+      bool xorEncrypted,
+      common::ResultVisibility resultVisibility) {
+    std::string outputPathPartner = folly::sformat(
+        "{}/output_path_partner.json_{}",
+        tempDir_,
+        folly::Random::secureRand64());
+    std::string outputPathPublisher = folly::sformat(
+        "{}/output_path_publisher.json_{}",
+        tempDir_,
+        folly::Random::secureRand64());
+
+    std::pair<std::string, std::uint16_t> publisherEndpoint = {
+        "127.0.0.1", portNo};
+    std::pair<std::string, std::uint16_t> partnerEndpoint = {
+        "127.0.0.1", (portNo)};
+
+    auto f1 = std::async(
+        doIt<shardSchemaType, common::PUBLISHER, usingBatch, inputEncryption>,
+        firstShardIndex,
+        numShards,
+        threshold,
+        publisherEndpoint,
+        baseDir,
+        inputFilePrefixPublisher,
+        outputPathPublisher,
+        useTls,
+        tlsDir,
+        xorEncrypted,
+        resultVisibility);
+
+    auto f2 = std::async(
+        doIt<shardSchemaType, common::PARTNER, usingBatch, inputEncryption>,
+        firstShardIndex,
+        numShards,
+        threshold,
+        partnerEndpoint,
+        baseDir,
+        inputFilePrefixPartner,
+        outputPathPartner,
+        useTls,
+        tlsDir,
+        xorEncrypted,
+        resultVisibility);
+
+    f1.wait();
+    f2.wait();
+    auto expectedObj = folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+        folly::sformat("{}", expectedOutputFile)));
+
+    // Check if the results match only in the party has visibility.
+    if (resultVisibility == common::ResultVisibility::kPublic ||
+        resultVisibility == common::ResultVisibility::kPublisher) {
+      EXPECT_EQ(
+          expectedObj,
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              folly::sformat("{}", outputPathPublisher))));
+    } else {
+      EXPECT_NE(
+          expectedObj,
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              folly::sformat("{}", outputPathPublisher))));
+    }
+
+    // Check if the results match only in the party has visibility.
+    if (resultVisibility == common::ResultVisibility::kPublic ||
+        resultVisibility == common::ResultVisibility::kPartner) {
+      EXPECT_EQ(
+          expectedObj,
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              folly::sformat("{}", outputPathPartner))));
+    } else {
+      EXPECT_NE(
+          expectedObj,
+          folly::parseJson(fbpcf::io::FileIOWrappers::readFile(
+              folly::sformat("{}", outputPathPartner))));
+    }
+    std::filesystem::remove(outputPathPartner);
+    std::filesystem::remove(outputPathPublisher);
+  }
+
+  template <
+      ShardSchemaType shardSchemaType,
+      int32_t schedulerId,
+      bool usingBatch,
+      common::InputEncryption inputEncryption>
+  static void doIt(
+      int32_t firstShardIndex,
+      int32_t numShards,
+      int64_t threshold,
+      const std::pair<std::string, std::uint16_t>& endPoint,
+      const std::string& inputPath,
+      const std::string& inputPrefix,
+      const std::string& outputPath,
+      bool useTls,
+      const std::string& tlsDir,
+      bool xorEncrypted,
+      common::ResultVisibility resultVisibility) {
+    std::map<
+        int32_t,
+        fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
+            PartyInfo>
+        partyInfos(
+            {{0, {endPoint.first, endPoint.second}},
+             {1, {endPoint.first, endPoint.second}}});
+
+    auto communicationAgentFactory = std::make_unique<
+        fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
+        schedulerId, partyInfos, useTls, tlsDir, "shard_combiner_test_traffic");
+
+    ShardCombinerApp<shardSchemaType, schedulerId, usingBatch, inputEncryption>(
+        std::move(communicationAgentFactory),
+        numShards,
+        firstShardIndex,
+        inputPath,
+        inputPrefix,
+        outputPath,
+        threshold,
+        xorEncrypted,
+        resultVisibility)
+        .run();
+  }
+
+  void testForShortCase(
+      std::string caseShortName,
+      bool xorEncrypted,
+      bool usingBatch,
+      bool useTls,
+      std::uint16_t portNo) {
+    const std::string inputPathAlice =
+        "publisher_attribution_correctness_" + caseShortName + "_out.json";
+    const std::string inputPathBob =
+        "partner_attribution_correctness_" + caseShortName + "_out.json";
+    const std::string expectedOutPath = baseDir_ +
+        "expected_shard_aggregator_correctness_test/expected_shard_aggregator_correctness_" +
+        caseShortName + "_out.json";
+
+    // Also test if cases work various visibility
+    std::vector<common::ResultVisibility> visibilityTypes{
+        common::ResultVisibility::kPublic,
+        common::ResultVisibility::kPartner,
+        common::ResultVisibility::kPublisher};
+
+    // For normal tests, set kanonymity threshold to zero
+    auto kanonymityThreshold = 0;
+    // For k-anonymity dedicated tests, set threshold to 100
+    if (caseShortName.find("kanonymity") != std::string::npos) {
+      kanonymityThreshold = 100;
+    }
+    for (auto visibility : visibilityTypes) {
+      if (usingBatch) {
+        runGame<
+            ShardSchemaType::kAdObjFormat,
+            true, // usingBatch
+            common::InputEncryption::Xor>(
+            0, // firstShardIndex
+            2, // numShards
+            kanonymityThreshold,
+            baseDir_ + "ad_object_format",
+            inputPathAlice,
+            inputPathBob,
+            expectedOutPath,
+            useTls,
+            tlsDir_,
+            portNo,
+            xorEncrypted,
+            common::ResultVisibility::kPublic);
+      } else {
+        runGame<
+            ShardSchemaType::kAdObjFormat,
+            false, // usingBatch
+            common::InputEncryption::Xor>(
+            0, // firstShardIndex
+            2, // numShards
+            kanonymityThreshold,
+            baseDir_ + "ad_object_format",
+            inputPathAlice,
+            inputPathBob,
+            expectedOutPath,
+            useTls,
+            tlsDir_,
+            portNo,
+            xorEncrypted,
+            common::ResultVisibility::kPublic);
+      }
+    }
+  }
+
+  void testLift(
+      bool xorEncrypted,
+      bool usingBatch,
+      bool useTls,
+      std::uint16_t portNo) {
+    const std::string partnerFileName = "partner_lift_input_shard.json";
+    const std::string publisherFileName = "publisher_lift_input_shard.json";
+    std::string expectedOutFileName = "lift_expected_output_shards_2.json";
+
+    int64_t kanonymityThreshold = 100;
+
+    if (usingBatch) {
+      runGame<
+          ShardSchemaType::kGroupedLiftMetrics,
+          true,
+          common::InputEncryption::Xor>(
+          0,
+          2, // numShards
+          kanonymityThreshold,
+          baseDir_ + "lift_threshold_test",
+          partnerFileName,
+          publisherFileName,
+          baseDir_ + "/lift_threshold_test/" + expectedOutFileName,
+          useTls,
+          tlsDir_,
+          portNo,
+          xorEncrypted,
+          common::ResultVisibility::kPublic);
+    } else {
+      runGame<
+          ShardSchemaType::kGroupedLiftMetrics,
+          false,
+          common::InputEncryption::Xor>(
+          0,
+          2, // numShards
+          kanonymityThreshold,
+          baseDir_ + "lift_threshold_test",
+          partnerFileName,
+          publisherFileName,
+          baseDir_ + "/lift_threshold_test/" + expectedOutFileName,
+          useTls,
+          tlsDir_,
+          portNo,
+          xorEncrypted,
+          common::ResultVisibility::kPublic);
+    }
+  }
+
+  std::uint16_t initialPort_;
+  std::string baseDir_;
+  std::string tlsDir_;
+  std::string tempDir_;
+};
+
+// Test cases are iterate in https://fb.quip.com/IUHDApxKEAli
+// -BEGIN- AdObject format related tests --
+// --- ONE TH ---
+TEST_P(ShardCombinerAppTestFixture, TestGenericShardAggCorrectnessAdObject) {
+  auto [useTls, usingBatch] = GetParam();
+  testForShortCase(
+      "old", false /* XorEncrypted */, usingBatch, useTls, initialPort_);
+  testForShortCase(
+      "mmt_nooverlap",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+  testForShortCase(
+      "mmt_overlap",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+  testForShortCase(
+      "clickonly_touchonly",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+  testForShortCase(
+      "clicktouch_touchonly",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+  testForShortCase(
+      "clickonly_clicktouch",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+  testForShortCase(
+      "clicktouch_clicktouch",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+  testForShortCase(
+      "kanonymity_allpass",
+      false /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_);
+}
+
+// --- adObjXor ---
+TEST_P(
+    ShardCombinerAppTestFixture,
+    TestGenericShardAggCorrectnessAdObjectXorNw) {
+  auto [useTls, usingBatch] = GetParam();
+  testForShortCase(
+      "kanonymity_allpass",
+      true /* XorEncrypted */,
+      usingBatch,
+      useTls,
+      initialPort_ + 10);
+}
+
+// -END- AdObject format related test --
+
+// -BEGIN- Test LiftNoNwEncrypt
+TEST_P(
+    ShardCombinerAppTestFixture,
+    TestGenericLiftCorrectnessPlainTextNwEncyption) {
+  auto [useTls, usingBatch] = GetParam();
+  testLift(false /* XorEncrypted */, usingBatch, useTls, initialPort_ + 20);
+}
+
+// Test LiftXor
+TEST_P(ShardCombinerAppTestFixture, TestGenericLiftCorrectnessXorNwEncrypted) {
+  auto [useTls, usingBatch] = GetParam();
+  testLift(true /* XorEncrypted */, usingBatch, useTls, initialPort_ + 30);
+}
+// -END- Test
+
+INSTANTIATE_TEST_CASE_P(
+    ShardCombinerAppTest,
+    ShardCombinerAppTestFixture,
+    ::testing::Combine(::testing::Bool(), ::testing::Bool()),
+    [](const testing::TestParamInfo<ShardCombinerAppTestFixture::ParamType>&
+           info) {
+      std::string tls = std::get<0>(info.param) ? "UseTls" : "NoTls";
+      std::string usingBatch =
+          std::get<1>(info.param) ? "UsingBatch" : "NoBatch";
+      std::string name = tls + "_" + usingBatch;
+      return name;
+    });
+
+} // namespace shard_combiner

--- a/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
@@ -5,13 +5,185 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <signal.h>
+
+#include <filesystem>
+#include <stdexcept>
+
+#include <gflags/gflags.h>
+
+#include <folly/Synchronized.h>
+#include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
+
+#include <fbpcf/aws/AwsSdk.h>
+#include <fbpcf/exception/ExceptionBase.h>
+#include <fbpcf/exception/exceptions.h>
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics_impl.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h"
+#include "fbpcs/performance_tools/CostEstimation.h"
+
+DEFINE_int32(party, 1, "1 = publisher, 2 = partner");
+DEFINE_int32(
+    visibility,
+    0,
+    "0 = public, 1 = publisher, 2 = partner"); // keeping this for consistency,
+                                               // TODO: fix order with
+                                               // ResultVisibility enum.
+DEFINE_string(server_ip, "", "Server's IP address");
+DEFINE_int32(port, 15200, "Server's port");
+DEFINE_string(input_base_path, "", "Input path where input files are located");
+DEFINE_int32(
+    first_shard_index,
+    0,
+    "index of first shard in input_path, first filename input_path_[first_shard_index]");
+DEFINE_int32(
+    num_shards,
+    1,
+    "Number of shards from input_path_[0] to input_path_[n-1]");
+DEFINE_string(output_path, "", "Output path where output file is located");
+DEFINE_int64(threshold, 100, "Threshold for K-anonymity");
+DEFINE_string(
+    metrics_format_type,
+    "ad_object",
+    "Options are 'ad_object' or 'lift'");
+DEFINE_string(run_name, "", "User given name used to write cost info in S3");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");
+DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(
+    log_cost_s3_region,
+    ".s3.us-west-2.amazonaws.com/",
+    "s3 regioni name");
+
+DEFINE_bool(
+    useTls,
+    false,
+    "flag to enable tls, note: if true, you have to provide tlsDir option.");
+DEFINE_string(tlsDir, "", "Directory to find tls certs.");
+DEFINE_bool(
+    use_xor_encryption,
+    true,
+    "Use XOR encryption while communicating intermediate results(uses LazyScheduler).");
 
 using namespace shard_combiner;
 
-int main() {
-  XLOG(INFO)
-      << "Place holder for the target file(to ensure crt1's entry to main).";
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  fbpcs::performance_tools::CostEstimation cost{
+      "shard_combiner", FLAGS_log_cost_s3_bucket, FLAGS_log_cost_s3_region};
+  cost.start();
+
+  fbpcf::AwsSdk::aquire();
+  // Ignore broken pipe signal, so that we finish the application incase ssh
+  // connection breaks.
+  signal(SIGPIPE, SIG_IGN);
+
+  XLOGF(INFO, "Party: {}", FLAGS_party);
+  XLOGF(INFO, "Visibility: {}", FLAGS_visibility);
+  XLOGF(INFO, "Server IP: {}", FLAGS_server_ip);
+  XLOGF(INFO, "Port: {}", FLAGS_port);
+  XLOGF(INFO, "Input path: {}", FLAGS_input_base_path);
+  XLOGF(INFO, "Number of shards: {}", FLAGS_num_shards);
+  XLOGF(INFO, "Output path: {}", FLAGS_output_path);
+  XLOGF(INFO, "K-anonymity threshold: {}", FLAGS_threshold);
+
+  // we use scheduler thats either 0 or 1,
+  FLAGS_party--;
+  assert(FLAGS_party == 0 || FLAGS_party == 1);
+
+  bool usingBatch = false;
+  common::InputEncryption inputEncryption = common::InputEncryption::Xor;
+
+  std::string inputPath =
+      FLAGS_input_base_path.substr(0, FLAGS_input_base_path.rfind("/"));
+  std::string inputFilePrefix = FLAGS_input_base_path.substr(
+      FLAGS_input_base_path.rfind("/") + 1, std::string::npos);
+
+  common::SchedulerStatistics schedulerStatistics;
+
+  if (FLAGS_metrics_format_type == "ad_object") {
+    schedulerStatistics = runApp<ShardSchemaType::kAdObjFormat>(
+        FLAGS_party,
+        usingBatch,
+        inputEncryption,
+        FLAGS_num_shards,
+        FLAGS_first_shard_index,
+        inputPath,
+        inputFilePrefix,
+        FLAGS_output_path,
+        FLAGS_threshold,
+        FLAGS_useTls,
+        FLAGS_tlsDir,
+        FLAGS_use_xor_encryption,
+        FLAGS_visibility,
+        FLAGS_server_ip,
+        FLAGS_port);
+  } else if (FLAGS_metrics_format_type == "lift") {
+    schedulerStatistics = runApp<ShardSchemaType::kGroupedLiftMetrics>(
+        FLAGS_party,
+        usingBatch,
+        inputEncryption,
+        FLAGS_num_shards,
+        FLAGS_first_shard_index,
+        inputPath,
+        inputFilePrefix,
+        FLAGS_output_path,
+        FLAGS_threshold,
+        FLAGS_useTls,
+        FLAGS_tlsDir,
+        FLAGS_use_xor_encryption,
+        FLAGS_visibility,
+        FLAGS_server_ip,
+        FLAGS_port);
+  } else {
+    std::string errStr = folly::sformat(
+        "unsupported metrics format type: {}", FLAGS_metrics_format_type);
+    XLOG(ERR) << errStr;
+    throw common::exceptions::NotSupportedError(errStr);
+  }
+
+  cost.end();
+  XLOG(INFO) << cost.getEstimatedCostString();
+  if (FLAGS_log_cost) {
+    std::string party_str =
+        (FLAGS_party == static_cast<int32_t>(common::PUBLISHER)) ? "Publisher"
+                                                                 : "Partner";
+    folly::dynamic extra_info = folly::dynamic::object(
+      "publisher_input_basepath",
+      party_str == "Publisher" ? FLAGS_input_base_path : "")
+      ("partner_input_basepath",
+      party_str == "Partner" ? FLAGS_input_base_path : "")
+      ("output_path", FLAGS_output_path)
+      ("num_shards", FLAGS_num_shards)
+      ("first_shard_index", FLAGS_first_shard_index)
+      ("metrics_format_type", FLAGS_metrics_format_type)
+      ("threshold", FLAGS_threshold)
+      ("use_xor_encryption", FLAGS_use_xor_encryption)
+      ("non_free_gates", schedulerStatistics.nonFreeGates)
+      ("free_gates", schedulerStatistics.freeGates)
+      ("scheduler_transmitted_network", schedulerStatistics.sentNetwork)
+      ("scheduler_received_network", schedulerStatistics.receivedNetwork)
+      ("mpc_traffic_details", schedulerStatistics.details);
+
+    folly::dynamic costDict =
+        cost.getEstimatedCostDynamic(FLAGS_run_name, party_str, extra_info);
+
+    auto objectName = folly::to<std::string>(
+        FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+    std::string costWriteStatus =
+        cost.writeToS3(party_str, objectName, costDict);
+    XLOGF(INFO, "{}", costWriteStatus);
+  }
   return 0;
 }

--- a/fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include <fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h>
+
+#include <fbpcs/emp_games/common/SchedulerStatistics.h>
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h"
+#include "fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h"
+
+namespace shard_combiner {
+
+template <ShardSchemaType shardSchemaType>
+common::SchedulerStatistics runApp(
+    int32_t schedulerId,
+    bool usingBatch,
+    common::InputEncryption inputEncryption,
+    std::int32_t numShards,
+    std::uint32_t shardStartIndex,
+    const std::string& inputPath,
+    const std::string& inputFilePrefix,
+    const std::string& outputPath,
+    std::int64_t threshold,
+    bool useTls,
+    const std::string& tlsDir,
+    bool useXorEncryption,
+    int32_t visibility,
+    std::string ip,
+    std::uint16_t port) {
+  assert(inputEncryption == common::InputEncryption::Xor);
+  assert(visibility == 0 || visibility == 1 || visibility == 2);
+
+  common::ResultVisibility resultVisibility;
+  switch (visibility) {
+    case 0:
+      resultVisibility = common::ResultVisibility::kPublic;
+      break;
+    case 1:
+      resultVisibility = common::ResultVisibility::kPublisher;
+      break;
+    case 2:
+      resultVisibility = common::ResultVisibility::kPartner;
+      break;
+  }
+
+  std::map<
+      int32_t,
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
+          PartyInfo>
+      partyInfos(
+          {{common::PUBLISHER, {ip, port}}, {common::PARTNER, {ip, port}}});
+
+  auto communicationAgentFactory = std::make_unique<
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
+      schedulerId, partyInfos, useTls, tlsDir, "shard_combiner_traffic");
+
+  common::SchedulerStatistics schedulerStats;
+  if (schedulerId == common::PUBLISHER) {
+    if (usingBatch) {
+      auto app = std::make_unique<ShardCombinerApp<
+          shardSchemaType,
+          common::PUBLISHER,
+          true /* usingBatch */,
+          common::InputEncryption::Xor>>(
+          std::move(communicationAgentFactory),
+          numShards,
+          shardStartIndex,
+          inputPath,
+          inputFilePrefix,
+          outputPath,
+          threshold,
+          useXorEncryption,
+          resultVisibility);
+      app->run();
+      return app->getSchedulerStatistics();
+    } else {
+      auto app = std::make_unique<ShardCombinerApp<
+          shardSchemaType,
+          common::PUBLISHER,
+          false /* usingBatch */,
+          common::InputEncryption::Xor>>(
+          std::move(communicationAgentFactory),
+          numShards,
+          shardStartIndex,
+          inputPath,
+          inputFilePrefix,
+          outputPath,
+          threshold,
+          useXorEncryption,
+          resultVisibility);
+      app->run();
+      return app->getSchedulerStatistics();
+    }
+  } else if (schedulerId == common::PARTNER) {
+    if (usingBatch) {
+      auto app = std::make_unique<ShardCombinerApp<
+          shardSchemaType,
+          common::PARTNER,
+          true /* usingBatch */,
+          common::InputEncryption::Xor>>(
+          std::move(communicationAgentFactory),
+          numShards,
+          shardStartIndex,
+          inputPath,
+          inputFilePrefix,
+          outputPath,
+          threshold,
+          useXorEncryption,
+          resultVisibility);
+      app->run();
+      return app->getSchedulerStatistics();
+    } else {
+      auto app = std::make_unique<ShardCombinerApp<
+          shardSchemaType,
+          common::PARTNER,
+          false /* usingBatch */,
+          common::InputEncryption::Xor>>(
+          std::move(communicationAgentFactory),
+          numShards,
+          shardStartIndex,
+          inputPath,
+          inputFilePrefix,
+          outputPath,
+          threshold,
+          useXorEncryption,
+          resultVisibility);
+      app->run();
+      return app->getSchedulerStatistics();
+    }
+  }
+  return {};
+}
+
+} // namespace shard_combiner


### PR DESCRIPTION
Summary:
# context
this commit conveys necessary things for running ShardCombiner as a standalone binary.

NOTE: I'm retaining the flag structure of the previous ShardAggregator(newer flags use default vals). Reason: allows faster porting to the new implementation in prod via feature gating(as not much of a change is necessary{only argv[0] will change} per Logan).

# changes in this diff
1. adds 3 new flags with defaults useTls, tlsDir, use_xor_encryption(to switch b/w plaintext nw scheduler and lazyScheduler)
2. I'm not using visibility flag in this impl, rather use_xor_encryption should provide a better option?

Reviewed By: gorel

Differential Revision: D38331552

