### PR TITLE
Add id combiner stage to mr pid stage

### DIFF
--- a/fbpcs/data_processing/service/id_spine_combiner.py
+++ b/fbpcs/data_processing/service/id_spine_combiner.py
@@ -27,6 +27,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
         output_path: str,
         num_shards: int,
         tmp_directory: str,
+        protocol_type: str,
         max_id_column_cnt: int = 1,
         sort_strategy: str = DEFAULT_SORT_STRATEGY,
         # TODO T106159008: padding_size and run_name are only temporarily optional
@@ -55,6 +56,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
                 run_name=run_name,
                 sort_strategy=sort_strategy,
                 log_cost=log_cost,
+                protocol_type=protocol_type,
             )
             cmd_args_list.append(cmd_args)
         return cmd_args_list

--- a/fbpcs/pid/entity/pid_stages.py
+++ b/fbpcs/pid/entity/pid_stages.py
@@ -14,9 +14,11 @@ class UnionPIDStage(Enum):
     PUBLISHER_SHARD = "PUBLISHER_SHARD"
     PUBLISHER_PREPARE = "PUBLISHER_PREPARE"
     PUBLISHER_RUN_PID = "PUBLISHER_RUN_PID"
+    PUBLISHER_RUN_MR_PID = "PUBLISHER_RUN_MR_PID"
     ADV_SHARD = "ADV_SHARD"
     ADV_PREPARE = "ADV_PREPARE"
     ADV_RUN_PID = "ADV_RUN_PID"
+    ADV_RUN_MR_PID = "ADV_RUN_MR_PID"
 
 
 class PIDStageFailureError(RuntimeError):
@@ -31,7 +33,9 @@ STAGE_TO_FILE_FORMAT_MAP: Dict[UnionPIDStage, str] = {
     UnionPIDStage.PUBLISHER_SHARD: "_publisher_sharded",
     UnionPIDStage.PUBLISHER_PREPARE: "_publisher_prepared",
     UnionPIDStage.PUBLISHER_RUN_PID: "_publisher_pid_matched",
+    UnionPIDStage.PUBLISHER_RUN_MR_PID: "_publisher_mr_pid_matched",
     UnionPIDStage.ADV_SHARD: "_advertiser_sharded",
     UnionPIDStage.ADV_PREPARE: "_advertiser_prepared",
     UnionPIDStage.ADV_RUN_PID: "_advertiser_pid_matched",
+    UnionPIDStage.ADV_RUN_MR_PID: "_advertiser_mr_pid_matched",
 }

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -99,6 +99,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
             input_stage_path = pc_instance.decoupled_aggregation_stage_output_base_path
         elif pc_instance.get_flow_cls_name in [
             "PrivateComputationPCF2StageFlow",
+            "PrivateComputationMRStageFlow",
             "PrivateComputationPCF2LocalTestStageFlow",
             "PrivateComputationPIDPATestStageFlow",
         ]:

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -6,6 +6,8 @@
 
 # pyre-strict
 
+from enum import Enum
+
 from fbpcs.pid.entity.pid_instance import PIDProtocol
 
 """
@@ -37,5 +39,9 @@ ATTRIBUTION_DEFAULT_PADDING_SIZE = 4
 DEFAULT_LOG_COST_TO_S3 = True
 DEFAULT_SORT_STRATEGY = "sort"
 DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT = 6
-
 FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"
+
+
+class Protocol(Enum):
+    PidProtocal = "PID"
+    MrPidProtocal = "MR_PID"

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -17,7 +17,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3, Protocol
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
@@ -42,12 +42,14 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         padding_size: Optional[int] = None,
+        protocol_type: str = Protocol.PidProtocal.value,
     ) -> None:
         self._onedocker_svc = onedocker_svc
         self._onedocker_binary_config_map = onedocker_binary_config_map
         self._log_cost_to_s3 = log_cost_to_s3
         self._logger: logging.Logger = logging.getLogger(__name__)
         self.padding_size = padding_size
+        self.protocol_type = protocol_type
 
     async def run_async(
         self,
@@ -78,6 +80,7 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
             combine_output_path,
             log_cost_to_s3=self._log_cost_to_s3,
             max_id_column_count=pc_instance.product_config.common.pid_max_column_count,
+            protocol_type=self.protocol_type,
         )
         self._logger.info("Finished running CombinerService")
 

--- a/fbpcs/private_computation/service/pid_mr_stage_service.py
+++ b/fbpcs/private_computation/service/pid_mr_stage_service.py
@@ -67,6 +67,9 @@ class PIDMRStageService(PrivateComputationStageService):
             and PID_WORKFLOW_CONFIGS in pid_configs[PIDMR]
             and SPARK_CONFIGS in pid_configs[PIDMR]
         ):
+            pc_configs = {
+                "numPidContainers": pc_instance.infra_config.num_pid_containers
+            }
             data_configs = {
                 INTPUT: self.get_s3uri_from_url(
                     pc_instance.product_config.common.input_path
@@ -83,6 +86,7 @@ class PIDMRStageService(PrivateComputationStageService):
                 **pid_configs[PIDMR][PID_RUN_CONFIGS],
                 **pid_configs[PIDMR][SPARK_CONFIGS],
                 **data_configs,
+                **pc_configs,
             }
 
             stage_state.instance_id = self.workflow_svc.start_workflow(

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -43,6 +43,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.service.constants import (
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     DEFAULT_LOG_COST_TO_S3,
+    Protocol,
 )
 from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
 from fbpcs.private_computation.service.private_computation_service_data import (
@@ -219,6 +220,7 @@ async def start_combiner_service(
     log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
     wait_for_containers: bool = False,
     max_id_column_count: int = 1,
+    protocol_type: str = Protocol.PidProtocal.value,
 ) -> List[ContainerInstance]:
     """Run combiner service and return those container instances
 
@@ -269,12 +271,20 @@ async def start_combiner_service(
         stage_data.service,
     )
 
+    if protocol_type == Protocol.MrPidProtocal.value:
+        spine_path = private_computation_instance.pid_mr_stage_output_spine_path
+        data_path = private_computation_instance.pid_mr_stage_output_data_path
+    else:
+        spine_path = private_computation_instance.pid_stage_output_spine_path
+        data_path = private_computation_instance.pid_stage_output_data_path
+
     args = combiner_service.build_args(
-        spine_path=private_computation_instance.pid_stage_output_spine_path,
-        data_path=private_computation_instance.pid_stage_output_data_path,
+        spine_path=spine_path,
+        data_path=data_path,
         output_path=combine_output_path,
         num_shards=private_computation_instance.infra_config.num_pid_containers,
         tmp_directory=binary_config.tmp_directory,
+        protocol_type=protocol_type,
         max_id_column_cnt=max_id_column_count,
         run_name=run_name,
         padding_size=padding_size,

--- a/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_prepare_data_stage_service.py
@@ -26,7 +26,10 @@ from fbpcs.private_computation.entity.product_config import (
     LiftConfig,
     ProductConfig,
 )
-from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
+from fbpcs.private_computation.service.constants import (
+    NUM_NEW_SHARDS_PER_FILE,
+    Protocol,
+)
 from fbpcs.private_computation.service.prepare_data_stage_service import (
     PrepareDataStageService,
 )
@@ -71,6 +74,7 @@ class TestPrepareDataStageService(IsolatedAsyncioTestCase):
                 + "_combine",
                 num_shards=self.test_num_containers,
                 tmp_directory=binary_config.tmp_directory,
+                protocol_type=Protocol.PidProtocal.value,
             )
             # pyre-fixme[20]: Argument `self` expected.
             IdSpineCombinerService.start_containers(


### PR DESCRIPTION
Summary:
## What is this stack?
In Single key protocol, the data can be sharded into multiple files and processed via multiple containers where each container picks up a shard. In multi key protocol, data cannot be sharded based on a single key which makes it difficult for id combiner to look across the entire data for the joining with the union id spine.

Since the existing Id combiner cannot communicate across multiple shards, we join the union ids with the original data inside MR-PID stages and skip this step in the ID combiner. To achieve this, MR-PID should output the sharded data based on the union Id and ID combiners can now individually perform aggregation on each shard.

PrivateComputationMRStageFlow needs to add ID_SPINE_COMBINER to run IdSpineCombinerStageService.

Design doc:
https://docs.google.com/document/d/1qeWq84OgB4w8nvZZTMMYvY0hEA8HZ4Q-1gsGIRCltDU/edit#

##  What
  * In PrivateComputationMRStageFlow, add IdSpineCombinerStageService

## Why
 *  The PrivateComputationMRStageFlow needs to add ID_SPINE_COMBINER stage

## Action items:
*  Milestone 1: refactor attribution id combiner
*  Milestone 2: refactor lift id combiner
*  Milestone 3: add MR PID attribution id combiner
*  Milestone 4: add MR PID lift id combiner
*  Milestone 5: add protocol_type to pcs to start combiner binary
* Milestone 6: add combiner stage service in PrivateComputationMRStageFlow

Reviewed By: Pradeepnitw

Differential Revision: D38528527

