### PR TITLE
Delete all instances of computing chunk size per-callsite (in fbpcs)

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombiner.cpp
@@ -31,8 +31,8 @@ MrPidAttributionIdCombiner::MrPidAttributionIdCombiner()
              << ", protocol_type: " << FLAGS_protocol_type;
 
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  spineIdFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), kBufferedReaderChunkSize);
+  spineIdFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
 }
 MrPidAttributionIdCombiner::~MrPidAttributionIdCombiner() {
   spineIdFile->close();

--- a/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombinerTest.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombinerTest.cpp
@@ -110,8 +110,7 @@ TEST_F(MrPidAttributionIdCombinerTest, TestProcessPublisher) {
   MrPidAttributionIdCombiner p;
 
   auto reader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  auto file = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(reader), fbpcf::io::kBufferedReaderChunkSize);
+  auto file = std::make_shared<fbpcf::io::BufferedReader>(std::move(reader));
   FileMetaData res = p.processHeader(file);
 
   std::vector<std::string> col{
@@ -126,8 +125,7 @@ TEST_F(MrPidAttributionIdCombinerTest, TestProcessPartner) {
   MrPidAttributionIdCombiner p;
 
   auto reader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  auto file = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(reader), fbpcf::io::kBufferedReaderChunkSize);
+  auto file = std::make_shared<fbpcf::io::BufferedReader>(std::move(reader));
   FileMetaData res = p.processHeader(file);
 
   std::vector<std::string> col{

--- a/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombiner.cpp
@@ -30,10 +30,9 @@ PidAttributionIdCombiner::PidAttributionIdCombiner()
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_data_path);
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), kBufferedReaderChunkSize);
-  spineIdFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), kBufferedReaderChunkSize);
+  dataFile = std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
+  spineIdFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
 }
 PidAttributionIdCombiner::~PidAttributionIdCombiner() {
   dataFile->close();

--- a/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombinerTest.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombinerTest.cpp
@@ -117,8 +117,8 @@ TEST_F(PidAttributionIdCombinerTest, TestProcessPublisher) {
   PidAttributionIdCombiner p;
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_data_path);
-  auto dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), fbpcf::io::kBufferedReaderChunkSize);
+  auto dataFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
   FileMetaData res = p.processHeader(dataFile);
 
   std::vector<std::string> col{
@@ -133,8 +133,8 @@ TEST_F(PidAttributionIdCombinerTest, TestProcessPartner) {
   PidAttributionIdCombiner p;
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_data_path);
-  auto dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), fbpcf::io::kBufferedReaderChunkSize);
+  auto dataFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
   FileMetaData res = p.processHeader(dataFile);
 
   std::vector<std::string> col{

--- a/fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp
+++ b/fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp
@@ -121,8 +121,8 @@ void idSwapMultiKey(
    * first read.
    */
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(spineIdPath);
-  auto spineIdFileDup = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), pid::combiner::kBufferedReaderChunkSize);
+  auto spineIdFileDup =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
   std::vector<std::string> header;
   folly::split(kCommaSplitRegex, headerLine, header);
 

--- a/fbpcs/data_processing/id_combiner/IdSwapMultiKey.h
+++ b/fbpcs/data_processing/id_combiner/IdSwapMultiKey.h
@@ -18,15 +18,6 @@
 namespace pid::combiner {
 
 /*
- * This chunk size has to be large enough that we don't make
- * unnecessary trips to cloud storage but small enough that
- * we don't cause OOM issues. This chunk size was chosen based
- * on the size of our containers as well as the expected size
- * of our files to fit the aforementioned constraints.
- */
-constexpr size_t kBufferedReaderChunkSize = 1073741824; // 2^30
-
-/*
  * This function implements the aggregation logic used by publisher PL run.
  * Currently, PL does not posses ability to handle duplicates. Multi-key
  * PID would introduce duplicates and this process would be required.

--- a/fbpcs/data_processing/id_combiner/test/IdSwapMultiKeyTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/IdSwapMultiKeyTest.cpp
@@ -56,15 +56,14 @@ class IdSwapMultiKeyTest : public testing::Test {
     std::string spineInputPath =
         "/tmp/AttributionIdSpineFileCombinerTestSpineInputPath" +
         std::to_string(randStart);
-    constexpr size_t kBufferedReaderChunkSize = 4096;
     data_processing::test_utils::writeVecToFile(dataInput, dataInputPath);
     data_processing::test_utils::writeVecToFile(spineInput, spineInputPath);
     auto dataReader = std::make_unique<fbpcf::io::FileReader>(dataInputPath);
     auto spineReader = std::make_unique<fbpcf::io::FileReader>(spineInputPath);
-    auto bufferedDataReader = std::make_shared<fbpcf::io::BufferedReader>(
-        std::move(dataReader), kBufferedReaderChunkSize);
-    auto bufferedSpineReader = std::make_shared<fbpcf::io::BufferedReader>(
-        std::move(spineReader), kBufferedReaderChunkSize);
+    auto bufferedDataReader =
+        std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
+    auto bufferedSpineReader =
+        std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
     std::string headerLine = bufferedDataReader->readLine();
     pid::combiner::idSwapMultiKey(
         bufferedDataReader,
@@ -223,15 +222,14 @@ TEST_F(IdSwapMultiKeyTest, MissingPrivateIdsSpine) {
   std::string spineInputPath =
       "/tmp/AttributionIdSpineFileCombinerTestSpineInputPath" +
       std::to_string(randStart);
-  constexpr size_t kBufferedReaderChunkSize = 4096;
   data_processing::test_utils::writeVecToFile(dataInput, dataInputPath);
   data_processing::test_utils::writeVecToFile(spineInput, spineInputPath);
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(dataInputPath);
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(spineInputPath);
-  auto bufferedDataReader = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), kBufferedReaderChunkSize);
-  auto bufferedSpineReader = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), kBufferedReaderChunkSize);
+  auto bufferedDataReader =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
+  auto bufferedSpineReader =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
   int32_t maxIdColumnCnt = 1;
   std::string headerLine = bufferedDataReader->readLine();
   ASSERT_DEATH(

--- a/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombiner.cpp
@@ -51,8 +51,8 @@ MrPidLiftIdCombiner::MrPidLiftIdCombiner(
              << ", protocol_type: " << protocolType;
 
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  spineIdFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), fbpcf::io::kBufferedReaderChunkSize);
+  spineIdFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
 }
 
 MrPidLiftIdCombiner::~MrPidLiftIdCombiner() {
@@ -61,8 +61,8 @@ MrPidLiftIdCombiner::~MrPidLiftIdCombiner() {
 
 std::stringstream MrPidLiftIdCombiner::idSwap(FileMetaData meta) {
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(spineIdFilePath);
-  auto spineIdFileDup = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), pid::combiner::kBufferedReaderChunkSize);
+  auto spineIdFileDup =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
 
   std::stringstream idSwapOutFile;
 

--- a/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombinerTest.cpp
@@ -141,8 +141,8 @@ TEST_F(MrPidLiftIdCombinerTest, TestProcessPublisher) {
       FLAGS_protocol_type);
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  auto dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), fbpcf::io::kBufferedReaderChunkSize);
+  auto dataFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
   FileMetaData res = p.processHeader(dataFile);
 
   EXPECT_EQ(res.headerLine, "id_,opportunity_timestamp,test_flag");
@@ -160,8 +160,8 @@ TEST_F(MrPidLiftIdCombinerTest, TestProcessPartner) {
       FLAGS_protocol_type);
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_spine_path);
-  auto dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), fbpcf::io::kBufferedReaderChunkSize);
+  auto dataFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
   FileMetaData res = p.processHeader(dataFile);
 
   EXPECT_EQ(res.headerLine, "id_,event_timestamp,value");

--- a/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombiner.cpp
@@ -50,10 +50,9 @@ PidLiftIdCombiner::PidLiftIdCombiner(
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(dataPath);
   auto spineReader = std::make_unique<fbpcf::io::FileReader>(spineIdFilePath);
-  dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), kBufferedReaderChunkSize);
-  spineIdFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(spineReader), kBufferedReaderChunkSize);
+  dataFile = std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
+  spineIdFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(spineReader));
 }
 PidLiftIdCombiner::~PidLiftIdCombiner() {
   dataFile->close();

--- a/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombinerTest.cpp
@@ -153,8 +153,8 @@ TEST_F(PidLiftIdCombinerTest, TestProcessPublisher) {
       FLAGS_protocol_type);
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_data_path);
-  auto dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), fbpcf::io::kBufferedReaderChunkSize);
+  auto dataFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
   FileMetaData res = p.processHeader(dataFile);
 
   EXPECT_EQ(res.headerLine, "id_,opportunity_timestamp,test_flag");
@@ -173,8 +173,8 @@ TEST_F(PidLiftIdCombinerTest, TestProcessPartner) {
       FLAGS_protocol_type);
 
   auto dataReader = std::make_unique<fbpcf::io::FileReader>(FLAGS_data_path);
-  auto dataFile = std::make_shared<fbpcf::io::BufferedReader>(
-      std::move(dataReader), fbpcf::io::kBufferedReaderChunkSize);
+  auto dataFile =
+      std::make_shared<fbpcf::io::BufferedReader>(std::move(dataReader));
   FileMetaData res = p.processHeader(dataFile);
 
   EXPECT_EQ(res.headerLine, "id_,event_timestamp,value");

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
@@ -40,8 +40,8 @@ static const std::string kIdColumnPrefix = "id_";
 UnionPIDDataPreparerResults UnionPIDDataPreparer::prepare() const {
   UnionPIDDataPreparerResults res;
   auto reader = std::make_unique<fbpcf::io::FileReader>(inputPath_);
-  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(reader), kBufferedReaderChunkSize);
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(reader));
 
   // Get a random ID to avoid potential name collisions if multiple
   // runs at the same time point to the same input file

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
@@ -18,15 +18,6 @@ struct UnionPIDDataPreparerResults {
   int64_t duplicateIdCount = 0;
 };
 
-/*
- * This chunk size has to be large enough that we don't make
- * unnecessary trips to cloud storage but small enough that
- * we don't cause OOM issues. This chunk size was chosen based
- * on the size of our containers as well as the expected size
- * of our files to fit the aforementioned constraints.
- */
-constexpr size_t kBufferedReaderChunkSize = 1073741824; // 2^30
-
 class UnionPIDDataPreparer {
  public:
   UnionPIDDataPreparer(

--- a/fbpcs/data_processing/sharding/GenericSharder.cpp
+++ b/fbpcs/data_processing/sharding/GenericSharder.cpp
@@ -87,16 +87,16 @@ std::vector<std::string> GenericSharder::genOutputPaths(
 void GenericSharder::shard() {
   std::size_t numShards = getOutputPaths().size();
   auto reader = std::make_unique<fbpcf::io::FileReader>(getInputPath());
-  auto bufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(reader), BUFFER_SIZE);
+  auto bufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(reader));
 
   std::vector<std::unique_ptr<fbpcf::io::BufferedWriter>> outFiles(0);
 
   for (std::size_t i = 0; i < numShards; ++i) {
     auto fileWriter =
         std::make_unique<fbpcf::io::FileWriter>(getOutputPaths().at(i));
-    auto bufferedWriter = std::make_unique<fbpcf::io::BufferedWriter>(
-        std::move(fileWriter), kBufferedWriterChunkSize);
+    auto bufferedWriter =
+        std::make_unique<fbpcf::io::BufferedWriter>(std::move(fileWriter));
     outFiles.push_back(std::move(bufferedWriter));
     XLOG(INFO) << "Created buffered writer for shard " << std::to_string(i);
   }
@@ -212,8 +212,8 @@ void GenericSharder::logShardDistribution() {
   const std::string& shardDistributionPath =
       outputPath + '_' + "shardDistribution";
   auto fWriter = std::make_unique<fbpcf::io::FileWriter>(shardDistributionPath);
-  auto bWriter = std::make_unique<fbpcf::io::BufferedWriter>(
-      std::move(fWriter), kBufferedWriterChunkSize);
+  auto bWriter =
+      std::make_unique<fbpcf::io::BufferedWriter>(std::move(fWriter));
   std::string shardDstributionJson = getShardDistributionJson();
   bWriter->writeString(shardDstributionJson);
   bWriter->close();

--- a/fbpcs/emp_games/common/Constants.h
+++ b/fbpcs/emp_games/common/Constants.h
@@ -12,14 +12,6 @@ namespace common {
 
 const int PUBLISHER = 0;
 const int PARTNER = 1;
-/*
- * This chunk size has to be large enough that we don't make
- * unnecessary trips to cloud storage but small enough that
- * we don't cause OOM issues. This chunk size was chosen based
- * on the size of our containers as well as the expected size
- * of our files to fit the aforementioned constraints.
- */
-constexpr size_t kBufferedReaderChunkSize = 1073741824; // 2^30
 
 enum class Visibility { Publisher, Xor };
 

--- a/fbpcs/emp_games/common/Csv.cpp
+++ b/fbpcs/emp_games/common/Csv.cpp
@@ -59,8 +59,8 @@ bool readCsv(
         readLine,
     std::function<void(const std::vector<std::string>&)> processHeader) {
   auto inlineReader = std::make_unique<fbpcf::io::FileReader>(fileName);
-  auto inlineBufferedReader = std::make_unique<fbpcf::io::BufferedReader>(
-      std::move(inlineReader), common::kBufferedReaderChunkSize);
+  auto inlineBufferedReader =
+      std::make_unique<fbpcf::io::BufferedReader>(std::move(inlineReader));
 
   std::string line = inlineBufferedReader->readLine();
   auto header = splitByComma(line, false);


### PR DESCRIPTION
Summary:
# Context
We want to have more intelligent defaults for the IO APIs. Cloud related upload/downlaod should have a larger buffer size to minimize IO operations, whereas local io should be smaller.

# This Diff
We get rid of all instances where a custom chunk size is specified (in fbpcs). This is only necessary if there is something special about the callsite.

# This Stack
1. Create separate constructor without chunkSize
2. Add a filepath member variable to IWriter and IReader
3. Create util functions to determine buffer size
4. Use the new util functions
5. Delete all other references to determining chunk sizes (in fbpcf)
6. **Delete all other references to determining chunk sizes (in fbpcs)**

Differential Revision: D39036741

