### PR TITLE
Synthetic data generator for PL

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.h
@@ -9,7 +9,6 @@
 
 #include <vector>
 
-#include "fbpcs/emp_games/lift/pcf2_calculator/InputData.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftFakeDataParams.h"
 
 namespace private_lift {


### PR DESCRIPTION
Summary:
We create a synthetic data generator for the lift stage in PL, by creating a binary that runs the synthetic data generator that is currently only used for generating random test files. The binary will take in parameters including the publisher and partner file paths, the number of files, number of conversions per user, number of rows, number of breakdowns and number of cohorts. It can also be used to generate data both locally and on AWS, where the instructions are in the test plan.

We currently also have another synthetic data generator for PL, but it runs too slowly for large files and also frequently has errors when uploading data to AWS. Hence we created this new generator to generate large files for the cost understanding project.

Reviewed By: adshastri

Differential Revision: D38809914

