### PR TITLE
Add Ad Id compression logic to the attribution game (#1406)

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -76,6 +76,20 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       size_t batchSize);
 
   /**
+   * Retrieve the original Ad Ids from touchpoint data
+   */
+  const std::vector<uint64_t> retrieveValidOriginalAdIds(
+      const int myRole,
+      std::vector<TouchpointT<usingBatch>>& touchpoints);
+  /**
+   * Create a compression map of the original Ad Id with the compressed Ad ID
+   */
+
+  void replaceAdIdWithCompressedAdId(
+      std::vector<TouchpointT<usingBatch>>& touchpoints,
+      std::vector<uint64_t>& validOriginalAdIds);
+
+  /**
    * Helper method for computing attributions.
    */
   const std::vector<SecBit<schedulerId, usingBatch>> computeAttributionsHelper(

--- a/fbpcs/emp_games/pcf2_attribution/AttributionReformattedOutput.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionReformattedOutput.h
@@ -17,7 +17,7 @@ namespace pcf2_attribution {
  * Store plaintext attribution result
  */
 struct OutputMetricReformatted {
-  uint64_t ad_id;
+  uint16_t ad_id;
   uint64_t conv_value;
   bool is_attributed;
 
@@ -160,7 +160,7 @@ class AttributionReformattedOutput {
       if constexpr (usingBatch) {
         for (size_t j = 0; j < revealedAdId.size(); ++j) {
           OutputMetricReformatted outputMetric{
-              revealedAdId.at(j).at(i),
+              static_cast<uint16_t>(revealedAdId.at(j).at(i)),
               revealedConvValue.at(j).at(i),
               revealedAttribution.at(j).at(i)};
           revealedMetric.emplace_back(outputMetric);
@@ -178,7 +178,7 @@ class AttributionReformattedOutput {
         // revealedAttribution for non-batch is related to batch by transposing
         for (size_t j = 0; j < revealedAdId.at(i).size(); ++j) {
           OutputMetricReformatted outputMetric{
-              revealedAdId.at(i).at(j),
+              static_cast<uint16_t>(revealedAdId.at(i).at(j)),
               revealedConvValue.at(i).at(j),
               revealedAttribution.at(i).at(j)};
           revealedMetric.emplace_back(outputMetric);

--- a/fbpcs/emp_games/pcf2_attribution/Constants.h
+++ b/fbpcs/emp_games/pcf2_attribution/Constants.h
@@ -15,7 +15,8 @@ const int kMaxConcurrency = 16;
 const size_t timeStampWidth = 32;
 const size_t targetIdWidth = 64;
 const size_t actionTypeWidth = 16;
-const size_t adIdWidth = 64;
+const size_t originalAdIdWidth = 64;
+const size_t adIdWidth = 16;
 const size_t convValueWidth = 32;
 
 template <int schedulerId, bool usingBatch = true>
@@ -47,6 +48,13 @@ using SecActionType = typename fbpcf::frontend::MpcGame<
     schedulerId>::template SecUnsignedInt<actionTypeWidth, usingBatch>;
 
 template <int schedulerId, bool usingBatch = true>
+using PubOriginalAdId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template PubUnsignedInt<originalAdIdWidth, usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecOriginalAdId = typename fbpcf::frontend::MpcGame<
+    schedulerId>::template SecUnsignedInt<originalAdIdWidth, usingBatch>;
+
+template <int schedulerId, bool usingBatch = true>
 using PubAdId = typename fbpcf::frontend::MpcGame<
     schedulerId>::template PubUnsignedInt<adIdWidth, usingBatch>;
 template <int schedulerId, bool usingBatch = true>
@@ -75,6 +83,9 @@ using SecTargetIdT =
 template <int schedulerId, bool usingBatch = true>
 using SecActionTypeT =
     ConditionalVector<SecActionType<schedulerId, usingBatch>, !usingBatch>;
+template <int schedulerId, bool usingBatch = true>
+using SecOriginalAdIdT =
+    ConditionalVector<SecOriginalAdId<schedulerId, usingBatch>, !usingBatch>;
 template <int schedulerId, bool usingBatch = true>
 using SecAdIdT =
     ConditionalVector<SecAdId<schedulerId, usingBatch>, !usingBatch>;

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -19,6 +19,7 @@ struct Touchpoint {
   ConditionalVector<uint64_t, usingBatch> ts;
   ConditionalVector<uint64_t, usingBatch> targetId;
   ConditionalVector<uint64_t, usingBatch> actionType;
+  ConditionalVector<uint64_t, usingBatch> originalAdId;
   ConditionalVector<uint64_t, usingBatch> adId;
 };
 
@@ -34,6 +35,7 @@ struct PrivateTouchpoint {
   SecTimestamp<schedulerId, usingBatch> ts;
   SecTargetId<schedulerId, usingBatch> targetId;
   SecActionType<schedulerId, usingBatch> actionType;
+  SecOriginalAdId<schedulerId, usingBatch> originalAdId;
   SecAdId<schedulerId, usingBatch> adId;
 
   explicit PrivateTouchpoint(const Touchpoint<usingBatch>& touchpoint)
@@ -49,10 +51,10 @@ struct PrivateTouchpoint {
           extractedAids(touchpoint.actionType);
       actionType =
           SecActionType<schedulerId, usingBatch>(std::move(extractedAids));
-      typename SecAdId<schedulerId, usingBatch>::ExtractedInt extractedAdIds(
-          touchpoint.adId);
-      adId = SecAdId<schedulerId, usingBatch>(std::move(extractedAdIds));
-
+      typename SecOriginalAdId<schedulerId, usingBatch>::ExtractedInt
+          extractedOriginalAdIds(touchpoint.originalAdId);
+      originalAdId = SecOriginalAdId<schedulerId, usingBatch>(
+          std::move(extractedOriginalAdIds));
     } else {
       ts = SecTimestamp<schedulerId, usingBatch>(
           touchpoint.ts, common::PUBLISHER);
@@ -60,9 +62,10 @@ struct PrivateTouchpoint {
           touchpoint.targetId, common::PUBLISHER);
       actionType = SecActionType<schedulerId, usingBatch>(
           touchpoint.actionType, common::PUBLISHER);
-      adId =
-          SecAdId<schedulerId, usingBatch>(touchpoint.adId, common::PUBLISHER);
+      originalAdId = SecOriginalAdId<schedulerId, usingBatch>(
+          touchpoint.originalAdId, common::PUBLISHER);
     }
+    adId = SecAdId<schedulerId, usingBatch>(touchpoint.adId, common::PUBLISHER);
   }
 };
 
@@ -93,7 +96,8 @@ struct ParsedTouchpoint {
   uint64_t ts = 0U;
   uint64_t targetId = 0U;
   uint64_t actionType = 0U;
-  uint64_t adId = 0U;
+  uint64_t originalAdId = 0U;
+  uint16_t adId = 0U;
 
   /**
    * If both are clicks, or both are views, the earliest one comes first.

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionTestUtils.h
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionTestUtils.h
@@ -126,7 +126,7 @@ inline AttributionOutputMetrics revealXORedReformattedResult(
           OutputMetricReformatted::fromDynamic(bobResults.at(i));
 
       revealedResults.push_back(OutputMetricReformatted{
-          aliceResult.ad_id ^ bobResult.ad_id,
+          static_cast<uint16_t>(aliceResult.ad_id ^ bobResult.ad_id),
           aliceResult.conv_value ^ bobResult.conv_value,
           aliceResult.is_attributed != bobResult.is_attributed}
                                     .toDynamic());


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/1406

Based on the flag, add a logic to retrieve the original Ad Ids from touchpoint data and create a compression map of the original Ad Id with the compressed Ad ID, replace the original Ad Id with compressed Ad Ids in the attribution logic and output generation.

The adid is in plaintext rather than secret share for XOR input encryption. For the plaintext scheduler, this means that both parties adid are the same, so when running this line, the adid will be 0, because they are treated as secret share rather than plaintext. If input encryption is XOR, we should store secret shared ad ids instead of plaintext. Thus when doing the ad id compression, the adId should also be in plaintext regardless of input encryption.

Reviewed By: ajinkya-ghonge

Differential Revision: D38223281

