### PR TITLE
Interface for [de+]serialization of LiftGameProcessedData

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
+#include "folly/logging/xlog.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -32,6 +34,16 @@ struct LiftGameProcessedData {
   std::vector<SecValue<schedulerId>> purchaseValues;
   std::vector<SecValueSquared<schedulerId>> purchaseValueSquared;
   SecBit<schedulerId> testReach;
+
+  void writeToCSV(
+      const std::string& globalParamsOutputPath,
+      const std::string& secretSharesOutputPath) const;
+
+  static LiftGameProcessedData readFromCSV(
+      const std::string& globalParamsInputPath,
+      const std::string& secretSharesInputPath);
 };
 
 } // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+void LiftGameProcessedData<schedulerId>::writeToCSV(
+    const std::string& globalParamsOutputPath,
+    const std::string& secretSharesOutputPath) const {
+  throw std::runtime_error("Unimplemented");
+}
+
+template <int schedulerId>
+LiftGameProcessedData<schedulerId>
+LiftGameProcessedData<schedulerId>::readFromCSV(
+    const std::string& globalParamsInputPath,
+    const std::string& secretSharesInputPath) {
+  throw std::runtime_error("Unimplemented");
+}
+} // namespace private_lift


### PR DESCRIPTION
Summary:
This defines the interface for serializing and deserializing a `LiftGameProcessedData` object to/from a CSV file. This object is the finished state of the `InputProcessor` after reading all the input files and secret sharing data. We need a way to store the intermediate secret shares for later use. It also works with the resharder logic out the box (https://fburl.com/code/y35xbauq). It writes the outputs to two files

`globalParamsPath` for constants such as
- numPartnerCohorts
- numPublisherBreakdowns
- numGroups
- numTestGroups
- valueBits
- valueSquaredBits

`secretSharesPath` for shardable batch values
- indexShares;
- testIndexShares;
- opportunityTimestamps;
- isValidOpportunityTimestamp;
- purchaseTimestamps;
- thresholdTimestamps;
- anyValidPurchaseTimestamp;
- purchaseValues;
- purchaseValueSquared;
- testReach;

My original thought was to use thrift structs for this. However this would require major changes to our B&R pipeline (https://fb.workplace.com/groups/thriftusers/posts/1056665801709498). Then I tried to use JSON and `folly::dynamic`, but realized that wouldn't quite work with the sharding logic unfortunately. Thus I have now switched to writing it into two CSV files where one can be sharded.

Differential Revision: D39322161

