### PR TITLE
Fix id_ column order error when run idSwap

### DIFF
--- a/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombinerTest.cpp
@@ -243,3 +243,34 @@ TEST_F(MrPidLiftIdCombinerTest, TestRunValidSortedSpinePublisherWithDup) {
       "id_,opportunity_timestamp,test_flag,num_impressions,num_clicks,total_spend,breakdown_id,opportunity,unregistered\n1,100,1,3,7,500,1,1,2\n10,200,0,2,2,100,0,1,6\n100,0,0,0,0,0,0,0,0\n123,0,0,0,0,0,0,0,0\n2,0,0,0,0,0,0,0,0\n3,150,0,5,5,400,1,1,4\n";
   EXPECT_EQ(outputFile.str(), expectedStr);
 }
+
+TEST_F(
+    MrPidLiftIdCombinerTest,
+    TestRunValidSortedSpinePublisherWithDupWithLastId) {
+  std::vector<std::string> spineInput = {
+      "opportunity_timestamp,test_flag,num_impressions,num_clicks,total_spend,breakdown_id,unregistered,id_",
+      "100,1,1,3,200,0,2,1",
+      "120,1,2,4,300,1,3,1",
+      "150,0,2,2,150,0,4,3",
+      "160,0,3,3,250,1,5,3",
+      "200,0,2,2,100,0,6,10",
+      "0,0,0,0,0,0,0,100",
+      "0,0,0,0,0,0,0,123",
+      "0,0,0,0,0,0,0,2",
+  };
+
+  createData(spineInput);
+  MrPidLiftIdCombiner p(
+      FLAGS_spine_path,
+      FLAGS_output_path,
+      FLAGS_tmp_directory,
+      FLAGS_sort_strategy,
+      FLAGS_max_id_column_cnt,
+      FLAGS_protocol_type);
+
+  p.run();
+  auto outputFile = readfile();
+  std::string expectedStr =
+      "id_,opportunity_timestamp,test_flag,num_impressions,num_clicks,total_spend,breakdown_id,opportunity,unregistered\n1,100,1,3,7,500,1,1,2\n10,200,0,2,2,100,0,1,6\n100,0,0,0,0,0,0,0,0\n123,0,0,0,0,0,0,0,0\n2,0,0,0,0,0,0,0,0\n3,150,0,5,5,400,1,1,4\n";
+  EXPECT_EQ(outputFile.str(), expectedStr);
+}


### PR DESCRIPTION
Summary:
## What is this stack?
Current MR PID id combiner always expects the first column in spine file as the id_.

Current MR PID protocol will output id_ as the last column.

aggregateLiftNonIdColumns() always expect first column as the id_.

When call aggregateLiftNonIdColumns() in MR PID ID combiner , it will have string to int error since we did not erase the id_ column and id_column is string.

error:
{F762275735}

##  What
The solution to fix the bug:
Same as the idSwapMultiKey():
Find the id_ column index, in MR PID, we only have one id_

      1. For header, remove the id_ column and add id_ as the first column. Get the index of id_ in header.
      2. For other rows, assign the id_ column as the private id and the rest columns as data_rows.  Create the pidToDataMap map with two private id and data rows.
      3. Run aggregateLiftNonIdColumns by reading spine file again. spineIdFileDup has header.
            1. Skip the header.
            2. Read each line to get private id by using index we found in the header.
            3. Do aggregateLiftNonIdColumns() on all records which belong to the same private id
            4. output the private id and aggregated data row
      4. Add a MR PID test which the publisher data has id_  as the last column

Differential Revision: D38851205

