### PR TITLE
Add DotproductApp to prepare input for DotproductGame

### DIFF
--- a/fbpcs/emp_games/dotproduct/DotproductApp.h
+++ b/fbpcs/emp_games/dotproduct/DotproductApp.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcf/io/api/FileIOWrappers.h>
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/scheduler/SchedulerHelper.h"
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+
+#include "fbpcs/emp_games/common/SchedulerStatistics.h"
+
+namespace pcf2_dotproduct {
+
+template <int MY_ROLE, int schedulerId>
+class DotproductApp {
+ public:
+  DotproductApp(
+      std::unique_ptr<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+          communicationAgentFactory,
+      std::string& inputFilePath,
+      std::string& outputFilePath,
+      int numFeatures,
+      int labelWidth,
+      const bool debugMode = false)
+      : communicationAgentFactory_(std::move(communicationAgentFactory)),
+        inputFilePath_(inputFilePath),
+        outputFilePath_(outputFilePath),
+        numFeatures_(numFeatures),
+        labelWidth_(labelWidth),
+        schedulerStatistics_{0, 0, 0, 0, 0},
+        debugMode_(debugMode) {}
+
+  void run() {
+    auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
+
+    auto scheduler = fbpcf::scheduler::createLazySchedulerWithRealEngine(
+        MY_ROLE, *communicationAgentFactory_);
+
+    XLOG(INFO) << "Starting Dotproduct App with role = " << MY_ROLE;
+  }
+
+  common::SchedulerStatistics getSchedulerStatistics() {
+    return schedulerStatistics_;
+  }
+
+ private:
+  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+      communicationAgentFactory_;
+  std::string inputFilePath_;
+  std::string outputFilePath_;
+  int numFeatures_;
+  int labelWidth_;
+  common::SchedulerStatistics schedulerStatistics_;
+  bool debugMode_;
+};
+
+} // namespace pcf2_dotproduct

--- a/fbpcs/emp_games/dotproduct/DotproductOptions.cpp
+++ b/fbpcs/emp_games/dotproduct/DotproductOptions.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/dotproduct/DotproductOptions.h"
+
+#include <gflags/gflags.h>
+
+DEFINE_int32(party, 1, "1 = publisher, 2 = partner");
+DEFINE_string(server_ip, "127.0.0.1", "Server's IP address");
+DEFINE_int32(port, 5000, "Server's port");
+DEFINE_string(input_base_path, "", "Local or s3 base path for the input file");
+DEFINE_string(
+    output_base_path,
+    "",
+    "Local or s3 base path where output files are written to");
+DEFINE_int32(
+    num_features,
+    50,
+    "Number of features in each row of the feature matrix");
+DEFINE_int32(
+    label_width,
+    16,
+    "Number of labels in each row of the label matrix");
+DEFINE_bool(
+    use_tls,
+    false,
+    "Whether to use TLS when communicating with the other party.");
+DEFINE_string(
+    tls_dir,
+    "",
+    "If using TLS, the directory that has the certificate, private key, and passphrase.");
+DEFINE_string(
+    run_name,
+    "",
+    "A user given run name that will be used in s3 filename");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");
+DEFINE_bool(debug, false, "If true, output will be in debug mode.");
+DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(
+    log_cost_s3_region,
+    ".s3.us-west-2.amazonaws.com/",
+    "s3 region name");

--- a/fbpcs/emp_games/dotproduct/DotproductOptions.h
+++ b/fbpcs/emp_games/dotproduct/DotproductOptions.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gflags/gflags_declare.h>
+
+DECLARE_int32(party);
+DECLARE_string(server_ip);
+DECLARE_int32(port);
+DECLARE_string(input_base_path);
+DECLARE_string(output_base_path);
+DECLARE_int32(num_features);
+DECLARE_int32(label_width);
+DECLARE_bool(use_tls);
+DECLARE_string(tls_dir);
+DECLARE_string(run_name);
+DECLARE_bool(log_cost);
+DECLARE_bool(debug);
+DECLARE_string(log_cost_s3_bucket);
+DECLARE_string(log_cost_s3_region);

--- a/fbpcs/emp_games/dotproduct/MainUtil.h
+++ b/fbpcs/emp_games/dotproduct/MainUtil.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <future>
+#include <memory>
+
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcs/emp_games/dotproduct/DotproductApp.h"
+
+namespace pcf2_dotproduct {
+
+template <int PARTY>
+inline common::SchedulerStatistics startDotProductApp(
+    std::string serverIp,
+    int port,
+    std::string& inputFilePath,
+    std::string& outFilePath,
+    int numFeatures,
+    int labelWidth,
+    bool useTls,
+    std::string tlsDir,
+    bool debugMode) {
+  std::map<
+      int,
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
+          PartyInfo>
+      partyInfos({{0, {serverIp, port}}, {1, {serverIp, port}}});
+
+  auto communicationAgentFactory = std::make_unique<
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
+      PARTY, partyInfos, useTls, tlsDir, "dotproduct_traffic");
+
+  auto app = std::make_unique<pcf2_dotproduct::DotproductApp<PARTY, PARTY>>(
+      std::move(communicationAgentFactory),
+      inputFilePath,
+      outFilePath,
+      numFeatures,
+      labelWidth,
+      debugMode);
+
+  app->run();
+  return app->getSchedulerStatistics();
+}
+
+} // namespace pcf2_dotproduct

--- a/fbpcs/emp_games/dotproduct/main.cpp
+++ b/fbpcs/emp_games/dotproduct/main.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gflags/gflags.h>
+#include <string>
+
+#include "folly/Format.h"
+#include "folly/init/Init.h"
+#include "folly/logging/xlog.h"
+
+#include <fbpcf/aws/AwsSdk.h>
+#include <fbpcs/performance_tools/CostEstimation.h>
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/dotproduct/DotproductApp.h"
+#include "fbpcs/emp_games/dotproduct/DotproductOptions.h"
+#include "fbpcs/emp_games/dotproduct/MainUtil.h"
+
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  fbpcs::performance_tools::CostEstimation cost =
+      fbpcs::performance_tools::CostEstimation(
+          "dotproduct",
+          FLAGS_log_cost_s3_bucket,
+          FLAGS_log_cost_s3_region,
+          "pcf2");
+  cost.start();
+
+  fbpcf::AwsSdk::aquire();
+
+  FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner
+                 // instead of 1 and 2
+
+  XLOGF(INFO, "Party: {}", FLAGS_party);
+  XLOGF(INFO, "Server IP: {}", FLAGS_server_ip);
+  XLOGF(INFO, "Port: {}", FLAGS_port);
+  XLOGF(INFO, "Base input path: {}", FLAGS_input_base_path);
+  XLOGF(INFO, "Base output path: {}", FLAGS_output_base_path);
+
+  common::SchedulerStatistics schedulerStatistics;
+  try {
+    if (FLAGS_party == common::PUBLISHER) {
+      XLOG(INFO)
+          << "Starting Dotproduct as Publisher, will wait for Partner...";
+
+      schedulerStatistics =
+          pcf2_dotproduct::startDotProductApp<common::PUBLISHER>(
+              FLAGS_server_ip,
+              FLAGS_port,
+              FLAGS_input_base_path,
+              FLAGS_output_base_path,
+              FLAGS_num_features,
+              FLAGS_label_width,
+              FLAGS_use_tls,
+              FLAGS_tls_dir,
+              FLAGS_debug);
+
+    } else if (FLAGS_party == common::PARTNER) {
+      XLOG(INFO)
+          << "Starting Dotproduct as Partner, will wait for Publisher...";
+
+      schedulerStatistics =
+          pcf2_dotproduct::startDotProductApp<common::PARTNER>(
+              FLAGS_server_ip,
+              FLAGS_port,
+              FLAGS_input_base_path,
+              FLAGS_output_base_path,
+              FLAGS_num_features,
+              FLAGS_label_width,
+              FLAGS_use_tls,
+              FLAGS_tls_dir,
+              FLAGS_debug);
+    } else {
+      XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
+    }
+
+  } catch (const std::exception& e) {
+    XLOG(ERR) << "Error: Exception caught in Dotproduct run.\n \t error msg: "
+              << e.what() << "\n \t input file: " << FLAGS_input_base_path;
+    std::exit(1);
+  }
+
+  cost.end();
+  XLOG(INFO, cost.getEstimatedCostString());
+
+  XLOGF(
+      INFO,
+      "Non-free gate count = {}, Free gate count = {}",
+      schedulerStatistics.nonFreeGates,
+      schedulerStatistics.freeGates);
+
+  XLOGF(
+      INFO,
+      "Sent network traffic = {}, Received network traffic = {}",
+      schedulerStatistics.sentNetwork,
+      schedulerStatistics.receivedNetwork);
+
+  if (FLAGS_log_cost) {
+    bool run_name_specified = FLAGS_run_name != "";
+    auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
+    auto party = (FLAGS_party == common::PUBLISHER) ? "Publisher" : "Partner";
+
+    folly::dynamic extra_info = folly::dynamic::object(
+        "publisher_input_path", (FLAGS_party == common::PUBLISHER) ? FLAGS_input_base_path : "")
+        ("partner_input_basepath", (FLAGS_party == common::PARTNER) ? FLAGS_input_base_path : "")
+        ("publisher_output_basepath", (FLAGS_party == common::PUBLISHER) ? FLAGS_output_base_path : "")
+        ("partner_output_basepath", (FLAGS_party ==  common::PARTNER) ? FLAGS_output_base_path : "")
+        ("num_features", FLAGS_num_features)
+        ("label_width", FLAGS_label_width)
+        ("non_free_gates", schedulerStatistics.nonFreeGates)
+        ("free_gates", schedulerStatistics.freeGates)
+        ("scheduler_transmitted_network", schedulerStatistics.sentNetwork)
+        ("scheduler_received_network", schedulerStatistics.receivedNetwork)
+        ("mpc_traffic_details", schedulerStatistics.details);
+
+    folly::dynamic costDict =
+        cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+    auto objectName = run_name_specified
+        ? run_name
+        : folly::to<std::string>(
+              FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+    XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
+  }
+
+  return 0;
+}

--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -31,7 +31,8 @@ const std::unordered_map<std::string, std::string> SUPPORTED_APPLICATIONS(
      {"lift", "pl-logs"},
      {"shard_aggregator", "sa-logs"},
      {"shard_combiner", "sc-logs"},
-     {"compactor", "comp-logs"}});
+     {"compactor", "comp-logs"},
+     {"dotproduct", "dotprod-logs"}});
 const std::vector<std::string> SUPPORTED_VERSIONS{"decoupled", "pcf2"};
 const std::string CLOUD = "aws";
 


### PR DESCRIPTION
Summary:
This diff create a DotproductApp that will be used to initialize a Dotproduct Game. This Dotproduct game will be used as a part of MPC-ML product. The diff includes the following files:

<main.cpp>: Entry point to the dotproduct, initiates starting
dotproductApp for both partner and publisher

<MainUtil.h>: Initializes engine, communication agent factory, and Dotproduct app. Runs the dotproductApp

<DotproductApp.h>: Initialize metrics collector, scheduler, logs the role of the ProductApp owner (i.e., Publisher or Partner)

<DotproductOptions.h>: Inputs to the DotproductApp

DotproductOptions.cpp>: Initializes default values for DotproductApp inputs

<TARGETS>: Add entry point to the dotproduct main function

Reviewed By: chualynn

Differential Revision: D39157526

