### PR TITLE
use generics

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -9,7 +9,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional, Type
+from typing import Generic, List, Optional, Type, TypeVar
 
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 
@@ -21,6 +21,9 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 
+# T can be any subtype of BoltCreateInstanceArgs
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+
 
 @dataclass
 class BoltState:
@@ -28,7 +31,7 @@ class BoltState:
     server_ips: Optional[List[str]] = None
 
 
-class BoltClient(ABC):
+class BoltClient(ABC, Generic[T]):
     """
     Exposes async methods for creating instances, running stages, updating instances,
     and validating the correctness of a computation
@@ -40,7 +43,7 @@ class BoltClient(ABC):
         )
 
     @abstractmethod
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
+    async def create_instance(self, instance_args: T) -> str:
         pass
 
     @abstractmethod
@@ -94,7 +97,7 @@ class BoltClient(ABC):
                 return stage
         return None
 
-    async def is_existing_instance(self, instance_args: BoltCreateInstanceArgs) -> bool:
+    async def is_existing_instance(self, instance_args: T) -> bool:
         """Returns whether the instance with instance_args exists
 
         Args:

--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -8,8 +8,7 @@
 
 from abc import ABC
 from dataclasses import dataclass
-
-from typing import Optional, Type
+from typing import Generic, Optional, Type, TypeVar
 
 from dataclasses_json import DataClassJsonMixin
 from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
@@ -17,7 +16,6 @@ from fbpcs.bolt.exceptions import IncompatibleStageError
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
@@ -28,17 +26,21 @@ class BoltCreateInstanceArgs(ABC):
     instance_id: str
 
 
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+U = TypeVar("U", bound=BoltCreateInstanceArgs)
+
+
 @dataclass
-class BoltPlayerArgs:
-    create_instance_args: BoltCreateInstanceArgs
+class BoltPlayerArgs(Generic[T]):
+    create_instance_args: T
     expected_result_path: Optional[str] = None
 
 
 @dataclass
-class BoltJob(DataClassJsonMixin):
+class BoltJob(DataClassJsonMixin, Generic[T, U]):
     job_name: str
-    publisher_bolt_args: BoltPlayerArgs
-    partner_bolt_args: BoltPlayerArgs
+    publisher_bolt_args: BoltPlayerArgs[T]
+    partner_bolt_args: BoltPlayerArgs[U]
     poll_interval: int = DEFAULT_POLL_INTERVAL_SEC
     num_tries: Optional[int] = None
 

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -106,7 +106,7 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
         return cls.from_dict(yml_dict)
 
 
-class BoltPCSClient(BoltClient):
+class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
     def __init__(
         self, pcs: PrivateComputationService, logger: Optional[logging.Logger] = None
     ) -> None:
@@ -115,10 +115,7 @@ class BoltPCSClient(BoltClient):
             logging.getLogger(__name__) if logger is None else logger
         )
 
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
-        assert isinstance(
-            instance_args, BoltPCSCreateInstanceArgs
-        )  # We will add generics later so that we can move the check to the type checker
+    async def create_instance(self, instance_args: BoltPCSCreateInstanceArgs) -> str:
         instance = self.pcs.create_instance(
             instance_id=instance_args.instance_id,
             role=instance_args.role,

--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -22,7 +22,10 @@ from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
 
 def parse_bolt_config(
     config: Dict[str, Any], logger: logging.Logger
-) -> Tuple[BoltRunner, List[BoltJob]]:
+) -> Tuple[
+    BoltRunner[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs],
+    List[BoltJob[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]],
+]:
 
     # create runner
     runner_config = config["runner"]
@@ -36,7 +39,7 @@ def parse_bolt_config(
 
 def create_bolt_runner(
     runner_config: Dict[str, Any], logger: logging.Logger
-) -> BoltRunner:
+) -> BoltRunner[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]:
     publisher_client_config = ConfigYamlDict.from_file(
         runner_config["publisher_client_config"]
     )
@@ -72,7 +75,9 @@ def create_bolt_runner(
     return runner
 
 
-def create_job_list(job_config_list: Dict[str, Any]) -> List[BoltJob]:
+def create_job_list(
+    job_config_list: Dict[str, Any]
+) -> List[BoltJob[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]]:
     bolt_job_list = []
     for job_name, job_config in job_config_list.items():
         publisher_args = job_config["publisher"]

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -5,14 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 import requests
-
 from fbpcs.bolt.bolt_client import BoltClient, BoltState
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 from fbpcs.bolt.constants import FBPCS_GRAPH_API_TOKEN
@@ -105,7 +103,14 @@ class BoltPAGraphAPICreateInstanceArgs(BoltCreateInstanceArgs):
     num_containers: str
 
 
-class BoltGraphAPIClient(BoltClient):
+BoltGraphAPICreateInstanceArgs = TypeVar(
+    "BoltGraphAPICreateInstanceArgs",
+    BoltPLGraphAPICreateInstanceArgs,
+    BoltPAGraphAPICreateInstanceArgs,
+)
+
+
+class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
     def __init__(
         self, config: Dict[str, Any], logger: Optional[logging.Logger] = None
     ) -> None:
@@ -121,7 +126,10 @@ class BoltGraphAPIClient(BoltClient):
         self.access_token = self._get_graph_api_token(config)
         self.params = {"access_token": self.access_token}
 
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
+    async def create_instance(
+        self,
+        instance_args: BoltGraphAPICreateInstanceArgs,
+    ) -> str:
         params = self.params.copy()
         if isinstance(instance_args, BoltPLGraphAPICreateInstanceArgs):
             params["breakdown_key"] = json.dumps(instance_args.breakdown_key)
@@ -190,7 +198,10 @@ class BoltGraphAPIClient(BoltClient):
                 "This method should not be called with expected results"
             )
 
-    async def is_existing_instance(self, instance_args: BoltCreateInstanceArgs) -> bool:
+    async def is_existing_instance(
+        self,
+        instance_args: BoltGraphAPICreateInstanceArgs,
+    ) -> bool:
         instance_id = instance_args.instance_id
         self.logger.info(f"Checking if {instance_id} exists...")
         if instance_id:

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -256,7 +256,11 @@ def run_study(
 
 
 async def run_bolt(
-    config: Dict[str, Any], logger: logging.Logger, job_list: List[BoltJob]
+    config: Dict[str, Any],
+    logger: logging.Logger,
+    job_list: List[
+        BoltJob[BoltPLGraphAPICreateInstanceArgs, BoltPCSCreateInstanceArgs]
+    ],
 ) -> None:
     """Run private lift with the BoltRunner in a dedicated function to ensure that
     the BoltRunner semaphore and runner.run_async share the same event loop.


### PR DESCRIPTION
Summary:
## What is this stack

- Bolt has been used in canary for weeks now and we haven't seen reports of any issues
- It's time to productionize
- Early in the stack, I rework some logic to raise the quality bar a bit. At the end of the stack, I delete the legacy runner.

## What

- Use generics across Bolt
    - BoltJob
    - BoltClients
    - BoltRunner

## Why

- This will allow pyre to enforce that the previously implicit relationship between jobs <-> clients <-> runner are being respected
- I.e. "pyre will yell at you if you try to pass the wrong arguments to clients"

Differential Revision: D39227358

