### PR TITLE
Changelog 2.0.0 Release

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -13,7 +13,14 @@ Types of changes
 - `Security` in case This project adheres to
   [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - 2.0.0] - put release date here
+## [Unreleased - 2.1.0] - put release date here
+### Added
+
+### Changed
+
+### Removed
+
+## [2.0.0] - 2022-09-07
 ### Added
 
 - Bolt:


### PR DESCRIPTION
Summary: Update the changelog to release FBPCS version 2.0.0. This release includes a breaking change (D39228310 (https://github.com/facebookresearch/fbpcs/commit/d1c9b63e07d08620f90f06161482b4cac643651e)) so we are bumping a major version.

Differential Revision: D39297668

