### PR TITLE
Add PCS feature enum for shard combiner feature gating

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -15,6 +15,7 @@ class PCSFeature(Enum):
     BOLT_RUNNER = "bolt_runner"
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
+    SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"
     UNKNOWN = "unknown"
 
     @staticmethod


### PR DESCRIPTION
Summary:
# context
Adding PCF 2 shard combiner GK entry to pcs_feature enum

Reviewed By: jrodal98, joe1234wu

Differential Revision: D38639484

