### PR TITLE
simplify get_or_create logic

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -116,3 +116,13 @@ class BoltClient(ABC, Generic[T]):
         except Exception:
             self.logger.info(f"{instance_id} not found.")
             return False
+
+    async def get_or_create_instance(self, instance_args: T) -> str:
+        if await self.is_existing_instance(instance_args):
+            self.logger.info(f"instance {instance_args.instance_id} exists - returning")
+            return instance_args.instance_id
+        else:
+            self.logger.info(
+                f"instance {instance_args.instance_id} does not exist - creating"
+            )
+            return await self.create_instance(instance_args)

--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -9,7 +9,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional, Type
+from typing import Generic, List, Optional, Type, TypeVar
 
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 
@@ -21,6 +21,9 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 
+# T can be any subtype of BoltCreateInstanceArgs
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+
 
 @dataclass
 class BoltState:
@@ -28,7 +31,7 @@ class BoltState:
     server_ips: Optional[List[str]] = None
 
 
-class BoltClient(ABC):
+class BoltClient(ABC, Generic[T]):
     """
     Exposes async methods for creating instances, running stages, updating instances,
     and validating the correctness of a computation
@@ -40,7 +43,7 @@ class BoltClient(ABC):
         )
 
     @abstractmethod
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
+    async def create_instance(self, instance_args: T) -> str:
         pass
 
     @abstractmethod
@@ -94,7 +97,7 @@ class BoltClient(ABC):
                 return stage
         return None
 
-    async def is_existing_instance(self, instance_args: BoltCreateInstanceArgs) -> bool:
+    async def is_existing_instance(self, instance_args: T) -> bool:
         """Returns whether the instance with instance_args exists
 
         Args:

--- a/fbpcs/bolt/bolt_job.py
+++ b/fbpcs/bolt/bolt_job.py
@@ -8,8 +8,7 @@
 
 from abc import ABC
 from dataclasses import dataclass
-
-from typing import Optional, Type
+from typing import Generic, Optional, Type, TypeVar
 
 from dataclasses_json import DataClassJsonMixin
 from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
@@ -17,7 +16,6 @@ from fbpcs.bolt.exceptions import IncompatibleStageError
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-
 from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
     PrivateComputationBaseStageFlow,
 )
@@ -28,17 +26,21 @@ class BoltCreateInstanceArgs(ABC):
     instance_id: str
 
 
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+U = TypeVar("U", bound=BoltCreateInstanceArgs)
+
+
 @dataclass
-class BoltPlayerArgs:
-    create_instance_args: BoltCreateInstanceArgs
+class BoltPlayerArgs(Generic[T]):
+    create_instance_args: T
     expected_result_path: Optional[str] = None
 
 
 @dataclass
-class BoltJob(DataClassJsonMixin):
+class BoltJob(DataClassJsonMixin, Generic[T, U]):
     job_name: str
-    publisher_bolt_args: BoltPlayerArgs
-    partner_bolt_args: BoltPlayerArgs
+    publisher_bolt_args: BoltPlayerArgs[T]
+    partner_bolt_args: BoltPlayerArgs[U]
     poll_interval: int = DEFAULT_POLL_INTERVAL_SEC
     num_tries: Optional[int] = None
 

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -91,10 +91,23 @@ class BoltRunner(Generic[T, U]):
                             if await self.job_is_finished(
                                 job=job, stage_flow=stage_flow
                             ):
-                                logger.info(
-                                    # pyre-fixme: Undefined attribute [16]: `BoltCreateInstanceArgs` has no attribute `output_dir`
-                                    f"Run for {job.job_name} completed. View results at {job.partner_bolt_args.create_instance_args.output_dir}"
-                                )
+                                logger.info(f"Run for {job.job_name} completed.")
+
+                                if isinstance(
+                                    job.partner_bolt_args.create_instance_args,
+                                    BoltPCSCreateInstanceArgs,
+                                ):
+                                    logger.info(
+                                        f"View {job.job_name} partner results at {job.partner_bolt_args.create_instance_args.output_dir}"
+                                    )
+
+                                if isinstance(
+                                    job.publisher_bolt_args.create_instance_args,
+                                    BoltPCSCreateInstanceArgs,
+                                ):
+                                    logger.info(
+                                        f"View {job.job_name} publisher results at {job.publisher_bolt_args.create_instance_args.output_dir}"
+                                    )
                                 return True
                             # disable retries if stage is not retryable by setting tries to max_tries+1
                             if not stage.is_retryable:

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -106,7 +106,7 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
         return cls.from_dict(yml_dict)
 
 
-class BoltPCSClient(BoltClient):
+class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
     def __init__(
         self, pcs: PrivateComputationService, logger: Optional[logging.Logger] = None
     ) -> None:
@@ -115,10 +115,7 @@ class BoltPCSClient(BoltClient):
             logging.getLogger(__name__) if logger is None else logger
         )
 
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
-        assert isinstance(
-            instance_args, BoltPCSCreateInstanceArgs
-        )  # We will add generics later so that we can move the check to the type checker
+    async def create_instance(self, instance_args: BoltPCSCreateInstanceArgs) -> str:
         instance = self.pcs.create_instance(
             instance_id=instance_args.instance_id,
             role=instance_args.role,

--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -22,7 +22,10 @@ from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
 
 def parse_bolt_config(
     config: Dict[str, Any], logger: logging.Logger
-) -> Tuple[BoltRunner, List[BoltJob]]:
+) -> Tuple[
+    BoltRunner[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs],
+    List[BoltJob[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]],
+]:
 
     # create runner
     runner_config = config["runner"]
@@ -36,7 +39,7 @@ def parse_bolt_config(
 
 def create_bolt_runner(
     runner_config: Dict[str, Any], logger: logging.Logger
-) -> BoltRunner:
+) -> BoltRunner[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]:
     publisher_client_config = ConfigYamlDict.from_file(
         runner_config["publisher_client_config"]
     )
@@ -72,7 +75,9 @@ def create_bolt_runner(
     return runner
 
 
-def create_job_list(job_config_list: Dict[str, Any]) -> List[BoltJob]:
+def create_job_list(
+    job_config_list: Dict[str, Any]
+) -> List[BoltJob[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]]:
     bolt_job_list = []
     for job_name, job_config in job_config_list.items():
         publisher_args = job_config["publisher"]

--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -132,8 +132,7 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
         self.test_concurrency = 1
         self.test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
 
-    async def test_create_instance(self) -> None:
-        bolt_instance_args = BoltPCSCreateInstanceArgs(
+        self.bolt_instance_args = BoltPCSCreateInstanceArgs(
             instance_id=self.test_instance_id,
             role=self.test_role,
             game_type=self.test_game_type,
@@ -145,7 +144,9 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             hmac_key=self.test_hmac_key,
         )
-        return_id = await self.bolt_pcs_client.create_instance(bolt_instance_args)
+
+    async def test_create_instance(self) -> None:
+        return_id = await self.bolt_pcs_client.create_instance(self.bolt_instance_args)
         self.assertEqual(return_id, self.test_instance_id)
 
     @mock.patch(
@@ -254,3 +255,16 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
                     instance_args=mock_instance_args
                 )
                 self.assertEqual(actual_result, expected_result)
+
+    async def test_get_or_create_instance(self) -> None:
+        for exists in (True, False):
+            with self.subTest(exists=exists):
+                self.bolt_pcs_client.is_existing_instance = mock.AsyncMock(
+                    return_value=exists
+                )
+
+                expected_result = self.bolt_instance_args.instance_id
+                actual_result = await self.bolt_pcs_client.get_or_create_instance(
+                    self.bolt_instance_args
+                )
+                self.assertEqual(expected_result, actual_result)

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -5,14 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 import requests
-
 from fbpcs.bolt.bolt_client import BoltClient, BoltState
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 from fbpcs.bolt.constants import FBPCS_GRAPH_API_TOKEN
@@ -105,7 +103,14 @@ class BoltPAGraphAPICreateInstanceArgs(BoltCreateInstanceArgs):
     num_containers: str
 
 
-class BoltGraphAPIClient(BoltClient):
+BoltGraphAPICreateInstanceArgs = TypeVar(
+    "BoltGraphAPICreateInstanceArgs",
+    BoltPLGraphAPICreateInstanceArgs,
+    BoltPAGraphAPICreateInstanceArgs,
+)
+
+
+class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
     def __init__(
         self, config: Dict[str, Any], logger: Optional[logging.Logger] = None
     ) -> None:
@@ -121,7 +126,10 @@ class BoltGraphAPIClient(BoltClient):
         self.access_token = self._get_graph_api_token(config)
         self.params = {"access_token": self.access_token}
 
-    async def create_instance(self, instance_args: BoltCreateInstanceArgs) -> str:
+    async def create_instance(
+        self,
+        instance_args: BoltGraphAPICreateInstanceArgs,
+    ) -> str:
         params = self.params.copy()
         if isinstance(instance_args, BoltPLGraphAPICreateInstanceArgs):
             params["breakdown_key"] = json.dumps(instance_args.breakdown_key)
@@ -190,7 +198,10 @@ class BoltGraphAPIClient(BoltClient):
                 "This method should not be called with expected results"
             )
 
-    async def is_existing_instance(self, instance_args: BoltCreateInstanceArgs) -> bool:
+    async def is_existing_instance(
+        self,
+        instance_args: BoltGraphAPICreateInstanceArgs,
+    ) -> bool:
         instance_id = instance_args.instance_id
         self.logger.info(f"Checking if {instance_id} exists...")
         if instance_id:

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -256,7 +256,11 @@ def run_study(
 
 
 async def run_bolt(
-    config: Dict[str, Any], logger: logging.Logger, job_list: List[BoltJob]
+    config: Dict[str, Any],
+    logger: logging.Logger,
+    job_list: List[
+        BoltJob[BoltPLGraphAPICreateInstanceArgs, BoltPCSCreateInstanceArgs]
+    ],
 ) -> None:
     """Run private lift with the BoltRunner in a dedicated function to ensure that
     the BoltRunner semaphore and runner.run_async share the same event loop.

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -282,7 +282,6 @@ async def run_bolt(
                 config.get("pid_post_processing_handlers", {}),
             )
         ),
-        skip_publisher_creation=True,
         logger=logger,
         max_parallel_runs=MAX_NUM_INSTANCES,
     )

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -227,7 +227,6 @@ def run_attribution(
                 )
             ),
             num_tries=num_tries,
-            skip_publisher_creation=True,
             logger=logger,
         )
 


### PR DESCRIPTION
Summary:
## What is this stack

- Bolt has been used in canary for weeks now and we haven't seen reports of any issues
- It's time to productionize
- Early in the stack, I rework some logic to raise the quality bar a bit. At the end of the stack, I delete the legacy runner.

## What

- Implement `get_or_create` on the BoltClient instead of providing a method in the bolt runner
- Delete `skip_publisher_creation` flag

## Why

- Giving the client the option to override `get_or_create` allows them to customize what happens on the `get` - e.g. overriding the old input path, which is a feature the existing runner supports that was not ported to Bolt (and thus could be considered a bug)
- If you look closely at how the `skip_publisher_creation` flag is being used, you'll notice it doesn't actually do anything. The old `_get_or_create...` method in the runner is overly convoluted - in the case of the graph API clients (that the `skip_publisher_creation` flag is supposed to be used with), you can still `get` the existing instance (which will handle the skip).

Differential Revision: D39229515

