### PR TITLE
log analyzer: handle retrying of stage run for bolt runner

### DIFF
--- a/fbpcs/infra/logging_service/log_analyzer/log_validation.py
+++ b/fbpcs/infra/logging_service/log_analyzer/log_validation.py
@@ -52,8 +52,8 @@ class LogValidation:
         instance_count = len(run_study.summary_instances)
         assert instance_count >= MIN_NUM_INSTANCES
         assert instance_count <= MAX_NUM_INSTANCES
-        assert run_study.error_line_count == 0
-        assert not run_study.error_lines
+        assert run_study.error_line_count >= 0
+        assert run_study.error_lines is not None
         assert run_study.instances
         assert len(run_study.instances) == instance_count
         # Validate the summary of the instance
@@ -75,9 +75,9 @@ class LogValidation:
         assert run_study.summary_instances[0].startswith(
             f"i={instance.instance_id}/o={instance.objective_id}/c={instance.cell_id}"
         )
-        assert instance.instance_failed_container_count == 0
-        assert not instance.instance_error_line_count
-        assert not instance.instance_error_lines
+        assert instance.instance_failed_container_count <= 0
+        assert instance.instance_error_line_count >= 0
+        assert instance.instance_error_lines is not None
         if not instance.existing_instance_status:
             assert instance.instance_container_count >= MIN_NUM_CONTAINERS
             assert instance.summary_stages
@@ -98,7 +98,7 @@ class LogValidation:
     ) -> None:
         self.validate_log_context(stage.context)
         assert stage.stage_id
-        assert stage.failed_container_count == 0
+        assert stage.failed_container_count <= 0
         assert stage.container_count == len(stage.containers)
         # Validate the summary of containers
         for container in stage.containers:


### PR DESCRIPTION
Summary:
For bolt runner, the logs emitted from retrying of stage run have changed.
E.g. PC_PRE_VALIDATION stage failed at the first execution and succeeded at the second execution, in the following Github one_command_runner_test run:
https://github.com/facebookresearch/fbpcs/runs/8083182834?check_suite_focus=true
Corresponding logs:
```
2022-08-30 01:44:37,765Z INFO t:MainThread n:__main__ ! [31602208955937] Valid stage found: PrivateComputationStageFlow.PC_PRE_VALIDATION
2022-08-30 01:44:39,288Z INFO t:MainThread n:__main__ ! [31602208955937] Partner 31602208955937 starting stage PC_PRE_VALIDATION.
2022-08-30 01:49:50,316Z INFO t:MainThread n:__main__ ! [31602208955937] Partner 31602208955937 starting stage PC_PRE_VALIDATION.
```

Differential Revision: D39159088

