### PR TITLE
Add PC Feature Flags to PCA binaries

### DIFF
--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -22,6 +22,10 @@
 
 DEFINE_int32(party, 1, "1 = publisher, 2 = partner");
 DEFINE_int32(visibility, 0, "0 = public, 1 = publisher, 2 = partner");
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");
 DEFINE_string(server_ip, "", "Server's IP address");
 DEFINE_int32(port, 15200, "Server's port");
 DEFINE_string(input_base_path, "", "Input path where input files are located");
@@ -72,6 +76,7 @@ int main(int argc, char* argv[]) {
 
   XLOGF(INFO, "Party: {}", FLAGS_party);
   XLOGF(INFO, "Visibility: {}", FLAGS_visibility);
+  XLOGF(INFO, "PC Feature Flags: {}", FLAGS_pc_feature_flags);
   XLOGF(INFO, "Server IP: {}", FLAGS_server_ip);
   XLOGF(INFO, "Port: {}", FLAGS_port);
   XLOGF(INFO, "Input path: {}", FLAGS_input_base_path);

--- a/fbpcs/emp_games/lift/calculator/main.cpp
+++ b/fbpcs/emp_games/lift/calculator/main.cpp
@@ -82,6 +82,10 @@ DEFINE_string(
     run_id,
     "",
     "A run_id used to identify all the logs in a PL run.");
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");
 
 using namespace private_lift;
 
@@ -146,6 +150,7 @@ int main(int argc, char** argv) {
                << "\tserver_ip_address: " << FLAGS_server_ip << "\n"
                << "\tport: " << FLAGS_port << "\n"
                << "\tconcurrency: " << FLAGS_concurrency << "\n"
+               << "\tpc_feature_flags:" << FLAGS_pc_feature_flags
                << "\tinput: " << inputFileLogList.str() << "\n"
                << "\trun_id: " << FLAGS_run_id;
   }

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -94,6 +94,10 @@ DEFINE_bool(
     compute_publisher_breakdowns,
     true,
     "To enable or disable computing publisher breakdown for result validation");
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
@@ -143,6 +147,7 @@ int main(int argc, char** argv) {
                << "\tconcurrency: " << FLAGS_concurrency << "\n"
                << "\tnumber of conversions per user: "
                << FLAGS_num_conversions_per_user << "\n"
+               << "\tpc_feature_flags:" << FLAGS_pc_feature_flags
                << "\tinput: " << inputFileLogList.str()
                << "\toutput: " << outputFileLogList.str() << "\n"
                << "\trun_id: " << FLAGS_run_id;

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
@@ -74,3 +74,7 @@ DEFINE_string(
     run_id,
     "",
     "A run_id used to identify all the logs in a PL/PA run.");
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h
@@ -31,3 +31,4 @@ DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
 DECLARE_bool(use_new_output_format);
 DECLARE_string(run_id);
+DECLARE_string(pc_feature_flags);

--- a/fbpcs/emp_games/pcf2_aggregation/main.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/main.cpp
@@ -47,6 +47,7 @@ int main(int argc, char* argv[]) {
   XLOGF(INFO, "Input clear text path: {}", FLAGS_input_base_path);
   XLOGF(INFO, "Base output path: {}", FLAGS_output_base_path);
   XLOGF(INFO, "Run Id: {}", FLAGS_run_id);
+  XLOGF(INFO, "PC Feature Flags: {}", FLAGS_pc_feature_flags);
 
   common::SchedulerStatistics schedulerStatistics;
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
@@ -70,3 +70,7 @@ DEFINE_string(
     run_id,
     "",
     "A run_id used to identify all the logs in a PL/PA run.");
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.h
@@ -30,3 +30,4 @@ DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
 DECLARE_bool(use_new_output_format);
 DECLARE_string(run_id);
+DECLARE_string(pc_feature_flags);

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -46,6 +46,7 @@ int main(int argc, char* argv[]) {
   XLOGF(INFO, "Base input path: {}", FLAGS_input_base_path);
   XLOGF(INFO, "Base output path: {}", FLAGS_output_base_path);
   XLOGF(INFO, "Run Id: {}", FLAGS_run_id);
+  XLOGF(INFO, "PC Feature Flags: {}", FLAGS_pc_feature_flags);
 
   common::SchedulerStatistics schedulerStatistics;
 


### PR DESCRIPTION
Summary:
## Why
We rolled out private computation feature gating in PCS tier https://fb.workplace.com/groups/164332244998024/permalink/919133852851189/
This diff stack is to propagate feature flags to PCA/PCF

## What
* define FLAGS_pc_feature_flags on PCA binaries

## Next
* propagate feature flags to binaries
* adding static function to loads the feature flags, and implemenet something like PCFeatures::isEnabled("myFlagName")

Differential Revision: D38375347

