### PR TITLE
Add run_id to PID binaries. (#73)

### DIFF
--- a/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
@@ -24,6 +24,11 @@ DEFINE_string(
     "/tmp/",
     "Directory where temporary files should be saved before final write");
 DEFINE_int32(max_column_cnt, 1, "Number of columns to write");
+
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");
 DEFINE_int32(log_every_n, 1'000'000, "How frequently to log updates");
 
 int main(int argc, char** argv) {

--- a/fbpcs/data_processing/sharding/shard_pid.cpp
+++ b/fbpcs/data_processing/sharding/shard_pid.cpp
@@ -22,6 +22,10 @@ DEFINE_string(
     output_base_path,
     "",
     "Local or s3 base path where output files are written to");
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");
 DEFINE_int32(
     file_start_index,
     0,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/Private-ID/pull/73

# Context
For Centralized Logging, we will use a unique run_id to identify a PL/PA run, this run_id will be generated on the partner side and will be consumed by publisher side during instance creation. This run_id will be included in all the multiple ENT instances involved in the run and will also be shared with all the backend components (thrift, PCS, PCA binaries).
Design Doc
https://docs.google.com/document/d/1vZNOq8GUT1D_7-MjSh2yNpUKVEsvpsYeFx1PjceyelQ/edit?usp=sharing
RunID Format
RunId will be in UUID format. Ex - 2621fda2-0eca-11ed-861d-0242ac120002

# This diff
Add run_id to PID binaries.

Reviewed By: Pradeepnitw, jiancao-yajc, yuyashiraki

Differential Revision: D38726020

