### PR TITLE
Sync thrift file of pid_mr_configs and update MR pid configs in measurement and PCS

### DIFF
--- a/fbpcs/private_computation/entity/pid_mr_config.py
+++ b/fbpcs/private_computation/entity/pid_mr_config.py
@@ -16,33 +16,19 @@ from dataclasses_json import dataclass_json, DataClassJsonMixin
 @dataclass_json
 @dataclass
 class PidRunConfigs:
-    metaBucketName: str
-    advBucketName: str
     pidMrMultikeyJarPath: str
 
 
 @dataclass_json
 @dataclass
 class PidWorkflowConfigs:
-    state_machine_arn: str
-
-
-@dataclass_json
-@dataclass
-class SparkConfigs:
-    numExecutors: int
-    executorCores: int
-    driverMemory: str
-    executorMemory: str
-    sqlShufflePartitions: int
-    masterInstanceType: str
+    stateMachineArn: str
 
 
 @dataclass
 class PidMrConfig(DataClassJsonMixin):
     runConfigs: PidRunConfigs
     workflowConfigs: PidWorkflowConfigs
-    sparkConfigs: SparkConfigs
 
 
 class Protocol(Enum):

--- a/fbpcs/private_computation/service/pid_mr_stage_service.py
+++ b/fbpcs/private_computation/service/pid_mr_stage_service.py
@@ -28,7 +28,6 @@ INTPUT = "inputPath"
 OUTPUT = "outputPath"
 INSTANCE = "instanceId"
 RUNID = "run_id"
-SPARK_CONFIGS = "sparkConfigs"
 S3URIFORMAT = "s3://{bucket}/{key}"
 PUB_PREFIX = "publisher_"
 PARTNER_PREFIX = "partner_"
@@ -65,7 +64,6 @@ class PIDMRStageService(PrivateComputationStageService):
             and PIDMR in pid_configs
             and PID_RUN_CONFIGS in pid_configs[PIDMR]
             and PID_WORKFLOW_CONFIGS in pid_configs[PIDMR]
-            and SPARK_CONFIGS in pid_configs[PIDMR]
         ):
             pc_configs = {
                 "numPidContainers": pc_instance.infra_config.num_pid_containers
@@ -84,7 +82,6 @@ class PIDMRStageService(PrivateComputationStageService):
             }
             pid_overall_configs = {
                 **pid_configs[PIDMR][PID_RUN_CONFIGS],
-                **pid_configs[PIDMR][SPARK_CONFIGS],
                 **data_configs,
                 **pc_configs,
             }

--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -28,7 +28,6 @@ from fbpcs.private_computation.service.pid_mr_stage_service import (
     PID_WORKFLOW_CONFIGS,
     PIDMR,
     PIDMRStageService,
-    SPARK_CONFIGS,
 )
 from fbpcs.private_computation.stage_flows.private_computation_mr_stage_flow import (
     PrivateComputationMRStageFlow,
@@ -66,9 +65,12 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
                     output_dir="https://mpc-aem-exp-platform-input.s3.us-west-2.amazonaws.com/pid_test/output",
                     pid_configs={
                         PIDMR: {
-                            PID_WORKFLOW_CONFIGS: {"state_machine_arn": "machine_arn"},
-                            PID_RUN_CONFIGS: {"conf": "conf1"},
-                            SPARK_CONFIGS: {"conf-2": "conf2"},
+                            PID_WORKFLOW_CONFIGS: {
+                                "stateMachineArn": "arn:aws:states:us-west-2:119557546360:stateMachine:pid-mr-e2e-adv-sfn"
+                            },
+                            PID_RUN_CONFIGS: {
+                                "pidMrMultikeyJarPath": "s3://one-docker-repository-prod/pid/private-id-mr/latest/pid-mr-multikey.jar"
+                            },
                         }
                     },
                 )


### PR DESCRIPTION
Summary:
# Context
We are updating mr pid configs on one reason.
1. reduce  the number of configurations  to simplify the use of MR PID protocol.

# Description
The new MR PID configs only have 2 parts like below:
1.PidRunConfigs.
```
struct PidRunConfigs {
  1: string pidMrMultikeyJarPath;
}
```
2.PidWorkflowConfigs
```
struct PidWorkflowConfigs {
  1: string stateMachineArn;
}
```

update configerator: https://www.internalfb.com/intern/wiki/Metric360-team/M360_Engineering/Local_Development/Thrift/Update_Thrift_Files/
Step 1: Update thrift file in Configerator
Step 2: Sync thrift file in Configerator to fbcode
```
configerator-thrift-updater ad_measurement/pid_mr/config.thrift
```
Step 3: Update mr pid configs in measurement and PCS

Differential Revision: D39439684

