### PR TITLE
change the initial status to initialized

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -114,9 +114,11 @@ class BoltRunner(Generic[T, U]):
                                         f"View {job.job_name} publisher results at {job.publisher_bolt_args.create_instance_args.output_dir}"
                                     )
                                 return True
+
                             # disable retries if stage is not retryable by setting tries to max_tries+1
                             if not stage.is_retryable:
                                 tries = max_tries + 1
+
                             await self.run_next_stage(
                                 publisher_id=publisher_id,
                                 partner_id=partner_id,
@@ -178,6 +180,7 @@ class BoltRunner(Generic[T, U]):
             # don't retry if started or completed status
             logger.info(f"Publisher {publisher_id} starting stage {stage.name}.")
             await self.publisher_client.run_stage(instance_id=publisher_id, stage=stage)
+
         server_ips = None
         if stage.is_joint_stage:
             server_ips = await self.get_server_ips_after_start(

--- a/fbpcs/private_computation/stage_flows/private_computation_base_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_base_stage_flow.py
@@ -41,6 +41,9 @@ class PrivateComputationBaseStageFlow(StageFlow):
     # TODO(T103297566): [BE] document PrivateComputationBaseStageFlow
     def __init__(self, data: PrivateComputationStageFlowData) -> None:
         super().__init__()
+        self.initialized_status: PrivateComputationInstanceStatus = (
+            data.initialized_status
+        )
         self.started_status: PrivateComputationInstanceStatus = data.started_status
         self.failed_status: PrivateComputationInstanceStatus = data.failed_status
         self.completed_status: PrivateComputationInstanceStatus = data.completed_status

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -621,7 +621,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 pl_instance = self.private_computation_service.run_stage(
                     pl_instance.infra_config.instance_id, stage, stage_svc
                 )
-                self.assertEqual(pl_instance.infra_config.status, stage.started_status)
+                self.assertEqual(
+                    pl_instance.infra_config.status, stage.initialized_status
+                )
 
         for data_test in _get_valid_stages_data():
             stage = data_test[0]
@@ -675,7 +677,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             pl_instance = self.private_computation_service.run_stage(
                 pl_instance.infra_config.instance_id, stage, stage_svc, dry_run=True
             )
-            self.assertEqual(pl_instance.infra_config.status, stage.started_status)
+            self.assertEqual(pl_instance.infra_config.status, stage.initialized_status)
 
         for data_test in _get_valid_stages_data():
             stage = data_test[0]
@@ -743,7 +745,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 pl_instance = self.private_computation_service.run_stage(
                     pl_instance.infra_config.instance_id, stage, stage_svc
                 )
-                self.assertEqual(pl_instance.infra_config.status, stage.started_status)
+                self.assertEqual(
+                    pl_instance.infra_config.status, stage.initialized_status
+                )
 
         for data_test in _get_valid_stages_data():
             stage = data_test[0]


### PR DESCRIPTION
Summary:
## Why
In this Diff stack series, I'm going to introduce new status call "initialzed" in each stage.
The reason of adding new status is to decouple containers warm up time in the run_next api, to reduce api latency.

To better understanding what my goal is. Here is the current state transitions looks like
https://pxl.cl/2cRlQ

as you see in above diagram, it's waiting for "all" containers spin-up then return the request to API.

Here is the goal of this diff stack changes.

https://pxl.cl/2cRmf

We will be adding new status "initialized" that we can return API request sooner, then leverage our current update mehod (chronos JOB) to transit the status to start.
Which will save the API latency a ton based on my previous [investigation](https://fb.workplace.com/groups/164332244998024/permalink/873521087412466/) by 60s + to <1.5 s

## What
* This is the series of diff stack
* change the initial status to initialized

Differential Revision: D39372944

