### PR TITLE
Serialize and deserialize constant values in LiftGameProcessedData

### DIFF
--- a/fbpcs/emp_games/common/Csv.cpp
+++ b/fbpcs/emp_games/common/Csv.cpp
@@ -5,12 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/String.h>
 #include <functional>
 #include <string>
 #include <vector>
 
 #include "fbpcf/io/api/BufferedReader.h"
+#include "fbpcf/io/api/BufferedWriter.h"
 #include "fbpcf/io/api/FileReader.h"
+#include "fbpcf/io/api/FileWriter.h"
 
 #include "Constants.h"
 #include "Csv.h"
@@ -74,6 +77,33 @@ bool readCsv(
     readLine(header, parts);
   }
   inlineBufferedReader->close();
+  return true;
+}
+
+bool writeCsv(
+    const std::string& fileName,
+    const std::vector<std::string>& header,
+    const std::vector<std::vector<std::string>>& data) {
+  auto inlineWriter = std::make_unique<fbpcf::io::FileWriter>(fileName);
+  auto inlineBufferedWriter =
+      std::make_unique<fbpcf::io::BufferedWriter>(std::move(inlineWriter));
+
+  std::string newLine = "\n";
+
+  std::string outputLine;
+  folly::join(',', header, outputLine);
+
+  inlineBufferedWriter->writeString(outputLine);
+  inlineBufferedWriter->writeString(newLine);
+
+  for (auto& parts : data) {
+    folly::join(",", parts, outputLine);
+    inlineBufferedWriter->writeString(outputLine);
+    inlineBufferedWriter->writeString(newLine);
+  }
+
+  inlineBufferedWriter->close();
+
   return true;
 }
 

--- a/fbpcs/emp_games/common/Csv.h
+++ b/fbpcs/emp_games/common/Csv.h
@@ -34,4 +34,9 @@ bool readCsv(
     std::function<void(const std::vector<std::string>&)> processHeader =
         [](auto) {});
 
+bool writeCsv(
+    const std::string& fileName,
+    const std::vector<std::string>& header,
+    const std::vector<std::vector<std::string>>& data);
+
 } // namespace private_measurement::csv

--- a/fbpcs/emp_games/common/test/test_data/input.csv
+++ b/fbpcs/emp_games/common/test/test_data/input.csv
@@ -1,0 +1,3 @@
+id,field1,field2,field3
+1,foo,bubba,gas
+2,trio,[1,2,3],[4,5,6]

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
+#include "folly/logging/xlog.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -32,6 +34,16 @@ struct LiftGameProcessedData {
   std::vector<SecValue<schedulerId>> purchaseValues;
   std::vector<SecValueSquared<schedulerId>> purchaseValueSquared;
   SecBit<schedulerId> testReach;
+
+  void writeToCSV(
+      const std::string& globalParamsOutputPath,
+      const std::string& secretSharesOutputPath) const;
+
+  static LiftGameProcessedData readFromCSV(
+      const std::string& globalParamsInputPath,
+      const std::string& secretSharesInputPath);
 };
 
 } // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -9,11 +9,21 @@
 
 #include <cstdint>
 #include <vector>
+#include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
 #include "folly/logging/xlog.h"
 
 namespace private_lift {
+
+inline const std::vector<std::string> GLOBAL_PARAMS_HEADER = {
+    "numPartnerCohorts",
+    "numPublisherBreakdowns",
+    "numGroups",
+    "numTestGroups",
+    "valueBits",
+    "valueSquaredBits",
+};
 
 template <int schedulerId>
 struct LiftGameProcessedData {

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <stdexcept>
+#include <string>
+
 #include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
 
 namespace private_lift {
@@ -16,7 +17,16 @@ template <int schedulerId>
 void LiftGameProcessedData<schedulerId>::writeToCSV(
     const std::string& globalParamsOutputPath,
     const std::string& secretSharesOutputPath) const {
-  throw std::runtime_error("Unimplemented");
+  std::vector<std::vector<std::string>> globalParams = {
+      {std::to_string(numPartnerCohorts),
+       std::to_string(numPublisherBreakdowns),
+       std::to_string(numGroups),
+       std::to_string(numTestGroups),
+       std::to_string(valueBits),
+       std::to_string(valueSquaredBits)}};
+
+  private_measurement::csv::writeCsv(
+      globalParamsOutputPath, GLOBAL_PARAMS_HEADER, globalParams);
 }
 
 template <int schedulerId>
@@ -24,6 +34,35 @@ LiftGameProcessedData<schedulerId>
 LiftGameProcessedData<schedulerId>::readFromCSV(
     const std::string& globalParamsInputPath,
     const std::string& secretSharesInputPath) {
-  throw std::runtime_error("Unimplemented");
+  LiftGameProcessedData<schedulerId> result;
+  result.numRows = 0;
+
+  private_measurement::csv::readCsv(
+      globalParamsInputPath,
+      [&result](
+          const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        for (size_t i = 0; i < header.size(); i++) {
+          auto column = header[i];
+          auto value = parts[i];
+          if (column == "numPartnerCohorts") {
+            result.numPartnerCohorts = std::stoul(value);
+          } else if (column == "numPublisherBreakdowns") {
+            result.numPublisherBreakdowns = std::stoul(value);
+          } else if (column == "numGroups") {
+            result.numGroups = std::stoul(value);
+          } else if (column == "numTestGroups") {
+            result.numTestGroups = std::stoul(value);
+          } else if (column == "valueBits") {
+            result.valueBits = std::stoul(value);
+          } else if (column == "valueSquaredBits") {
+            result.valueSquaredBits = std::stoul(value);
+          } else {
+            LOG(WARNING) << "Warning: Unknown column in csv: " << column;
+          }
+        }
+      });
+
+  return result;
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+void LiftGameProcessedData<schedulerId>::writeToCSV(
+    const std::string& globalParamsOutputPath,
+    const std::string& secretSharesOutputPath) const {
+  throw std::runtime_error("Unimplemented");
+}
+
+template <int schedulerId>
+LiftGameProcessedData<schedulerId>
+LiftGameProcessedData<schedulerId>::readFromCSV(
+    const std::string& globalParamsInputPath,
+    const std::string& secretSharesInputPath) {
+  throw std::runtime_error("Unimplemented");
+}
+} // namespace private_lift


### PR DESCRIPTION
Summary:
Implements partial serialization of constants in LiftGameProcessedData as added in D39322161. Unimplemented values will just have dummy data.

  uint32_t numPartnerCohorts;
  uint32_t numPublisherBreakdowns;
  uint32_t numGroups;
  uint32_t numTestGroups;
  uint8_t valueBits;
  uint8_t valueSquaredBits;

These are written as a single line to a CSV file. The sharder will not need to touch these parameters, and they will be used in each shard of the UDP data.

Differential Revision: D39443227

