### PR TITLE
Add lambda access to the minimal policy

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -183,7 +183,7 @@ resource "aws_iam_role_policy_attachment" "lambda_kinesis_role" {
 resource "aws_lambda_function" "lambda_processor" {
   s3_bucket     = var.data_processing_lambda_s3_bucket
   s3_key        = var.data_processing_lambda_s3_key
-  function_name = "cb-data-ingestion-stream-processor${var.tag_postfix}"
+  function_name = var.data_ingestion_lambda_name
   role          = aws_iam_role.lambda_iam.arn
   handler       = "data_transformation_lambda.lambda_handler"
   runtime       = "python3.8"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/variable.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/variable.tf
@@ -8,6 +8,11 @@ variable "data_processing_output_bucket" {
   default     = ""
 }
 
+variable "data_ingestion_lambda_name" {
+  description = "The data ingestion Lambda function name"
+  default     = ""
+}
+
 variable "data_processing_lambda_s3_bucket" {
   description = "Source S3 bucket for data processing lambda deployment file"
   default     = ""

--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -291,6 +291,7 @@ deploy_aws_resources() {
         -var "tag_postfix=$tag_postfix" \
         -var "aws_account_id=$aws_account_id" \
         -var "data_processing_output_bucket=$s3_bucket_data_pipeline" \
+        -var "data_ingestion_lambda_name=$data_ingestion_lambda_name" \
         -var "data_processing_lambda_s3_bucket=$s3_bucket_for_storage" \
         -var "data_processing_lambda_s3_key=lambda.zip" \
         -var "data_upload_key_path=$data_upload_key_path" \
@@ -365,6 +366,7 @@ deploy_aws_resources() {
         --policy_name "$policy_name" \
         --region "$region" \
         --firehose_stream_name "$firehose_stream_name" \
+        --data_ingestion_lambda_name "$data_ingestion_lambda_name" \
         --data_bucket_name "$s3_bucket_data_pipeline" \
         --config_bucket_name "$s3_bucket_for_storage" \
         --database_name "$database_name" \
@@ -410,6 +412,7 @@ glue_crawler_name="mpc-events-crawler${tag_postfix}"
 table_name=${s3_bucket_data_pipeline//-/_}
 data_upload_key_path="semi-automated-data-ingestion"
 query_results_key_path="query-results"
+data_ingestion_lambda_name="cb-data-ingestion-stream-processor${tag_postfix}"
 
 if "$undeploy"
 then

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -294,6 +294,7 @@ class AwsDeploymentHelper:
             "FIREHOSE_STREAM_NAME": policy_params.firehose_stream_name,
             "DATEBASE_NAME": policy_params.database_name,
             "TABLE_NAME": policy_params.table_name,
+            "DATA_INGESTION_LAMBDA_NAME": policy_params.data_ingestion_lambda_name,
         }
 
         file_path = os.path.join(os.path.dirname(__file__), file_name)

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -48,6 +48,7 @@ class AwsDeploymentHelperTool:
                 table_name=self.cli_args.table_name,
                 cluster_name=self.cli_args.cluster_name,
                 ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
+                data_ingestion_lambda_name=self.cli_args.data_ingestion_lambda_name,
             )
             self.aws_deployment_helper_obj.create_policy(
                 policy_name=self.cli_args.policy_name, policy_params=policy_params

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
@@ -110,6 +110,14 @@ class AwsParserBuilder:
             required=False,
             help="ECS task execution role name",
         )
+
+        iam_policy_command_group.add_argument(
+            "--data_ingestion_lambda_name",
+            type=str,
+            required=False,
+            help="Data ingestion Lambda name",
+        )
+
         return self
 
     def with_attach_iam_policy_parser_arguments(

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
@@ -44,6 +44,13 @@
             ]
         },
         {
+            "Action": [
+                "lambda:*"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${DATA_INGESTION_LAMBDA_NAME}"
+        },
+        {
             "Effect": "Allow",
             "Action": "ecs:*",
             "Resource": [

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -17,3 +17,4 @@ class PolicyParams:
     table_name: str
     cluster_name: str
     ecs_task_execution_role_name: str
+    data_ingestion_lambda_name: str

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
@@ -30,6 +30,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
         test_table_name = "test-table"
         test_cluster_name = "test-cluster"
         test_ecs_task_execution_role_name = "test-ecs-execution-role"
+        test_data_ingestion_lambda_name = "test-di-lambda-name"
 
         with self.subTest("add_iam_user_basic"):
             cli_args = self.setup_cli_args_mock()
@@ -64,6 +65,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
             cli_args.table_name = test_table_name
             cli_args.cluster_name = test_cluster_name
             cli_args.ecs_task_execution_role_name = test_ecs_task_execution_role_name
+            cli_args.data_ingestion_lambda_name = test_data_ingestion_lambda_name
             aws_deployment_helper_tool = AwsDeploymentHelperTool(cli_args)
 
             aws_deployment_helper_tool.create()
@@ -78,6 +80,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
                     table_name=test_table_name,
                     cluster_name=test_cluster_name,
                     ecs_task_execution_role_name=test_ecs_task_execution_role_name,
+                    data_ingestion_lambda_name=test_data_ingestion_lambda_name,
                 ),
             )
 


### PR DESCRIPTION
Summary:
The server needs access to the data ingestion lambda function so that it can
return the lambda function status when rendering the validation section of the
diagnostics page.

Differential Revision: D38842121

