### PR TITLE
Back out "Use factories to create Eager/Lazy schedulers"

### DIFF
--- a/fbpcs/emp_games/compactor/main.cpp
+++ b/fbpcs/emp_games/compactor/main.cpp
@@ -17,7 +17,6 @@
 #include "fbpcf/aws/AwsSdk.h"
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/io/api/FileIOWrappers.h"
-#include "fbpcf/scheduler/LazySchedulerFactory.h"
 #include "fbpcs/emp_games/compactor/AttributionOutput.h"
 #include "fbpcs/emp_games/compactor/CompactorGame.h"
 #include "fbpcs/performance_tools/CostEstimation.h"
@@ -102,9 +101,8 @@ int main(int argc, char** argv) {
       FLAGS_party, std::move(partyInfos), tlsInfo, "compactor_traffic");
 
   XLOG(INFO) << "Creating scheduler\n";
-  auto scheduler = fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-                       FLAGS_party, *commAgentFactory)
-                       ->create();
+  auto scheduler = fbpcf::scheduler::createLazySchedulerWithRealEngine(
+      FLAGS_party, *commAgentFactory);
 
   XLOG(INFO) << "Starting game\n";
   auto game = compactor::ShuffleBasedCompactorGame<AttributionValue, 0>(

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -6,8 +6,8 @@
  */
 
 #include <fbpcf/io/api/FileIOWrappers.h>
-#include <fbpcf/scheduler/LazySchedulerFactory.h>
 #include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
+#include <fbpcf/scheduler/SchedulerHelper.h>
 #include <vector>
 
 namespace private_lift {
@@ -90,9 +90,8 @@ template <int schedulerId>
 std::unique_ptr<fbpcf::scheduler::IScheduler>
 CalculatorApp<schedulerId>::createScheduler() {
   return useXorEncryption_
-      ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+      ? fbpcf::scheduler::createLazySchedulerWithRealEngine(
             party_, *communicationAgentFactory_)
-            ->create()
       : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
             party_, *communicationAgentFactory_)
             .create();

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationApp.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <fbpcf/io/api/FileIOWrappers.h>
-#include <fbpcf/scheduler/LazySchedulerFactory.h>
 #include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AggregationGame.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h"
@@ -50,9 +50,8 @@ class AggregationApp {
         ? fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
               MY_ROLE, *communicationAgentFactory_)
               .create()
-        : fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-              MY_ROLE, *communicationAgentFactory_)
-              ->create();
+        : fbpcf::scheduler::createLazySchedulerWithRealEngine(
+              MY_ROLE, *communicationAgentFactory_);
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
 
     AggregationGame<schedulerId> game(

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -10,7 +10,7 @@
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include <string>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
-#include "fbpcf/scheduler/LazySchedulerFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/pcf2_attribution/AttributionGame.h"
 
@@ -42,9 +42,8 @@ class AttributionApp {
 
   void run() {
     auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
-    auto scheduler = fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-                         MY_ROLE, *communicationAgentFactory_)
-                         ->create();
+    auto scheduler = fbpcf::scheduler::createLazySchedulerWithRealEngine(
+        MY_ROLE, *communicationAgentFactory_);
 
     AttributionGame<schedulerId, usingBatch, inputEncryption> game(
         std::move(scheduler));

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h
@@ -18,8 +18,8 @@
 #include <fbpcf/engine/communication/IPartyCommunicationAgentFactory.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcf/scheduler/IScheduler.h>
-#include <fbpcf/scheduler/LazySchedulerFactory.h>
 #include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
+#include <fbpcf/scheduler/SchedulerHelper.h>
 
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -65,9 +65,8 @@ class ShardCombinerApp {
 
   void run() {
     auto scheduler = useXorEncryption_
-        ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+        ? fbpcf::scheduler::createLazySchedulerWithRealEngine(
               schedulerId, *communicationAgentFactory_)
-              ->create()
         : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<true /*unsafe*/>(
               schedulerId, *communicationAgentFactory_)
               .create();
@@ -91,8 +90,8 @@ class ShardCombinerApp {
 
     std::unordered_map<int32_t, folly::dynamic> ret;
 
-    // Insert revealed results only if the party has access for the result
-    // to be revealed. Otherwise, insert dummy result.
+    // Insert revealed results only if the party has access for the result to be
+    // revealed. Otherwise, insert dummy result.
     if (resultVisibility_ == common::ResultVisibility::kPublisher ||
         resultVisibility_ == common::ResultVisibility::kPublic) {
       ret.insert(std::make_pair(
@@ -104,8 +103,8 @@ class ShardCombinerApp {
       ret.insert(std::make_pair(common::PUBLISHER, dummyResult->toDynamic()));
     }
 
-    // Insert revealed results only if the party has access for the result
-    // to be revealed. Otherwise, insert dummy result.
+    // Insert revealed results only if the party has access for the result to be
+    // revealed. Otherwise, insert dummy result.
     if (resultVisibility_ == common::ResultVisibility::kPartner ||
         resultVisibility_ == common::ResultVisibility::kPublic) {
       ret.insert(std::make_pair(


### PR DESCRIPTION
Summary:
Original commit changeset: e8f33b0e1f6d

Original Phabricator Diff: D38879639 (https://github.com/facebookresearch/fbpcs/commit/a68562eeccc1b24e9112463c547a9ff967aecdb8)

Original Diff broke fbpcs build, due to fbpcf changes in a previous diff not released yet.

Reviewed By: robotal

Differential Revision: D39043198

