### PR TITLE
Adding run_id to Id combiner binaries.

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
     folly::dynamic extra_info = folly::dynamic::object(
         "padding_size", FLAGS_padding_size)("spine_path", FLAGS_spine_path)(
         "data_path",
-        FLAGS_data_path)("output_path", FLAGS_output_path)("sort_strategy", FLAGS_sort_strategy);
+        FLAGS_data_path)("output_path", FLAGS_output_path)("sort_strategy", FLAGS_sort_strategy)("run_id", FLAGS_run_id);
 
     XLOGF(
         INFO,

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
@@ -36,3 +36,7 @@ DEFINE_string(
     ".s3.us-west-2.amazonaws.com/",
     "s3 region name");
 DEFINE_string(protocol_type, "PID", "protocol type");
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h
@@ -21,3 +21,4 @@ DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
 DECLARE_int32(max_id_column_cnt);
 DECLARE_string(protocol_type);
+DECLARE_string(run_id);

--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp
@@ -30,3 +30,7 @@ DEFINE_string(
     "Sorting strategy selected for the output data - options: (sort|keep_original)");
 DEFINE_int32(max_id_column_cnt, 1, "Maximum number of id columns to use as id");
 DEFINE_string(protocol_type, "PID", "protocol type");
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");

--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h
@@ -17,3 +17,4 @@ DECLARE_int32(multi_conversion_limit);
 DECLARE_string(sort_strategy);
 DECLARE_int32(max_id_column_cnt);
 DECLARE_string(protocol_type);
+DECLARE_string(run_id);


### PR DESCRIPTION
Summary:
# Context
For Centralized Logging, we will use a unique run_id to identify a PL/PA run, this run_id will be generated on the partner side and will be consumed by publisher side during instance creation. This run_id will be included in all the multiple ENT instances involved in the run and will also be shared with all the backend components (thrift, PCS, PCA binaries).
Design Doc
https://docs.google.com/document/d/1vZNOq8GUT1D_7-MjSh2yNpUKVEsvpsYeFx1PjceyelQ/edit?usp=sharing
RunID Format
RunId will be in UUID format. Ex - 2621fda2-0eca-11ed-861d-0242ac120002

# This diff
Add run_id to Id combiner binaries.

Differential Revision: D38733555

