### PR TITLE
Add a cron GitHub action to build the Coordinator image every hour during the work day.

### DIFF
--- a/.github/workflows/build_coordinator.yml
+++ b/.github/workflows/build_coordinator.yml
@@ -1,0 +1,25 @@
+name: Build Coordinator image
+
+on:
+  schedule:
+    - cron: '0 0,15-23 * * 1-5'
+
+env:
+  DISTRO: ubuntu
+  LOCAL_IMAGE_NAME: coordinator-local
+  IMAGE_TAG: latest-build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Coordinator image
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: |
+          docker build --build-arg FBPCS_BUNDLE_ID=${{ env.IMAGE_TAG }} -f ./fbpcs/Dockerfile -t ${{ env.LOCAL_IMAGE_NAME }}:${{ env.IMAGE_TAG }} .


### PR DESCRIPTION
Summary:
## Background
Currently we build the coordinator and onedocker images on every commit to FBPCS. This helps us catch most of the changes that affect the process. This does not include changes to PID and FBPCP though. To properly test any changes that would happen, we need both the OneDocker and Coordinators built and to test with them.

## This change
This commit adds a cron action that will build the OneDocker image every hour during the work day (8 AM - 5 PM PDT).

Differential Revision: D38750486

