### PR TITLE
added regression test for partner output.txt logs in Github one_command_runner_test workflow

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -32,6 +32,7 @@ env:
   FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
   FBPCS_IMAGE_NAME: coordinator
   FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
+  CONSOLE_OUTPUT_FILE: /tmp/output.txt
 
 jobs:
   ### Private Lift E2E tests
@@ -49,6 +50,8 @@ jobs:
         run: echo ${{ github.event.inputs.tracker_hash}}
 
       - name: One command runner
+        id: runner
+        continue-on-error: true
         run: |
           ./fbpcs/scripts/run_fbpcs.sh run_study \
           ${{ github.event.inputs.study_id }} \
@@ -56,7 +59,18 @@ jobs:
           --input_paths=${{ github.event.inputs.input_path }} \
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
           -- \
-          --version=${{ github.event.inputs.tag }}
+          --version=${{ github.event.inputs.tag }} > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
+
+      - name: Print runner console output
+        continue-on-error: true
+        run: |
+          cat ${{env.CONSOLE_OUTPUT_FILE}}
+
+      - name: Abort when runner failed
+        if: steps.runner.outcome != 'success'
+        run: |
+          echo "Please check the runner console output in the above step." ; \
+          exit 1
 
       - name: Validate Results
         # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
@@ -70,3 +84,10 @@ jobs:
           --expected_result_path=${{ github.event.inputs.expected_result_path }} \
           -- \
           --version=${{ github.event.inputs.tag }}
+
+      - name: Validate runner logs
+        # First command extracts the pc-cli log lines starting with "... ! Command line: ..." into a file.
+        run: |
+          sed -n '/^.* ! Command line: .*/,$p' < ${{env.CONSOLE_OUTPUT_FILE}} > ${{env.CONSOLE_OUTPUT_FILE}}.extracted
+          docker run --rm -v "${{env.CONSOLE_OUTPUT_FILE}}.extracted:${{env.CONSOLE_OUTPUT_FILE}}" ${{env.FBPCS_CONTAINER_REPO_URL}}/${{env.FBPCS_IMAGE_NAME}}:${{github.event.inputs.tag}} \
+          python -m fbpcs.infra.logging_service.log_analyzer.log_analyzer ${{env.CONSOLE_OUTPUT_FILE}} --validate_one_runner_logs


### PR DESCRIPTION
Summary:
Output.txt logs are redirected to /tmp/output.txt in the AWS build machine, and the logs are always printed into the workflow message upon success or failure.
When runner failed, the workflow will abort.

Differential Revision: D38849701

