### PR TITLE
Using factories to create network plaintext schedulers (#345)

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -6,6 +6,7 @@
  */
 
 #include <fbpcf/io/api/FileIOWrappers.h>
+#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
@@ -91,7 +92,8 @@ CalculatorApp<schedulerId>::createScheduler() {
   return useXorEncryption_
       ? fbpcf::scheduler::createLazySchedulerWithRealEngine(
             party_, *communicationAgentFactory_)
-      : fbpcf::scheduler::createNetworkPlaintextScheduler<false>(
-            party_, *communicationAgentFactory_);
+      : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
+            party_, *communicationAgentFactory_)
+            .create();
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fbpcf/io/api/FileIOWrappers.h>
+#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -46,8 +47,9 @@ class AggregationApp {
 
   void run() {
     auto scheduler = outputVisibility_ == common::Visibility::Publisher
-        ? fbpcf::scheduler::createNetworkPlaintextScheduler<false>(
+        ? fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
               MY_ROLE, *communicationAgentFactory_)
+              .create()
         : fbpcf::scheduler::createLazySchedulerWithRealEngine(
               MY_ROLE, *communicationAgentFactory_);
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationGameTest.cpp
@@ -233,8 +233,8 @@ void testAttributionResultWithScheduler(
 }
 
 TEST(AggregationGameTest, TestAttributionResultNetworkPlaintextScheduler) {
-  testAttributionResultWithScheduler(
-      fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>);
+  testAttributionResultWithScheduler(fbpcf::getSchedulerCreator<unsafe>(
+      fbpcf::SchedulerType::NetworkPlaintext));
 }
 
 TEST(AggregationGameTest, TestAttributionResultEagerScheduler) {
@@ -304,7 +304,8 @@ TEST(
     AggregationGameTest,
     TestAttributionReformattedResultNetworkPlaintextScheduler) {
   testAttributionReformattedResultWithScheduler(
-      fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>);
+      fbpcf::getSchedulerCreator<unsafe>(
+          fbpcf::SchedulerType::NetworkPlaintext));
 }
 
 TEST(AggregationGameTest, TestAttributionReformattedResultEagerScheduler) {
@@ -335,10 +336,7 @@ std::vector<uint64_t> retrieveValidAdIdsWithSchedulerAndRealEngine(
 }
 
 void testRetrieveValidAdIdsWithScheduler(
-    std::unique_ptr<fbpcf::scheduler::IScheduler> schedulerCreator(
-        int myId,
-        fbpcf::engine::communication::IPartyCommunicationAgentFactory&
-            communicationAgentFactory)) {
+    fbpcf::SchedulerCreator schedulerCreator) {
   std::vector<std::vector<TouchpointMetadata>> publisherTouchpointMetadata{
       std::vector<TouchpointMetadata>{
           TouchpointMetadata{0, 8000, true, 100, 0},
@@ -385,8 +383,8 @@ void testRetrieveValidAdIdsWithScheduler(
 }
 
 TEST(AggregationGameTest, TestRetrieveValidAdIdsNetworkPlaintextScheduler) {
-  testRetrieveValidAdIdsWithScheduler(
-      fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>);
+  testRetrieveValidAdIdsWithScheduler(fbpcf::getSchedulerCreator<unsafe>(
+      fbpcf::SchedulerType::NetworkPlaintext));
 }
 
 TEST(AggregationGameTest, TestRetrieveValidAdIdsEagerScheduler) {

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h
@@ -18,6 +18,7 @@
 #include <fbpcf/engine/communication/IPartyCommunicationAgentFactory.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/scheduler/IScheduler.h>
+#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 
 #include "fbpcs/emp_games/common/Constants.h"
@@ -66,8 +67,9 @@ class ShardCombinerApp {
     auto scheduler = useXorEncryption_
         ? fbpcf::scheduler::createLazySchedulerWithRealEngine(
               schedulerId, *communicationAgentFactory_)
-        : fbpcf::scheduler::createNetworkPlaintextScheduler<true /*unsafe*/>(
-              schedulerId, *communicationAgentFactory_);
+        : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true /*unsafe*/>(
+              schedulerId, *communicationAgentFactory_)
+              .create();
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
 
     XLOG(INFO) << "Made scheduler: " << schedulerId;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcf/pull/345

Change the callsites of the `createNetworkPlaintextScheduler` method to use the method from the NetworkPlaintextSchedulerFactory instead

- [x] TestHelper.h
- [x] BillionaireProblemGameTest.cpp
- [x] ShardCombinerApp.h
- [x] InputProcessorTest.cpp
- [x] AggregationGameTest.cpp
- [x] AggregationApp.h
- [x] AttributorTest.cpp
- [x] AggregatorTest.cpp
- [x] CalculatorApp_impl.h

Finally, will remove the createNetworkPlaintextScheduler method from SchedulerHelper.h

Reviewed By: adshastri

Differential Revision: D38724193

