### PR TITLE
InputProcessor -> std::unique_ptr<InputProcessor>

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -48,15 +48,7 @@ class Aggregator {
       : myRole_{myRole},
         inputProcessor_{inputProcessor},
         attributor_{std::move(attributor)},
-        numRows_{inputProcessor.getNumRows()},
-        numPartnerCohorts_{inputProcessor.getNumPartnerCohorts()},
-        numPublisherBreakdowns_{inputProcessor.getNumPublisherBreakdowns()},
-        numGroups_{inputProcessor.getNumGroups()},
-        numTestGroups_{inputProcessor.getNumTestGroups()},
-        numConversionsPerUser_{numConversionsPerUser},
-        communicationAgentFactory_{communicationAgentFactory},
-        indexShares_{inputProcessor.getIndexShares()},
-        testIndexShares_{inputProcessor.getTestIndexShares()} {
+        communicationAgentFactory_{communicationAgentFactory} {
     initOram();
     sumEvents();
     sumConverters();
@@ -145,12 +137,6 @@ class Aggregator {
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
   std::unique_ptr<Attributor<schedulerId>> attributor_;
-  int64_t numRows_;
-  uint32_t numPartnerCohorts_;
-  uint32_t numPublisherBreakdowns_;
-  uint32_t numGroups_;
-  uint32_t numTestGroups_;
-  int32_t numConversionsPerUser_;
   OutputMetricsData metrics_;
 
   std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
@@ -171,8 +157,6 @@ class Aggregator {
       Intp<false, valueSquaredWidth>>>
       valueSquaredWriteOnlyOramFactory_;
 
-  std::vector<std::vector<bool>> indexShares_;
-  std::vector<std::vector<bool>> testIndexShares_;
   std::unordered_map<int64_t, OutputMetricsData> cohortMetrics_;
   std::unordered_map<int64_t, OutputMetricsData> publisherBreakdowns_;
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -39,14 +39,14 @@ class Aggregator {
  public:
   Aggregator(
       int myRole,
-      InputProcessor<schedulerId> inputProcessor,
+      std::unique_ptr<InputProcessor<schedulerId>> inputProcessor,
       std::unique_ptr<Attributor<schedulerId>> attributor,
       int32_t numConversionsPerUser,
       std::shared_ptr<
           fbpcf::engine::communication::IPartyCommunicationAgentFactory>
           communicationAgentFactory)
       : myRole_{myRole},
-        inputProcessor_{inputProcessor},
+        inputProcessor_{std::move(inputProcessor)},
         attributor_{std::move(attributor)},
         communicationAgentFactory_{communicationAgentFactory} {
     initOram();
@@ -135,7 +135,7 @@ class Aggregator {
       bool testOnly) const;
 
   int32_t myRole_;
-  InputProcessor<schedulerId> inputProcessor_;
+  std::unique_ptr<InputProcessor<schedulerId>> inputProcessor_;
   std::unique_ptr<Attributor<schedulerId>> attributor_;
   OutputMetricsData metrics_;
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -9,6 +9,7 @@
 
 #include "folly/logging/xlog.h"
 
+#include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
 
 namespace private_lift {
@@ -16,8 +17,10 @@ namespace private_lift {
 template <int schedulerId>
 class Attributor {
  public:
-  Attributor(int myRole, InputProcessor<schedulerId> inputProcessor)
-      : myRole_{myRole}, inputProcessor_{inputProcessor} {
+  Attributor(
+      int myRole,
+      std::unique_ptr<InputProcessor<schedulerId>> inputProcessor)
+      : myRole_{myRole}, inputProcessor_{std::move(inputProcessor)} {
     calculateEvents();
     calculateNumConvSquaredAndValueSquaredAndConverters();
     calculateMatch();
@@ -78,7 +81,7 @@ class Attributor {
   void calculateValues();
 
   int32_t myRole_;
-  InputProcessor<schedulerId> inputProcessor_;
+  std::unique_ptr<InputProcessor<schedulerId>> inputProcessor_;
 
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -17,9 +17,7 @@ template <int schedulerId>
 class Attributor {
  public:
   Attributor(int myRole, InputProcessor<schedulerId> inputProcessor)
-      : myRole_{myRole},
-        inputProcessor_{inputProcessor},
-        numRows_{inputProcessor.getNumRows()} {
+      : myRole_{myRole}, inputProcessor_{inputProcessor} {
     calculateEvents();
     calculateNumConvSquaredAndValueSquaredAndConverters();
     calculateMatch();
@@ -81,7 +79,6 @@ class Attributor {
 
   int32_t myRole_;
   InputProcessor<schedulerId> inputProcessor_;
-  int64_t numRows_;
 
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -41,24 +43,27 @@ void Attributor<
     auto numConv = events_.size() - i;
     auto convSquared = static_cast<uint32_t>(numConv * numConv);
     SecNumConvSquared<schedulerId> numConvSquared(
-        std::vector(numRows_, convSquared), common::PUBLISHER);
+        std::vector(inputProcessor_.getNumRows(), convSquared),
+        common::PUBLISHER);
     numConvSquaredArray.push_back(numConvSquared);
   }
   // The numConvSquared is zero if there are no valid events
   SecNumConvSquared<schedulerId> zero{
-      std::vector<uint32_t>(numRows_, 0), common::PUBLISHER};
+      std::vector<uint32_t>(inputProcessor_.getNumRows(), 0),
+      common::PUBLISHER};
   numConvSquaredArray.push_back(zero);
 
   std::vector<SecValueSquared<schedulerId>> valueSquaredArray =
       inputProcessor_.getPurchaseValueSquared();
   // The value squared is zero if there are no valid events
   SecValueSquared<schedulerId> zeroValueSquared{
-      std::vector<int64_t>(numRows_, 0), common::PUBLISHER};
+      std::vector<int64_t>(inputProcessor_.getNumRows(), 0), common::PUBLISHER};
   valueSquaredArray.push_back(zeroValueSquared);
 
   std::vector<SecBit<schedulerId>> eventArray = events_;
   SecBit<schedulerId> zeroBit{
-      std::vector<bool>(numRows_, false), common::PUBLISHER};
+      std::vector<bool>(inputProcessor_.getNumRows(), false),
+      common::PUBLISHER};
   eventArray.push_back(zeroBit);
 
   int stepSize = 1; // we process the array elements in pairs with indices
@@ -128,7 +133,8 @@ void Attributor<schedulerId>::calculateValues() {
     XLOG(FATAL)
         << "Numbers of event bits and/or purchase values are inconsistent.";
   }
-  auto zero = PubValue<schedulerId>(std::vector<int64_t>(numRows_, 0));
+  auto zero = PubValue<schedulerId>(
+      std::vector<int64_t>(inputProcessor_.getNumRows(), 0));
   for (size_t i = 0; i < events_.size(); ++i) {
     // The value is the purchase value if there is a valid event, otherwise it
     // is zero

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -10,6 +10,8 @@
 #include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
+#include "fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp.h"
+
 namespace private_lift {
 
 template <int schedulerId>

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorGame.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorGame.h
@@ -33,11 +33,12 @@ class CalculatorGame : public fbpcf::frontend::MpcGame<schedulerId> {
   std::string play(const CalculatorGameConfig& config) {
     auto inputProcessor = InputProcessor<schedulerId>(
         party_, config.inputData, config.numConversionsPerUser);
-    auto attributor =
-        std::make_unique<Attributor<schedulerId>>(party_, inputProcessor);
+    auto attributor = std::make_unique<Attributor<schedulerId>>(
+        party_, std::make_unique<InputProcessor<schedulerId>>(inputProcessor));
     auto aggregator = Aggregator<schedulerId>(
         party_,
-        inputProcessor,
+        std::make_unique<InputProcessor<schedulerId>>(
+            std::move(inputProcessor)),
         std::move(attributor),
         config.numConversionsPerUser,
         communicationAgentFactory_);

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+
 namespace private_lift {
 
 template <int schedulerId>

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AggregatorTest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
@@ -33,11 +34,11 @@ Aggregator<schedulerId> createAggregatorWithScheduler(
       std::move(scheduler));
   auto inputProcessor =
       InputProcessor<schedulerId>(myRole, inputData, numConversionsPerUser);
-  auto attributor =
-      std::make_unique<Attributor<schedulerId>>(myRole, inputProcessor);
+  auto attributor = std::make_unique<Attributor<schedulerId>>(
+      myRole, std::make_unique<InputProcessor<schedulerId>>(inputProcessor));
   return Aggregator<schedulerId>(
       myRole,
-      inputProcessor,
+      std::make_unique<InputProcessor<schedulerId>>(std::move(inputProcessor)),
       std::move(attributor),
       numConversionsPerUser,
       factory);

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/AttributorTest.cpp
@@ -30,9 +30,9 @@ Attributor<schedulerId> createAttributorWithScheduler(
   auto scheduler = schedulerFactory.get().create();
   fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
       std::move(scheduler));
-  auto inputProcessor =
-      InputProcessor<schedulerId>(myRole, inputData, numConversionsPerUser);
-  return Attributor<schedulerId>(myRole, inputProcessor);
+  auto inputProcessor = std::make_unique<InputProcessor<schedulerId>>(
+      myRole, inputData, numConversionsPerUser);
+  return Attributor<schedulerId>(myRole, std::move(inputProcessor));
 }
 
 class AttributorTest : public ::testing::Test {


### PR DESCRIPTION
Summary: Switching the InputProcessor member variable to be a std::unique_ptr in `Aggregator` and `Attributor` classes. This is needed so that these objects can work on a generic IInputProcessor interface with virtual methods.

Differential Revision: D39003555

