### PR TITLE
Pass RunId to PID from PCS service.

### DIFF
--- a/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
@@ -24,6 +24,11 @@ DEFINE_string(
     "/tmp/",
     "Directory where temporary files should be saved before final write");
 DEFINE_int32(max_column_cnt, 1, "Number of columns to write");
+
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");
 DEFINE_int32(log_every_n, 1'000'000, "How frequently to log updates");
 
 int main(int argc, char** argv) {

--- a/fbpcs/data_processing/service/pid_prepare_binary_service.py
+++ b/fbpcs/data_processing/service/pid_prepare_binary_service.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import Optional
+
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
@@ -18,6 +20,7 @@ class PIDPrepareBinaryService(RunBinaryBaseService):
         output_path: str,
         tmp_directory: str = "/tmp/",
         max_column_count: int = 1,
+        run_id: Optional[str] = None,
     ) -> str:
         cmd_args = " ".join(
             [
@@ -27,6 +30,13 @@ class PIDPrepareBinaryService(RunBinaryBaseService):
                 f"--max_column_cnt={max_column_count}",
             ]
         )
+        if run_id is not None:
+            cmd_args = " ".join(
+                [
+                    cmd_args,
+                    f"--run_id={run_id}",
+                ]
+            )
         return cmd_args
 
     @staticmethod

--- a/fbpcs/data_processing/service/pid_run_protocol_binary_service.py
+++ b/fbpcs/data_processing/service/pid_run_protocol_binary_service.py
@@ -26,6 +26,7 @@ class PIDRunProtocolBinaryService(RunBinaryBaseService):
         use_row_numbers: bool = False,
         server_hostname: Optional[str] = None,
         metric_path: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> str:
 
         cmd_ls = []
@@ -49,6 +50,9 @@ class PIDRunProtocolBinaryService(RunBinaryBaseService):
         # later will support use-rowk-number feature
         if use_row_numbers:
             cmd_ls.append("--use-row-numbers")
+
+        if run_id is not None:
+            cmd_ls.append(f"--run_id {run_id}")
 
         return " ".join(cmd_ls)
 

--- a/fbpcs/data_processing/sharding/shard_pid.cpp
+++ b/fbpcs/data_processing/sharding/shard_pid.cpp
@@ -22,6 +22,10 @@ DEFINE_string(
     output_base_path,
     "",
     "Local or s3 base path where output files are written to");
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");
 DEFINE_int32(
     file_start_index,
     0,

--- a/fbpcs/private_computation/service/pid_mr_stage_service.py
+++ b/fbpcs/private_computation/service/pid_mr_stage_service.py
@@ -27,6 +27,7 @@ PIDMR = "pid_mr"
 INTPUT = "inputPath"
 OUTPUT = "outputPath"
 INSTANCE = "instanceId"
+RUNID = "run_id"
 SPARK_CONFIGS = "sparkConfigs"
 S3URIFORMAT = "s3://{bucket}/{key}"
 PUB_PREFIX = "publisher_"
@@ -76,6 +77,7 @@ class PIDMRStageService(PrivateComputationStageService):
                 INSTANCE: self.removePrefixForInstance(
                     pc_instance.infra_config.instance_id
                 ),
+                RUNID: pc_instance.infra_config.run_id,
             }
             pid_overall_configs = {
                 **pid_configs[PIDMR][PID_RUN_CONFIGS],

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -120,6 +120,7 @@ class PIDPrepareStageService(PrivateComputationStageService):
                 output_path=get_sharded_filepath(output_path, shard),
                 tmp_directory=onedocker_binary_config.tmp_directory,
                 max_column_count=pc_instance.product_config.common.pid_max_column_count,
+                run_id=pc_instance.infra_config.run_id,
             )
             args_list.append(args_per_shard)
         # start containers

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -130,6 +130,7 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
                 metric_path=metric_paths[shard] if metric_paths else None,
                 use_row_numbers=use_row_numbers,
                 server_hostname=server_hostnames[shard] if server_hostnames else None,
+                run_id=pc_instance.infra_config.run_id,
             )
             args_list.append(args_per_shard)
         # start containers

--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -39,57 +39,64 @@ from fbpcs.service.workflow_sfn import SfnWorkflowService
 class TestPIDMRStageService(IsolatedAsyncioTestCase):
     @patch("fbpcs.private_computation.service.pid_mr_stage_service.PIDMRStageService")
     async def test_run_async(self, pid_mr_svc_mock) -> None:
-        flow = PrivateComputationMRStageFlow
-        infra_config: InfraConfig = InfraConfig(
-            instance_id="publisher_123",
-            role=PrivateComputationRole.PUBLISHER,
-            status=PrivateComputationInstanceStatus.PID_MR_STARTED,
-            status_update_ts=1600000000,
-            instances=[],
-            game_type=PrivateComputationGameType.LIFT,
-            num_pid_containers=1,
-            num_mpc_containers=1,
-            num_files_per_mpc_container=1,
-            status_updates=[],
-            _stage_flow_cls_name=flow.get_cls_name(),
-        )
-        common: CommonProductConfig = CommonProductConfig(
-            input_path="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/input.csv",
-            output_dir="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output",
-            pid_configs={
-                PIDMR: {
-                    PID_WORKFLOW_CONFIGS: {"state_machine_arn": "machine_arn"},
-                    PID_RUN_CONFIGS: {"conf": "conf1"},
-                    SPARK_CONFIGS: {"conf-2": "conf2"},
-                }
-            },
-        )
-        product_config: ProductConfig = LiftConfig(
-            common=common,
-        )
+        for test_run_id in (None, "2621fda2-0eca-11ed-861d-0242ac120002"):
+            with self.subTest(test_run_id=test_run_id):
+                flow = PrivateComputationMRStageFlow
+                infra_config: InfraConfig = InfraConfig(
+                    instance_id="publisher_123",
+                    role=PrivateComputationRole.PUBLISHER,
+                    status=PrivateComputationInstanceStatus.PID_MR_STARTED,
+                    status_update_ts=1600000000,
+                    instances=[],
+                    game_type=PrivateComputationGameType.LIFT,
+                    num_pid_containers=1,
+                    num_mpc_containers=1,
+                    num_files_per_mpc_container=1,
+                    status_updates=[],
+                    _stage_flow_cls_name=flow.get_cls_name(),
+                    run_id=test_run_id,
+                )
+                common: CommonProductConfig = CommonProductConfig(
+                    input_path="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test_data/stress_test/input.csv",
+                    output_dir="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output",
+                    pid_configs={
+                        PIDMR: {
+                            PID_WORKFLOW_CONFIGS: {"state_machine_arn": "machine_arn"},
+                            PID_RUN_CONFIGS: {"conf": "conf1"},
+                            SPARK_CONFIGS: {"conf-2": "conf2"},
+                        }
+                    },
+                )
+                product_config: ProductConfig = LiftConfig(
+                    common=common,
+                )
 
-        pc_instance = PrivateComputationInstance(
-            infra_config=infra_config,
-            product_config=product_config,
-        )
+                pc_instance = PrivateComputationInstance(
+                    infra_config=infra_config,
+                    product_config=product_config,
+                )
 
-        service = SfnWorkflowService("us-west-2", "access_key", "access_data")
-        service.start_workflow = MagicMock(return_value="execution_arn")
-        service.get_workflow_status = MagicMock(return_value=WorkflowStatus.COMPLETED)
-        stage_svc = PIDMRStageService(
-            service,
-        )
-        await stage_svc.run_async(pc_instance)
+                service = SfnWorkflowService("us-west-2", "access_key", "access_data")
+                service.start_workflow = MagicMock(return_value="execution_arn")
+                service.get_workflow_status = MagicMock(
+                    return_value=WorkflowStatus.COMPLETED
+                )
+                stage_svc = PIDMRStageService(
+                    service,
+                )
+                await stage_svc.run_async(pc_instance)
 
-        self.assertEqual(
-            stage_svc.get_status(pc_instance),
-            PrivateComputationInstanceStatus.PID_MR_COMPLETED,
-        )
-        self.assertEqual(
-            pc_instance.pid_mr_stage_output_data_path,
-            "https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output/publisher_123_out_dir/pid_mr",
-        )
-        self.assertEqual(
-            pc_instance.infra_config.instances[0].instance_id, "execution_arn"
-        )
-        self.assertIsInstance(pc_instance.infra_config.instances[0], StageStateInstance)
+                self.assertEqual(
+                    stage_svc.get_status(pc_instance),
+                    PrivateComputationInstanceStatus.PID_MR_COMPLETED,
+                )
+                self.assertEqual(
+                    pc_instance.pid_mr_stage_output_data_path,
+                    "https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output/publisher_123_out_dir/pid_mr",
+                )
+                self.assertEqual(
+                    pc_instance.infra_config.instances[0].instance_id, "execution_arn"
+                )
+                self.assertIsInstance(
+                    pc_instance.infra_config.instances[0], StageStateInstance
+                )

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-from typing import List
+from typing import List, Optional
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -61,6 +61,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             pc_role: PrivateComputationRole,
             multikey_enabled: bool,
             test_num_containers: int,
+            test_run_id: Optional[str] = None,
         ) -> None:
             pid_protocol = (
                 PIDProtocol.UNION_PID_MULTIKEY
@@ -77,6 +78,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 test_num_containers=test_num_containers,
                 multikey_enabled=multikey_enabled,
                 pid_max_column_count=max_col_cnt_expect,
+                run_id=test_run_id,
             )
             stage_svc = PIDPrepareStageService(
                 storage_svc=self.mock_storage_svc,
@@ -100,7 +102,10 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 ] = self.onedocker_binary_config.repository_path
 
             args_ls_expect = self.get_args_expected(
-                pc_role, test_num_containers, max_col_cnt_expect
+                pc_role,
+                test_num_containers,
+                max_col_cnt_expect,
+                test_run_id,
             )
             # test the start_containers is called with expected parameters
             self.mock_onedocker_svc.start_containers.assert_called_with(
@@ -132,17 +137,20 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             [PrivateComputationRole.PUBLISHER, PrivateComputationRole.PARTNER],
             [True, False],
             [1, 2],
+            [None, "2621fda2-0eca-11ed-861d-0242ac120002"],
         )
-        for pc_role, multikey_enabled, test_num_containers in data_tests:
+        for pc_role, multikey_enabled, test_num_containers, test_run_id in data_tests:
             with self.subTest(
                 pc_role=pc_role,
                 multikey_enabled=multikey_enabled,
                 test_num_containers=test_num_containers,
+                test_run_id=test_run_id,
             ):
                 await _run_sub_test(
                     pc_role=pc_role,
                     multikey_enabled=multikey_enabled,
                     test_num_containers=test_num_containers,
+                    test_run_id=test_run_id,
                 )
 
     def create_sample_pc_instance(
@@ -152,6 +160,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         pid_max_column_count: int = 1,
         multikey_enabled: bool = False,
         status: PrivateComputationInstanceStatus = PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+        run_id: Optional[str] = None,
     ) -> PrivateComputationInstance:
         infra_config: InfraConfig = InfraConfig(
             instance_id=self.pc_instance_id,
@@ -164,6 +173,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=test_num_containers,
             num_files_per_mpc_container=test_num_containers,
             status_updates=[],
+            run_id=run_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.input_path,
@@ -196,6 +206,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         pc_role: PrivateComputationRole,
         test_num_containers: int,
         max_col_cnt_expected: int,
+        test_run_id: Optional[str] = None,
     ) -> List[str]:
         arg_ls = []
         if pc_role is PrivateComputationRole.PUBLISHER:
@@ -208,4 +219,18 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_prepared_{i} --tmp_directory=/tmp --max_column_cnt={max_col_cnt_expected}"
                 for i in range(test_num_containers)
             ]
-        return arg_ls
+
+        modified_arg_ls = []
+        for arg in arg_ls:
+            modified_arg = arg
+            if test_run_id is not None:
+                modified_arg = " ".join(
+                    [
+                        arg,
+                        f"--run_id={test_run_id}",
+                    ]
+                )
+            else:
+                modified_arg = arg
+            modified_arg_ls.append(modified_arg)
+        return modified_arg_ls


### PR DESCRIPTION
Summary:
# Context
For Centralized Logging, we will use a unique run_id to identify a PL/PA run, this run_id will be generated on the partner side and will be consumed by publisher side during instance creation. This run_id will be included in all the multiple ENT instances involved in the run and will also be shared with all the backend components (thrift, PCS, PCA binaries).
Design Doc
https://docs.google.com/document/d/1vZNOq8GUT1D_7-MjSh2yNpUKVEsvpsYeFx1PjceyelQ/edit?usp=sharing
RunID Format
RunId will be in UUID format. Ex - 2621fda2-0eca-11ed-861d-0242ac120002

# This diff
Add run_id to PID binaries.

Differential Revision: D38728209

