### PR TITLE
Consume container_type in PCSContainerService

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -49,6 +49,7 @@ class PCSContainerService(ContainerService):
             container_definition=container_definition,
             cmd=cmd,
             env_vars=env_vars,
+            container_type=container_type,
         )
         log_url = None
         if self.log_retriever:


### PR DESCRIPTION
Summary: MPC uses PCSContainerService when starting containers, so it needs to consume container_type otherwise customized container won't work

Differential Revision: D39156023

