### PR TITLE
Back out "Using factories to create network plaintext schedulers"

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -6,7 +6,6 @@
  */
 
 #include <fbpcf/io/api/FileIOWrappers.h>
-#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
@@ -92,8 +91,7 @@ CalculatorApp<schedulerId>::createScheduler() {
   return useXorEncryption_
       ? fbpcf::scheduler::createLazySchedulerWithRealEngine(
             party_, *communicationAgentFactory_)
-      : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
-            party_, *communicationAgentFactory_)
-            .create();
+      : fbpcf::scheduler::createNetworkPlaintextScheduler<false>(
+            party_, *communicationAgentFactory_);
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -25,9 +25,8 @@ Attributor<schedulerId> createAttributorWithScheduler(
     int numConversionsPerUser,
     std::reference_wrapper<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
-    std::reference_wrapper<fbpcf::scheduler::ISchedulerFactory<unsafe>>
-        schedulerFactory) {
-  auto scheduler = schedulerFactory.get().create();
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myRole, factory);
   fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
       std::move(scheduler));
   auto inputProcessor =
@@ -63,15 +62,9 @@ class AttributorTest : public ::testing::Test {
         epoch,
         numConversionsPerUser);
 
+    auto schedulerCreator =
+        fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>;
     auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
-
-    auto schedulerFactory0 =
-        fbpcf::scheduler::NetworkPlaintextSchedulerFactory<unsafe>(
-            0, *factories[0]);
-
-    auto schedulerFactory1 =
-        fbpcf::scheduler::NetworkPlaintextSchedulerFactory<unsafe>(
-            1, *factories[1]);
 
     auto future0 = std::async(
         createAttributorWithScheduler<0>,
@@ -81,8 +74,7 @@ class AttributorTest : public ::testing::Test {
         std::reference_wrapper<
             fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
             *factories[0]),
-        std::reference_wrapper<fbpcf::scheduler::ISchedulerFactory<unsafe>>(
-            schedulerFactory0));
+        schedulerCreator);
 
     auto future1 = std::async(
         createAttributorWithScheduler<1>,
@@ -92,8 +84,7 @@ class AttributorTest : public ::testing::Test {
         std::reference_wrapper<
             fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
             *factories[1]),
-        std::reference_wrapper<fbpcf::scheduler::ISchedulerFactory<unsafe>>(
-            schedulerFactory1));
+        schedulerCreator);
 
     publisherAttributor_ = std::make_unique<Attributor<0>>(future0.get());
     partnerAttributor_ = std::make_unique<Attributor<1>>(future1.get());

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -8,7 +8,6 @@
 #include <gtest/gtest.h>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/scheduler/ISchedulerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 
@@ -24,9 +23,10 @@ InputProcessor<schedulerId> createInputProcessorWithScheduler(
     int myRole,
     InputData inputData,
     int numConversionsPerUser,
-    std::reference_wrapper<fbpcf::scheduler::ISchedulerFactory<unsafe>>
-        schedulerFactory) {
-  auto scheduler = schedulerFactory.get().create();
+    std::reference_wrapper<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
+    fbpcf::SchedulerCreator schedulerCreator) {
+  auto scheduler = schedulerCreator(myRole, factory);
   fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
       std::move(scheduler));
   return InputProcessor<schedulerId>(myRole, inputData, numConversionsPerUser);
@@ -61,31 +61,29 @@ class InputProcessorTest : public ::testing::TestWithParam<bool> {
         epoch,
         numConversionsPerUser);
 
+    auto schedulerCreator =
+        fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>;
     auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
-
-    auto schedulerFactory0 =
-        fbpcf::scheduler::NetworkPlaintextSchedulerFactory<unsafe>(
-            0, *factories[0]);
-
-    auto schedulerFactory1 =
-        fbpcf::scheduler::NetworkPlaintextSchedulerFactory<unsafe>(
-            1, *factories[1]);
 
     auto future0 = std::async(
         createInputProcessorWithScheduler<0>,
         0,
         publisherInputData,
         numConversionsPerUser,
-        std::reference_wrapper<fbpcf::scheduler::ISchedulerFactory<unsafe>>(
-            schedulerFactory0));
+        std::reference_wrapper<
+            fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+            *factories[0]),
+        schedulerCreator);
 
     auto future1 = std::async(
         createInputProcessorWithScheduler<1>,
         1,
         partnerInputData,
         numConversionsPerUser,
-        std::reference_wrapper<fbpcf::scheduler::ISchedulerFactory<unsafe>>(
-            schedulerFactory1));
+        std::reference_wrapper<
+            fbpcf::engine::communication::IPartyCommunicationAgentFactory>(
+            *factories[1]),
+        schedulerCreator);
 
     publisherInputProcessor_ = future0.get();
     partnerInputProcessor_ = future1.get();

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <fbpcf/io/api/FileIOWrappers.h>
-#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -47,9 +46,8 @@ class AggregationApp {
 
   void run() {
     auto scheduler = outputVisibility_ == common::Visibility::Publisher
-        ? fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
+        ? fbpcf::scheduler::createNetworkPlaintextScheduler<false>(
               MY_ROLE, *communicationAgentFactory_)
-              .create()
         : fbpcf::scheduler::createLazySchedulerWithRealEngine(
               MY_ROLE, *communicationAgentFactory_);
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationGameTest.cpp
@@ -233,8 +233,8 @@ void testAttributionResultWithScheduler(
 }
 
 TEST(AggregationGameTest, TestAttributionResultNetworkPlaintextScheduler) {
-  testAttributionResultWithScheduler(fbpcf::getSchedulerCreator<unsafe>(
-      fbpcf::SchedulerType::NetworkPlaintext));
+  testAttributionResultWithScheduler(
+      fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(AggregationGameTest, TestAttributionResultEagerScheduler) {
@@ -304,8 +304,7 @@ TEST(
     AggregationGameTest,
     TestAttributionReformattedResultNetworkPlaintextScheduler) {
   testAttributionReformattedResultWithScheduler(
-      fbpcf::getSchedulerCreator<unsafe>(
-          fbpcf::SchedulerType::NetworkPlaintext));
+      fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(AggregationGameTest, TestAttributionReformattedResultEagerScheduler) {
@@ -336,7 +335,10 @@ std::vector<uint64_t> retrieveValidAdIdsWithSchedulerAndRealEngine(
 }
 
 void testRetrieveValidAdIdsWithScheduler(
-    fbpcf::SchedulerCreator schedulerCreator) {
+    std::unique_ptr<fbpcf::scheduler::IScheduler> schedulerCreator(
+        int myId,
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory&
+            communicationAgentFactory)) {
   std::vector<std::vector<TouchpointMetadata>> publisherTouchpointMetadata{
       std::vector<TouchpointMetadata>{
           TouchpointMetadata{0, 8000, true, 100, 0},
@@ -383,8 +385,8 @@ void testRetrieveValidAdIdsWithScheduler(
 }
 
 TEST(AggregationGameTest, TestRetrieveValidAdIdsNetworkPlaintextScheduler) {
-  testRetrieveValidAdIdsWithScheduler(fbpcf::getSchedulerCreator<unsafe>(
-      fbpcf::SchedulerType::NetworkPlaintext));
+  testRetrieveValidAdIdsWithScheduler(
+      fbpcf::scheduler::createNetworkPlaintextScheduler<unsafe>);
 }
 
 TEST(AggregationGameTest, TestRetrieveValidAdIdsEagerScheduler) {

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h
@@ -18,7 +18,6 @@
 #include <fbpcf/engine/communication/IPartyCommunicationAgentFactory.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/scheduler/IScheduler.h>
-#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include <fbpcf/scheduler/SchedulerHelper.h>
 
 #include "fbpcs/emp_games/common/Constants.h"
@@ -67,9 +66,8 @@ class ShardCombinerApp {
     auto scheduler = useXorEncryption_
         ? fbpcf::scheduler::createLazySchedulerWithRealEngine(
               schedulerId, *communicationAgentFactory_)
-        : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true /*unsafe*/>(
-              schedulerId, *communicationAgentFactory_)
-              .create();
+        : fbpcf::scheduler::createNetworkPlaintextScheduler<true /*unsafe*/>(
+              schedulerId, *communicationAgentFactory_);
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
 
     XLOG(INFO) << "Made scheduler: " << schedulerId;


### PR DESCRIPTION
Summary:
Original commit changeset: c97f4865bed0

Original Phabricator Diff: D38724193 (https://github.com/facebookresearch/fbpcs/commit/857f5aeacb26796c152fb9c7ccf2cdb2fc6e6339)

Reviewed By: adshastri

Differential Revision: D38842909

