### PR TITLE
Input Processor interface

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -14,7 +14,7 @@
 #include "fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h"
 #include "fbpcs/emp_games/lift/common/GroupedLiftMetrics.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/Attributor.h"
-#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/OutputMetricsData.h"
 
 namespace private_lift {
@@ -39,7 +39,7 @@ class Aggregator {
  public:
   Aggregator(
       int myRole,
-      std::unique_ptr<InputProcessor<schedulerId>> inputProcessor,
+      std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor,
       std::unique_ptr<Attributor<schedulerId>> attributor,
       int32_t numConversionsPerUser,
       std::shared_ptr<
@@ -135,7 +135,7 @@ class Aggregator {
       bool testOnly) const;
 
   int32_t myRole_;
-  std::unique_ptr<InputProcessor<schedulerId>> inputProcessor_;
+  std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor_;
   std::unique_ptr<Attributor<schedulerId>> attributor_;
   OutputMetricsData metrics_;
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -10,7 +10,7 @@
 #include "folly/logging/xlog.h"
 
 #include "fbpcs/emp_games/common/Constants.h"
-#include "fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h"
 
 namespace private_lift {
 
@@ -19,7 +19,7 @@ class Attributor {
  public:
   Attributor(
       int myRole,
-      std::unique_ptr<InputProcessor<schedulerId>> inputProcessor)
+      std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor)
       : myRole_{myRole}, inputProcessor_{std::move(inputProcessor)} {
     calculateEvents();
     calculateNumConvSquaredAndValueSquaredAndConverters();
@@ -81,7 +81,7 @@ class Attributor {
   void calculateValues();
 
   int32_t myRole_;
-  std::unique_ptr<InputProcessor<schedulerId>> inputProcessor_;
+  std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor_;
 
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcs/emp_games/lift/pcf2_calculator/Constants.h>
+#include <cstdint>
+#include <vector>
+namespace private_lift {
+
+template <int schedulerId>
+class IInputProcessor {
+ public:
+  virtual ~IInputProcessor() = default;
+
+  virtual int64_t getNumRows() const = 0;
+
+  virtual uint32_t getNumPartnerCohorts() const = 0;
+
+  virtual uint32_t getNumPublisherBreakdowns() const = 0;
+
+  virtual uint32_t getNumGroups() const = 0;
+
+  virtual uint32_t getNumTestGroups() const = 0;
+
+  virtual uint8_t getValueBits() const = 0;
+
+  virtual uint8_t getValueSquaredBits() const = 0;
+
+  virtual const std::vector<std::vector<bool>>& getIndexShares() const = 0;
+
+  virtual const std::vector<std::vector<bool>>& getTestIndexShares() const = 0;
+
+  // TODO add better types to PCF and replace
+  virtual const SecTimestamp<schedulerId>& getOpportunityTimestamps() const = 0;
+
+  virtual const SecBit<schedulerId>& getIsValidOpportunityTimestamp() const = 0;
+
+  virtual const std::vector<SecTimestamp<schedulerId>>& getPurchaseTimestamps()
+      const = 0;
+
+  virtual const std::vector<SecTimestamp<schedulerId>>& getThresholdTimestamps()
+      const = 0;
+
+  virtual const SecBit<schedulerId>& getAnyValidPurchaseTimestamp() const = 0;
+
+  virtual const std::vector<SecValue<schedulerId>>& getPurchaseValues()
+      const = 0;
+
+  virtual const std::vector<SecValueSquared<schedulerId>>&
+  getPurchaseValueSquared() const = 0;
+
+  virtual const SecBit<schedulerId>& getTestReach() const = 0;
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -12,6 +12,7 @@
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/Util.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/InputData.h"
 
 namespace private_lift {
@@ -19,7 +20,7 @@ namespace private_lift {
  * This class handles privately sharing all the input data in MPC.
  */
 template <int schedulerId>
-class InputProcessor {
+class InputProcessor : public IInputProcessor<schedulerId> {
  public:
   InputProcessor(int myRole, InputData inputData, int32_t numConversionsPerUser)
       : myRole_{myRole},
@@ -41,72 +42,74 @@ class InputProcessor {
 
   InputProcessor() {}
 
-  int64_t getNumRows() const {
+  int64_t getNumRows() const override {
     return numRows_;
   }
 
-  uint32_t getNumPartnerCohorts() const {
+  uint32_t getNumPartnerCohorts() const override {
     return numPartnerCohorts_;
   }
 
-  uint32_t getNumPublisherBreakdowns() const {
+  uint32_t getNumPublisherBreakdowns() const override {
     return numPublisherBreakdowns_;
   }
 
-  uint32_t getNumGroups() const {
+  uint32_t getNumGroups() const override {
     return numGroups_;
   }
 
-  uint32_t getNumTestGroups() const {
+  uint32_t getNumTestGroups() const override {
     return numTestGroups_;
   }
 
-  uint8_t getValueBits() const {
+  uint8_t getValueBits() const override {
     return valueBits_;
   }
 
-  uint8_t getValueSquaredBits() const {
+  uint8_t getValueSquaredBits() const override {
     return valueSquaredBits_;
   }
 
-  const std::vector<std::vector<bool>> getIndexShares() const {
+  const std::vector<std::vector<bool>>& getIndexShares() const override {
     return indexShares_;
   }
 
-  const std::vector<std::vector<bool>> getTestIndexShares() const {
+  const std::vector<std::vector<bool>>& getTestIndexShares() const override {
     return testIndexShares_;
   }
 
-  const SecTimestamp<schedulerId> getOpportunityTimestamps() const {
+  const SecTimestamp<schedulerId>& getOpportunityTimestamps() const override {
     return opportunityTimestamps_;
   }
 
-  const SecBit<schedulerId> getIsValidOpportunityTimestamp() const {
+  const SecBit<schedulerId>& getIsValidOpportunityTimestamp() const override {
     return isValidOpportunityTimestamp_;
   }
 
-  const std::vector<SecTimestamp<schedulerId>> getPurchaseTimestamps() const {
+  const std::vector<SecTimestamp<schedulerId>>& getPurchaseTimestamps()
+      const override {
     return purchaseTimestamps_;
   }
 
-  const std::vector<SecTimestamp<schedulerId>> getThresholdTimestamps() const {
+  const std::vector<SecTimestamp<schedulerId>>& getThresholdTimestamps()
+      const override {
     return thresholdTimestamps_;
   }
 
-  const SecBit<schedulerId> getAnyValidPurchaseTimestamp() const {
+  const SecBit<schedulerId>& getAnyValidPurchaseTimestamp() const override {
     return anyValidPurchaseTimestamp_;
   }
 
-  const std::vector<SecValue<schedulerId>> getPurchaseValues() const {
+  const std::vector<SecValue<schedulerId>>& getPurchaseValues() const override {
     return purchaseValues_;
   }
 
-  const std::vector<SecValueSquared<schedulerId>> getPurchaseValueSquared()
-      const {
+  const std::vector<SecValueSquared<schedulerId>>& getPurchaseValueSquared()
+      const override {
     return purchaseValueSquared_;
   }
 
-  const SecBit<schedulerId> getTestReach() const {
+  const SecBit<schedulerId>& getTestReach() const override {
     return testReach_;
   }
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -253,9 +253,10 @@ void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
 
   XLOG(INFO) << "Share if any purchase timestamp is valid";
   std::vector<bool> anyValidPurchaseTimestamp;
-  for (auto& purchaseTimestampArray : inputData_.getPurchaseTimestampArrays()) {
+  for (const std::vector<uint32_t>& purchaseTimestampArray :
+       inputData_.getPurchaseTimestampArrays()) {
     bool anyValidPurchaseTs = false;
-    for (auto purchaseTs : purchaseTimestampArray) {
+    for (uint32_t purchaseTs : purchaseTimestampArray) {
       // compute whether each row contains at least one valid (positive)
       // purchase timestamp
       anyValidPurchaseTs = anyValidPurchaseTs | (purchaseTs > 0);


### PR DESCRIPTION
Summary:
Adding an interface for the InputProcessor which has methods that will be used by the Attributor and Aggregator classes.

The current InputProcessor is instantiated using an [InputData](https://fburl.com/code/2x99njmu) object which reads from the local filesystem one of the input csv's from the reshard stage. The idea behind this interface is that we don't actually care how we load those MPC types into the InputProcessor. We can add an InputProcessor which reads from a file of secret shares (computed in another stage), as well as a InputProcessor which runs the UDP algorithm on the the plaintext data. This is exactly what we will do in later steps.

Reviewed By: RuiyuZhu

Differential Revision: D39003554

