### PR TITLE
Add a cron GitHub action to build the Onedocker image every hour of the work day.

### DIFF
--- a/.github/workflows/build_onedocker.yml
+++ b/.github/workflows/build_onedocker.yml
@@ -1,0 +1,29 @@
+name: Build OneDocker image
+
+on:
+  schedule:
+    - cron: '0 0,15-23 * * 1-5'
+
+env:
+  DISTRO: ubuntu
+  TIME_RANGE: 24 hours
+
+jobs:
+  ### Build onedocker image
+  build_image:
+    name: Build Image
+    runs-on: self-hosted
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Remove unused images
+        run: |
+          df -h
+          docker image prune -af
+          df -h
+
+      - name: Build onedocker image
+        run: |
+          ./build-docker.sh onedocker -f


### PR DESCRIPTION
Summary:
## Background
Currently we build the onedocker image on every commit to FBPCS. This helps us catch most of the changes that affect the process. This does not include changes to PID and FBPCP though.

## This change
This commit adds a cron action that will build the OneDocker image every hour during the work day (8 AM - 5 PM PDT).

Differential Revision: D38709566

