### PR TITLE
Adding glue logs and configs along with container logs

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -12,7 +12,7 @@ import shutil
 from dataclasses import dataclass
 from enum import Enum
 from pprint import pprint
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from fbpcs.infra.logging_service.download_logs.cloud_error.utils_error import (
     NotSupportedContentType,
@@ -126,7 +126,7 @@ class Utils:
         return file_name
 
     @staticmethod
-    def string_formatter(preset_string: str, *args: str) -> str:
+    def string_formatter(preset_string: str, *args: Optional[str]) -> str:
         return preset_string.format(*args)
 
 
@@ -139,6 +139,8 @@ class StringFormatter(str, Enum):
     ZIPPED_FOLDER_NAME = "{}.zip"
     KINESIS_FIREHOSE_DELIVERY_STREAM = "cb-data-ingestion-stream-{}"
     LAMBDA_LOG_GROUP_NAME = "/aws/lambda/{}"
+    GLUE_CRAWLER_NAME = "mpc-events-crawler-{}"
+    GLUE_ETL_NAME = "glue-ETL-{}"
 
 
 @dataclass


### PR DESCRIPTION
Summary:
**What**
This diff is part of the data infra pipeline logging project. In data infra pipeline we use 2 glue resources:
1. Glue crawler
2. Glue ETL - for semi automated pipeline

In this diff we capture logs for both of these glue resources. When semi_automated pipeline is deprecated, Glue ETL log capture will be removed from here as well.

**Why**
This will help in debugging Glue related failures in data infra pipeline

**Context**
https://docs.google.com/document/d/1cMD9IQ8uF6MS1PRvOh8cr-1el7MO952SjUanAzAGJzw/edit?usp=sharing

Differential Revision: D39528414

