### PR TITLE
Enable PID MR stage Flow using feature gate

### DIFF
--- a/fbpcs/common/feature/pcs_feature_gate_utils.py
+++ b/fbpcs/common/feature/pcs_feature_gate_utils.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Optional, Set, Type
+
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_mr_pid_pcf2_lift_stage_flow import (
+    PrivateComputationMrPidPCF2LiftStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_mr_stage_flow import (
+    PrivateComputationMRStageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
+    PrivateComputationPCF2StageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
+    PrivateComputationStageFlow,
+)
+from fbpcs.utils.optional import unwrap_or_default
+
+
+def get_stage_flow(
+    game_type: PrivateComputationGameType,
+    pcs_feature_enums: Set[PCSFeature],
+    stage_flow_cls: Optional[Type[PrivateComputationBaseStageFlow]] = None,
+) -> Type[PrivateComputationBaseStageFlow]:
+    selected_stage_flow_cls = unwrap_or_default(
+        optional=stage_flow_cls,
+        default=PrivateComputationPCF2StageFlow
+        if game_type is PrivateComputationGameType.ATTRIBUTION
+        else PrivateComputationStageFlow,
+    )
+
+    # warning, enabled feature gating will override stage flow, Please contact PSI team to have a similar adoption
+    if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID in pcs_feature_enums:
+        selected_stage_flow_cls = (
+            PrivateComputationMRStageFlow
+            if game_type is PrivateComputationGameType.ATTRIBUTION
+            else PrivateComputationMrPidPCF2LiftStageFlow
+        )
+    return selected_stage_flow_cls

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -15,6 +15,7 @@ class PCSFeature(Enum):
     BOLT_RUNNER = "bolt_runner"
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
+    PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"
     UNKNOWN = "unknown"
 


### PR DESCRIPTION
Summary:
Context:
As we plan to pilot run pid mr, we created a new stage flow that runs PID. In order to enable this feature for a limited pilot run advertisers we add a feature gate (GK - private_attribution_with_mr_pid) that will allow specific users. This feature gate needs to be used to pick specific stage flow based on the game type.

As we plan to run preliminary tests for attribution and Lift. We use the same GK to pick the appropriate stageflow based on the game type. We may add different GK for rollout.

This diff:
Uses PCSFeatures to select the appropriate MR pid  stage flow class based on the game type.

Reviewed By: wenqingren

Differential Revision: D38811938

