### PR TITLE
Modify PCSContainerInstance to use keyword arguments (#400)

### DIFF
--- a/fbpcs/common/entity/pcs_container_instance.py
+++ b/fbpcs/common/entity/pcs_container_instance.py
@@ -23,8 +23,8 @@ class PCSContainerInstance(ContainerInstance):
         cls, container_instance: ContainerInstance, log_url: Optional[str] = None
     ) -> "PCSContainerInstance":
         return cls(
-            container_instance.instance_id,
-            container_instance.ip_address,
-            container_instance.status,
-            log_url,
+            instance_id=container_instance.instance_id,
+            ip_address=container_instance.ip_address,
+            status=container_instance.status,
+            log_url=log_url,
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcp/pull/400

## Context
We want to enable customized containers in our infra ([design doc](https://docs.google.com/document/d/1UqaK6VXEoIVUHSJnYs_Ydju8)). Therefore we need to add cpu & memory properties to ContainerInstance;
## This commit
Change ```PCSContainerInstance``` to use keyword arguments to prevent breaks when we add cpu and memory to ```ContainerInstance ``` later

Differential Revision: D38553232

