### PR TITLE
Update fbpcp version to 0.3.0

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes
 ## [Unreleased]
 ### Added
   - Added an option to specify a CertificateRequest when creating an mpc game instance
+  - Upgrade fbpcp dependency to 0.3.0
 ### Changed
 
 ### Removed

--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -3,7 +3,7 @@ botocore==1.21.65
 cython==0.29.30 # required by thriftpy2 setup
 dataclasses-json==0.5.2 # fbpcp requires this version, so we must as well
 docopt>=0.6.2
-fbpcp>=0.2.2 # depending on: boto3, botocore
+fbpcp>=0.3.0 # depending on: boto3, botocore
 marshmallow==3.5.1
 networkx>=2.6.3
 requests>=2.26.0


### PR DESCRIPTION
Summary:
fbpcp 0.3.0 was released but it wasn't specified in the fbpcs requirements which led to an error: https://github.com/facebookresearch/fbpcs/runs/8017777982?check_suite_focus=true

this diff upgrades the fbpcp dependency

Reviewed By: gorel

Differential Revision: D39024666

