### PR TITLE
pass feature_flgas to PCA binaries in PCS tier

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -26,6 +26,7 @@ Types of changes
 
 ### Changed
   - Mark validate_container_definition as deprecated in PCSContainerService since it is no longer a public method in ContainerService in fbpcp
+  - Set pc_feature_flags one docker args
 ### Removed
 
 ## [1.10.0] - 2022-08-12

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -48,6 +48,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="num_files", required=True),
             OneDockerArgument(name="concurrency", required=True),
             OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
         ],
     },
     GameNames.PCF2_LIFT.value: {
@@ -62,6 +63,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="log_cost", required=False),
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
         ],
     },
     GameNames.SHARD_AGGREGATOR.value: {
@@ -77,6 +79,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="visibility", required=False),
             OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
         ],
     },
     GameNames.PCF2_SHARD_COMBINER.value: {
@@ -142,6 +145,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="use_new_output_format", required=False),
             OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
         ],
     },
     GameNames.PCF2_AGGREGATION.value: {
@@ -161,6 +165,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="use_new_output_format", required=False),
             OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
         ],
     },
 }

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -147,6 +147,10 @@ class AggregateShardsStageService(PrivateComputationStageService):
                 "run_id": pc_instance.infra_config.run_id,
             },
         ]
+        if pc_instance.feature_flags is not None:
+            for arg in game_args:
+                arg["pc_feature_flags"] = pc_instance.feature_flags
+
         # We should only export visibility to scribe when it's set
         if (
             pc_instance.product_config.common.result_visibility

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -190,6 +190,10 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
             "run_id": private_computation_instance.infra_config.run_id,
         }
+        if private_computation_instance.feature_flags is not None:
+            common_compute_game_args[
+                "pc_feature_flags"
+            ] = private_computation_instance.feature_flags
 
         game_args = []
 

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -180,6 +180,10 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "use_new_output_format": False,
             "run_id": private_computation_instance.infra_config.run_id,
         }
+        if private_computation_instance.feature_flags is not None:
+            common_game_args[
+                "pc_feature_flags"
+            ] = private_computation_instance.feature_flags
 
         game_args = [
             {

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -186,6 +186,10 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             "use_postfix": True,
             "run_id": private_computation_instance.infra_config.run_id,
         }
+        if private_computation_instance.feature_flags is not None:
+            common_game_args[
+                "pc_feature_flags"
+            ] = private_computation_instance.feature_flags
 
         game_args = [
             {

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -184,6 +184,10 @@ class PCF2LiftStageService(PrivateComputationStageService):
             "log_cost": self._log_cost_to_s3,
             "run_id": private_computation_instance.infra_config.run_id,
         }
+        if private_computation_instance.feature_flags is not None:
+            common_compute_game_args[
+                "pc_feature_flags"
+            ] = private_computation_instance.feature_flags
 
         game_args = []
 

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -15,6 +15,7 @@ from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
     PrivateComputationGameType,
 )
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -86,6 +87,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
                 else "",
                 "log_cost": True,
                 "run_id": self.run_id,
+                "pc_feature_flags": private_computation_instance.feature_flags,
             }
         ]
 
@@ -115,6 +117,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
             run_id=self.run_id,
+            pcs_features={PCSFeature.PCS_DUMMY},
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -108,6 +108,7 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                 "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
                 "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
                 "run_id": self.run_id,
+                "pc_feature_flags": PCSFeature.PCS_DUMMY.value,
             },
             {
                 "input_base_path": private_computation_instance.data_processing_output_path,
@@ -116,6 +117,7 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                 "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
                 "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
                 "run_id": self.run_id,
+                "pc_feature_flags": PCSFeature.PCS_DUMMY.value,
             },
         ]
 

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -756,13 +756,15 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         input_directory = "input_directory"
         output_directory = "output_directory"
         server_ips = ["192.0.2.0", "192.0.2.1"]
-        game_args = {
-            "input_filenames": input_file,
-            "input_directory": input_directory,
-            "output_filenames": output_file,
-            "output_directory": output_directory,
-            "concurrency": 1,
-        }
+        game_args = [
+            {
+                "input_filenames": input_file,
+                "input_directory": input_directory,
+                "output_filenames": output_file,
+                "output_directory": output_directory,
+                "concurrency": 1,
+            }
+        ]
         binary_version = self.onedocker_binary_config_map[
             OneDockerBinaryNames.LIFT_COMPUTE.value
         ].binary_version
@@ -776,8 +778,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             binary_version=binary_version,
             container_timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
             server_ips=server_ips,
-            # pyre-fixme[6]: For 9th param expected `Optional[List[Dict[str,
-            #  typing.Any]]]` but got `Dict[str, Union[int, str]]`.
             game_args=game_args,
         )
 


### PR DESCRIPTION
Summary:
## Why
We rolled out private computation feature gating in PCS tier https://fb.workplace.com/groups/164332244998024/permalink/919133852851189/
This diff stack is to propagate feature flags to PCA/PCF

## What
* propagate feature flags to binaries

## Next
* adding static function to loads the feature flags, and implemenet something like PCFeatures::isEnabled("myFlagName")

Differential Revision: D38367989

