### PR TITLE
Trace log for empty run_id if not in unit test

### DIFF
--- a/fbpcs/common/service/graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/graphapi_trace_logging_service.py
@@ -37,10 +37,6 @@ class GraphApiTraceLoggingService(TraceLoggingService):
         status: CheckpointStatus,
         checkpoint_data: Optional[Dict[str, str]] = None,
     ) -> None:
-        if run_id is None:
-            self.logger.debug("No run_id provided - skipping write_checkpoint")
-            return
-
         form_data = {
             "operation": "write_checkpoint",
             "run_id": run_id,

--- a/fbpcs/common/service/graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/graphapi_trace_logging_service.py
@@ -29,7 +29,7 @@ class GraphApiTraceLoggingService(TraceLoggingService):
     def __init__(self, endpoint_url: str) -> None:
         self.endpoint_url = endpoint_url
 
-    def write_checkpoint(
+    def _write_checkpoint_impl(
         self,
         run_id: Optional[str],
         instance_id: str,

--- a/fbpcs/common/service/simple_trace_logging_service.py
+++ b/fbpcs/common/service/simple_trace_logging_service.py
@@ -16,7 +16,7 @@ from fbpcs.common.service.trace_logging_service import (
 
 
 class SimpleTraceLoggingService(TraceLoggingService):
-    def write_checkpoint(
+    def _write_checkpoint_impl(
         self,
         run_id: Optional[str],
         instance_id: str,

--- a/fbpcs/common/service/simple_trace_logging_service.py
+++ b/fbpcs/common/service/simple_trace_logging_service.py
@@ -24,10 +24,6 @@ class SimpleTraceLoggingService(TraceLoggingService):
         status: CheckpointStatus,
         checkpoint_data: Optional[Dict[str, str]] = None,
     ) -> None:
-        if run_id is None:
-            self.logger.debug("No run_id provided - skipping write_checkpoint")
-            return
-
         result = {
             "operation": "write_checkpoint",
             "run_id": run_id,

--- a/fbpcs/common/service/test/test_graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_graphapi_trace_logging_service.py
@@ -38,19 +38,6 @@ class TestGraphApiTraceLoggingService(TestCase):
         self.svc = GraphApiTraceLoggingService(TEST_ENDPOINT_URL)
         self.svc.logger = self.logger
 
-    def test_write_checkpoint_no_run_id(self) -> None:
-        # Act
-        self.svc.write_checkpoint(
-            run_id=None,
-            instance_id="instance456",
-            checkpoint_name="foo",
-            status=CheckpointStatus.STARTED,
-        )
-
-        # Assert
-        self.logger.debug.assert_called_once()
-        self.logger.info.assert_not_called()
-
     def test_write_checkpoint_simple(self) -> None:
         # Arrange
         form_data = {

--- a/fbpcs/common/service/test/test_graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_graphapi_trace_logging_service.py
@@ -14,6 +14,7 @@ import requests
 
 from fbpcs.common.service.graphapi_trace_logging_service import (
     GraphApiTraceLoggingService,
+    RESPONSE_TIMEOUT,
 )
 from fbpcs.common.service.trace_logging_service import CheckpointStatus
 
@@ -25,6 +26,15 @@ class TestGraphApiTraceLoggingService(TestCase):
     def setUp(self) -> None:
         self.logger = mock.create_autospec(logging.Logger)
         self.mock_requests = mock.create_autospec(requests)
+        # "wtf is this line?"
+        # Well, we've mocked out the entire requests lib in the line above.
+        # If we don't *reset* the exceptions module to point to the *real*
+        # module, we'll get a bizarre error when running unit tests:
+        #     except requests.exceptions.Timeout:
+        # TypeError: catching classes that do not inherit from BaseException is not allowed
+        # This is because after mocking, Timeout is a *MagicMock*, not an Exception.
+        # The line below will fix that oddity.
+        self.mock_requests.exceptions = requests.exceptions
         self.svc = GraphApiTraceLoggingService(TEST_ENDPOINT_URL)
         self.svc.logger = self.logger
 
@@ -66,8 +76,68 @@ class TestGraphApiTraceLoggingService(TestCase):
         # Assert
         self.logger.info.assert_called_once()
         self.mock_requests.post.assert_called_once_with(
-            TEST_ENDPOINT_URL, json=form_data
+            TEST_ENDPOINT_URL,
+            json=form_data,
+            timeout=RESPONSE_TIMEOUT,
         )
+
+    def test_write_checkpoint_request_timeout(self) -> None:
+        # Arrange
+        expected_log_data = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+                "extra_info": "Timeout reaching endpoint",
+            }
+        )
+        self.mock_requests.post.side_effect = requests.exceptions.Timeout()
+
+        # Act
+        with mock.patch(
+            "fbpcs.common.service.graphapi_trace_logging_service.requests",
+            self.mock_requests,
+        ):
+            self.svc.write_checkpoint(
+                run_id="run123",
+                instance_id="instance456",
+                checkpoint_name="foo",
+                status=CheckpointStatus.STARTED,
+            )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_log_data)
+
+    def test_write_checkpoint_other_exception(self) -> None:
+        # Arrange
+        expected_log_data = json.dumps(
+            {
+                "operation": "write_checkpoint",
+                "run_id": "run123",
+                "instance_id": "instance456",
+                "checkpoint_name": "foo",
+                "status": str(CheckpointStatus.STARTED),
+                "extra_info": "Unexpected error: Something else occurred",
+            }
+        )
+        self.mock_requests.post.side_effect = Exception("Something else occurred")
+
+        # Act
+        with mock.patch(
+            "fbpcs.common.service.graphapi_trace_logging_service.requests",
+            self.mock_requests,
+        ):
+            self.svc.write_checkpoint(
+                run_id="run123",
+                instance_id="instance456",
+                checkpoint_name="foo",
+                status=CheckpointStatus.STARTED,
+            )
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_log_data)
 
     def test_write_checkpoint_custom_data(self) -> None:
         # Arrange
@@ -97,5 +167,7 @@ class TestGraphApiTraceLoggingService(TestCase):
         # Assert
         self.logger.info.assert_called_once()
         self.mock_requests.post.assert_called_once_with(
-            TEST_ENDPOINT_URL, json=form_data
+            TEST_ENDPOINT_URL,
+            json=form_data,
+            timeout=RESPONSE_TIMEOUT,
         )

--- a/fbpcs/common/service/test/test_simple_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_simple_trace_logging_service.py
@@ -35,17 +35,6 @@ class TestSimpleTraceLoggingService(TestCase):
         self.logger.info.assert_not_called()
 
     def test_write_checkpoint_simple(self) -> None:
-        # Arrange
-        expected_dump = json.dumps(
-            {
-                "operation": "write_checkpoint",
-                "run_id": "run123",
-                "instance_id": "instance456",
-                "checkpoint_name": "foo",
-                "status": str(CheckpointStatus.STARTED),
-            }
-        )
-
         # Act
         self.svc.write_checkpoint(
             run_id="run123",
@@ -55,21 +44,15 @@ class TestSimpleTraceLoggingService(TestCase):
         )
 
         # Assert
-        self.logger.info.assert_called_once_with(expected_dump)
+        self.logger.info.assert_called_once()
+        # TODO(T131856635): Check actual logger output
+        # Ideally we should check the contents more closely, but since
+        # we augment the data with a filepath (which can change in our test context),
+        # it's *really* annoying to figure out what exactly it should look like here.
 
     def test_write_checkpoint_custom_data(self) -> None:
         # Arrange
         data = {"bar": "baz", "quux": "quuz"}
-        expected_dump = json.dumps(
-            {
-                "operation": "write_checkpoint",
-                "run_id": "run123",
-                "instance_id": "instance456",
-                "checkpoint_name": "foo",
-                "status": str(CheckpointStatus.STARTED),
-                "checkpoint_data": json.dumps(data),
-            }
-        )
 
         # Act
         self.svc.write_checkpoint(
@@ -81,4 +64,9 @@ class TestSimpleTraceLoggingService(TestCase):
         )
 
         # Assert
-        self.logger.info.assert_called_once_with(expected_dump)
+        self.logger.info.assert_called_once()
+        # TODO(T131856635): Check actual logger output
+        # Ideally we should check the contents more closely, but since
+        # we augment the data with a filepath (which can change in our test context),
+        # it's *really* annoying to figure out what exactly it should look like here.
+        self.assertIn("quux", self.logger.info.call_args_list[0][0][0])

--- a/fbpcs/common/service/test/test_simple_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_simple_trace_logging_service.py
@@ -21,19 +21,6 @@ class TestSimpleTraceLoggingService(TestCase):
         self.svc = SimpleTraceLoggingService()
         self.svc.logger = self.logger
 
-    def test_write_checkpoint_no_run_id(self) -> None:
-        # Act
-        self.svc.write_checkpoint(
-            run_id=None,
-            instance_id="instance456",
-            checkpoint_name="foo",
-            status=CheckpointStatus.STARTED,
-        )
-
-        # Assert
-        self.logger.debug.assert_called_once()
-        self.logger.info.assert_not_called()
-
     def test_write_checkpoint_simple(self) -> None:
         # Act
         self.svc.write_checkpoint(


### PR DESCRIPTION
Summary:
# What
* Title
# Why
* We had a discussion and decided that we should just not log trace logs for _unit tests_, but otherwise... storage is cheap, let's get as much info as possible.

Differential Revision: D39484378

