### PR TITLE
adding feature flags instance property for passing to binaries

### DIFF
--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -321,3 +321,12 @@ class PrivateComputationInstance(InstanceBase):
             return False
 
         return feature in self.infra_config.pcs_features
+
+    @property
+    def feature_flags(self) -> Optional[str]:
+        if self.infra_config.pcs_features:
+            return ",".join(
+                [feature.value for feature in self.infra_config.pcs_features]
+            )
+
+        return None


### PR DESCRIPTION
Summary:
## Why
We rolled out private computation feature gating in PCS tier https://fb.workplace.com/groups/164332244998024/permalink/919133852851189/
This diff stack is to propagate feature flags to PCA/PCF

## What
* adding feature flags property in pc instance

## Next
* propagate feature flags to binaries
* adding static function to loads the feature flags, and implemenet something like PCFeatures::isEnabled("myFlagName")

Differential Revision: D38765334

