### PR TITLE
add PCF2.0 ShardCombiner, cmakelist and corresponding one docker binary paths.

### DIFF
--- a/binaries_out_lists/emp_games.txt
+++ b/binaries_out_lists/emp_games.txt
@@ -1,5 +1,6 @@
 lift_calculator
 pcf2_lift_calculator
+pcf2_shard_combiner
 decoupled_attribution_calculator
 decoupled_aggregation_calculator
 pcf2_attribution_calculator

--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -144,3 +144,18 @@ target_link_libraries(
   empgamecommon
   perftools)
 install(TARGETS pcf2_lift_calculator DESTINATION bin)
+
+# pcf2_shard_combiner
+file(GLOB pcf2_shard_combiner_src
+  "fbpcs/emp_games/pcf2_shard_combiner/**.cpp"
+  "fbpcs/emp_games/pcf2_shard_combiner/**.h"
+  "fbpcs/emp_games/pcf2_shard_combiner/util/**.h")
+list(FILTER pcf2_shard_combiner_src EXCLUDE REGEX ".*Test.*")
+add_executable(
+  pcf2_shard_combiner
+  ${pcf2_shard_combiner_src})
+target_link_libraries(
+  pcf2_shard_combiner
+  empgamecommon
+  perftools)
+install(TARGETS pcf2_shard_combiner DESTINATION bin)

--- a/docker/emp_games/Dockerfile.ubuntu
+++ b/docker/emp_games/Dockerfile.ubuntu
@@ -19,6 +19,7 @@ COPY fbpcs/performance_tools/ ./fbpcs/performance_tools
 COPY fbpcs/emp_games/attribution/ ./fbpcs/emp_games/attribution
 COPY fbpcs/emp_games/pcf2_attribution/ ./fbpcs/emp_games/pcf2_attribution
 COPY fbpcs/emp_games/pcf2_aggregation/ ./fbpcs/emp_games/pcf2_aggregation
+COPY fbpcs/emp_games/pcf2_shard_combiner/ ./fbpcs/emp_games/pcf2_shard_combiner
 COPY fbpcs/emp_games/lift/ ./fbpcs/emp_games/lift
 COPY fbpcs/emp_games/common/ ./fbpcs/emp_games/common
 

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -97,6 +97,7 @@ RUN ln -s pcf2_attribution_calculator /home/pcs/onedocker/package/pcf2_attributi
 RUN ln -s pcf2_aggregation_calculator /home/pcs/onedocker/package/pcf2_aggregation
 RUN ln -s lift_calculator /home/pcs/onedocker/package/lift
 RUN ln -s pcf2_lift_calculator /home/pcs/onedocker/package/pcf2_lift
+RUN ln -s pcf2_shard_combiner /home/pcs/onedocker/package/pcf2_shard-combiner
 RUN ln -s shard_aggregator /home/pcs/onedocker/package/shard-aggregator
 
 WORKDIR /home/pcs

--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -70,6 +70,7 @@ docker cp temp_container:/usr/local/bin/decoupled_aggregation_calculator "$SCRIP
 docker cp temp_container:/usr/local/bin/pcf2_attribution_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/pcf2_aggregation_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/shard_aggregator "$SCRIPT_DIR/binaries_out/."
+docker cp temp_container:/usr/local/bin/pcf2_shard_combiner "$SCRIPT_DIR/binaries_out/."
 docker rm -f temp_container
 fi
 

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -93,6 +93,20 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="visibility", required=False),
         ],
     },
+    GameNames.PCF2_SHARD_COMBINER.value: {
+        "onedocker_package_name": OneDockerBinaryNames.PCF2_SHARD_COMBINER.value,
+        "arguments": [
+            OneDockerArgument(name="input_base_path", required=True),
+            OneDockerArgument(name="num_shards", required=True),
+            OneDockerArgument(name="output_path", required=True),
+            OneDockerArgument(name="metrics_format_type", required=True),
+            OneDockerArgument(name="threshold", required=True),
+            OneDockerArgument(name="first_shard_index", required=False),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="visibility", required=False),
+        ],
+    },
     GameNames.DECOUPLED_ATTRIBUTION.value: {
         "onedocker_package_name": OneDockerBinaryNames.DECOUPLED_ATTRIBUTION.value,
         "arguments": [

--- a/promote_scripts/promote_binaries.sh
+++ b/promote_scripts/promote_binaries.sh
@@ -27,6 +27,7 @@ binary_names=(
     'private_attribution/pcf2_attribution'
     'private_attribution/pcf2_aggregation'
     'private_attribution/shard-aggregator'
+    'private_attribution/pcf2_shard-combiner'
     'pid/private-id-client'
     'pid/private-id-server'
     'pid/private-id-multi-key-client'

--- a/upload-binaries-to-s3-test.sh
+++ b/upload-binaries-to-s3-test.sh
@@ -38,6 +38,7 @@ decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_
 pcf2_attribution="$attribution_repo/pcf2_attribution/${TAG}/pcf2_attribution"
 pcf2_aggregation="$attribution_repo/pcf2_aggregation/${TAG}/pcf2_aggregation"
 shard_aggregator_package="$attribution_repo/shard-aggregator/${TAG}/shard-aggregator"
+pcf2_shard_combiner_package="$attribution_repo/pcf2_shard-combiner/${TAG}/pcf2_shard-combiner"
 data_processing_repo="s3://$one_docker_repo/data_processing"
 private_id_repo="s3://$one_docker_repo/pid"
 validation_repo="s3://$one_docker_repo/validation"
@@ -51,6 +52,7 @@ aws s3 cp decoupled_aggregation_calculator "$decoupled_aggregation"
 aws s3 cp pcf2_attribution_calculator "$pcf2_attribution"
 aws s3 cp pcf2_aggregation_calculator "$pcf2_aggregation"
 aws s3 cp shard_aggregator "$shard_aggregator_package"
+aws s3 cp pcf2_shard_combiner "$pcf2_shard_combiner_package"
 cd .. || exit
 fi
 

--- a/upload-binaries-to-s3.sh
+++ b/upload-binaries-to-s3.sh
@@ -38,6 +38,7 @@ decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_
 pcf2_attribution="$attribution_repo/pcf2_attribution/${TAG}/pcf2_attribution"
 pcf2_aggregation="$attribution_repo/pcf2_aggregation/${TAG}/pcf2_aggregation"
 shard_aggregator_package="$attribution_repo/shard-aggregator/${TAG}/shard-aggregator"
+pcf2_shard_combiner_package="$attribution_repo/pcf2_shard-combiner/${TAG}/pcf2_shard-combiner"
 data_processing_repo="s3://$one_docker_repo/data_processing"
 private_id_repo="s3://$one_docker_repo/pid"
 validation_repo="s3://$one_docker_repo/validation"
@@ -51,6 +52,7 @@ aws s3 cp decoupled_aggregation_calculator "$decoupled_aggregation"
 aws s3 cp pcf2_attribution_calculator "$pcf2_attribution"
 aws s3 cp pcf2_aggregation_calculator "$pcf2_aggregation"
 aws s3 cp shard_aggregator "$shard_aggregator_package"
+aws s3 cp pcf2_shard_combiner "$pcf2_shard_combiner_package"
 cd .. || exit
 fi
 


### PR DESCRIPTION
Summary: We update the build scripts in order to build the binaries for PCF2 PL and upload them to AWS, following the instructions in https://www.internalfb.com/intern/wiki/Private_Computation_Platform_(PCP)/Internal_Developer_Guide/How_to_add_a_stage_to_PCS/Step_4:_Update_Github_CI/CD/

Reviewed By: anthonyzhang25

Differential Revision: D38396607

