### PR TITLE
Don't copy InputProcessor members into Attributor and Aggregator members

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -48,15 +48,7 @@ class Aggregator {
       : myRole_{myRole},
         inputProcessor_{inputProcessor},
         attributor_{std::move(attributor)},
-        numRows_{inputProcessor.getNumRows()},
-        numPartnerCohorts_{inputProcessor.getNumPartnerCohorts()},
-        numPublisherBreakdowns_{inputProcessor.getNumPublisherBreakdowns()},
-        numGroups_{inputProcessor.getNumGroups()},
-        numTestGroups_{inputProcessor.getNumTestGroups()},
-        numConversionsPerUser_{numConversionsPerUser},
-        communicationAgentFactory_{communicationAgentFactory},
-        indexShares_{inputProcessor.getIndexShares()},
-        testIndexShares_{inputProcessor.getTestIndexShares()} {
+        communicationAgentFactory_{communicationAgentFactory} {
     initOram();
     sumEvents();
     sumConverters();
@@ -145,12 +137,6 @@ class Aggregator {
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   std::unique_ptr<Attributor<schedulerId>> attributor_;
-  int64_t numRows_;
-  uint32_t numPartnerCohorts_;
-  uint32_t numPublisherBreakdowns_;
-  uint32_t numGroups_;
-  uint32_t numTestGroups_;
-  int32_t numConversionsPerUser_;
   OutputMetricsData metrics_;
 
   std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
@@ -171,8 +157,6 @@ class Aggregator {
       Intp<false, valueSquaredWidth>>>
       valueSquaredWriteOnlyOramFactory_;
 
-  std::vector<std::vector<bool>> indexShares_;
-  std::vector<std::vector<bool>> testIndexShares_;
   std::unordered_map<int64_t, OutputMetricsData> cohortMetrics_;
   std::unordered_map<int64_t, OutputMetricsData> publisherBreakdowns_;
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -17,9 +17,7 @@ template <int schedulerId>
 class Attributor {
  public:
   Attributor(int myRole, InputProcessor<schedulerId> inputProcessor)
-      : myRole_{myRole},
-        inputProcessor_{inputProcessor},
-        numRows_{inputProcessor.getNumRows()} {
+      : myRole_{myRole}, inputProcessor_{inputProcessor} {
     calculateEvents();
     calculateNumConvSquaredAndValueSquaredAndConverters();
     calculateMatch();
@@ -81,7 +79,6 @@ class Attributor {
 
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
-  int64_t numRows_;
 
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -41,24 +43,27 @@ void Attributor<
     auto numConv = events_.size() - i;
     auto convSquared = static_cast<uint32_t>(numConv * numConv);
     SecNumConvSquared<schedulerId> numConvSquared(
-        std::vector(numRows_, convSquared), common::PUBLISHER);
+        std::vector(inputProcessor_.getNumRows(), convSquared),
+        common::PUBLISHER);
     numConvSquaredArray.push_back(numConvSquared);
   }
   // The numConvSquared is zero if there are no valid events
   SecNumConvSquared<schedulerId> zero{
-      std::vector<uint32_t>(numRows_, 0), common::PUBLISHER};
+      std::vector<uint32_t>(inputProcessor_.getNumRows(), 0),
+      common::PUBLISHER};
   numConvSquaredArray.push_back(zero);
 
   std::vector<SecValueSquared<schedulerId>> valueSquaredArray =
       inputProcessor_.getPurchaseValueSquared();
   // The value squared is zero if there are no valid events
   SecValueSquared<schedulerId> zeroValueSquared{
-      std::vector<int64_t>(numRows_, 0), common::PUBLISHER};
+      std::vector<int64_t>(inputProcessor_.getNumRows(), 0), common::PUBLISHER};
   valueSquaredArray.push_back(zeroValueSquared);
 
   std::vector<SecBit<schedulerId>> eventArray = events_;
   SecBit<schedulerId> zeroBit{
-      std::vector<bool>(numRows_, false), common::PUBLISHER};
+      std::vector<bool>(inputProcessor_.getNumRows(), false),
+      common::PUBLISHER};
   eventArray.push_back(zeroBit);
 
   int stepSize = 1; // we process the array elements in pairs with indices
@@ -128,7 +133,8 @@ void Attributor<schedulerId>::calculateValues() {
     XLOG(FATAL)
         << "Numbers of event bits and/or purchase values are inconsistent.";
   }
-  auto zero = PubValue<schedulerId>(std::vector<int64_t>(numRows_, 0));
+  auto zero = PubValue<schedulerId>(
+      std::vector<int64_t>(inputProcessor_.getNumRows(), 0));
   for (size_t i = 0; i < events_.size(); ++i) {
     // The value is the purchase value if there is a valid event, otherwise it
     // is zero

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
 namespace private_lift {
 
 template <int schedulerId>


### PR DESCRIPTION
Summary:
Currently these classes are copying some values from the InputProcessor and storing them as local member variables. This is a bad idea as it creates extra copies of the data and in the future could diverge on implementation.

For my immediate usage in the next diffs I plan to convert the `inputProcessor` constructor variable into a `std::unique_ptr` and when we call `std::move()` on it, we lose all these values. Either we first copy them and then std::move the inputProcessor, or we just use the source of truth (the inputProcessor) in the business logic directly which is more cleaner.

Differential Revision: D39002510

