### PR TITLE
Fix Rust log missing issue

### DIFF
--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -139,7 +139,9 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
             pid_protocol, pc_role
         )
         onedocker_binary_config = self._onedocker_binary_config_map[binary_name]
-        env_vars = {}
+        env_vars = {
+            "RUST_LOG": "info",
+        }
         if onedocker_binary_config.repository_path:
             env_vars[
                 ONEDOCKER_REPOSITORY_PATH

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -112,7 +112,9 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 pid_protocol, pc_role
             )
             binary_config = self.onedocker_binary_config_map[binary_name]
-            env_vars = {}
+            env_vars = {
+                "RUST_LOG": "info",
+            }
             if binary_config.repository_path:
                 env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
 


### PR DESCRIPTION
Summary:
# Context
We found that Rust code is not having any logs logged in CloudWatch.

Please do bunnylol cloud mpc-aem before seeing below example logs.

old CloudWatch log: https://fburl.com/gm39yvr5
new CloudWatch log: https://fburl.com/a7t42vx0

Though above examples are from EP, it is also affecting prod. (https://fburl.com/8z0d2f7y)

# Details
We found a root cause. [RUST_LOG: 'info'](https://www.internalfb.com/code/fbsource/[166327d6901e272d8899b18e3c175963c116ea89]/fbcode/fbpcs/pid/service/pid_service/pid_run_protocol_stage.py?lines=286-291) flag went missing in [here](https://www.internalfb.com/code/fbsource/[e1a61d2cd7b0591683ea2e84d6ff111b219e4709]/fbcode/fbpcs/private_computation/service/pid_run_protocol_stage_service.py?lines=143-146).

We simply add the RUST_LOG: 'info' flag back for PID protocol binary to fix this problem.

Reviewed By: rajprateek

Differential Revision: D39028574

