### PR TITLE
Fix for failing pcf2 lift github tests.

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
     folly::dynamic extra_info = folly::dynamic::object(
         "padding_size", FLAGS_padding_size)("spine_path", FLAGS_spine_path)(
         "data_path",
-        FLAGS_data_path)("output_path", FLAGS_output_path)("sort_strategy", FLAGS_sort_strategy);
+        FLAGS_data_path)("output_path", FLAGS_output_path)("sort_strategy", FLAGS_sort_strategy)("run_id", FLAGS_run_id);
 
     XLOGF(
         INFO,

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
@@ -36,3 +36,7 @@ DEFINE_string(
     ".s3.us-west-2.amazonaws.com/",
     "s3 region name");
 DEFINE_string(protocol_type, "PID", "protocol type");
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h
@@ -21,3 +21,4 @@ DECLARE_string(log_cost_s3_bucket);
 DECLARE_string(log_cost_s3_region);
 DECLARE_int32(max_id_column_cnt);
 DECLARE_string(protocol_type);
+DECLARE_string(run_id);

--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp
@@ -30,3 +30,7 @@ DEFINE_string(
     "Sorting strategy selected for the output data - options: (sort|keep_original)");
 DEFINE_int32(max_id_column_cnt, 1, "Maximum number of id columns to use as id");
 DEFINE_string(protocol_type, "PID", "protocol type");
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");

--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h
@@ -17,3 +17,4 @@ DECLARE_int32(multi_conversion_limit);
 DECLARE_string(sort_strategy);
 DECLARE_int32(max_id_column_cnt);
 DECLARE_string(protocol_type);
+DECLARE_string(run_id);

--- a/fbpcs/data_processing/service/id_spine_combiner.py
+++ b/fbpcs/data_processing/service/id_spine_combiner.py
@@ -36,6 +36,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
         # run_name is the binary name used by the log cost to s3 feature
         run_name: Optional[str] = None,
         log_cost: Optional[bool] = False,
+        run_id: Optional[str] = None,
     ) -> List[str]:
         # TODO: Combiner could be made async so we don't have to spawn our
         # own ThreadPoolExecutor here and instead use async primitives
@@ -55,6 +56,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
                 run_name=run_name,
                 sort_strategy=sort_strategy,
                 log_cost=log_cost,
+                run_id=run_id,
             )
             cmd_args_list.append(cmd_args)
         return cmd_args_list

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -280,6 +280,7 @@ async def start_combiner_service(
         padding_size=padding_size,
         multi_conversion_limit=multi_conversion_limit,
         log_cost=log_cost,
+        run_id=private_computation_instance.infra_config.run_id,
     )
     env_vars = {}
     if binary_config.repository_path:

--- a/fbpcs/tests/github/bolt_config.yml
+++ b/fbpcs/tests/github/bolt_config.yml
@@ -59,14 +59,14 @@ jobs:
       input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/publisher_e2e_input.csv
       # optional args #
       output_dir: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/outputs
-      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/publisher_expected_result.json
+      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/publisher_expected_result_pcf2.json
     # partner player args
     partner:
       # required args #
       input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
       # optional args #
       output_dir: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/outputs
-      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json
+      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result_pcf2.json
     # args shared by both publisher and partner
     shared:
       # required args #


### PR DESCRIPTION
Summary:
Github tests for pcf2_lift are broken, as the expected results are not matching.
The result of pcf2_lift are different than original lift, as there is no value for testConvHistogram and controlConvHistogram.
Thus uploaded a corrected file to S3 and corrected the same in bolt_config job.

Differential Revision: D38834890

