### PR TITLE
Move custom binaries to dev

### DIFF
--- a/upload-binaries-to-s3-test.sh
+++ b/upload-binaries-to-s3-test.sh
@@ -29,7 +29,7 @@ if [[ ! " $PACKAGES " =~ $PACKAGE ]] || [[ ! " $TAG " =~ $TAG ]]; then
 fi
 shift
 
-one_docker_repo="one-docker-repository-test"
+one_docker_repo="one-docker-repository-custom"
 lift_package="s3://$one_docker_repo/private_lift/lift/${TAG}/lift"
 pcf2_lift_package="s3://$one_docker_repo/private_lift/pcf2_lift/${TAG}/pcf2_lift"
 attribution_repo="s3://$one_docker_repo/private_attribution"


### PR DESCRIPTION
Summary:
Moving custom binaries to dev aws env, in order to move non prod resources out of prod so that prod can be locked down later.
[More Context](https://docs.google.com/document/d/1kthI64nO7SDjTA_8u5NlRSQhfHcOS2ppRzcHKz_cEEQ/edit#heading=h.ojn6t4mgsqv6)
[Progress](https://docs.google.com/document/d/19wY1QLcyeVdqitH8o3IoIo4ebtDtLdaG77GxWf4mskM/edit#)

Reviewed By: ajinkya-ghonge

Differential Revision: D38882758

