### PR TITLE
Re-order Input Processor methods

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor.h
@@ -34,7 +34,6 @@ class InputProcessor : public IInputProcessor<schedulerId> {
     shareBitsForValuesStep();
     privatelyShareGroupIdsStep();
     privatelySharePopulationStep();
-    privatelyShareGroupIdsStep();
     privatelyShareIndexSharesStep();
     privatelyShareTestIndexSharesStep();
     privatelyShareTimestampsStep();
@@ -59,11 +58,11 @@ class InputProcessor : public IInputProcessor<schedulerId> {
   // Share number of bits needed to store the input value and its square
   void shareBitsForValuesStep();
 
-  // Privately share popoulation
-  void privatelySharePopulationStep();
-
   // Privately share cohort ids and breakdown ids.
   void privatelyShareGroupIdsStep();
+
+  // Privately share popoulation
+  void privatelySharePopulationStep();
 
   // Privately share index shares of group ids encoding the population, cohorts
   // and publisher breakdowns.

--- a/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/InputProcessor_impl.h
@@ -31,16 +31,6 @@ void InputProcessor<schedulerId>::validateNumRowsStep() {
 }
 
 template <int schedulerId>
-void InputProcessor<schedulerId>::privatelySharePopulationStep() {
-  XLOG(INFO) << "Share control population";
-  controlPopulation_ = common::privatelyShareArrayWithPaddingFrom<
-      common::PUBLISHER,
-      bool,
-      SecBit<schedulerId>>(
-      inputData_.getControlPopulation(), liftGameProcessedData_.numRows, 0);
-}
-
-template <int schedulerId>
 void InputProcessor<schedulerId>::shareNumGroupsStep() {
   // TODO: We shouldn't be using MPC for this, it should just be shared over
   // a normal network socket as part of the protocol setup
@@ -124,6 +114,16 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
       bool,
       SecBit<schedulerId>>(
       booleanBreakdownGroupIds, liftGameProcessedData_.numRows, 0);
+}
+
+template <int schedulerId>
+void InputProcessor<schedulerId>::privatelySharePopulationStep() {
+  XLOG(INFO) << "Share control population";
+  controlPopulation_ = common::privatelyShareArrayWithPaddingFrom<
+      common::PUBLISHER,
+      bool,
+      SecBit<schedulerId>>(
+      inputData_.getControlPopulation(), liftGameProcessedData_.numRows, 0);
 }
 
 template <int schedulerId>


### PR DESCRIPTION
Summary:
I have some OCD around this class regarding the ordering of

- The functions called in InputProcessor.h
- The order the signatures are defined
- The order the methods are implemented

This diff brings those in sync to make reading the code a bit simpler.

Differential Revision: D39442177

