### PR TITLE
Fix Hotfix action

### DIFF
--- a/.github/workflows/create-hotfix.yml
+++ b/.github/workflows/create-hotfix.yml
@@ -43,4 +43,4 @@ jobs:
         run: git cherry-pick ${{ github.event.inputs.hotfix_commit }}
 
       - name: Push hotfix commit to origin
-        run: git push -u origin ${{ env.BRANCH_NAME }}
+        run: git push -f -u origin ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Summary:
## Background
Right now the hotfix action is broken because the hotfix branch already exists on the origin and is not in the same order as the main branch we are creating the new hotfix branch from, causing the following error on push

https://pxl.cl/2bRlg

## This change
This change updates the action to force push the new hotfix branch to overwrite the old one. This will allow for the overwrite to the new hotfix branch and we can continue the hotfix process from there.

Differential Revision: D39056131

