### PR TITLE
Add try/catch and timeout to Graph API trace logging

### DIFF
--- a/fbpcs/common/service/test/test_graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_graphapi_trace_logging_service.py
@@ -14,6 +14,7 @@ import requests
 
 from fbpcs.common.service.graphapi_trace_logging_service import (
     GraphApiTraceLoggingService,
+    RESPONSE_TIMEOUT,
 )
 from fbpcs.common.service.trace_logging_service import CheckpointStatus
 
@@ -25,6 +26,15 @@ class TestGraphApiTraceLoggingService(TestCase):
     def setUp(self) -> None:
         self.logger = mock.create_autospec(logging.Logger)
         self.mock_requests = mock.create_autospec(requests)
+        # "wtf is this line?"
+        # Well, we've mocked out the entire requests lib in the line above.
+        # If we don't *reset* the exceptions module to point to the *real*
+        # module, we'll get a bizarre error when running unit tests:
+        #     except requests.exceptions.Timeout:
+        # TypeError: catching classes that do not inherit from BaseException is not allowed
+        # This is because after mocking, Timeout is a *MagicMock*, not an Exception.
+        # The line below will fix that oddity.
+        self.mock_requests.exceptions = requests.exceptions
         self.svc = GraphApiTraceLoggingService(TEST_ENDPOINT_URL)
         self.svc.logger = self.logger
 
@@ -66,8 +76,68 @@ class TestGraphApiTraceLoggingService(TestCase):
         # Assert
         self.logger.info.assert_called_once()
         self.mock_requests.post.assert_called_once_with(
-            TEST_ENDPOINT_URL, json=form_data
+            TEST_ENDPOINT_URL,
+            json=form_data,
+            timeout=RESPONSE_TIMEOUT,
         )
+
+    def test_write_checkpoint_request_timeout(self) -> None:
+        # Arrange
+        expected_log_data = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+                "extra_info": "Timeout reaching endpoint",
+            }
+        )
+        self.mock_requests.post.side_effect = requests.exceptions.Timeout()
+
+        # Act
+        with mock.patch(
+            "fbpcs.common.service.graphapi_trace_logging_service.requests",
+            self.mock_requests,
+        ):
+            self.svc.write_checkpoint(
+                run_id="run123",
+                instance_id="instance456",
+                checkpoint_name="foo",
+                status=CheckpointStatus.STARTED,
+            )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_log_data)
+
+    def test_write_checkpoint_other_exception(self) -> None:
+        # Arrange
+        expected_log_data = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+                "extra_info": "Unexpected error: Something else occurred",
+            }
+        )
+        self.mock_requests.post.side_effect = Exception("Something else occurred")
+
+        # Act
+        with mock.patch(
+            "fbpcs.common.service.graphapi_trace_logging_service.requests",
+            self.mock_requests,
+        ):
+            self.svc.write_checkpoint(
+                run_id="run123",
+                instance_id="instance456",
+                checkpoint_name="foo",
+                status=CheckpointStatus.STARTED,
+            )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_log_data)
 
     def test_write_checkpoint_custom_data(self) -> None:
         # Arrange
@@ -97,5 +167,7 @@ class TestGraphApiTraceLoggingService(TestCase):
         # Assert
         self.logger.info.assert_called_once()
         self.mock_requests.post.assert_called_once_with(
-            TEST_ENDPOINT_URL, json=form_data
+            TEST_ENDPOINT_URL,
+            json=form_data,
+            timeout=RESPONSE_TIMEOUT,
         )


### PR DESCRIPTION
Summary:
# What
* Add try/except so that trace logging is an infallible operation
* Add a timeout to the Graph API call to not block the run forever
# Why
* Trace logging (and logging/monitoring in general) should be an infallible operation that has no possibility of breaking the run. This adds some more defensive coding to ensure that remains true.

Differential Revision: D39480302

