### PR TITLE
log analyzer: log validation should not fail when seeing error lines in the output.txt log

### DIFF
--- a/fbpcs/infra/logging_service/log_analyzer/log_validation.py
+++ b/fbpcs/infra/logging_service/log_analyzer/log_validation.py
@@ -52,8 +52,8 @@ class LogValidation:
         instance_count = len(run_study.summary_instances)
         assert instance_count >= MIN_NUM_INSTANCES
         assert instance_count <= MAX_NUM_INSTANCES
-        assert run_study.error_line_count == 0
-        assert not run_study.error_lines
+        assert run_study.error_line_count >= 0
+        assert run_study.error_lines is not None
         assert run_study.instances
         assert len(run_study.instances) == instance_count
         # Validate the summary of the instance
@@ -75,9 +75,11 @@ class LogValidation:
         assert run_study.summary_instances[0].startswith(
             f"i={instance.instance_id}/o={instance.objective_id}/c={instance.cell_id}"
         )
-        assert instance.instance_failed_container_count == 0
-        assert not instance.instance_error_line_count
-        assert not instance.instance_error_lines
+        # When there are any failed containers, the failed container count becomes negative.
+        # E.g. -2 means two containers had failed.
+        assert instance.instance_failed_container_count <= 0
+        assert instance.instance_error_line_count >= 0
+        assert instance.instance_error_lines is not None
         if not instance.existing_instance_status:
             assert instance.instance_container_count >= MIN_NUM_CONTAINERS
             assert instance.summary_stages
@@ -98,7 +100,8 @@ class LogValidation:
     ) -> None:
         self.validate_log_context(stage.context)
         assert stage.stage_id
-        assert stage.failed_container_count == 0
+        # When there are any failed containers, the failed container count becomes negative.
+        assert stage.failed_container_count <= 0
         assert stage.container_count == len(stage.containers)
         # Validate the summary of containers
         for container in stage.containers:


### PR DESCRIPTION
Summary:
Study run can complete successfully by retrying stage runs after error occurred. Such case should not fail the log validation.
For example, in the following Github one_command_runner_test run, the failure from "Validate runner log" step is not desired:
https://github.com/facebookresearch/fbpcs/runs/8083182834?check_suite_focus=true

Differential Revision: D39159023

