### PR TITLE
Get data infra lambda logs from AWS Cloudwatch logs and upload on S3

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/cloud_error/cloud_error.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud_error/cloud_error.py
@@ -18,6 +18,10 @@ class AwsS3Exception(AwsException):
     pass
 
 
+class AwsKinesisException(AwsException):
+    pass
+
+
 class AwsCloudwatchLogsFetchException(AwsCloudwatchException):
     pass
 
@@ -43,4 +47,8 @@ class AwsCloudwatchLogStreamFetchException(AwsCloudwatchException):
 
 
 class AwsS3BucketVerificationException(AwsS3Exception):
+    pass
+
+
+class AwsKinesisFirehoseDeliveryStreamFetchException(AwsKinesisException):
     pass

--- a/fbpcs/infra/logging_service/download_logs/cloud_error/utils_error.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud_error/utils_error.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class UtilsException(Exception):
+    pass
+
+
+class NotSupportedContentType(UtilsException):
+    pass

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -11,11 +11,18 @@ import shutil
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
+from pprint import pprint
+from typing import Any, Dict, List, Union
+
+from fbpcs.infra.logging_service.download_logs.cloud_error.utils_error import (
+    NotSupportedContentType,
+)
 
 
 class Utils:
-    def create_file(self, file_location: str, content: List[str]) -> None:
+    def create_file(
+        self, file_location: str, content: Union[List[str], Dict[str, Any]]
+    ) -> None:
         """
         Create file in the file location with content.
         Args:
@@ -38,7 +45,7 @@ class Utils:
     def write_to_file(
         cls,
         file_object: io.TextIOWrapper,
-        contents: List[str],
+        contents: Union[List[str], Dict[str, Any]],
         append_newline: bool = True,
     ) -> None:
         """
@@ -49,10 +56,18 @@ class Utils:
         Returns:
             None
         """
-        for content in contents:
-            if append_newline:
-                content = content + "\n"
-            file_object.write(content)
+        if isinstance(contents, list):
+            for content in contents:
+                if append_newline:
+                    content = content + "\n"
+                file_object.write(content)
+        elif isinstance(contents, dict):
+            pprint(contents, stream=file_object)
+            file_object.write("\n")
+        else:
+            raise NotSupportedContentType(
+                "Unable to write to the file. Content type not supported."
+            )
 
     @staticmethod
     def create_folder(folder_location: str) -> None:
@@ -122,6 +137,7 @@ class StringFormatter(str, Enum):
     LOCAL_ZIP_FOLDER_LOCATION = "{}.zip"
     FILE_LOCATION = "{}/{}"
     ZIPPED_FOLDER_NAME = "{}.zip"
+    KINESIS_FIREHOSE_DELIVERY_STREAM = "cb-data-ingestion-stream-{}"
 
 
 @dataclass

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -138,6 +138,7 @@ class StringFormatter(str, Enum):
     FILE_LOCATION = "{}/{}"
     ZIPPED_FOLDER_NAME = "{}.zip"
     KINESIS_FIREHOSE_DELIVERY_STREAM = "cb-data-ingestion-stream-{}"
+    LAMBDA_LOG_GROUP_NAME = "/aws/lambda/{}"
 
 
 @dataclass
@@ -155,3 +156,12 @@ class DeploymentLogFiles(str, Enum):
     @classmethod
     def list(cls) -> List[str]:
         return [e.value for e in DeploymentLogFiles]
+
+
+class DataInfraLambda(str, Enum):
+    STREAM_PROCESSING = "cb-data-ingestion-stream-processor-{}"
+    SEMI_AUTOMATED = "manual-upload-trigger-{}"
+
+    @classmethod
+    def list(cls) -> List[str]:
+        return [e.value for e in DataInfraLambda]


### PR DESCRIPTION
Summary:
**What**
This diff is part of the data infra pipeline logging project. In data infra pipeline we use 2 lambda:
1. stream_processing lambda
2. semi_automated_pipeline lambda

In this diff we capture logs for both of these lambda. When semi_automated pipeline is deprecated, it will be removed from here as well.

**Why**
Capturing lambda logs will give Meta engineers more information when debugging any issue.

**Context**
https://docs.google.com/document/d/1cMD9IQ8uF6MS1PRvOh8cr-1el7MO952SjUanAzAGJzw/edit?usp=sharing

Differential Revision: D39453796

