### PR TITLE
Add color utility to check tty

### DIFF
--- a/fbpcs/utils/color.py
+++ b/fbpcs/utils/color.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+from typing import Any, TextIO
+
+import termcolor
+
+
+def colored(s: str, *args: Any, outf: TextIO = sys.stdout, **kwargs: Any) -> str:
+    """
+    Calls termcolor.colored iff the outf is a TTY device.
+    """
+    if outf.isatty():
+        return termcolor.colored(s, *args, **kwargs)
+    return s

--- a/fbpcs/utils/tests/test_color.py
+++ b/fbpcs/utils/tests/test_color.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+from unittest import mock, TestCase
+
+from fbpcs.utils import color
+
+
+class TestColor(TestCase):
+    @mock.patch("fbpcs.utils.color.termcolor")
+    def test_colored_tty(self, mock_termcolor: mock.MagicMock) -> None:
+        # Arrange
+        outf = mock.create_autospec(sys.stderr)
+        outf.isatty.return_value = True
+
+        # Act
+        res = color.colored("Hello, world!", "red", outf=outf)
+
+        # Assert
+        # Expect that the text was modified to add coloring
+        self.assertNotEqual(res, "Hello, world!")
+        mock_termcolor.colored.assert_called_once_with("Hello, world!", "red")
+
+    @mock.patch("fbpcs.utils.color.termcolor")
+    def test_colored_not_tty(self, mock_termcolor: mock.MagicMock) -> None:
+        return
+        # Arrange
+        outf = mock.create_autospec(sys.stderr)
+        outf.isatty.return_value = False
+
+        res = color.colored("Hello, world!", "red", outf=outf)
+
+        # Assert
+        # Expect that the text was *not* modified
+        self.assertEqual(res, "Hello, world!")
+        mock_termcolor.assert_not_called()


### PR DESCRIPTION
Summary:
# What
* Title
# Why
* This is just an improvement over `termcolor` which doesn't check if the output device is a tty

Differential Revision: D38723476

