### PR TITLE
Read the mapping json from S3 in shard aggregation game

### DIFF
--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetrics.h
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetrics.h
@@ -89,4 +89,23 @@ class AggMetrics {
 
   void checkMyType(AggMetricsTag tag) const;
 };
+
+struct CompressedAdIdToOriginalAdId {
+  std::unordered_map<std::string, uint64_t> compressedAdIdToAdIdMap;
+
+  static CompressedAdIdToOriginalAdId fromDynamic(const folly::dynamic& obj) {
+    CompressedAdIdToOriginalAdId map;
+    std::unordered_map<std::string, uint64_t> compressedAdIdToAdIdMap;
+
+    for (auto& pair : obj.items()) {
+      std::string compressedAdId = pair.first.asString();
+      uint64_t originalAdId = pair.second.asInt();
+      std::pair<std::string, uint64_t> t{compressedAdId, originalAdId};
+      compressedAdIdToAdIdMap.insert(t);
+    }
+
+    map.compressedAdIdToAdIdMap = compressedAdIdToAdIdMap;
+    return map;
+  }
+};
 } // namespace private_measurement

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.h
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.h
@@ -33,6 +33,8 @@ class ShardAggregatorApp
       int64_t threshold,
       const std::string& inputPath,
       const std::string& outputPath,
+      const std::string& inputMappingPath,
+      const bool useNewOutputFormat,
       const std::string& metricsFormatType = "ad_object")
       : fbpcf::EmpApp<
             ShardAggregatorGame<emp::NetIO>,
@@ -45,13 +47,18 @@ class ShardAggregatorApp
         inputPath_{inputPath},
         outputPath_{outputPath},
         visibility_{visibility},
-        metricsFormatType_{metricsFormatType} {}
+        metricsFormatType_{metricsFormatType},
+        inputMappingPath_{inputMappingPath},
+        useNewOutputFormat_{useNewOutputFormat} {}
 
   void run() override;
 
  protected:
   std::vector<std::shared_ptr<private_measurement::AggMetrics>> getInputData()
       override;
+
+  private_measurement::CompressedAdIdToOriginalAdId getCompressedMapping();
+
   void putOutputData(const std::shared_ptr<private_measurement::AggMetrics>&
                          outputData) override;
 
@@ -71,5 +78,7 @@ class ShardAggregatorApp
   std::string outputPath_;
   fbpcf::Visibility visibility_;
   std::string metricsFormatType_;
+  std::string inputMappingPath_;
+  bool useNewOutputFormat_;
 };
 } // namespace measurement::private_attribution

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorAppTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorAppTest.cpp
@@ -51,6 +51,8 @@ class ShardAggregatorAppTest : public ::testing::Test {
       int64_t threshold,
       const std::string& inputPath,
       const std::string& outputPath,
+      const std::string& inputMappingPath,
+      const bool useNewOutputFormat,
       const std::string& metricsFormatType) {
     ShardAggregatorApp(
         party,
@@ -62,6 +64,8 @@ class ShardAggregatorAppTest : public ::testing::Test {
         threshold,
         inputPath,
         outputPath,
+        inputMappingPath,
+        useNewOutputFormat,
         metricsFormatType)
         .run();
   }
@@ -74,6 +78,8 @@ class ShardAggregatorAppTest : public ::testing::Test {
       const std::string& metricsFormatType,
       const std::string& expectedAliceOutPath,
       const std::string& expectedBobOutPath,
+      const std::string& inputMappingPath,
+      const bool useNewOutputFormat,
       const fbpcf::Visibility visibility = fbpcf::Visibility::Public) {
     auto futureAlice = std::async(
         runGame,
@@ -86,6 +92,8 @@ class ShardAggregatorAppTest : public ::testing::Test {
         threshold,
         inputPathAlice,
         outputPathAlice_,
+        inputMappingPath,
+        useNewOutputFormat,
         metricsFormatType);
     auto futureBob = std::async(
         runGame,
@@ -98,6 +106,8 @@ class ShardAggregatorAppTest : public ::testing::Test {
         threshold,
         inputPathBob,
         outputPathBob_,
+        inputMappingPath,
+        useNewOutputFormat,
         metricsFormatType);
 
     futureAlice.wait();
@@ -162,7 +172,9 @@ TEST_F(ShardAggregatorAppTest, TestGenericShardAggCorrectnessAdObject) {
         inputPathBob,
         "ad_object", // metricsFormatType
         expectedOutPath,
-        expectedOutPath);
+        expectedOutPath,
+        "",
+        false);
   }
 }
 
@@ -181,7 +193,9 @@ TEST_F(ShardAggregatorAppTest, TestGenericShardAggSimpleAdObject) {
       inputPathBob,
       "ad_object", // metricsFormatType
       expectedOutPath,
-      expectedOutPath);
+      expectedOutPath,
+      "",
+      false);
 }
 
 TEST_F(ShardAggregatorAppTest, TestGenericShardAggCorrectnessLift) {
@@ -198,7 +212,9 @@ TEST_F(ShardAggregatorAppTest, TestGenericShardAggCorrectnessLift) {
       inputPathBob,
       "lift", // metricsFormatType
       expectedOutPath,
-      expectedOutPath);
+      expectedOutPath,
+      "",
+      false);
 }
 
 TEST_F(
@@ -218,7 +234,9 @@ TEST_F(
       inputPathBob,
       "lift", // metricsFormatType
       expectedOutPath,
-      expectedOutPath);
+      expectedOutPath,
+      "",
+      false);
 }
 
 TEST_F(
@@ -240,6 +258,8 @@ TEST_F(
       "lift", // metricsFormatType
       zeroMetrics,
       expectedOutPath,
+      "",
+      false,
       fbpcf::Visibility::Bob);
 }
 
@@ -258,6 +278,8 @@ TEST_F(ShardAggregatorAppTest, TestGenericShardAggCorrectnessLiftAnonymous) {
       inputPathBob,
       "lift", // metricsFormatType
       expectedOutPath,
-      expectedOutPath);
+      expectedOutPath,
+      "",
+      false);
 }
 } // namespace measurement::private_attribution

--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -53,6 +53,11 @@ DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",
     "s3 regioni name");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");
+DEFINE_string(
+    input_ad_id_mapping_path,
+    "",
+    "Input path where the compressed adId mapping files are located");
 
 int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
@@ -73,7 +78,7 @@ int main(int argc, char* argv[]) {
   XLOGF(INFO, "Number of shards: {}", FLAGS_num_shards);
   XLOGF(INFO, "Output path: {}", FLAGS_output_path);
   XLOGF(INFO, "K-anonymity threshold: {}", FLAGS_threshold);
-  XLOGF(INFO, "Run Id: {}", FLAGS_run_id);
+  XLOGF(INFO, "Input ad id mapping path: {}", FLAGS_input_ad_id_mapping_path);
 
   XLOG(INFO) << "Start aggregating...";
 
@@ -91,6 +96,8 @@ int main(int argc, char* argv[]) {
         FLAGS_threshold,
         FLAGS_input_base_path,
         FLAGS_output_path,
+        FLAGS_input_ad_id_mapping_path,
+        FLAGS_use_new_output_format,
         FLAGS_metrics_format_type)
         .run();
   } catch (const fbpcf::ExceptionBase& e) {


### PR DESCRIPTION
Summary: Read the compressed adId to original adId mapping json file from S3 in the shard aggregation.

Reviewed By: chualynn

Differential Revision: D38477007

