### PR TITLE
RC E2E test for PL on PCF 2.0

### DIFF
--- a/.github/workflows/rc_one_command_runner_test.yml
+++ b/.github/workflows/rc_one_command_runner_test.yml
@@ -1,0 +1,72 @@
+name: RC new features one command runner test
+
+on:
+  workflow_dispatch:
+    inputs:
+      study_id:
+        description: Lift study id
+        required: true
+        default: 619791979506548
+      objective_id:
+        description: Lift objective id
+        required: true
+        default: 1349568402234048
+      input_path:
+        description: S3 path to synthetic data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
+      expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json
+      tag:
+        description: Version tag to use
+        required: true
+        default: rc
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
+
+env:
+  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
+  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_RC_GRAPH_API_TOKEN }}
+
+jobs:
+  ### Private Lift E2E tests
+  pl_test:
+    name: Private Lift E2E Tests
+    runs-on: self-hosted
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash}}
+
+      - name: One command runner
+        run: |
+          ./fbpcs/scripts/run_fbpcs.sh run_study \
+          ${{ github.event.inputs.study_id }} \
+          --objective_ids=${{ github.event.inputs.objective_id }} \
+          --input_paths=${{ github.event.inputs.input_path }} \
+          --config=./fbpcs/tests/github/rc_config_one_command_runner_test.yml \
+          -- \
+          --version=${{ github.event.inputs.tag }}
+
+      - name: Validate Results
+        # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
+        # the fbpcs_instances directory is where instances are written to (feature of run_fbpcs.sh)
+        # the config.yml specifies that /fbpcs_instances is the instance repo, which is the source of the "/{}"
+        run: |
+          find fbpcs_instances -regex 'fbpcs_instances/[0-9]+' | xargs -I {} ./fbpcs/scripts/run_fbpcs.sh \
+          validate \
+          "/{}" \
+          --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
+          --expected_result_path=${{ github.event.inputs.expected_result_path }} \
+          -- \
+          --version=${{ github.event.inputs.tag }}

--- a/fbpcs/tests/github/rc_config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/rc_config_one_command_runner_test.yml
@@ -1,0 +1,46 @@
+private_computation:
+  dependency:
+    PrivateComputationInstanceRepository:
+      class: fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository
+      constructor:
+        base_dir: /fbpcs_instances
+    ContainerService:
+      class: fbpcp.service.container_aws.AWSContainerService
+      constructor:
+        region: us-west-2
+        cluster: onedocker-cluster-rc-tier-partner
+        subnets: [subnet-0f2b6cf90a5bfc8fa,subnet-006b6437e79d33d06,subnet-07c5bd3358e70e157,subnet-0968c31c698e17908,]
+        access_key_id:
+        access_key_data:
+    StorageService:
+      class: fbpcp.service.storage_s3.S3StorageService
+      constructor:
+        region: us-west-2
+        access_key_id:
+        access_key_data:
+    ValidationConfig:
+      is_validating: false
+      synthetic_shard_path:
+    OneDockerBinaryConfig:
+      default:
+        constructor:
+          tmp_directory: /tmp
+          binary_version: latest
+    OneDockerServiceConfig:
+      constructor:
+        task_definition: onedocker-task-rc-tier-partner:1#onedocker-container-rc-tier-partner
+pid:
+  dependency:
+mpc:
+  dependency:
+    MPCGameService:
+      class: fbpcp.service.mpc_game.MPCGameService
+      dependency:
+        PrivateComputationGameRepository:
+          class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository
+    MPCInstanceRepository:
+      class: fbpcs.common.repository.mpc_instance_local.LocalMPCInstanceRepository
+      constructor:
+        base_dir: /fbpcs_instances
+graphapi:
+  access_token: TODO


### PR DESCRIPTION
Summary:
We cannot use the existing RC tests for PL on PCF 2.0. This is because we will not be able to test the existing prod path i.e. regression testing. Thus I am creating a new PL test specifically for RC tier.
This test will use the business - Rivendell Grocery, which we will add to GK of features that have made it to RC. This way we would be able to test new RC features as well as do regression testing.

Differential Revision: D38970556

