### PR TITLE
Update Input processor interface to use data struct

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator_impl.h
@@ -16,7 +16,7 @@ template <int schedulerId>
 void Aggregator<schedulerId>::initOram() {
   // Initialize ORAM
   bool isPublisher = (myRole_ == common::PUBLISHER);
-  if (inputProcessor_->getNumGroups() > 4) {
+  if (inputProcessor_->getLiftGameProcessedData().numGroups > 4) {
     // If the ORAM size is larger than 4, linear ORAM is less efficient
     // theoretically
     unsignedWriteOnlyOramFactory_ =
@@ -46,7 +46,7 @@ void Aggregator<schedulerId>::initOram() {
             isPublisher, 0, 1, *communicationAgentFactory_);
   }
 
-  if (inputProcessor_->getNumTestGroups() > 4) {
+  if (inputProcessor_->getLiftGameProcessedData().numTestGroups > 4) {
     testUnsignedWriteOnlyOramFactory_ =
         fbpcf::mpc_std_lib::oram::getSecureWriteOnlyOramFactory<
             Intp<false, valueWidth>,
@@ -117,16 +117,18 @@ void Aggregator<schedulerId>::sumEvents() {
   std::vector<std::vector<std::vector<bool>>> valueSharesArray;
   for (auto events : attributor_->getEvents()) {
     std::vector<std::vector<bool>> valueShares(
-        valueWidth, std::vector<bool>(inputProcessor_->getNumRows(), 0));
+        valueWidth,
+        std::vector<bool>(
+            inputProcessor_->getLiftGameProcessedData().numRows, 0));
     valueShares[0] = events.extractBit().getValue();
     valueSharesArray.push_back(std::move(valueShares));
   }
-  auto oram =
-      unsignedWriteOnlyOramFactory_->create(inputProcessor_->getNumGroups());
+  auto oram = unsignedWriteOnlyOramFactory_->create(
+      inputProcessor_->getLiftGameProcessedData().numGroups);
   auto aggregationOutput = aggregate<false, valueWidth, true>(
-      inputProcessor_->getIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().indexShares,
       valueSharesArray,
-      inputProcessor_->getNumGroups(),
+      inputProcessor_->getLiftGameProcessedData().numGroups,
       std::move(oram));
 
   // Extract metrics
@@ -134,12 +136,16 @@ void Aggregator<schedulerId>::sumEvents() {
   metrics_.testEvents = std::get<0>(populationOutput);
   metrics_.controlEvents = std::get<1>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].testEvents = std::get<0>(cohortOutput).at(i);
     cohortMetrics_[i].controlEvents = std::get<1>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].testEvents = std::get<0>(breakdownOutput).at(i);
     publisherBreakdowns_[i].controlEvents = std::get<1>(breakdownOutput).at(i);
   }
@@ -150,14 +156,16 @@ void Aggregator<schedulerId>::sumConverters() {
   XLOG(INFO) << "Aggregate converters";
   // Aggregate across test/control and cohorts
   std::vector<std::vector<bool>> valueShares(
-      valueWidth, std::vector<bool>(inputProcessor_->getNumRows(), 0));
+      valueWidth,
+      std::vector<bool>(
+          inputProcessor_->getLiftGameProcessedData().numRows, 0));
   valueShares[0] = attributor_->getConverters().extractBit().getValue();
-  auto oram =
-      unsignedWriteOnlyOramFactory_->create(inputProcessor_->getNumGroups());
+  auto oram = unsignedWriteOnlyOramFactory_->create(
+      inputProcessor_->getLiftGameProcessedData().numGroups);
   auto aggregationOutput = aggregate<false, valueWidth, false>(
-      inputProcessor_->getIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().indexShares,
       valueShares,
-      inputProcessor_->getNumGroups(),
+      inputProcessor_->getLiftGameProcessedData().numGroups,
       std::move(oram));
 
   // Extract metrics
@@ -165,12 +173,16 @@ void Aggregator<schedulerId>::sumConverters() {
   metrics_.testConverters = std::get<0>(populationOutput);
   metrics_.controlConverters = std::get<1>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].testConverters = std::get<0>(cohortOutput).at(i);
     cohortMetrics_[i].controlConverters = std::get<1>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].testConverters = std::get<0>(breakdownOutput).at(i);
     publisherBreakdowns_[i].controlConverters =
         std::get<1>(breakdownOutput).at(i);
@@ -183,12 +195,12 @@ void Aggregator<schedulerId>::sumNumConvSquared() {
   // Aggregate across test/control and cohorts
   auto valueShares =
       attributor_->getNumConvSquared().extractIntShare().getBooleanShares();
-  auto oram =
-      unsignedWriteOnlyOramFactory_->create(inputProcessor_->getNumGroups());
+  auto oram = unsignedWriteOnlyOramFactory_->create(
+      inputProcessor_->getLiftGameProcessedData().numGroups);
   auto aggregationOutput = aggregate<false, valueWidth, false>(
-      inputProcessor_->getIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().indexShares,
       valueShares,
-      inputProcessor_->getNumGroups(),
+      inputProcessor_->getLiftGameProcessedData().numGroups,
       std::move(oram));
 
   // Extract metrics
@@ -196,12 +208,16 @@ void Aggregator<schedulerId>::sumNumConvSquared() {
   metrics_.testNumConvSquared = std::get<0>(populationOutput);
   metrics_.controlNumConvSquared = std::get<1>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].testNumConvSquared = std::get<0>(cohortOutput).at(i);
     cohortMetrics_[i].controlNumConvSquared = std::get<1>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].testNumConvSquared =
         std::get<0>(breakdownOutput).at(i);
     publisherBreakdowns_[i].controlNumConvSquared =
@@ -214,14 +230,16 @@ void Aggregator<schedulerId>::sumMatch() {
   XLOG(INFO) << "Aggregate matchCount";
   // Aggregate across test/control and cohorts
   std::vector<std::vector<bool>> valueShares(
-      valueWidth, std::vector<bool>(inputProcessor_->getNumRows(), 0));
+      valueWidth,
+      std::vector<bool>(
+          inputProcessor_->getLiftGameProcessedData().numRows, 0));
   valueShares[0] = attributor_->getMatch().extractBit().getValue();
-  auto oram =
-      unsignedWriteOnlyOramFactory_->create(inputProcessor_->getNumGroups());
+  auto oram = unsignedWriteOnlyOramFactory_->create(
+      inputProcessor_->getLiftGameProcessedData().numGroups);
   auto aggregationOutput = aggregate<false, valueWidth, false>(
-      inputProcessor_->getIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().indexShares,
       valueShares,
-      inputProcessor_->getNumGroups(),
+      inputProcessor_->getLiftGameProcessedData().numGroups,
       std::move(oram));
 
   // Extract metrics
@@ -229,12 +247,16 @@ void Aggregator<schedulerId>::sumMatch() {
   metrics_.testMatchCount = std::get<0>(populationOutput);
   metrics_.controlMatchCount = std::get<1>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].testMatchCount = std::get<0>(cohortOutput).at(i);
     cohortMetrics_[i].controlMatchCount = std::get<1>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].testMatchCount = std::get<0>(breakdownOutput).at(i);
     publisherBreakdowns_[i].controlMatchCount =
         std::get<1>(breakdownOutput).at(i);
@@ -248,27 +270,33 @@ void Aggregator<schedulerId>::sumReachedConversions() {
   std::vector<std::vector<std::vector<bool>>> valueSharesArray;
   for (auto events : attributor_->getReachedConversions()) {
     std::vector<std::vector<bool>> valueShares(
-        valueWidth, std::vector<bool>(inputProcessor_->getNumRows(), 0));
+        valueWidth,
+        std::vector<bool>(
+            inputProcessor_->getLiftGameProcessedData().numRows, 0));
     valueShares[0] = events.extractBit().getValue();
     valueSharesArray.push_back(std::move(valueShares));
   }
   auto oram = testUnsignedWriteOnlyOramFactory_->create(
-      inputProcessor_->getNumTestGroups());
+      inputProcessor_->getLiftGameProcessedData().numTestGroups);
   auto aggregationOutput = aggregate<false, valueWidth, true>(
-      inputProcessor_->getTestIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().testIndexShares,
       valueSharesArray,
-      inputProcessor_->getNumTestGroups(),
+      inputProcessor_->getLiftGameProcessedData().numTestGroups,
       std::move(oram));
 
   // Extract metrics
   auto populationOutput = revealPopulationOutput(aggregationOutput, true);
   metrics_.reachedConversions = std::get<0>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, true);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].reachedConversions = std::get<0>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, true);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].reachedConversions =
         std::get<0>(breakdownOutput).at(i);
   }
@@ -283,12 +311,12 @@ void Aggregator<schedulerId>::sumValues() {
     auto valueShares = input.extractIntShare().getBooleanShares();
     valueSharesArray.push_back(std::move(valueShares));
   }
-  auto oram =
-      signedWriteOnlyOramFactory_->create(inputProcessor_->getNumGroups());
+  auto oram = signedWriteOnlyOramFactory_->create(
+      inputProcessor_->getLiftGameProcessedData().numGroups);
   auto aggregationOutput = aggregate<true, valueWidth, true>(
-      inputProcessor_->getIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().indexShares,
       valueSharesArray,
-      inputProcessor_->getNumGroups(),
+      inputProcessor_->getLiftGameProcessedData().numGroups,
       std::move(oram));
 
   // Extract metrics
@@ -296,12 +324,16 @@ void Aggregator<schedulerId>::sumValues() {
   metrics_.testValue = std::get<0>(populationOutput);
   metrics_.controlValue = std::get<1>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].testValue = std::get<0>(cohortOutput).at(i);
     cohortMetrics_[i].controlValue = std::get<1>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].testValue = std::get<0>(breakdownOutput).at(i);
     publisherBreakdowns_[i].controlValue = std::get<1>(breakdownOutput).at(i);
   }
@@ -317,22 +349,26 @@ void Aggregator<schedulerId>::sumReachedValues() {
     valueSharesArray.push_back(std::move(valueShares));
   }
   auto oram = testSignedWriteOnlyOramFactory_->create(
-      inputProcessor_->getNumTestGroups());
+      inputProcessor_->getLiftGameProcessedData().numTestGroups);
   auto aggregationOutput = aggregate<true, valueWidth, true>(
-      inputProcessor_->getTestIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().testIndexShares,
       valueSharesArray,
-      inputProcessor_->getNumTestGroups(),
+      inputProcessor_->getLiftGameProcessedData().numTestGroups,
       std::move(oram));
 
   // Extract metrics
   auto populationOutput = revealPopulationOutput(aggregationOutput, true);
   metrics_.reachedValue = std::get<0>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, true);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].reachedValue = std::get<0>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, true);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].reachedValue = std::get<0>(breakdownOutput).at(i);
   }
 }
@@ -344,11 +380,11 @@ void Aggregator<schedulerId>::sumValueSquared() {
   auto valueShares =
       attributor_->getValueSquared().extractIntShare().getBooleanShares();
   auto oram = valueSquaredWriteOnlyOramFactory_->create(
-      inputProcessor_->getNumGroups());
+      inputProcessor_->getLiftGameProcessedData().numGroups);
   auto aggregationOutput = aggregate<false, valueSquaredWidth, false>(
-      inputProcessor_->getIndexShares(),
+      inputProcessor_->getLiftGameProcessedData().indexShares,
       valueShares,
-      inputProcessor_->getNumGroups(),
+      inputProcessor_->getLiftGameProcessedData().numGroups,
       std::move(oram));
 
   // Extract metrics
@@ -356,12 +392,16 @@ void Aggregator<schedulerId>::sumValueSquared() {
   metrics_.testValueSquared = std::get<0>(populationOutput);
   metrics_.controlValueSquared = std::get<1>(populationOutput);
   auto cohortOutput = revealCohortOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     cohortMetrics_[i].testValueSquared = std::get<0>(cohortOutput).at(i);
     cohortMetrics_[i].controlValueSquared = std::get<1>(cohortOutput).at(i);
   }
   auto breakdownOutput = revealBreakdownOutput(aggregationOutput, false);
-  for (size_t i = 0; i < inputProcessor_->getNumPublisherBreakdowns(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++i) {
     publisherBreakdowns_[i].testValueSquared =
         std::get<0>(breakdownOutput).at(i);
     publisherBreakdowns_[i].controlValueSquared =
@@ -411,20 +451,26 @@ Aggregator<schedulerId>::revealCohortOutput(
     bool testOnly) const {
   std::vector<NativeIntp<isSigned, width>> testCohortOutput;
   std::vector<NativeIntp<isSigned, width>> controlCohortOutput;
-  for (size_t i = 0; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+       ++i) {
     auto test = aggregationOutput.at(i);
     SecInt<schedulerId, isSigned, width> control;
     if (!testOnly) {
-      control = aggregationOutput.at(i + inputProcessor_->getNumGroups() / 2);
+      control = aggregationOutput.at(
+          i + inputProcessor_->getLiftGameProcessedData().numGroups / 2);
     }
-    if (inputProcessor_->getNumPublisherBreakdowns() > 0) {
+    if (inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns >
+        0) {
       test = test +
-          aggregationOutput.at(i + inputProcessor_->getNumPartnerCohorts());
+          aggregationOutput.at(
+              i +
+              inputProcessor_->getLiftGameProcessedData().numPartnerCohorts);
       if (!testOnly) {
         control = control +
             aggregationOutput.at(
-                i + inputProcessor_->getNumGroups() / 2 +
-                inputProcessor_->getNumPartnerCohorts());
+                i + inputProcessor_->getLiftGameProcessedData().numGroups / 2 +
+                inputProcessor_->getLiftGameProcessedData().numPartnerCohorts);
       }
     }
     // Extract cohort metrics
@@ -446,11 +492,15 @@ Aggregator<schedulerId>::revealBreakdownOutput(
     bool testOnly) const {
   std::vector<NativeIntp<isSigned, width>> testBreakdownOutput;
   std::vector<NativeIntp<isSigned, width>> controlBreakdownOutput;
-  for (size_t j = 0; j < inputProcessor_->getNumPublisherBreakdowns(); ++j) {
+  for (size_t j = 0;
+       j < inputProcessor_->getLiftGameProcessedData().numPublisherBreakdowns;
+       ++j) {
     // The order of the metrics are test and breakdown 0, test and
     // breakdown 1, control and breakdown 0, control and breakdown 1.
-    size_t testStartIndex = j * inputProcessor_->getNumGroups() / 4;
-    size_t controlStartIndex = (2 + j) * inputProcessor_->getNumGroups() / 4;
+    size_t testStartIndex =
+        j * inputProcessor_->getLiftGameProcessedData().numGroups / 4;
+    size_t controlStartIndex =
+        (2 + j) * inputProcessor_->getLiftGameProcessedData().numGroups / 4;
     // Initialize test/control metrics for the case where there are no partner
     // cohorts.
     auto test = aggregationOutput.at(testStartIndex);
@@ -458,7 +508,9 @@ Aggregator<schedulerId>::revealBreakdownOutput(
     if (!testOnly) {
       control = aggregationOutput.at(controlStartIndex);
     }
-    for (size_t i = 1; i < inputProcessor_->getNumPartnerCohorts(); ++i) {
+    for (size_t i = 1;
+         i < inputProcessor_->getLiftGameProcessedData().numPartnerCohorts;
+         ++i) {
       test = test + aggregationOutput.at(i + testStartIndex);
       if (!testOnly) {
         control = control + aggregationOutput.at(i + controlStartIndex);
@@ -482,13 +534,17 @@ Aggregator<schedulerId>::revealPopulationOutput(
   // Initialize test/control metrics for the case where there are no partner
   // cohorts
   auto test = aggregationOutput.at(0);
-  auto control = aggregationOutput.at(inputProcessor_->getNumGroups() / 2);
-  for (size_t i = 1; i < inputProcessor_->getNumGroups() / 2; ++i) {
+  auto control = aggregationOutput.at(
+      inputProcessor_->getLiftGameProcessedData().numGroups / 2);
+  for (size_t i = 1;
+       i < inputProcessor_->getLiftGameProcessedData().numGroups / 2;
+       ++i) {
     // Compute test/control metrics by summing up metrics for each population
     test = test + aggregationOutput.at(i);
     if (!testOnly) {
       control = control +
-          aggregationOutput.at(i + inputProcessor_->getNumGroups() / 2);
+          aggregationOutput.at(
+              i + inputProcessor_->getLiftGameProcessedData().numGroups / 2);
     }
   }
   auto testOutput = test.extractIntShare().getValue();

--- a/fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h
@@ -7,9 +7,8 @@
 
 #pragma once
 
-#include <fbpcs/emp_games/lift/pcf2_calculator/Constants.h>
-#include <cstdint>
-#include <vector>
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -17,44 +16,8 @@ class IInputProcessor {
  public:
   virtual ~IInputProcessor() = default;
 
-  virtual int64_t getNumRows() const = 0;
-
-  virtual uint32_t getNumPartnerCohorts() const = 0;
-
-  virtual uint32_t getNumPublisherBreakdowns() const = 0;
-
-  virtual uint32_t getNumGroups() const = 0;
-
-  virtual uint32_t getNumTestGroups() const = 0;
-
-  virtual uint8_t getValueBits() const = 0;
-
-  virtual uint8_t getValueSquaredBits() const = 0;
-
-  virtual const std::vector<std::vector<bool>>& getIndexShares() const = 0;
-
-  virtual const std::vector<std::vector<bool>>& getTestIndexShares() const = 0;
-
-  // TODO add better types to PCF and replace
-  virtual const SecTimestamp<schedulerId>& getOpportunityTimestamps() const = 0;
-
-  virtual const SecBit<schedulerId>& getIsValidOpportunityTimestamp() const = 0;
-
-  virtual const std::vector<SecTimestamp<schedulerId>>& getPurchaseTimestamps()
+  virtual const LiftGameProcessedData<schedulerId>& getLiftGameProcessedData()
       const = 0;
-
-  virtual const std::vector<SecTimestamp<schedulerId>>& getThresholdTimestamps()
-      const = 0;
-
-  virtual const SecBit<schedulerId>& getAnyValidPurchaseTimestamp() const = 0;
-
-  virtual const std::vector<SecValue<schedulerId>>& getPurchaseValues()
-      const = 0;
-
-  virtual const std::vector<SecValueSquared<schedulerId>>&
-  getPurchaseValueSquared() const = 0;
-
-  virtual const SecBit<schedulerId>& getTestReach() const = 0;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <fbpcs/emp_games/lift/pcf2_calculator/Constants.h>
 #include "folly/logging/xlog.h"
 
 #include "fbpcs/emp_games/common/Constants.h"
@@ -25,8 +26,9 @@ class InputProcessor : public IInputProcessor<schedulerId> {
   InputProcessor(int myRole, InputData inputData, int32_t numConversionsPerUser)
       : myRole_{myRole},
         inputData_{inputData},
-        numRows_{inputData.getNumRows()},
         numConversionsPerUser_{numConversionsPerUser} {
+    liftGameProcessedData_.numRows = inputData.getNumRows();
+
     validateNumRowsStep();
     shareNumGroupsStep();
     shareBitsForValuesStep();
@@ -42,75 +44,9 @@ class InputProcessor : public IInputProcessor<schedulerId> {
 
   InputProcessor() {}
 
-  int64_t getNumRows() const override {
-    return numRows_;
-  }
-
-  uint32_t getNumPartnerCohorts() const override {
-    return numPartnerCohorts_;
-  }
-
-  uint32_t getNumPublisherBreakdowns() const override {
-    return numPublisherBreakdowns_;
-  }
-
-  uint32_t getNumGroups() const override {
-    return numGroups_;
-  }
-
-  uint32_t getNumTestGroups() const override {
-    return numTestGroups_;
-  }
-
-  uint8_t getValueBits() const override {
-    return valueBits_;
-  }
-
-  uint8_t getValueSquaredBits() const override {
-    return valueSquaredBits_;
-  }
-
-  const std::vector<std::vector<bool>>& getIndexShares() const override {
-    return indexShares_;
-  }
-
-  const std::vector<std::vector<bool>>& getTestIndexShares() const override {
-    return testIndexShares_;
-  }
-
-  const SecTimestamp<schedulerId>& getOpportunityTimestamps() const override {
-    return opportunityTimestamps_;
-  }
-
-  const SecBit<schedulerId>& getIsValidOpportunityTimestamp() const override {
-    return isValidOpportunityTimestamp_;
-  }
-
-  const std::vector<SecTimestamp<schedulerId>>& getPurchaseTimestamps()
+  const LiftGameProcessedData<schedulerId>& getLiftGameProcessedData()
       const override {
-    return purchaseTimestamps_;
-  }
-
-  const std::vector<SecTimestamp<schedulerId>>& getThresholdTimestamps()
-      const override {
-    return thresholdTimestamps_;
-  }
-
-  const SecBit<schedulerId>& getAnyValidPurchaseTimestamp() const override {
-    return anyValidPurchaseTimestamp_;
-  }
-
-  const std::vector<SecValue<schedulerId>>& getPurchaseValues() const override {
-    return purchaseValues_;
-  }
-
-  const std::vector<SecValueSquared<schedulerId>>& getPurchaseValueSquared()
-      const override {
-    return purchaseValueSquared_;
-  }
-
-  const SecBit<schedulerId>& getTestReach() const override {
-    return testReach_;
+    return liftGameProcessedData_;
   }
 
  private:
@@ -147,30 +83,15 @@ class InputProcessor : public IInputProcessor<schedulerId> {
 
   int32_t myRole_;
   InputData inputData_;
-  int64_t numRows_;
-  int32_t numConversionsPerUser_;
-  uint32_t numPartnerCohorts_;
-  uint32_t numPublisherBreakdowns_;
-  uint32_t numGroups_;
-  uint32_t numTestGroups_;
-  uint8_t valueBits_;
-  uint8_t valueSquaredBits_;
 
-  SecTimestamp<schedulerId> opportunityTimestamps_;
-  SecBit<schedulerId> isValidOpportunityTimestamp_;
-  std::vector<SecTimestamp<schedulerId>> purchaseTimestamps_;
-  std::vector<SecTimestamp<schedulerId>> thresholdTimestamps_;
-  SecBit<schedulerId> anyValidPurchaseTimestamp_;
-  std::vector<SecValue<schedulerId>> purchaseValues_;
-  std::vector<SecValueSquared<schedulerId>> purchaseValueSquared_;
-  SecBit<schedulerId> testReach_;
+  int32_t numConversionsPerUser_;
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
   SecBit<schedulerId> breakdownGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
-  std::vector<std::vector<bool>> indexShares_;
-  std::vector<std::vector<bool>> testIndexShares_;
+
+  LiftGameProcessedData<schedulerId> liftGameProcessedData_;
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -17,10 +17,10 @@ void InputProcessor<schedulerId>::validateNumRowsStep() {
   const size_t width = 32;
   auto publisherNumRows = common::
       shareIntFrom<schedulerId, width, common::PUBLISHER, common::PARTNER>(
-          myRole_, numRows_);
+          myRole_, liftGameProcessedData_.numRows);
   auto partnerNumRows = common::
       shareIntFrom<schedulerId, width, common::PARTNER, common::PUBLISHER>(
-          myRole_, numRows_);
+          myRole_, liftGameProcessedData_.numRows);
 
   if (publisherNumRows != partnerNumRows) {
     XLOG(ERR) << "The publisher has " << publisherNumRows
@@ -36,7 +36,8 @@ void InputProcessor<schedulerId>::privatelySharePopulationStep() {
   controlPopulation_ = common::privatelyShareArrayWithPaddingFrom<
       common::PUBLISHER,
       bool,
-      SecBit<schedulerId>>(inputData_.getControlPopulation(), numRows_, 0);
+      SecBit<schedulerId>>(
+      inputData_.getControlPopulation(), liftGameProcessedData_.numRows, 0);
 }
 
 template <int schedulerId>
@@ -53,31 +54,34 @@ void InputProcessor<schedulerId>::shareNumGroupsStep() {
               << " groups.";
     exit(1);
   }
-  numPartnerCohorts_ = common::
+  liftGameProcessedData_.numPartnerCohorts = common::
       shareIntFrom<schedulerId, groupWidth, common::PARTNER, common::PUBLISHER>(
           myRole_, inputData_.getNumGroups());
-  numPublisherBreakdowns_ = common::
+  liftGameProcessedData_.numPublisherBreakdowns = common::
       shareIntFrom<schedulerId, groupWidth, common::PUBLISHER, common::PARTNER>(
           myRole_, inputData_.getNumGroups());
-  if (numPublisherBreakdowns_ > 2) {
+  if (liftGameProcessedData_.numPublisherBreakdowns > 2) {
     XLOG(ERR)
-        << "The input has " << numPublisherBreakdowns_
+        << "The input has " << liftGameProcessedData_.numPublisherBreakdowns
         << " publisher breakdowns but we only support 2 publisher breakdowns.";
     exit(1);
   }
   // The number of groups is 2 (for test/control population) times the number of
   // partner cohorts and the number of publisher breakdowns. If there are no
   // cohorts or breakdowns, we multiply by 1 instead.
-  numGroups_ = 2 * std::max(uint32_t(1), numPartnerCohorts_) *
-      std::max(uint32_t(1), numPublisherBreakdowns_);
+  liftGameProcessedData_.numGroups = 2 *
+      std::max(uint32_t(1), liftGameProcessedData_.numPartnerCohorts) *
+      std::max(uint32_t(1), liftGameProcessedData_.numPublisherBreakdowns);
   // The test groups consist of the groups corresponding to the test population,
   // and one additional group for the control population (disregarding
   // breakdown or cohort id). These are used for computing reach metrics, which
   // are only for the test population.
-  numTestGroups_ = 1 + numGroups_ / 2;
-  XLOG(INFO) << "Will be computing metrics for " << numPublisherBreakdowns_
-             << " publisher breakdowns and " << numPartnerCohorts_
-             << " partner cohorts";
+  liftGameProcessedData_.numTestGroups =
+      1 + liftGameProcessedData_.numGroups / 2;
+  XLOG(INFO) << "Will be computing metrics for "
+             << liftGameProcessedData_.numPublisherBreakdowns
+             << " publisher breakdowns and "
+             << liftGameProcessedData_.numPartnerCohorts << " partner cohorts";
 }
 
 template <int schedulerId>
@@ -88,18 +92,19 @@ void InputProcessor<schedulerId>::shareBitsForValuesStep() {
   auto valueSquaredBits =
       static_cast<uint64_t>(inputData_.getNumBitsForValueSquared());
 
-  valueBits_ = common::shareIntFrom<
+  liftGameProcessedData_.valueBits = common::shareIntFrom<
       schedulerId,
       numBitsForValuesWidth,
       common::PARTNER,
       common::PUBLISHER>(myRole_, valueBits);
-  valueSquaredBits_ = common::shareIntFrom<
+  liftGameProcessedData_.valueSquaredBits = common::shareIntFrom<
       schedulerId,
       numBitsForValuesWidth,
       common::PARTNER,
       common::PUBLISHER>(myRole_, valueSquaredBits);
-  XLOG(INFO) << "Num bits for values: " << valueBits_;
-  XLOG(INFO) << "Num bits for values squared: " << valueSquaredBits_;
+  XLOG(INFO) << "Num bits for values: " << liftGameProcessedData_.valueBits;
+  XLOG(INFO) << "Num bits for values squared: "
+             << liftGameProcessedData_.valueSquaredBits;
 }
 
 template <int schedulerId>
@@ -108,7 +113,8 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
   cohortGroupIds_ = common::privatelyShareArrayWithPaddingFrom<
       common::PARTNER,
       uint32_t,
-      SecGroup<schedulerId>>(inputData_.getGroupIds(), numRows_, 0);
+      SecGroup<schedulerId>>(
+      inputData_.getGroupIds(), liftGameProcessedData_.numRows, 0);
 
   XLOG(INFO) << "Share publisher breakdown group ids";
   std::vector<bool> booleanBreakdownGroupIds(
@@ -116,7 +122,8 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
   breakdownGroupIds_ = common::privatelyShareArrayWithPaddingFrom<
       common::PUBLISHER,
       bool,
-      SecBit<schedulerId>>(booleanBreakdownGroupIds, numRows_, 0);
+      SecBit<schedulerId>>(
+      booleanBreakdownGroupIds, liftGameProcessedData_.numRows, 0);
 }
 
 template <int schedulerId>
@@ -134,36 +141,43 @@ void InputProcessor<schedulerId>::privatelyShareIndexSharesStep() {
   std::vector<uint32_t> testBreakdown1GroupIds;
   std::vector<uint32_t> controlBreakdown0GroupIds;
   std::vector<uint32_t> controlBreakdown1GroupIds;
-  if (numPartnerCohorts_ > 0) {
+  if (liftGameProcessedData_.numPartnerCohorts > 0) {
     for (auto groupId : inputData_.getGroupIds()) {
-      if (numPublisherBreakdowns_ > 0) {
-        testBreakdown1GroupIds.push_back(groupId + numPartnerCohorts_);
-        controlBreakdown0GroupIds.push_back(groupId + 2 * numPartnerCohorts_);
-        controlBreakdown1GroupIds.push_back(groupId + 3 * numPartnerCohorts_);
+      if (liftGameProcessedData_.numPublisherBreakdowns > 0) {
+        testBreakdown1GroupIds.push_back(
+            groupId + liftGameProcessedData_.numPartnerCohorts);
+        controlBreakdown0GroupIds.push_back(
+            groupId + 2 * liftGameProcessedData_.numPartnerCohorts);
+        controlBreakdown1GroupIds.push_back(
+            groupId + 3 * liftGameProcessedData_.numPartnerCohorts);
       } else {
-        controlBreakdown0GroupIds.push_back(groupId + numPartnerCohorts_);
+        controlBreakdown0GroupIds.push_back(
+            groupId + liftGameProcessedData_.numPartnerCohorts);
       }
     }
   }
 
   SecGroup<schedulerId> secControlGroupIds;
-  if (numPublisherBreakdowns_ > 0) {
+  if (liftGameProcessedData_.numPublisherBreakdowns > 0) {
     // We share the new group ids with padding values 1, 2 and 3, to account for
     // the case where there are no cohorts.
     auto secTestBreakdown1GroupIds = common::privatelyShareArrayWithPaddingFrom<
         common::PARTNER,
         uint32_t,
-        SecGroup<schedulerId>>(testBreakdown1GroupIds, numRows_, 1);
+        SecGroup<schedulerId>>(
+        testBreakdown1GroupIds, liftGameProcessedData_.numRows, 1);
     auto secControlBreakdown0GroupIds =
         common::privatelyShareArrayWithPaddingFrom<
             common::PARTNER,
             uint32_t,
-            SecGroup<schedulerId>>(controlBreakdown0GroupIds, numRows_, 2);
+            SecGroup<schedulerId>>(
+            controlBreakdown0GroupIds, liftGameProcessedData_.numRows, 2);
     auto secControlBreakdown1GroupIds =
         common::privatelyShareArrayWithPaddingFrom<
             common::PARTNER,
             uint32_t,
-            SecGroup<schedulerId>>(controlBreakdown1GroupIds, numRows_, 3);
+            SecGroup<schedulerId>>(
+            controlBreakdown1GroupIds, liftGameProcessedData_.numRows, 3);
 
     // We now set the group ids depending on whether each row is a test or
     // control, and whether the breakdown id is 0 or 1.
@@ -176,15 +190,17 @@ void InputProcessor<schedulerId>::privatelyShareIndexSharesStep() {
     secControlGroupIds = common::privatelyShareArrayWithPaddingFrom<
         common::PARTNER,
         uint32_t,
-        SecGroup<schedulerId>>(controlBreakdown0GroupIds, numRows_, 1);
+        SecGroup<schedulerId>>(
+        controlBreakdown0GroupIds, liftGameProcessedData_.numRows, 1);
   }
 
   auto secGroupIds = testGroupIds_.mux(controlPopulation_, secControlGroupIds);
   // Generate index shares from group ids
-  indexShares_ = secGroupIds.extractIntShare().getBooleanShares();
+  liftGameProcessedData_.indexShares =
+      secGroupIds.extractIntShare().getBooleanShares();
   // Resize to width needed for the number of groups
-  size_t groupWidth = std::ceil(std::log2(numGroups_));
-  indexShares_.resize(groupWidth);
+  size_t groupWidth = std::ceil(std::log2(liftGameProcessedData_.numGroups));
+  liftGameProcessedData_.indexShares.resize(groupWidth);
 }
 
 template <int schedulerId>
@@ -197,23 +213,29 @@ void InputProcessor<schedulerId>::privatelyShareTestIndexSharesStep() {
   // in total, and we assign the first numPartnerCohorts_ to breakdown id 0, the
   // second numPartnerCohorts_ to breakdown id 1, and the last group id to the
   // control population.
-  std::vector<uint32_t> controlGroupIds(numRows_, numTestGroups_ - 1);
+  std::vector<uint32_t> controlGroupIds(
+      liftGameProcessedData_.numRows, liftGameProcessedData_.numTestGroups - 1);
 
   // We share the new control group ids
   auto secControlGroupIds = common::privatelyShareArrayWithPaddingFrom<
       common::PARTNER,
       uint32_t,
-      SecGroup<schedulerId>>(controlGroupIds, numRows_, numTestGroups_ - 1);
+      SecGroup<schedulerId>>(
+      controlGroupIds,
+      liftGameProcessedData_.numRows,
+      liftGameProcessedData_.numTestGroups - 1);
 
   // We now set the group ids depending on whether each row is a test or
   // control
   auto secGroupIds = testGroupIds_.mux(controlPopulation_, secControlGroupIds);
 
   // Generate index shares from group ids
-  testIndexShares_ = secGroupIds.extractIntShare().getBooleanShares();
+  liftGameProcessedData_.testIndexShares =
+      secGroupIds.extractIntShare().getBooleanShares();
   // Resize to width needed for the number of groups
-  size_t testGroupWidth = std::ceil(std::log2(numTestGroups_));
-  testIndexShares_.resize(testGroupWidth);
+  size_t testGroupWidth =
+      std::ceil(std::log2(liftGameProcessedData_.numTestGroups));
+  liftGameProcessedData_.testIndexShares.resize(testGroupWidth);
 }
 
 template <int schedulerId>
@@ -221,11 +243,14 @@ void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
   // TODO: We're using 32 bits for timestamps along with an offset setting the
   // epoch to 2019-01-01. This will break in the year 2087.
   XLOG(INFO) << "Share opportunity timestamps";
-  opportunityTimestamps_ = common::privatelyShareArrayWithPaddingFrom<
-      common::PUBLISHER,
-      uint32_t,
-      SecTimestamp<schedulerId>>(
-      inputData_.getOpportunityTimestamps(), numRows_, 0);
+  liftGameProcessedData_.opportunityTimestamps =
+      common::privatelyShareArrayWithPaddingFrom<
+          common::PUBLISHER,
+          uint32_t,
+          SecTimestamp<schedulerId>>(
+          inputData_.getOpportunityTimestamps(),
+          liftGameProcessedData_.numRows,
+          0);
 
   XLOG(INFO) << "Share if opportunity timestamps are valid";
   std::vector<bool> isValidOpportunityTimestamp;
@@ -236,20 +261,23 @@ void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
         (inputData_.getControlPopulation().at(i) |
          inputData_.getTestPopulation().at(i)));
   }
-  isValidOpportunityTimestamp_ = common::privatelyShareArrayWithPaddingFrom<
-      common::PUBLISHER,
-      bool,
-      SecBit<schedulerId>>(isValidOpportunityTimestamp, numRows_, 0);
+  liftGameProcessedData_.isValidOpportunityTimestamp =
+      common::privatelyShareArrayWithPaddingFrom<
+          common::PUBLISHER,
+          bool,
+          SecBit<schedulerId>>(
+          isValidOpportunityTimestamp, liftGameProcessedData_.numRows, 0);
 
   XLOG(INFO) << "Share purchase timestamps";
-  purchaseTimestamps_ = common::privatelyShareTransposedArraysWithPaddingFrom<
-      common::PARTNER,
-      uint32_t,
-      SecTimestamp<schedulerId>>(
-      inputData_.getPurchaseTimestampArrays(),
-      numRows_,
-      numConversionsPerUser_,
-      0);
+  liftGameProcessedData_.purchaseTimestamps =
+      common::privatelyShareTransposedArraysWithPaddingFrom<
+          common::PARTNER,
+          uint32_t,
+          SecTimestamp<schedulerId>>(
+          inputData_.getPurchaseTimestampArrays(),
+          liftGameProcessedData_.numRows,
+          numConversionsPerUser_,
+          0);
 
   XLOG(INFO) << "Share if any purchase timestamp is valid";
   std::vector<bool> anyValidPurchaseTimestamp;
@@ -263,10 +291,12 @@ void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
     }
     anyValidPurchaseTimestamp.push_back(anyValidPurchaseTs);
   }
-  anyValidPurchaseTimestamp_ = common::privatelyShareArrayWithPaddingFrom<
-      common::PARTNER,
-      bool,
-      SecBit<schedulerId>>(anyValidPurchaseTimestamp, numRows_, 0);
+  liftGameProcessedData_.anyValidPurchaseTimestamp =
+      common::privatelyShareArrayWithPaddingFrom<
+          common::PARTNER,
+          bool,
+          SecBit<schedulerId>>(
+          anyValidPurchaseTimestamp, liftGameProcessedData_.numRows, 0);
 
   XLOG(INFO) << "Share threshold timestamps";
   // Threshold timestamps are valid (positive) purchase timestamp with added
@@ -284,11 +314,15 @@ void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
     thresholdTimestampArrays.push_back(std::move(thresholdTimestampArray));
   }
   // Secretly share threshold timestamps
-  thresholdTimestamps_ = common::privatelyShareTransposedArraysWithPaddingFrom<
-      common::PARTNER,
-      uint32_t,
-      SecTimestamp<schedulerId>>(
-      thresholdTimestampArrays, numRows_, numConversionsPerUser_, 0);
+  liftGameProcessedData_.thresholdTimestamps =
+      common::privatelyShareTransposedArraysWithPaddingFrom<
+          common::PARTNER,
+          uint32_t,
+          SecTimestamp<schedulerId>>(
+          thresholdTimestampArrays,
+          liftGameProcessedData_.numRows,
+          numConversionsPerUser_,
+          0);
 }
 
 template <int schedulerId>
@@ -297,21 +331,26 @@ void InputProcessor<schedulerId>::privatelySharePurchaseValuesStep() {
   // Since the input values are processed row by row, while we will be doing
   // batch computations with the values across the rows, we have to first
   // transpose the input arrays before sharing them in MPC.
-  purchaseValues_ = common::privatelyShareTransposedArraysWithPaddingFrom<
-      common::PARTNER,
-      int64_t,
-      SecValue<schedulerId>>(
-      inputData_.getPurchaseValueArrays(), numRows_, numConversionsPerUser_, 0);
+  liftGameProcessedData_.purchaseValues =
+      common::privatelyShareTransposedArraysWithPaddingFrom<
+          common::PARTNER,
+          int64_t,
+          SecValue<schedulerId>>(
+          inputData_.getPurchaseValueArrays(),
+          liftGameProcessedData_.numRows,
+          numConversionsPerUser_,
+          0);
 
   XLOG(INFO) << "Share purchase values squared";
-  purchaseValueSquared_ = common::privatelyShareTransposedArraysWithPaddingFrom<
-      common::PARTNER,
-      int64_t,
-      SecValueSquared<schedulerId>>(
-      inputData_.getPurchaseValueSquaredArrays(),
-      numRows_,
-      numConversionsPerUser_,
-      0);
+  liftGameProcessedData_.purchaseValueSquared =
+      common::privatelyShareTransposedArraysWithPaddingFrom<
+          common::PARTNER,
+          int64_t,
+          SecValueSquared<schedulerId>>(
+          inputData_.getPurchaseValueSquaredArrays(),
+          liftGameProcessedData_.numRows,
+          numConversionsPerUser_,
+          0);
 }
 
 template <int schedulerId>
@@ -325,10 +364,10 @@ void InputProcessor<schedulerId>::privatelyShareTestReachStep() {
         inputData_.getTestPopulation().at(i) &
         (inputData_.getNumImpressions().at(i) > 0));
   }
-  testReach_ = common::privatelyShareArrayWithPaddingFrom<
+  liftGameProcessedData_.testReach = common::privatelyShareArrayWithPaddingFrom<
       common::PUBLISHER,
       bool,
-      SecBit<schedulerId>>(testReach, numRows_, 0);
+      SecBit<schedulerId>>(testReach, liftGameProcessedData_.numRows, 0);
 }
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+struct LiftGameProcessedData {
+  int64_t numRows;
+  uint32_t numPartnerCohorts;
+  uint32_t numPublisherBreakdowns;
+  uint32_t numGroups;
+  uint32_t numTestGroups;
+  uint8_t valueBits;
+  uint8_t valueSquaredBits;
+  std::vector<std::vector<bool>> indexShares;
+  std::vector<std::vector<bool>> testIndexShares;
+  SecTimestamp<schedulerId> opportunityTimestamps;
+  SecBit<schedulerId> isValidOpportunityTimestamp;
+  std::vector<SecTimestamp<schedulerId>> purchaseTimestamps;
+  std::vector<SecTimestamp<schedulerId>> thresholdTimestamps;
+  SecBit<schedulerId> anyValidPurchaseTimestamp;
+  std::vector<SecValue<schedulerId>> purchaseValues;
+  std::vector<SecValueSquared<schedulerId>> purchaseValueSquared;
+  SecBit<schedulerId> testReach;
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -93,49 +93,70 @@ class InputProcessorTest : public ::testing::TestWithParam<bool> {
 };
 
 TEST_P(InputProcessorTest, testNumRows) {
-  EXPECT_EQ(publisherInputProcessor_.getNumRows(), 33);
-  EXPECT_EQ(partnerInputProcessor_.getNumRows(), 33);
+  EXPECT_EQ(publisherInputProcessor_.getLiftGameProcessedData().numRows, 33);
+  EXPECT_EQ(partnerInputProcessor_.getLiftGameProcessedData().numRows, 33);
 }
 
 TEST_P(InputProcessorTest, testBitsForValues) {
-  EXPECT_EQ(publisherInputProcessor_.getValueBits(), 10);
-  EXPECT_EQ(partnerInputProcessor_.getValueBits(), 10);
-  EXPECT_EQ(publisherInputProcessor_.getValueSquaredBits(), 15);
-  EXPECT_EQ(partnerInputProcessor_.getValueSquaredBits(), 15);
+  EXPECT_EQ(publisherInputProcessor_.getLiftGameProcessedData().valueBits, 10);
+  EXPECT_EQ(partnerInputProcessor_.getLiftGameProcessedData().valueBits, 10);
+  EXPECT_EQ(
+      publisherInputProcessor_.getLiftGameProcessedData().valueSquaredBits, 15);
+  EXPECT_EQ(
+      partnerInputProcessor_.getLiftGameProcessedData().valueSquaredBits, 15);
 }
 
 TEST_P(InputProcessorTest, testNumPartnerCohorts) {
-  EXPECT_EQ(publisherInputProcessor_.getNumPartnerCohorts(), 3);
-  EXPECT_EQ(partnerInputProcessor_.getNumPartnerCohorts(), 3);
+  EXPECT_EQ(
+      publisherInputProcessor_.getLiftGameProcessedData().numPartnerCohorts, 3);
+  EXPECT_EQ(
+      partnerInputProcessor_.getLiftGameProcessedData().numPartnerCohorts, 3);
 }
 
 TEST_P(InputProcessorTest, testNumBreakdowns) {
   if (computePublisherBreakdowns_) {
-    EXPECT_EQ(publisherInputProcessor_.getNumPublisherBreakdowns(), 2);
-    EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 2);
+    EXPECT_EQ(
+        publisherInputProcessor_.getLiftGameProcessedData()
+            .numPublisherBreakdowns,
+        2);
+    EXPECT_EQ(
+        partnerInputProcessor_.getLiftGameProcessedData()
+            .numPublisherBreakdowns,
+        2);
   } else {
-    EXPECT_EQ(publisherInputProcessor_.getNumPublisherBreakdowns(), 0);
-    EXPECT_EQ(partnerInputProcessor_.getNumPublisherBreakdowns(), 0);
+    EXPECT_EQ(
+        publisherInputProcessor_.getLiftGameProcessedData()
+            .numPublisherBreakdowns,
+        0);
+    EXPECT_EQ(
+        partnerInputProcessor_.getLiftGameProcessedData()
+            .numPublisherBreakdowns,
+        0);
   }
 }
 
 TEST_P(InputProcessorTest, testNumGroups) {
   if (computePublisherBreakdowns_) {
-    EXPECT_EQ(publisherInputProcessor_.getNumGroups(), 12);
-    EXPECT_EQ(partnerInputProcessor_.getNumGroups(), 12);
+    EXPECT_EQ(
+        publisherInputProcessor_.getLiftGameProcessedData().numGroups, 12);
+    EXPECT_EQ(partnerInputProcessor_.getLiftGameProcessedData().numGroups, 12);
   } else {
-    EXPECT_EQ(publisherInputProcessor_.getNumGroups(), 6);
-    EXPECT_EQ(partnerInputProcessor_.getNumGroups(), 6);
+    EXPECT_EQ(publisherInputProcessor_.getLiftGameProcessedData().numGroups, 6);
+    EXPECT_EQ(partnerInputProcessor_.getLiftGameProcessedData().numGroups, 6);
   }
 }
 
 TEST_P(InputProcessorTest, testNumTestGroups) {
   if (computePublisherBreakdowns_) {
-    EXPECT_EQ(publisherInputProcessor_.getNumTestGroups(), 7);
-    EXPECT_EQ(partnerInputProcessor_.getNumTestGroups(), 7);
+    EXPECT_EQ(
+        publisherInputProcessor_.getLiftGameProcessedData().numTestGroups, 7);
+    EXPECT_EQ(
+        partnerInputProcessor_.getLiftGameProcessedData().numTestGroups, 7);
   } else {
-    EXPECT_EQ(publisherInputProcessor_.getNumTestGroups(), 4);
-    EXPECT_EQ(partnerInputProcessor_.getNumTestGroups(), 4);
+    EXPECT_EQ(
+        publisherInputProcessor_.getLiftGameProcessedData().numTestGroups, 4);
+    EXPECT_EQ(
+        partnerInputProcessor_.getLiftGameProcessedData().numTestGroups, 4);
   }
 }
 
@@ -157,9 +178,10 @@ std::vector<uint32_t> convertIndexSharesToGroupIds(
 }
 
 TEST_P(InputProcessorTest, testIndexShares) {
-  auto publisherShares = publisherInputProcessor_.getIndexShares();
-  size_t groupWidth =
-      std::ceil(std::log2(publisherInputProcessor_.getNumGroups()));
+  auto publisherShares =
+      publisherInputProcessor_.getLiftGameProcessedData().indexShares;
+  size_t groupWidth = std::ceil(
+      std::log2(publisherInputProcessor_.getLiftGameProcessedData().numGroups));
   EXPECT_EQ(publisherShares.size(), groupWidth);
   std::vector<uint32_t> expectGroupIds;
   if (computePublisherBreakdowns_) {
@@ -174,9 +196,10 @@ TEST_P(InputProcessorTest, testIndexShares) {
 }
 
 TEST_P(InputProcessorTest, testTestIndexShares) {
-  auto publisherShares = publisherInputProcessor_.getTestIndexShares();
-  size_t testGroupWidth =
-      std::ceil(std::log2(publisherInputProcessor_.getNumTestGroups()));
+  auto publisherShares =
+      publisherInputProcessor_.getLiftGameProcessedData().testIndexShares;
+  size_t testGroupWidth = std::ceil(std::log2(
+      publisherInputProcessor_.getLiftGameProcessedData().numTestGroups));
   EXPECT_EQ(publisherShares.size(), testGroupWidth);
   std::vector<uint32_t> expectTestGroupIds;
   if (computePublisherBreakdowns_) {
@@ -192,13 +215,13 @@ TEST_P(InputProcessorTest, testTestIndexShares) {
 
 TEST_P(InputProcessorTest, testOpportunityTimestamps) {
   auto future0 = std::async([&] {
-    return publisherInputProcessor_.getOpportunityTimestamps()
-        .openToParty(0)
+    return publisherInputProcessor_.getLiftGameProcessedData()
+        .opportunityTimestamps.openToParty(0)
         .getValue();
   });
   auto future1 = std::async([&] {
-    return partnerInputProcessor_.getOpportunityTimestamps()
-        .openToParty(0)
+    return partnerInputProcessor_.getLiftGameProcessedData()
+        .opportunityTimestamps.openToParty(0)
         .getValue();
   });
   auto opportunityTimestamps0 = future0.get();
@@ -212,13 +235,13 @@ TEST_P(InputProcessorTest, testOpportunityTimestamps) {
 
 TEST_P(InputProcessorTest, testIsValidOpportunityTimestamp) {
   auto future0 = std::async([&] {
-    return publisherInputProcessor_.getIsValidOpportunityTimestamp()
-        .openToParty(0)
+    return publisherInputProcessor_.getLiftGameProcessedData()
+        .isValidOpportunityTimestamp.openToParty(0)
         .getValue();
   });
   auto future1 = std::async([&] {
-    return partnerInputProcessor_.getIsValidOpportunityTimestamp()
-        .openToParty(0)
+    return partnerInputProcessor_.getLiftGameProcessedData()
+        .isValidOpportunityTimestamp.openToParty(0)
         .getValue();
   });
   auto isValidOpportunityTimestamp0 = future0.get();
@@ -233,10 +256,12 @@ template <int schedulerId>
 std::vector<std::vector<uint64_t>> revealPurchaseTimestamps(
     InputProcessor<schedulerId> inputProcessor) {
   std::vector<std::vector<uint64_t>> purchaseTimestamps;
-  for (size_t i = 0; i < inputProcessor.getPurchaseTimestamps().size(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor.getLiftGameProcessedData().purchaseTimestamps.size();
+       ++i) {
     purchaseTimestamps.push_back(
-        std::move(inputProcessor.getPurchaseTimestamps()
-                      .at(i)
+        std::move(inputProcessor.getLiftGameProcessedData()
+                      .purchaseTimestamps.at(i)
                       .openToParty(0)
                       .getValue()));
   }
@@ -263,10 +288,12 @@ template <int schedulerId>
 std::vector<std::vector<uint64_t>> revealThresholdTimestamps(
     InputProcessor<schedulerId> inputProcessor) {
   std::vector<std::vector<uint64_t>> thresholdTimestamps;
-  for (size_t i = 0; i < inputProcessor.getThresholdTimestamps().size(); ++i) {
+  for (size_t i = 0;
+       i < inputProcessor.getLiftGameProcessedData().thresholdTimestamps.size();
+       ++i) {
     thresholdTimestamps.push_back(
-        std::move(inputProcessor.getThresholdTimestamps()
-                      .at(i)
+        std::move(inputProcessor.getLiftGameProcessedData()
+                      .thresholdTimestamps.at(i)
                       .openToParty(0)
                       .getValue()));
   }
@@ -291,13 +318,13 @@ TEST_P(InputProcessorTest, testThresholdTimestamps) {
 
 TEST_P(InputProcessorTest, testAnyValidPurchaseTimestamp) {
   auto future0 = std::async([&] {
-    return publisherInputProcessor_.getAnyValidPurchaseTimestamp()
-        .openToParty(0)
+    return publisherInputProcessor_.getLiftGameProcessedData()
+        .anyValidPurchaseTimestamp.openToParty(0)
         .getValue();
   });
   auto future1 = std::async([&] {
-    return partnerInputProcessor_.getAnyValidPurchaseTimestamp()
-        .openToParty(0)
+    return partnerInputProcessor_.getLiftGameProcessedData()
+        .anyValidPurchaseTimestamp.openToParty(0)
         .getValue();
   });
   auto anyValidPurchaseTimestamp0 = future0.get();
@@ -312,9 +339,13 @@ template <int schedulerId>
 std::vector<std::vector<int64_t>> revealPurchaseValues(
     InputProcessor<schedulerId> inputProcessor) {
   std::vector<std::vector<int64_t>> purchaseValues;
-  for (size_t i = 0; i < inputProcessor.getPurchaseValues().size(); ++i) {
-    purchaseValues.push_back(std::move(
-        inputProcessor.getPurchaseValues().at(i).openToParty(0).getValue()));
+  for (size_t i = 0;
+       i < inputProcessor.getLiftGameProcessedData().purchaseValues.size();
+       ++i) {
+    purchaseValues.push_back(std::move(inputProcessor.getLiftGameProcessedData()
+                                           .purchaseValues.at(i)
+                                           .openToParty(0)
+                                           .getValue()));
   }
   return purchaseValues;
 }
@@ -336,10 +367,12 @@ template <int schedulerId>
 std::vector<std::vector<int64_t>> revealPurchaseValueSquared(
     InputProcessor<schedulerId> inputProcessor) {
   std::vector<std::vector<int64_t>> purchaseValueSquared;
-  for (size_t i = 0; i < inputProcessor.getPurchaseValueSquared().size(); ++i) {
+  for (size_t i = 0; i <
+       inputProcessor.getLiftGameProcessedData().purchaseValueSquared.size();
+       ++i) {
     purchaseValueSquared.push_back(
-        std::move(inputProcessor.getPurchaseValueSquared()
-                      .at(i)
+        std::move(inputProcessor.getLiftGameProcessedData()
+                      .purchaseValueSquared.at(i)
                       .openToParty(0)
                       .getValue()));
   }
@@ -366,10 +399,14 @@ TEST_P(InputProcessorTest, testPurchaseValueSquared) {
 
 TEST_P(InputProcessorTest, testReach) {
   auto future0 = std::async([&] {
-    return publisherInputProcessor_.getTestReach().openToParty(0).getValue();
+    return publisherInputProcessor_.getLiftGameProcessedData()
+        .testReach.openToParty(0)
+        .getValue();
   });
   auto future1 = std::async([&] {
-    return partnerInputProcessor_.getTestReach().openToParty(0).getValue();
+    return partnerInputProcessor_.getLiftGameProcessedData()
+        .testReach.openToParty(0)
+        .getValue();
   });
   auto testReach0 = future0.get();
   auto testReach1 = future1.get();


### PR DESCRIPTION
Summary:
Followup from D39003554. This diff is quite a handful as it refactors a bunch of PCF2 PL code to work with a new data struct called `LiftGameProcessedData`.

Previous approach was to directly call getters for each member variable in `InputProcessor`, however this approach is prone to creating lots of copies as data is not returned by reference.

This API for InputProcessor now just includes a

`getLiftGameProcessedData` which returns a const ref to the MPC'ified input data. We can add serialization / deserialization functionality in a future diff to make the secret share input processor simple to reason about.

- Removed all getters from IInputProcessor
- Moved members variables into a single member struct `LiftGameProcessedData`
- Replaced all references in code to getters to use the new struct.

It's a lot of code changes but mostly non-functional.

Differential Revision: D39178354

