### PR TITLE
Remove partial dependency in PCSContainerService (#405)

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -17,7 +17,7 @@ Types of changes
 ### Added
 
 ### Changed
-
+  - Mark validate_container_definition as deprecated in PCSContainerService since it is no longer a public method in ContainerService in fbpcp
 ### Removed
 
 ## [1.10.0] - 2022-08-12

--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -15,6 +15,8 @@ from fbpcp.service.container_aws import AWSContainerService
 from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
 from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
 
+from fbpcs.private_computation.service.utils import deprecated
+
 
 class PCSContainerService(ContainerService):
     def __init__(self, inner_container_service: ContainerService) -> None:
@@ -80,7 +82,8 @@ class PCSContainerService(ContainerService):
     def get_current_instances_count(self) -> int:
         return self.inner_container_service.get_current_instances_count()
 
+    @deprecated(
+        "validate_container_definition is no longer a public method in container service"
+    )
     def validate_container_definition(self, container_definition: str) -> None:
-        return self.inner_container_service.validate_container_definition(
-            container_definition
-        )
+        pass


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcp/pull/405

We decided that validate_container_definitions should not be a public API in container service. This diff is to remove it and resolve the conflict.

The validation logic has been moved in D38629555, to ensure the backward compatibility, we firstly changed the function body to ``pass``.

Differential Revision: D38604420

