### PR TITLE
Don't use colored output if stdout isn't a tty

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -13,7 +13,7 @@ from enum import Enum
 
 from fbpcs.pl_coordinator.constants import FBPCS_GRAPH_API_TOKEN
 from fbpcs.private_computation.entity.pcs_tier import PCSTier
-from termcolor import colored
+from fbpcs.utils.color import colored
 
 # decorators are a serious pain to add typing for, so I'm not going to bother...
 # pyre-ignore

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -51,8 +51,8 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 from fbpcs.service.workflow import WorkflowService
+from fbpcs.utils.color import colored
 from fbpcs.utils.config_yaml import reflect
-from termcolor import colored
 
 
 def create_instance(

--- a/fbpcs/stage_flow/stage_flow.py
+++ b/fbpcs/stage_flow/stage_flow.py
@@ -11,7 +11,7 @@ from functools import cached_property
 from typing import Any, Dict, Generic, Optional, Tuple, Type, TypeVar
 
 from fbpcs.stage_flow.exceptions import StageFlowStageNotFoundError
-from termcolor import colored
+from fbpcs.utils.color import colored
 
 
 # C  -> Class

--- a/fbpcs/utils/color.py
+++ b/fbpcs/utils/color.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+from typing import Any, Dict, TextIO
+
+import termcolor
+
+
+def colored(s: str, *args: Any, outf: TextIO = sys.stdout, **kwargs: Any) -> str:
+    """
+    Calls termcolor.colored iff the outf is a TTY device.
+    """
+    if outf.isatty():
+        return termcolor.colored(s, *args, **kwargs)
+    return s

--- a/fbpcs/utils/tests/test_color.py
+++ b/fbpcs/utils/tests/test_color.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import sys
+from unittest import mock, TestCase
+
+from fbpcs.utils import color
+
+
+class TestColor(TestCase):
+    @mock.patch("fbpcs.utils.color.termcolor")
+    def test_colored_tty(self, mock_termcolor: mock.MagicMock) -> None:
+        # Arrange
+        outf = mock.create_autospec(sys.stderr)
+        outf.isatty.return_value = True
+
+        # Act
+        res = color.colored("Hello, world!", "red", outf=outf)
+
+        # Assert
+        # Expect that the text was modified to add coloring
+        self.assertNotEqual(res, "Hello, world!")
+        mock_termcolor.colored.assert_called_once_with("Hello, world!", "red")
+
+    @mock.patch("fbpcs.utils.color.termcolor")
+    def test_colored_not_tty(self, mock_termcolor: mock.MagicMock) -> None:
+        return
+        # Arrange
+        outf = mock.create_autospec(sys.stderr)
+        outf.isatty.return_value = False
+
+        res = color.colored("Hello, world!", "red", outf=outf)
+
+        # Assert
+        # Expect that the text was *not* modified
+        self.assertEqual(res, "Hello, world!")
+        mock_termcolor.assert_not_called()


### PR DESCRIPTION
Summary:
# What
* Title
# Why
* If the output device isn't a tty, you get weird codes like `0m;031m]Hello world!` this, which makes it awkward to read. This is an attempt to stop those codes from printing when you send output to a file

Differential Revision: D38723658

