### PR TITLE
skip continer warm up when call PRE_VALIDATION & PID_SHARD stages

### DIFF
--- a/fbpcs/common/entity/stage_state_instance.py
+++ b/fbpcs/common/entity/stage_state_instance.py
@@ -39,6 +39,12 @@ class StageStateInstance(InstanceBase):
 
     @property
     def server_ips(self) -> List[str]:
+        if self.status in [
+            StageStateInstanceStatus.UNKNOWN,
+            StageStateInstanceStatus.CREATED,
+        ]:
+            return []
+
         return [
             checked_cast(str, container.ip_address) for container in self.containers
         ]
@@ -63,6 +69,8 @@ class StageStateInstance(InstanceBase):
         elif all(status is ContainerInstanceStatus.COMPLETED for status in statuses):
             self.status = StageStateInstanceStatus.COMPLETED
             self.end_ts = int(time.time())
+        elif ContainerInstanceStatus.UNKNOWN in statuses:
+            self.status = StageStateInstanceStatus.UNKNOWN
         elif ContainerInstanceStatus.STARTED in statuses:
             self.status = StageStateInstanceStatus.STARTED
         else:

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -31,6 +31,7 @@ class RunBinaryBaseService:
         timeout: Optional[int] = None,
         wait_for_containers_to_finish: bool = False,
         env_vars: Optional[Dict[str, str]] = None,
+        wait_for_containers_to_start_up: bool = True,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
@@ -43,6 +44,9 @@ class RunBinaryBaseService:
             timeout=timeout,
             env_vars=env_vars,
         )
+        if not wait_for_containers_to_start_up:
+            logger.info("Skipped container warm up")
+            return pending_containers
 
         with RetryHandler(
             ThrottlingError, logger=logger, backoff_seconds=30

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -200,6 +200,7 @@ def get_pc_status_from_stage_state(
     # calling onedocker_svc to update newest containers in StageState
     stage_state_instance_status = stage_instance.update_status(onedocker_svc)
     current_stage = private_computation_instance.current_stage
+    # only update when StageStateInstanceStatus transit to Started/Completed/Failed, or remain the current status
     if stage_state_instance_status is StageStateInstanceStatus.STARTED:
         status = current_stage.started_status
     elif stage_state_instance_status is StageStateInstanceStatus.COMPLETED:


### PR DESCRIPTION
Summary:
## Why
In this Diff stack series, I'm going to introduce new status call "initialzed" in each stage.
The reason of adding new status is to decouple containers warm up time in the run_next api, to reduce api latency.

To better understanding what my goal is. Here is the current state transitions looks like
https://pxl.cl/2cRlQ

as you see in above diagram, it's waiting for "all" containers spin-up then return the request to API.

Here is the goal of this diff stack changes.

https://pxl.cl/2cRmf

We will be adding new status "initialized" that we can return API request sooner, then leverage our current update mehod (chronos JOB) to transit the status to start.
Which will save the API latency a ton based on my previous [investigation](https://fb.workplace.com/groups/164332244998024/permalink/873521087412466/) by 60s + to <1.5 s

## What
* This is the series of diff stack
* slowly roll out changes, this diff only remove busy wait time in PC_VALIDATION/PID_SHARD stage

Differential Revision: D39511894

