### PR TITLE
reduce log size by 80%

### DIFF
--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -28,8 +28,8 @@ Usage:
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
     pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [--run_id=<run_id>] [options]
     pc-cli pre_validate --config=<config_file> [--dataset_id=<dataset_id>] --input_path=<input_path> [--timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>] [options]
-    pc-cli bolt_e2e --bolt_config=<bolt_config_file>
-    pc-cli secret_scrubber <secret_input_path> <scrubbed_output_path>
+    pc-cli bolt_e2e --bolt_config=<bolt_config_file> [options]
+    pc-cli secret_scrubber <secret_input_path> <scrubbed_output_path> [options]
 
 
 Options:


### PR DESCRIPTION
Summary:
## What

- Only log instance json after starting a stage or if there was a change recently

## Why

- D38556918 (https://github.com/facebookresearch/fbpcs/commit/c58b71d4fb464a397a02df3ca7bc0db12760cee3) introduced some log statements in the BoltPCSClient for use with the log analyzer. This adds a lot of spam into the logs to the point where github cannot even display them all. When I tried to download the raw logs, my browser stopped responding. Generally speaking, it makes reading the raw logs extremely difficult.
- We don't need to log every update instance request, since we're only interested in the start of the stage and end of the stage
- This slowed down debugging in S288948

Differential Revision: D39046579

