### PR TITLE
get stage instance from pc_instances list by stage name

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -54,6 +54,7 @@ class PrivateComputationGameType(Enum):
     ATTRIBUTION = "ATTRIBUTION"
 
 
+# TODO: T126201525 [BE] remove PIDInstance in FBPCS
 UnionedPCInstance = Union[
     PIDInstance, PCSMPCInstance, PostProcessingInstance, StageStateInstance
 ]

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -313,6 +313,22 @@ class PrivateComputationInstance(InstanceBase):
             server_ips_list = last_instance.server_ips or []
         return server_ips_list
 
+    # TODO: T130501878 BE only support StageStateInstance for now, replace this to all self.infra_config.instances[-1] code
+    def get_stage_instance(
+        self, stage: Optional["PrivateComputationBaseStageFlow"] = None
+    ) -> Optional[StageStateInstance]:
+        if not self.infra_config.instances:
+            return None
+
+        stage = stage or self.current_stage
+        # reversed traverse from the last stage instance
+        for stage_instance in reversed(self.infra_config.instances):
+            if isinstance(stage_instance, StageStateInstance):
+                if stage.name == stage_instance.stage_name:
+                    return stage_instance
+
+        return None
+
     def has_feature(self, feature: PCSFeature) -> bool:
         if feature is PCSFeature.UNKNOWN:
             logging.warning(

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -132,15 +132,12 @@ class PCPreValidationStageService(PrivateComputationStageService):
             )
 
             task_id = ""
-            if pc_instance.infra_config.instances:
-                last_instance = pc_instance.infra_config.instances[-1]
-                if isinstance(last_instance, StageStateInstance):
-                    last_container = last_instance.containers[-1]
-                    task_id = (
-                        last_container.instance_id.split("/")[-1]
-                        if last_container
-                        else ""
-                    )
+            stage_instance = pc_instance.get_stage_instance()
+            if stage_instance is not None:
+                last_container = stage_instance.containers[-1]
+                task_id = (
+                    last_container.instance_id.split("/")[-1] if last_container else ""
+                )
 
             if instance_status == self._failed_status and task_id:
                 region = self._pc_validator_config.region

--- a/fbpcs/private_computation/service/pid_mr_stage_service.py
+++ b/fbpcs/private_computation/service/pid_mr_stage_service.py
@@ -110,17 +110,9 @@ class PIDMRStageService(PrivateComputationStageService):
             The latest status for private_computation_instance
         """
         status = pc_instance.infra_config.status
-        if pc_instance.infra_config.instances:
-            # TODO: we should have some identifier or stage_name
-            # to pick up the right instance instead of the last one
-            last_instance = pc_instance.infra_config.instances[-1]
-            if not isinstance(last_instance, StageStateInstance):
-                raise ValueError(
-                    f"The last instance type not StageStateInstance but {type(last_instance)}"
-                )
-            stage_name = last_instance.stage_name
-            stage_id = last_instance.instance_id
-            assert stage_name == pc_instance.current_stage.name
+        stage_instance = pc_instance.get_stage_instance()
+        if stage_instance is not None:
+            stage_id = stage_instance.instance_id
             pid_configs = pc_instance.product_config.common.pid_configs
             stage_state_instance_status = WorkflowStatus.STARTED
             if pid_configs:

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -254,7 +254,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         container_instance = ContainerInstance(instance_id=instance_id)
         stage_state_instance = StageStateInstance(
             instance_id="instance-id-0",
-            stage_name="stage-name-1",
+            stage_name="PC_PRE_VALIDATION",
             containers=[container_instance],
         )
         unioned_pc_instances = [stage_state_instance]


### PR DESCRIPTION
Summary:
## Why
we used to select `last` stage instance to take it as current stage, ideally nothing wrong but it's misleading when developing stage service. this diff is to have `pc_instance` support a api to retreive stage_instange by stage as identifier

## What
* support `stage_state_instance` only in `get_stage_instance` api
* replace the code are using `infra.instances[-1] to get last instance

Reviewed By: jrodal98

Differential Revision: D39076549

