### PR TITLE
implement get_cluster_instance with NotImplementError on pce_container_service.py

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -8,6 +8,8 @@
 
 from typing import Dict, List, Optional
 
+from fbpcp.entity.cluster_instance import Cluster
+
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.container import ContainerService
@@ -87,3 +89,6 @@ class PCSContainerService(ContainerService):
     )
     def validate_container_definition(self, container_definition: str) -> None:
         pass
+
+    def get_cluster_instance(self) -> Cluster:
+        raise NotImplementedError


### PR DESCRIPTION
Summary: A new method get_cluster_instance is add to ContainerService, this diff is to add the implement details to the child class. here NoImplementError is implemented.

Reviewed By: joe1234wu

Differential Revision: D38749175

