### PR TITLE
Serialize and Deserialize LiftGameProcessedData array values

### DIFF
--- a/fbpcs/emp_games/common/Csv.cpp
+++ b/fbpcs/emp_games/common/Csv.cpp
@@ -5,12 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/String.h>
 #include <functional>
 #include <string>
 #include <vector>
 
 #include "fbpcf/io/api/BufferedReader.h"
+#include "fbpcf/io/api/BufferedWriter.h"
 #include "fbpcf/io/api/FileReader.h"
+#include "fbpcf/io/api/FileWriter.h"
 
 #include "Constants.h"
 #include "Csv.h"
@@ -74,6 +77,33 @@ bool readCsv(
     readLine(header, parts);
   }
   inlineBufferedReader->close();
+  return true;
+}
+
+bool writeCsv(
+    const std::string& fileName,
+    const std::vector<std::string>& header,
+    const std::vector<std::vector<std::string>>& data) {
+  auto inlineWriter = std::make_unique<fbpcf::io::FileWriter>(fileName);
+  auto inlineBufferedWriter =
+      std::make_unique<fbpcf::io::BufferedWriter>(std::move(inlineWriter));
+
+  std::string newLine = "\n";
+
+  std::string outputLine;
+  folly::join(',', header, outputLine);
+
+  inlineBufferedWriter->writeString(outputLine);
+  inlineBufferedWriter->writeString(newLine);
+
+  for (auto& parts : data) {
+    folly::join(",", parts, outputLine);
+    inlineBufferedWriter->writeString(outputLine);
+    inlineBufferedWriter->writeString(newLine);
+  }
+
+  inlineBufferedWriter->close();
+
   return true;
 }
 

--- a/fbpcs/emp_games/common/Csv.h
+++ b/fbpcs/emp_games/common/Csv.h
@@ -34,4 +34,9 @@ bool readCsv(
     std::function<void(const std::vector<std::string>&)> processHeader =
         [](auto) {});
 
+bool writeCsv(
+    const std::string& fileName,
+    const std::vector<std::string>& header,
+    const std::vector<std::vector<std::string>>& data);
+
 } // namespace private_measurement::csv

--- a/fbpcs/emp_games/common/test/test_data/input.csv
+++ b/fbpcs/emp_games/common/test/test_data/input.csv
@@ -1,0 +1,3 @@
+id,field1,field2,field3
+1,foo,bubba,gas
+2,trio,[1,2,3],[4,5,6]

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
+#include "folly/logging/xlog.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -32,6 +34,16 @@ struct LiftGameProcessedData {
   std::vector<SecValue<schedulerId>> purchaseValues;
   std::vector<SecValueSquared<schedulerId>> purchaseValueSquared;
   SecBit<schedulerId> testReach;
+
+  void writeToCSV(
+      const std::string& globalParamsOutputPath,
+      const std::string& secretSharesOutputPath) const;
+
+  static LiftGameProcessedData readFromCSV(
+      const std::string& globalParamsInputPath,
+      const std::string& secretSharesInputPath);
 };
 
 } // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -25,6 +25,13 @@ inline const std::vector<std::string> GLOBAL_PARAMS_HEADER = {
     "valueSquaredBits",
 };
 
+inline const std::vector<std::string> SECRET_SHARES_HEADER = {
+    "id_",
+    "opportunityTimestamps",
+    "isValidOpportunityTimestamp",
+    "anyValidPurchaseTimestamp",
+    "testReach"};
+
 template <int schedulerId>
 struct LiftGameProcessedData {
   int64_t numRows;
@@ -52,6 +59,19 @@ struct LiftGameProcessedData {
   static LiftGameProcessedData readFromCSV(
       const std::string& globalParamsInputPath,
       const std::string& secretSharesInputPath);
+
+ private:
+  template <typename T>
+  static std::string joinColumn(
+      std::vector<std::vector<T>> data,
+      size_t columnIndex);
+
+  template <typename T>
+  static std::vector<T> extractColumn(
+      std::vector<std::vector<T>> data,
+      size_t columnIndex);
+
+  static std::vector<std::string> splitValueArray(const std::string& str);
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -9,11 +9,21 @@
 
 #include <cstdint>
 #include <vector>
+#include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
 #include "folly/logging/xlog.h"
 
 namespace private_lift {
+
+inline const std::vector<std::string> GLOBAL_PARAMS_HEADER = {
+    "numPartnerCohorts",
+    "numPublisherBreakdowns",
+    "numGroups",
+    "numTestGroups",
+    "valueBits",
+    "valueSquaredBits",
+};
 
 template <int schedulerId>
 struct LiftGameProcessedData {

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <stdexcept>
+#include <string>
+
 #include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
 
 namespace private_lift {
@@ -16,7 +17,16 @@ template <int schedulerId>
 void LiftGameProcessedData<schedulerId>::writeToCSV(
     const std::string& globalParamsOutputPath,
     const std::string& secretSharesOutputPath) const {
-  throw std::runtime_error("Unimplemented");
+  std::vector<std::vector<std::string>> globalParams = {
+      {std::to_string(numPartnerCohorts),
+       std::to_string(numPublisherBreakdowns),
+       std::to_string(numGroups),
+       std::to_string(numTestGroups),
+       std::to_string(valueBits),
+       std::to_string(valueSquaredBits)}};
+
+  private_measurement::csv::writeCsv(
+      globalParamsOutputPath, GLOBAL_PARAMS_HEADER, globalParams);
 }
 
 template <int schedulerId>
@@ -24,6 +34,35 @@ LiftGameProcessedData<schedulerId>
 LiftGameProcessedData<schedulerId>::readFromCSV(
     const std::string& globalParamsInputPath,
     const std::string& secretSharesInputPath) {
-  throw std::runtime_error("Unimplemented");
+  LiftGameProcessedData<schedulerId> result;
+  result.numRows = 0;
+
+  private_measurement::csv::readCsv(
+      globalParamsInputPath,
+      [&result](
+          const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        for (size_t i = 0; i < header.size(); i++) {
+          auto column = header[i];
+          auto value = parts[i];
+          if (column == "numPartnerCohorts") {
+            result.numPartnerCohorts = std::stoul(value);
+          } else if (column == "numPublisherBreakdowns") {
+            result.numPublisherBreakdowns = std::stoul(value);
+          } else if (column == "numGroups") {
+            result.numGroups = std::stoul(value);
+          } else if (column == "numTestGroups") {
+            result.numTestGroups = std::stoul(value);
+          } else if (column == "valueBits") {
+            result.valueBits = std::stoul(value);
+          } else if (column == "valueSquaredBits") {
+            result.valueSquaredBits = std::stoul(value);
+          } else {
+            LOG(WARNING) << "Warning: Unknown column in csv: " << column;
+          }
+        }
+      });
+
+  return result;
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <iterator>
 #include <string>
 
 #include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
@@ -27,6 +29,33 @@ void LiftGameProcessedData<schedulerId>::writeToCSV(
 
   private_measurement::csv::writeCsv(
       globalParamsOutputPath, GLOBAL_PARAMS_HEADER, globalParams);
+
+  std::vector<std::vector<std::string>> secretShares(numRows);
+
+  std::vector<uint64_t> opportunityTimestampsShares =
+      opportunityTimestamps.extractIntShare().getValue();
+  std::vector<bool> isValidOpportunityTimestampShares =
+      isValidOpportunityTimestamp.extractBit().getValue();
+  std::vector<bool> anyValidPurchaseTimestampShares =
+      anyValidPurchaseTimestamp.extractBit().getValue();
+  std::vector<bool> testReachShares = testReach.extractBit().getValue();
+
+  for (size_t i = 0; i < numRows; i++) {
+    secretShares[i] = std::vector<std::string>();
+    secretShares[i].reserve(SECRET_SHARES_HEADER.size());
+
+    // id_ column
+    secretShares[i].push_back(std::to_string(i));
+    secretShares[i].push_back(std::to_string(opportunityTimestampsShares[i]));
+    secretShares[i].push_back(
+        std::to_string(isValidOpportunityTimestampShares[i]));
+    secretShares[i].push_back(
+        std::to_string(anyValidPurchaseTimestampShares[i]));
+    secretShares[i].push_back(std::to_string(testReachShares[i]));
+  }
+
+  private_measurement::csv::writeCsv(
+      secretSharesOutputPath, SECRET_SHARES_HEADER, secretShares);
 }
 
 template <int schedulerId>
@@ -62,6 +91,53 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
           }
         }
       });
+  std::vector<uint64_t> opportunityTimestampsShares;
+  std::vector<bool> isValidOpportunityTimestampShares;
+  std::vector<bool> anyValidPurchaseTimestampShares;
+  std::vector<bool> testReachShares;
+
+  private_measurement::csv::readCsv(
+      secretSharesInputPath,
+      [&result,
+       &opportunityTimestampsShares,
+       &isValidOpportunityTimestampShares,
+       &anyValidPurchaseTimestampShares,
+       &testReachShares](
+          const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        result.numRows++;
+        for (size_t i = 0; i < header.size(); i++) {
+          auto column = header[i];
+          auto value = parts[i];
+          if (column == "opportunityTimestamps") {
+            opportunityTimestampsShares.push_back(std::stoull(value));
+          } else if (column == "isValidOpportunityTimestamp") {
+            isValidOpportunityTimestampShares.push_back(std::stoul(value));
+          } else if (column == "anyValidPurchaseTimestamp") {
+            anyValidPurchaseTimestampShares.push_back(std::stoul(value));
+          } else if (column == "testReach") {
+            testReachShares.push_back(std::stoul(value));
+          } else if (column != "id_") {
+            LOG(WARNING) << "Warning: Unknown column in csv: " << column;
+          }
+        }
+      });
+
+  if (result.numRows == 0) {
+    XLOG(FATAL, "Lift Game shares file was empty");
+  }
+
+  result.opportunityTimestamps = SecTimestamp<schedulerId>(
+      typename SecTimestamp<schedulerId>::ExtractedInt(
+          opportunityTimestampsShares));
+  result.isValidOpportunityTimestamp =
+      SecBit<schedulerId>(typename SecBit<schedulerId>::ExtractedBit(
+          isValidOpportunityTimestampShares));
+  result.anyValidPurchaseTimestamp =
+      SecBit<schedulerId>(typename SecBit<schedulerId>::ExtractedBit(
+          anyValidPurchaseTimestampShares));
+  result.testReach = SecBit<schedulerId>(
+      typename SecBit<schedulerId>::ExtractedBit(testReachShares));
 
   return result;
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+void LiftGameProcessedData<schedulerId>::writeToCSV(
+    const std::string& globalParamsOutputPath,
+    const std::string& secretSharesOutputPath) const {
+  throw std::runtime_error("Unimplemented");
+}
+
+template <int schedulerId>
+LiftGameProcessedData<schedulerId>
+LiftGameProcessedData<schedulerId>::readFromCSV(
+    const std::string& globalParamsInputPath,
+    const std::string& secretSharesInputPath) {
+  throw std::runtime_error("Unimplemented");
+}
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -154,13 +154,23 @@ class InputProcessorTest : public ::testing::TestWithParam<bool> {
     future3.get();
 
     cleanup(publisherGlobalParamsOutput);
+    cleanup(publisherSecretSharesOutput);
     cleanup(partnerGlobalParamsOutput);
+    cleanup(partnerSecretSharesOutput);
   }
 };
 
 TEST_P(InputProcessorTest, testNumRows) {
   EXPECT_EQ(publisherInputProcessor_.getLiftGameProcessedData().numRows, 33);
   EXPECT_EQ(partnerInputProcessor_.getLiftGameProcessedData().numRows, 33);
+
+  EXPECT_EQ(
+      publisherInputProcessor_.getLiftGameProcessedData().numRows,
+      publisherDeserialized_.numRows);
+
+  EXPECT_EQ(
+      partnerInputProcessor_.getLiftGameProcessedData().numRows,
+      partnerDeserialized_.numRows);
 }
 
 TEST_P(InputProcessorTest, testBitsForValues) {
@@ -333,12 +343,25 @@ TEST_P(InputProcessorTest, testOpportunityTimestamps) {
         .getValue();
   });
   auto opportunityTimestamps0 = future0.get();
-  auto opportunityTimestamps1 = future1.get();
+  future1.get();
   std::vector<uint64_t> expectOpportunityTimestamps = {
       0,   0,   0,   100, 100, 100, 100, 100, 100, 100, 100,
       100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
       100, 100, 0,   100, 100, 100, 100, 100, 100, 100, 100};
   EXPECT_EQ(opportunityTimestamps0, expectOpportunityTimestamps);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.opportunityTimestamps.openToParty(0)
+        .getValue();
+  });
+  auto future3 = std::async([&] {
+    return partnerDeserialized_.opportunityTimestamps.openToParty(0).getValue();
+  });
+
+  auto deserializedOpportunityTimestamps = future2.get();
+  future3.get();
+
+  EXPECT_EQ(opportunityTimestamps0, deserializedOpportunityTimestamps);
 }
 
 TEST_P(InputProcessorTest, testIsValidOpportunityTimestamp) {
@@ -353,11 +376,26 @@ TEST_P(InputProcessorTest, testIsValidOpportunityTimestamp) {
         .getValue();
   });
   auto isValidOpportunityTimestamp0 = future0.get();
-  auto isValidOpportunityTimestamp1 = future1.get();
+  future1.get();
   std::vector<bool> expectIsValidOpportunityTimestamp = {
       0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1,
       1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1};
   EXPECT_EQ(isValidOpportunityTimestamp0, expectIsValidOpportunityTimestamp);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.isValidOpportunityTimestamp.openToParty(0)
+        .getValue();
+  });
+  auto future3 = std::async([&] {
+    return partnerDeserialized_.isValidOpportunityTimestamp.openToParty(0)
+        .getValue();
+  });
+
+  auto deserializedIsValidOpportunityTimestamp = future2.get();
+  future3.get();
+
+  EXPECT_EQ(
+      isValidOpportunityTimestamp0, deserializedIsValidOpportunityTimestamp);
 }
 
 template <int schedulerId>
@@ -441,6 +479,20 @@ TEST_P(InputProcessorTest, testAnyValidPurchaseTimestamp) {
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   EXPECT_EQ(anyValidPurchaseTimestamp0, expectAnyValidPurchaseTimestamp);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.anyValidPurchaseTimestamp.openToParty(0)
+        .getValue();
+  });
+  auto future3 = std::async([&] {
+    return partnerDeserialized_.anyValidPurchaseTimestamp.openToParty(0)
+        .getValue();
+  });
+
+  auto anyValidPurchaseTimestampDeserialized = future2.get();
+  future3.get();
+
+  EXPECT_EQ(anyValidPurchaseTimestamp0, anyValidPurchaseTimestampDeserialized);
 }
 
 template <int schedulerId>
@@ -517,12 +569,23 @@ TEST_P(InputProcessorTest, testReach) {
         .getValue();
   });
   auto testReach0 = future0.get();
-  auto testReach1 = future1.get();
+  future1.get();
 
   std::vector<bool> expectTestReach = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                        0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0};
   EXPECT_EQ(testReach0, expectTestReach);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.testReach.openToParty(0).getValue();
+  });
+  auto future3 = std::async(
+      [&] { return partnerDeserialized_.testReach.openToParty(0).getValue(); });
+
+  auto testReachDeserialized = future2.get();
+  future3.get();
+
+  EXPECT_EQ(testReach0, testReachDeserialized);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Summary:
This diff adds serialization and deserialization of the following values in LiftGameProcessedData:

  SecTimestamp<schedulerId> opportunityTimestamps;
  SecBit<schedulerId> isValidOpportunityTimestamp;
  SecBit<schedulerId> anyValidPurchaseTimestamp;
  SecBit<schedulerId> testReach;

As each row has a single value, it will end up in the CSV as a single value per row.

In the deserialization step we collect all the rows into a vector for each value to be loaded into the MPC type.

Differential Revision: D39547913

