### PR TITLE
Adding unittest for function `get_command_list`

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
@@ -59,7 +59,9 @@ class TerraformDeploymentUtils:
         """
         self.input = False
 
-    def get_command_list(self, command: str, *args: Any, **kwargs: str) -> List[str]:
+    def get_command_list(
+        self, command: str, *args: Any, **kwargs: Dict[str, Any]
+    ) -> List[str]:
         """
         Converts command string to list and updates commands with terraform options provided through kwargs and args.
         """
@@ -77,7 +79,6 @@ class TerraformDeploymentUtils:
             # terraform CLI accepts options with "-" using "_" will results in error
             key = key.replace("_", "-")
 
-            # pyre-fixme
             func = type_to_func_dict.get(type(value), self.add_other_options)
 
             # pyre-fixme

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
@@ -6,6 +6,9 @@
 # pyre-strict
 
 import unittest
+from typing import Any, Dict
+
+from fbpcs.infra.pce_deployment_library.deploy_library.models import FlaggedOption
 
 from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_deployment_utils import (
     TerraformDeploymentUtils,
@@ -21,8 +24,73 @@ class TestTerraformDeploymentUtils(unittest.TestCase):
         pass
 
     def test_get_command_list(self) -> None:
-        # T125643785
-        pass
+        command: str = "terraform apply"
+        with self.subTest("OptionTypeDict"):
+            kwargs: Dict[str, Any] = {
+                "backend-config": {
+                    "region": "fake_region",
+                    "access_key": "fake_access_key",
+                }
+            }
+            expected_value = [
+                "terraform",
+                "apply",
+                '-backend-config "region=fake_region"',
+                '-backend-config "access_key=fake_access_key"',
+            ]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEqual(expected_value, return_value)
+
+        with self.subTest("OptionTypeList"):
+            kwargs: Dict[str, Any] = {"target": ["fake_region", "fake_access_key"]}
+            expected_value = [
+                "terraform",
+                "apply",
+                '-target="fake_region"',
+                '-target="fake_access_key"',
+            ]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEqual(expected_value, return_value)
+
+        with self.subTest("OptionTypeBool"):
+            kwargs: Dict[str, Any] = {"input": False}
+            expected_value = ["terraform", "apply", "-input=false"]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEqual(expected_value, return_value)
+
+        with self.subTest("OptionTypeFlaggedOption"):
+            kwargs: Dict[str, Any] = {"reconfigure": FlaggedOption}
+            expected_value = ["terraform", "apply", "-reconfigure"]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, **kwargs
+            )
+            self.assertEqual(expected_value, return_value)
+
+        with self.subTest("OptionTypeDictWithArgs"):
+            kwargs: Dict[str, Any] = {
+                "backend-config": {
+                    "region": "fake_region",
+                    "access_key": "fake_access_key",
+                }
+            }
+            args = ("test_test",)
+            expected_value = [
+                "terraform",
+                "apply",
+                '-backend-config "region=fake_region"',
+                '-backend-config "access_key=fake_access_key"',
+                "test_test",
+            ]
+            return_value = self.terraform_deployment_utils.get_command_list(
+                command, *args, **kwargs
+            )
+            self.assertEqual(expected_value, return_value)
 
     def test_add_dict_options(self) -> None:
         pass


### PR DESCRIPTION
Summary:
Adding unittest for function `get_command_list` in class `TerraformDeploymentUtils`

Code link for `get_command_list`: https://www.internalfb.com/code/fbsource/fbcode/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py?lines=62

Differential Revision: D38668448

