### PR TITLE
Get Kinesis firehose details and upload logs on S3

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/cloud_error/cloud_error.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud_error/cloud_error.py
@@ -18,6 +18,10 @@ class AwsS3Exception(AwsException):
     pass
 
 
+class AwsKinesisException(AwsException):
+    pass
+
+
 class AwsCloudwatchLogsFetchException(AwsCloudwatchException):
     pass
 
@@ -43,4 +47,8 @@ class AwsCloudwatchLogStreamFetchException(AwsCloudwatchException):
 
 
 class AwsS3BucketVerificationException(AwsS3Exception):
+    pass
+
+
+class AwsKinesisFirehoseDeliveryStreamFetchException(AwsKinesisException):
     pass

--- a/fbpcs/infra/logging_service/download_logs/cloud_error/utils_error.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud_error/utils_error.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class UtilsException(Exception):
+    pass
+
+
+class NotSupportedContentType(UtilsException):
+    pass

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -11,11 +11,18 @@ import shutil
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
+from pprint import pprint
+from typing import Any, Dict, List, Union
+
+from fbpcs.infra.logging_service.download_logs.cloud_error.utils_error import (
+    NotSupportedContentType,
+)
 
 
 class Utils:
-    def create_file(self, file_location: str, content: List[str]) -> None:
+    def create_file(
+        self, file_location: str, content: Union[List[str], Dict[str, Any]]
+    ) -> None:
         """
         Create file in the file location with content.
         Args:
@@ -38,7 +45,7 @@ class Utils:
     def write_to_file(
         cls,
         file_object: io.TextIOWrapper,
-        contents: List[str],
+        contents: Union[List[str], Dict[str, Any]],
         append_newline: bool = True,
     ) -> None:
         """
@@ -49,10 +56,18 @@ class Utils:
         Returns:
             None
         """
-        for content in contents:
-            if append_newline:
-                content = content + "\n"
-            file_object.write(content)
+        if isinstance(contents, list):
+            for content in contents:
+                if append_newline:
+                    content = content + "\n"
+                file_object.write(content)
+        elif isinstance(contents, dict):
+            pprint(contents, stream=file_object)
+            file_object.write("\n")
+        else:
+            raise NotSupportedContentType(
+                "Unable to write to the file. Content type not supported."
+            )
 
     @staticmethod
     def create_folder(folder_location: str) -> None:
@@ -122,6 +137,7 @@ class StringFormatter(str, Enum):
     LOCAL_ZIP_FOLDER_LOCATION = "{}.zip"
     FILE_LOCATION = "{}/{}"
     ZIPPED_FOLDER_NAME = "{}.zip"
+    KINESIS_FIREHOSE_DELIVERY_STREAM = "cb-data-ingestion-stream-{}"
 
 
 @dataclass


### PR DESCRIPTION
Summary:
**What**
This diff is part of the data infra pipeline logging project. AWS kinesis firehose is used to process events in the pipeline. In this diff we get gather error logs and configs and upload on S3 along with container and deployment logs

This diff uploads 2 logs:
1. kinesis error logs
2. kinesis configs

Error logs will be used to check if any errors were encountered in processing the events. Configs are used to check status of the kinesis and if logging is enabled in the kinesis.

**Why**
Right now we don't capture errors in kinesis. This diff will help with that. Additionally, it will help in fetching kinesis configs, to help us in debugging in case any misconfiguration is causing the issue.

**Context**
https://docs.google.com/document/d/1cMD9IQ8uF6MS1PRvOh8cr-1el7MO952SjUanAzAGJzw/edit?usp=sharing

Differential Revision: D39286548

