### PR TITLE
Install missing build dependency for the FBPCS pce_deployment image

### DIFF
--- a/docker/pce_deployment/Dockerfile.ubuntu
+++ b/docker/pce_deployment/Dockerfile.ubuntu
@@ -14,8 +14,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ##########################################
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    gcc \
     jq \
     python3.8 \
+    python3-dev \
     python3-pip \
     unzip \
     sudo


### PR DESCRIPTION
Summary:
An issue was encountered that prevented build of the `pce_deployment` image against the aarch64/arm64 platform.

Building the Docker image against aarch64 fails due to some missing build dependencies: `gcc`, `python3-dev`. This is because a project dependency, the `psutil` wheel, is not distributed with the aarch64 build and instead it is compiled from source (see [Wheel support for linux aarch64 · Issue #1782 · giampaolo/psutil · GitHub](https://github.com/giampaolo/psutil/issues/1782)).

This change updates the corresponding Dockerfile to install the dependencies required to compile the wheel.

Reviewed By: ajaybhargavb

Differential Revision: D38541052

