### PR TITLE
Set Kinesis to use dynamic partitioning on the event timestamp

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -11,6 +11,7 @@ import base64
 import json
 import os
 import re
+from datetime import datetime
 from ipaddress import ip_address, IPv4Address, IPv6Address
 from typing import Dict, List, Tuple
 
@@ -180,6 +181,14 @@ def lambda_handler(
         data = json.dumps(data) + "\n"
         data = data.encode("utf-8")
         row["data"] = base64.b64encode(data)
+        date_time = datetime.fromtimestamp(int(timestamp))
+        partition_keys = {
+            "year": date_time.strftime("%Y"),
+            "month": date_time.strftime("%m"),
+            "day": date_time.strftime("%d"),
+            "hour": date_time.strftime("%H"),
+        }
+        row["metadata"] = {"partitionKeys": partition_keys}
         output.append(row)
 
     print("finished data transformation.")

--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -37,8 +37,11 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
     bucket_arn          = aws_s3_bucket.bucket.arn
     buffer_size         = 128
     buffer_interval     = 900
-    prefix              = "${var.events_data}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
+    prefix              = "${var.events_data}/year=!{partitionKeyFromLambda:year}/month=!{partitionKeyFromLambda:month}/day=!{partitionKeyFromLambda:day}/hour=!{partitionKeyFromLambda:hour}/"
     error_output_prefix = "!{firehose:error-output-type}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
+    dynamic_partitioning_configuration {
+      enabled = "true"
+    }
     processing_configuration {
       enabled = "true"
 


### PR DESCRIPTION
Summary:
Previously the events were flowing into the current time. However to support
backfilling we need to do this dynamic partitioning based on the event's
timestamp instead.

Differential Revision: D39030814

