### PR TITLE
Add support for VPC Flow logging in PCEs

### DIFF
--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/networking.tf
@@ -113,3 +113,11 @@ resource "aws_default_security_group" "default" {
     Name = "onedocker-security-group${var.tag_postfix}"
   }
 }
+
+resource "aws_flow_log" "onedocker_vpc" {
+  count                = var.vpc_logging.enabled ? 1 : 0
+  log_destination      = var.vpc_logging.bucket_arn
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.main.id
+}

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce/variable.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce/variable.tf
@@ -34,3 +34,20 @@ variable "pce_id" {
   type        = string
   description = "The identifier for marking the cloud resources are in PCE"
 }
+
+variable "vpc_logging" {
+  description = "An object which configures VPC logging"
+  type = object({
+    enabled    = bool
+    bucket_arn = string
+  })
+  default = {
+    enabled    = false
+    bucket_arn = ""
+  }
+
+  validation {
+    condition     = var.vpc_logging.enabled == false || var.vpc_logging.bucket_arn != ""
+    error_message = "An S3 bucket ARN must be provided if VPC logging is enabled (ex. 'arn:aws:s3:::YOUR-BUCKET-NAME')."
+  }
+}


### PR DESCRIPTION
Summary:
This change adds support for PCEs to optionally be deployed with VPC Flow logs enabled for write to a configurable S3 bucket.

VPC Flow logs track IP traffic across network interfaces in the VPC. These could be used for security monitoring purposes. You can read more about VPC Flow logs here: [Logging IP Traffic using VPC Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html)'

After this change, VPC Flow Logs are still disabled by default. Enabling them requires the following new parameters to be passed to `deploy.sh` when running the `deploy` command:
* `--vpc_logging_enabled true`
* `--vpc_log_bucket_arn "YOUR-BUCKET-ARN"`

For logs to be written, the configured S3 bucket will also need to allow logging via its permissions policy as described here: [AWS - Publish flow logs to Amazon S3 - Amazon S3 bucket permissions for flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-permissions)

Reviewed By: ajaybhargavb

Differential Revision: D38630192

