### PR TITLE
revert D39280787, will need to fix ser/de in next diff

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 class PCSFeature(Enum):
 
+    BOLT_RUNNER = "bolt_runner"
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"


### PR DESCRIPTION
Summary:
## Why
in previous D39280787 (https://github.com/facebookresearch/fbpcs/commit/902cf59541581b9aeb0d5e5acc2e4fe7e1509adc) we removed BOLT_RUNNER but it's cause der old instance issue
```
  File "/dev/shm/uid-99/1726a28f-seed-nspid4026532935_cgpid4151924-ns-4026532932/marshmallow/schema.py", line 722, in load
    return self._do_load(
  File "/dev/shm/uid-99/1726a28f-seed-nspid4026532935_cgpid4151924-ns-4026532932/marshmallow/schema.py", line 904, in _do_load
    raise exc
marshmallow.exceptions.ValidationError: {'pcs_features': {0: ['Invalid enum member BOLT_RUNNER']}}
```

this is a quick revert, will have a final fixture including better der in next diff

Reviewed By: musebc

Differential Revision: D39393642

