### PR TITLE
Migrate all constructors to use the struct TlsInfo instead of raw arguments (#362)

### DIFF
--- a/fbpcs/emp_games/compactor/main.cpp
+++ b/fbpcs/emp_games/compactor/main.cpp
@@ -82,6 +82,13 @@ int main(int argc, char** argv) {
              << ", size: " << input.size() << "\n";
 
   XLOG(INFO) << "Creating communication agent factory\n";
+
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -91,7 +98,7 @@ int main(int argc, char** argv) {
            {PARTNER_ROLE, {FLAGS_host, FLAGS_port}}}};
   auto commAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      FLAGS_party, std::move(partyInfos), "compactor_traffic");
+      FLAGS_party, std::move(partyInfos), tlsInfo, "compactor_traffic");
 
   XLOG(INFO) << "Creating scheduler\n";
   auto scheduler = fbpcf::scheduler::createLazySchedulerWithRealEngine(

--- a/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
@@ -91,12 +91,18 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
             {{0, {serverIp, port + index * 100}},
              {1, {serverIp, port + index * 100}}});
 
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo
+        tlsInfo;
+    tlsInfo.certPath = "";
+    tlsInfo.keyPath = "";
+    tlsInfo.passphrasePath = "";
+    tlsInfo.useTls = false;
+
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
         PARTY,
         partyInfos,
-        false,
-        "",
+        tlsInfo,
         "lift_traffic_for_thread_" + std::to_string(index));
 
     // Each CalculatorApp runs numFiles sequentially on a single thread

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -42,6 +42,12 @@ void runCalculatorApp(
     std::string tlsDir,
     bool useTls,
     bool useXorEncryption) {
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = useTls ? (tlsDir + "/cert.pem") : "";
+  tlsInfo.keyPath = useTls ? (tlsDir + "/key.pem") : "";
+  tlsInfo.passphrasePath = useTls ? (tlsDir + "/passphrase.pem") : "";
+  tlsInfo.useTls = useTls;
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -50,7 +56,7 @@ void runCalculatorApp(
 
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      myId, partyInfos, useTls, tlsDir, "lift_test_traffic");
+      myId, partyInfos, tlsInfo, "lift_test_traffic");
 
   auto app = std::make_unique<CalculatorApp<schedulerId>>(
       myId,

--- a/fbpcs/emp_games/pcf2_aggregation/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_aggregation/MainUtil.h
@@ -77,12 +77,18 @@ inline common::SchedulerStatistics startAggregationAppsForShardedFilesHelper(
             {{0, {serverIp, port + index * 100}},
              {1, {serverIp, port + index * 100}}});
 
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo
+        tlsInfo;
+    tlsInfo.certPath = "";
+    tlsInfo.keyPath = "";
+    tlsInfo.passphrasePath = "";
+    tlsInfo.useTls = false;
+
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
         PARTY,
         partyInfos,
-        false,
-        "",
+        tlsInfo,
         "aggregation_traffic_for_thread_" + std::to_string(index));
 
     // Each AggregationApp runs numFiles sequentially on a single thread

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
@@ -43,6 +43,13 @@ static void runGame(
     const std::string& tlsDir,
     bool useNewOutputFormat) {
   FLAGS_use_new_output_format = useNewOutputFormat;
+
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = useTls ? (tlsDir + "/cert.pem") : "";
+  tlsInfo.keyPath = useTls ? (tlsDir + "/key.pem") : "";
+  tlsInfo.passphrasePath = useTls ? (tlsDir + "/passphrase.pem") : "";
+  tlsInfo.useTls = useTls;
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -51,7 +58,7 @@ static void runGame(
 
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      PARTY, partyInfos, useTls, tlsDir, "aggregation_test_traffic");
+      PARTY, partyInfos, tlsInfo, "aggregation_test_traffic");
 
   AggregationApp<PARTY, schedulerId>(
       inputEncryption,

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -11,6 +11,7 @@
 #include <future>
 #include <memory>
 
+#include <fbpcf/engine/communication/SocketPartyCommunicationAgent.h>
 #include <folly/dynamic.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcs/emp_games/pcf2_attribution/AttributionApp.h"
@@ -85,12 +86,18 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
             {{0, {serverIp, port + static_cast<int>(index) * 100}},
              {1, {serverIp, port + static_cast<int>(index) * 100}}});
 
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo
+        tlsInfo;
+    tlsInfo.certPath = "";
+    tlsInfo.keyPath = "";
+    tlsInfo.passphrasePath = "";
+    tlsInfo.useTls = false;
+
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
         PARTY,
         partyInfos,
-        false,
-        "",
+        tlsInfo,
         "attribution_traffic_for_thread_" + std::to_string(index));
 
     // Each AttributionApp runs numFiles sequentially on a single thread

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
@@ -37,6 +37,12 @@ static void runGame(
     const std::string& outputPath,
     bool useTls,
     const std::string& tlsDir) {
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = useTls ? (tlsDir + "/cert.pem") : "";
+  tlsInfo.keyPath = useTls ? (tlsDir + "/key.pem") : "";
+  tlsInfo.passphrasePath = useTls ? (tlsDir + "/passphrase.pem") : "";
+  tlsInfo.useTls = useTls;
+
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -45,7 +51,7 @@ static void runGame(
 
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      PARTY, partyInfos, useTls, tlsDir, "attribution_test_traffic");
+      PARTY, partyInfos, tlsInfo, "attribution_test_traffic");
 
   AttributionApp<PARTY, schedulerId, usingBatch, inputEncryption>(
       std::move(communicationAgentFactory),

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
@@ -161,6 +161,13 @@ class ShardCombinerAppTestFixture
       const std::string& tlsDir,
       bool xorEncrypted,
       common::ResultVisibility resultVisibility) {
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo
+        tlsInfo;
+    tlsInfo.certPath = useTls ? (tlsDir + "/cert.pem") : "";
+    tlsInfo.keyPath = useTls ? (tlsDir + "/key.pem") : "";
+    tlsInfo.passphrasePath = useTls ? (tlsDir + "/passphrase.pem") : "";
+    tlsInfo.useTls = useTls;
+
     std::map<
         int32_t,
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -171,7 +178,7 @@ class ShardCombinerAppTestFixture
 
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-        schedulerId, partyInfos, useTls, tlsDir, "shard_combiner_test_traffic");
+        schedulerId, partyInfos, tlsInfo, "shard_combiner_test_traffic");
 
     ShardCombinerApp<shardSchemaType, schedulerId, usingBatch, inputEncryption>(
         std::move(communicationAgentFactory),

--- a/fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h
@@ -52,6 +52,12 @@ common::SchedulerStatistics runApp(
       break;
   }
 
+  fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo tlsInfo;
+  tlsInfo.certPath = "";
+  tlsInfo.keyPath = "";
+  tlsInfo.passphrasePath = "";
+  tlsInfo.useTls = false;
+
   std::map<
       int32_t,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -61,7 +67,7 @@ common::SchedulerStatistics runApp(
 
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      schedulerId, partyInfos, useTls, tlsDir, "shard_combiner_traffic");
+      schedulerId, partyInfos, tlsInfo, "shard_combiner_traffic");
 
   common::SchedulerStatistics schedulerStats;
   if (schedulerId == common::PUBLISHER) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcf/pull/362

In T128792539, a bootcamper helped us add a struct for Tls information. We want to deprecate all callsites of the legacy constructor. That is done in this diff.

Reviewed By: RuiyuZhu

Differential Revision: D38926124

