### PR TITLE
remove stage flow argument from BoltJob

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -44,6 +44,12 @@ class BoltClient(ABC):
         pass
 
     @abstractmethod
+    async def get_stage_flow(
+        self, instance_id: str
+    ) -> Optional[Type[PrivateComputationBaseStageFlow]]:
+        pass
+
+    @abstractmethod
     async def run_stage(
         self,
         instance_id: str,

--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -7,12 +7,13 @@
 # pyre-strict
 
 from abc import ABC
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from typing import Optional, Type
 
-from dataclasses_json import config, DataClassJsonMixin
+from dataclasses_json import DataClassJsonMixin
 from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
+from fbpcs.bolt.exceptions import IncompatibleStageError
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -38,41 +39,32 @@ class BoltJob(DataClassJsonMixin):
     job_name: str
     publisher_bolt_args: BoltPlayerArgs
     partner_bolt_args: BoltPlayerArgs
-    stage_flow: Type[PrivateComputationBaseStageFlow] = field(
-        metadata={
-            **config(
-                # the enum will be represented as a list of its members, so we can
-                # use the first enum member to get the class name
-                encoder=lambda x: x[0].get_cls_name(),
-                # if no value is provided in the yaml file, then the dataclass json
-                # library will return the default stage flow. Otherwise, if it was
-                # provided in the yaml file, we should decode the string.
-                decoder=lambda x: x
-                if x is PrivateComputationBaseStageFlow
-                else PrivateComputationBaseStageFlow.cls_name_to_cls(x),
-            )
-        },
-    )
     poll_interval: int = DEFAULT_POLL_INTERVAL_SEC
     num_tries: Optional[int] = None
-    final_stage: Optional[PrivateComputationBaseStageFlow] = None
 
-    def __post_init__(self) -> None:
-        if self.stage_flow is PrivateComputationBaseStageFlow:
-            raise ValueError(
-                f"Stage flow should not be {PrivateComputationBaseStageFlow}, pass a specific stage flow."
-            )
-        if self.final_stage is None:
-            self.final_stage = self.stage_flow.get_last_stage()
+    # allows the final stage to be configured for each job to stop a run early
+    # if one isn't given, final_stage defaults to the final stage of the job's stage_flow
+    final_stage: Optional[PrivateComputationBaseStageFlow] = None
 
     def is_finished(
         self,
         publisher_status: PrivateComputationInstanceStatus,
         partner_status: PrivateComputationInstanceStatus,
+        stage_flow: Type[PrivateComputationBaseStageFlow],
     ) -> bool:
+        # TODO: T130069872 There is a potential risk that graph API's final_stage is RESULTS_READY, which is translated to AGGREGATION COMPLETED
+        # https://fburl.com/code/j3dl2uld, if final_stage defaults to stage_flow's last stage then it will be stuck
+        if (
+            self.final_stage is not None
+            and self.final_stage.get_cls_name() != stage_flow.get_cls_name()
+        ):
+            raise IncompatibleStageError(
+                f"Final stage {self.final_stage} is not part of {stage_flow.get_cls_name()}"
+            )
+
         final_status = (
             self.final_stage.completed_status
             if self.final_stage
-            else self.stage_flow.get_last_stage().completed_status
+            else stage_flow.get_last_stage().completed_status
         )
         return (publisher_status is final_status) and (partner_status is final_status)

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -147,6 +147,12 @@ class BoltPCSClient(BoltClient):
         )
         return instance.infra_config.instance_id
 
+    async def get_stage_flow(
+        self, instance_id: str
+    ) -> Optional[Type[PrivateComputationBaseStageFlow]]:
+        pc_instance = self.pcs.get_instance(instance_id)
+        return pc_instance.stage_flow
+
     async def run_stage(
         self,
         instance_id: str,

--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -108,7 +108,6 @@ def create_job_list(job_config_list: Dict[str, Any]) -> List[BoltJob]:
             job_name=job_name,
             publisher_bolt_args=publisher_bolt_args,
             partner_bolt_args=partner_bolt_args,
-            stage_flow=publisher_create_instance_args.stage_flow_cls,
             poll_interval=job_specific_args.get(
                 "poll_interval", DEFAULT_POLL_INTERVAL_SEC
             ),

--- a/fbpcs/bolt/test/test_bolt_job.py
+++ b/fbpcs/bolt/test/test_bolt_job.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest import mock
+
+from fbpcs.bolt.bolt_job import BoltJob
+from fbpcs.bolt.exceptions import IncompatibleStageError
+from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_flow import (
+    PrivateComputationDecoupledStageFlow,
+)
+
+from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
+)
+
+
+class TestBoltJob(unittest.TestCase):
+    @mock.patch("fbpcs.bolt.bolt_job.BoltPlayerArgs")
+    @mock.patch("fbpcs.bolt.bolt_job.BoltPlayerArgs")
+    def test_job_is_finished(
+        self,
+        mock_publisher_args,
+        mock_partner_args,
+    ) -> None:
+        for (
+            job_final_stage,
+            publisher_status,
+            partner_status,
+            stage_flow,
+            expected_result,
+            expected_side_effect,
+        ) in self._get_test_data():
+            with self.subTest(
+                job_final_stage=job_final_stage,
+                publisher_status=publisher_status,
+                partner_status=partner_status,
+                stage_flow=stage_flow,
+                expected_result=expected_result,
+                expected_side_effect=expected_side_effect,
+            ):
+                job = BoltJob(
+                    job_name="test",
+                    publisher_bolt_args=mock_publisher_args,
+                    partner_bolt_args=mock_partner_args,
+                    final_stage=job_final_stage,
+                )
+                if expected_side_effect:
+                    with self.assertRaises(IncompatibleStageError):
+                        job.is_finished(
+                            publisher_status=publisher_status,
+                            partner_status=partner_status,
+                            stage_flow=stage_flow,
+                        )
+                else:
+                    result = job.is_finished(
+                        publisher_status=publisher_status,
+                        partner_status=partner_status,
+                        stage_flow=stage_flow,
+                    )
+                    self.assertEqual(expected_result, result)
+
+    def _get_test_data(self):
+        # job_final_stage, publisher_status, partner_status, stage_flow, expected_result, expected_side_effect,
+        return (
+            (
+                PrivateComputationStageFlow.AGGREGATE,
+                PrivateComputationStageFlow.AGGREGATE.completed_status,
+                PrivateComputationStageFlow.AGGREGATE.completed_status,
+                PrivateComputationStageFlow,
+                True,
+                False,
+            ),
+            (
+                PrivateComputationStageFlow.AGGREGATE,
+                PrivateComputationStageFlow.AGGREGATE.completed_status,
+                PrivateComputationStageFlow.COMPUTE.completed_status,
+                PrivateComputationStageFlow,
+                False,
+                False,
+            ),
+            (  # final_stage is None, taking stage flow
+                None,
+                PrivateComputationStageFlow.get_last_stage().completed_status,
+                PrivateComputationStageFlow.get_last_stage().completed_status,
+                PrivateComputationStageFlow,
+                True,
+                False,
+            ),
+            (  # Expect exception
+                PrivateComputationStageFlow.AGGREGATE,
+                PrivateComputationStageFlow.AGGREGATE.completed_status,
+                PrivateComputationStageFlow.AGGREGATE.completed_status,
+                PrivateComputationDecoupledStageFlow,
+                False,
+                True,
+            ),
+        )

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -9,7 +9,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 import requests
 
@@ -143,6 +143,12 @@ class BoltGraphAPIClient(BoltClient):
         raise TypeError(
             f"Instance args must be of type {BoltPLGraphAPICreateInstanceArgs} or {BoltPAGraphAPICreateInstanceArgs}"
         )
+
+    async def get_stage_flow(
+        self, instance_id: str
+    ) -> Optional[Type[PrivateComputationBaseStageFlow]]:
+        """GraphAPI didn't return stageflow info"""
+        return None
 
     async def run_stage(
         self,

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -187,7 +187,6 @@ def run_study(
                 job_name=f"Job [cell_id: {cell_id}][obj_id: {obj_id}]",
                 publisher_bolt_args=publisher_args,
                 partner_bolt_args=partner_args,
-                stage_flow=stage_flow,
                 num_tries=num_tries,
                 final_stage=final_stage,
                 poll_interval=60,

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -200,7 +200,6 @@ def run_attribution(
             job_name=f"Job [dataset_id: {dataset_id}][timestamp: {dt_arg}",
             publisher_bolt_args=publisher_args,
             partner_bolt_args=partner_args,
-            stage_flow=stage_flow,
             num_tries=num_tries,
             final_stage=final_stage,
             poll_interval=60,


### PR DESCRIPTION
Summary:
## Why
We passed stage flow via BoltJob to bolt runner as the last stage identifier if the final stage argument didn't specific, this diff to have a central place (BoltClient) to have stage flow

## What
* add abstract method `get_stage_flow` in Bolt client
* delete stage_flow from BoltJob
* update job `is_finished` to have stage flow pass in from runner
* runner call publisher/partner client to get stage flow

Differential Revision: D38892288

