### PR TITLE
Adding ts delta in each status_updates within pc_instance config

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -64,6 +64,7 @@ UnionedPCInstance = Union[
 class StatusUpdate:
     status: PrivateComputationInstanceStatus
     status_update_ts: int
+    status_update_ts_delta: int
 
 
 # called in post_status_hook
@@ -77,11 +78,16 @@ def post_update_status(obj: "InfraConfig") -> None:
 
 # called in post_status_hook
 def append_status_updates(obj: "InfraConfig") -> None:
-    pair: StatusUpdate = StatusUpdate(
-        obj.status,
-        obj.status_update_ts,
+    ts_delta = 0
+    if obj.status_updates:
+        ts_delta = obj.status_update_ts - obj.status_updates[-1].status_update_ts
+
+    update_entity = StatusUpdate(
+        status=obj.status,
+        status_update_ts=obj.status_update_ts,
+        status_update_ts_delta=ts_delta,
     )
-    obj.status_updates.append(pair)
+    obj.status_updates.append(update_entity)
 
 
 # create update_generic_hook for status

--- a/fbpcs/private_computation/test/entity/test_infra_config.py
+++ b/fbpcs/private_computation/test/entity/test_infra_config.py
@@ -45,7 +45,11 @@ class TestInfraConfigFreeFunctions(unittest.TestCase):
             status_updates=[],
         )
         original_end_ts = config.end_ts
-        expected_status_updates = [StatusUpdate(config.status, 444)]
+        expected_status_updates = [
+            StatusUpdate(
+                status=config.status, status_update_ts=444, status_update_ts_delta=0
+            )
+        ]
 
         # Act
         post_update_status(config)
@@ -70,7 +74,11 @@ class TestInfraConfigFreeFunctions(unittest.TestCase):
             num_files_per_mpc_container=100,
             status_updates=[],
         )
-        expected_status_updates = [StatusUpdate(config.status, 555)]
+        expected_status_updates = [
+            StatusUpdate(
+                status=config.status, status_update_ts=555, status_update_ts_delta=0
+            )
+        ]
 
         # Act
         post_update_status(config)


### PR DESCRIPTION
Summary:
## Why
in post_update_status hook, we append status updates including ts. it's a little tricky to see the ts delta if you dont have super power on math calculation
## What
* adding ts delta in the hook

Differential Revision: D38638379

