### PR TITLE
Use a prefix in the S3 bucket as the root path for the Glue crawler

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -72,7 +72,7 @@ resource "aws_glue_crawler" "mpc_events_crawler" {
   )
 
   s3_target {
-    path = "s3://${var.data_processing_output_bucket}"
+    path = "s3://${var.data_processing_output_bucket}/${var.events_data}"
     exclusions = [
       "processing-failed**",
       "${var.data_upload_key_path}/**",

--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -37,7 +37,7 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
     bucket_arn          = aws_s3_bucket.bucket.arn
     buffer_size         = 128
     buffer_interval     = 900
-    prefix              = "year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
+    prefix              = "${var.events_data}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
     error_output_prefix = "!{firehose:error-output-type}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/hour=!{timestamp:HH}/"
     processing_configuration {
       enabled = "true"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/variable.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/variable.tf
@@ -42,3 +42,8 @@ variable "query_results_key_path" {
   description = "the object key where Athena query results are stored"
   default     = "query-results"
 }
+
+variable "events_data" {
+  description = "S3 prefix that Kinesis FH writes to and Glue crawler reads from"
+  default     = "events_data"
+}


### PR DESCRIPTION
Summary: This is to make the Glue crawler more resilient.  There have been instances of files getting added to the root of the bucket which affects the crawling.  With this change, Firehose will output to a prefix in the bucket & the crawler will use that as the root.

Reviewed By: marksliva

Differential Revision: D39047627

