### PR TITLE
Don't send placeholder run_id since None is supported

### DIFF
--- a/fbpcs/common/service/simple_trace_logging_service.py
+++ b/fbpcs/common/service/simple_trace_logging_service.py
@@ -18,12 +18,16 @@ from fbpcs.common.service.trace_logging_service import (
 class SimpleTraceLoggingService(TraceLoggingService):
     def write_checkpoint(
         self,
-        run_id: str,
+        run_id: Optional[str],
         instance_id: str,
         checkpoint_name: str,
         status: CheckpointStatus,
         checkpoint_data: Optional[Dict[str, str]] = None,
     ) -> None:
+        if run_id is None:
+            self.logger.debug("No run_id provided - skipping write_checkpoint")
+            return
+
         result = {
             "operation": "write_checkpoint",
             "run_id": run_id,

--- a/fbpcs/common/service/test/test_simple_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_simple_trace_logging_service.py
@@ -21,6 +21,19 @@ class TestSimpleTraceLoggingService(TestCase):
         self.svc = SimpleTraceLoggingService()
         self.svc.logger = self.logger
 
+    def test_write_checkpoint_no_run_id(self) -> None:
+        # Act
+        self.svc.write_checkpoint(
+            run_id=None,
+            instance_id="instance456",
+            checkpoint_name="foo",
+            status=CheckpointStatus.STARTED,
+        )
+
+        # Assert
+        self.logger.debug.assert_called_once()
+        self.logger.info.assert_not_called()
+
     def test_write_checkpoint_simple(self) -> None:
         # Arrange
         expected_dump = json.dumps(

--- a/fbpcs/common/service/trace_logging_service.py
+++ b/fbpcs/common/service/trace_logging_service.py
@@ -28,7 +28,7 @@ class TraceLoggingService(abc.ABC):
     @abc.abstractmethod
     def write_checkpoint(
         self,
-        run_id: str,
+        run_id: Optional[str],
         instance_id: str,
         checkpoint_name: str,
         status: CheckpointStatus,

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -90,7 +90,6 @@ from fbpcs.utils.optional import unwrap_or_default
 
 T = TypeVar("T")
 
-MISSING_RUN_ID_PLACEHOLDER = "unknown"
 PCSERVICE_ENTITY_NAME = "pcservice"
 
 
@@ -180,7 +179,7 @@ class PrivateComputationService:
 
         checkpoint_name = f"{role.value}_CREATE"
         self.trace_logging_svc.write_checkpoint(
-            run_id=run_id or MISSING_RUN_ID_PLACEHOLDER,
+            run_id=run_id,
             instance_id=instance_id,
             checkpoint_name=checkpoint_name,
             status=CheckpointStatus.STARTED,
@@ -281,7 +280,7 @@ class PrivateComputationService:
         self.instance_repository.create(instance)
 
         self.trace_logging_svc.write_checkpoint(
-            run_id=instance.infra_config.run_id or MISSING_RUN_ID_PLACEHOLDER,
+            run_id=instance.infra_config.run_id,
             instance_id=instance_id,
             checkpoint_name=checkpoint_name,
             status=CheckpointStatus.COMPLETED,
@@ -473,7 +472,7 @@ class PrivateComputationService:
 
         checkpoint_name = f"{pc_instance.infra_config.role.value}_{stage.name}"
         self.trace_logging_svc.write_checkpoint(
-            run_id=pc_instance.infra_config.run_id or MISSING_RUN_ID_PLACEHOLDER,
+            run_id=pc_instance.infra_config.run_id,
             instance_id=instance_id,
             checkpoint_name=checkpoint_name,
             status=CheckpointStatus.STARTED,
@@ -485,7 +484,7 @@ class PrivateComputationService:
         except Exception as e:
             self.logger.error(f"Caught exception when running {stage}\n{e}")
             self.trace_logging_svc.write_checkpoint(
-                run_id=pc_instance.infra_config.run_id or MISSING_RUN_ID_PLACEHOLDER,
+                run_id=pc_instance.infra_config.run_id,
                 instance_id=instance_id,
                 checkpoint_name=checkpoint_name,
                 status=CheckpointStatus.FAILED,
@@ -505,7 +504,7 @@ class PrivateComputationService:
             self.logger.warning("Failed to retrieve log URLs for instance")
 
         self.trace_logging_svc.write_checkpoint(
-            run_id=pc_instance.infra_config.run_id or MISSING_RUN_ID_PLACEHOLDER,
+            run_id=pc_instance.infra_config.run_id,
             instance_id=instance_id,
             checkpoint_name=checkpoint_name,
             status=CheckpointStatus.COMPLETED,


### PR DESCRIPTION
Summary:
# What
* Title - allow `None` to be used in call
# Why
* The API changed to allow None in the previous diff and gives a better explanation
* There's no need for a dummy placeholder now

Differential Revision: D38634861

