### PR TITLE
Increase num concurrent instances to 3

### DIFF
--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -29,8 +29,7 @@ MAX_TRIES = 2
 RETRY_INTERVAL = 60
 
 MIN_NUM_INSTANCES = 1
-# TODO T120485688 investigate multi objective issue and re-enable the feature
-MAX_NUM_INSTANCES = 1
+MAX_NUM_INSTANCES = 3
 PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 57600  # 8 hr instance sla, 2 tries per stage, total 16 hrs.
 


### PR DESCRIPTION
Summary:
## What

* Increase number of concurrent instances in production PL runners from 1 -> 3
* Move BoltRunner execution logic into a dedicated async function

## Why

* In D38524668, I ran a stress test with three concurrent instances, each with 31M publisher rows and 4M partner rows. This corresponds to 7 pid containers each, compared to the 3.5 median we see in production. Given that the stress test succeeded and that we've seen numerous stage=CREATED issues and instances that complete but do not meet our 8 hour SLA lately due to only running one instance, it seems appropriate to bump the number of concurrent instances up now.
* There was a fun bug with calling Bolt from run_study where, if num_objectives > MAX_NUM_INSTANCES, then an asyncio error would be raised due to the BoltRunner semaphore using a different event loop than run_async. To fix this, I put the BoltRunner creation and calling of run_async into the same async function so that they share an event loop. Long term, it would be a best practice to have PC-CLI `main` be async and have the `asyncio.run` entrypoint there instead to avoid subtle bugs like this.

Differential Revision: D38556689

