### PR TITLE
Moving create S3 folder logic from download_logs to aws_cloud as it is specific to aws

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/cloud/test/test_aws_cloud.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud/test/test_aws_cloud.py
@@ -119,12 +119,15 @@ class TestAwsCloud(unittest.TestCase):
             self.assertEqual(
                 expected,
                 self.aws_container_logs.get_s3_folder_contents(
-                    "bucket", "folder", "def678"
+                    bucket_name="bucket",
+                    folder_name="folder",
+                    next_continuation_token="def678",
                 ),
             )
             self.aws_container_logs.s3_client.list_objects_v2.assert_called_once_with(
                 Bucket="bucket",
                 Prefix="folder",
+                MaxKeys=1,
                 ContinuationToken="def678",
             )
 

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -75,7 +75,7 @@ class TestDownloadLogs(unittest.TestCase):
         # Error cases #
         ###############
         error_cases = [
-            ("head_bucket", "NoSuchBucket", "Couldn't find bucket.*"),
+            ("head_bucket", "NoSuchBucket", "Couldn't find the S3 bucket.*"),
             ("head_bucket", "SomethingElseHappenedException", "Couldn't find the S3.*"),
         ]
         for s3_endpoint, error_code, exc_regex in error_cases:


### PR DESCRIPTION
Summary:
**What**
`download_logs.py` file has the python code which helps in downloading container logs and uploading logs to AWS S3. `download_logs.py` has cloud specific code which needs to be moved out to cloud library.

**Change**
Moving create S3 folder logic from `download_logs.py` to `aws_cloud.py` as it is specific to AWS
This is a follow up diff of D38646302 (https://github.com/facebookresearch/fbpcs/commit/83b38707533d59b04e7a10db728c5f5bcb5d37e8)
Also addressing review comment on D38694693 (https://github.com/facebookresearch/fbpcs/commit/193f1d3120b479e550f094d31ae1baa96f5542f8)

**Context**
https://docs.google.com/document/d/1cMD9IQ8uF6MS1PRvOh8cr-1el7MO952SjUanAzAGJzw/edit?usp=sharing

Differential Revision: D38855238

