### PR TITLE
Add trace_logging_svc to the post processing handler

### DIFF
--- a/fbpcs/post_processing_handler/tests/dummy_handler.py
+++ b/fbpcs/post_processing_handler/tests/dummy_handler.py
@@ -9,7 +9,7 @@
 
 import logging
 import random
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from fbpcs.post_processing_handler.exception import PostProcessingHandlerRuntimeError
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
@@ -19,15 +19,21 @@ if TYPE_CHECKING:
         PrivateComputationInstance,
     )
 from fbpcp.service.storage import StorageService
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
 
 
 class PostProcessingDummyHandler(PostProcessingHandler):
     """A dummy post processing handler used for testing handler management logic."""
 
-    def __init__(self, probability_of_failure: float = 0) -> None:
+    def __init__(
+        self,
+        trace_logging_svc: Optional[TraceLoggingService] = None,
+        probability_of_failure: float = 0,
+    ) -> None:
         super().__init__()
         self.probability_of_failure = probability_of_failure
         self.logger: logging.Logger = logging.getLogger(__name__)
+        self.trace_logging_svc = trace_logging_svc
 
     async def run(
         self,

--- a/fbpcs/private_computation/test/service/test_post_processing_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_post_processing_stage_service.py
@@ -36,19 +36,29 @@ from fbpcs.private_computation.service.post_processing_stage_service import (
 
 
 class TestPostProcessingStageService(IsolatedAsyncioTestCase):
+    @patch("fbpcs.common.service.trace_logging_service.TraceLoggingService")
     @patch("fbpcp.service.storage_s3.S3StorageService")
-    def setUp(self, mock_storage_svc) -> None:
+    def setUp(self, mock_storage_svc, mock_trace_logging_svc) -> None:
         self.mock_storage_svc = mock_storage_svc
+        self.mock_trace_logging_svc = mock_trace_logging_svc
 
-    async def test_post_processing_all_succeed(self) -> None:
+    @patch("fbpcs.common.service.trace_logging_service.TraceLoggingService")
+    async def test_post_processing_all_succeed(self, mock_trace_logging_svc) -> None:
         # create two handlers that never fail
         handlers = {
-            f"handler{i}": PostProcessingDummyHandler(probability_of_failure=0)
+            f"handler{i}": PostProcessingDummyHandler(
+                probability_of_failure=0, trace_logging_svc=mock_trace_logging_svc
+            )
             for i in range(2)
         }
-        # pyre-fixme[6]: For 2nd param expected `Dict[str, PostProcessingHandler]`
-        #  but got `Dict[str, PostProcessingDummyHandler]`.
-        stage_svc = PostProcessingStageService(self.mock_storage_svc, handlers)
+
+        stage_svc = PostProcessingStageService(
+            self.mock_storage_svc,
+            # pyre-fixme[6]: For 2nd param expected `Dict[str, PostProcessingHandler]`
+            #  but got `Dict[str, PostProcessingDummyHandler]`.
+            handlers,
+            self.mock_trace_logging_svc,
+        )
 
         private_computation_instance = self._create_pc_instance()
         await stage_svc.run_async(private_computation_instance)
@@ -76,15 +86,23 @@ class TestPostProcessingStageService(IsolatedAsyncioTestCase):
             expected_handler_statuses,
         )
 
-    async def test_post_processing_all_fail(self) -> None:
+    @patch("fbpcs.common.service.trace_logging_service.TraceLoggingService")
+    async def test_post_processing_all_fail(self, mock_trace_logging_svc) -> None:
         # create two handlers that always fail
         handlers = {
-            f"handler{i}": PostProcessingDummyHandler(probability_of_failure=1)
+            f"handler{i}": PostProcessingDummyHandler(
+                probability_of_failure=1, trace_logging_svc=mock_trace_logging_svc
+            )
             for i in range(2)
         }
-        # pyre-fixme[6]: For 2nd param expected `Dict[str, PostProcessingHandler]`
-        #  but got `Dict[str, PostProcessingDummyHandler]`.
-        stage_svc = PostProcessingStageService(self.mock_storage_svc, handlers)
+
+        stage_svc = PostProcessingStageService(
+            self.mock_storage_svc,
+            # pyre-fixme[6]: For 2nd param expected `Dict[str, PostProcessingHandler]`
+            #  but got `Dict[str, PostProcessingDummyHandler]`.
+            handlers,
+            self.mock_trace_logging_svc,
+        )
 
         private_computation_instance = self._create_pc_instance()
         await stage_svc.run_async(private_computation_instance)
@@ -112,15 +130,23 @@ class TestPostProcessingStageService(IsolatedAsyncioTestCase):
             expected_handler_statuses,
         )
 
-    async def test_post_processing_one_fail(self) -> None:
+    @patch("fbpcs.common.service.trace_logging_service.TraceLoggingService")
+    async def test_post_processing_one_fail(self, mock_trace_logging_svc) -> None:
         # create two handlers, one that fails, one that succeeds
         handlers = {
-            f"handler{i}": PostProcessingDummyHandler(probability_of_failure=i)
+            f"handler{i}": PostProcessingDummyHandler(
+                probability_of_failure=i, trace_logging_svc=mock_trace_logging_svc
+            )
             for i in range(2)
         }
-        # pyre-fixme[6]: For 2nd param expected `Dict[str, PostProcessingHandler]`
-        #  but got `Dict[str, PostProcessingDummyHandler]`.
-        stage_svc = PostProcessingStageService(self.mock_storage_svc, handlers)
+
+        stage_svc = PostProcessingStageService(
+            self.mock_storage_svc,
+            # pyre-fixme[6]: For 2nd param expected `Dict[str, PostProcessingHandler]`
+            #  but got `Dict[str, PostProcessingDummyHandler]`.
+            handlers,
+            self.mock_trace_logging_svc,
+        )
 
         private_computation_instance = self._create_pc_instance()
         await stage_svc.run_async(private_computation_instance)


### PR DESCRIPTION
Summary:
# What
* Add trace_logging_svc to all post processing handler ```__init__```:
   1. experimentation_metrics_logger
   2. export_s3_costs_to_hive
   3. Export_to_scribe
   4. pid_export_to_scribe
   5. Pid_intersection_rate_check

* When build post processing handlers in the thrift server(private_computation_service_wrapper.py), pass trace_logging_svc to _get_post_processing_handlers()
```

def _get_post_processing_handlers(
    config: Dict[str, Any],
    trace_logging_svc: TraceLoggingService,
) -> Dict[str, PostProcessingHandler]:
```
* There are two ways to create post processing handler .
One way is to use yml file. The other way is to use HandlerConfig.
HandlerConfig need to update processing handler after  creating TraceLoggingService.

design doc: https://docs.google.com/document/d/1WlttunaCg6kjS4A-UVkpVOn_lQnamA0lRa8ykFMvW_A/edit#

# Why
* need to use check_point function in trace_logging_svc
* need to add Centralized tracing logging for all post processing handlers

Differential Revision: D39073425

