### PR TITLE
Serialize and Deserialize indexShares and testIndexShares

### DIFF
--- a/fbpcs/emp_games/common/Csv.cpp
+++ b/fbpcs/emp_games/common/Csv.cpp
@@ -5,12 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/String.h>
 #include <functional>
 #include <string>
 #include <vector>
 
 #include "fbpcf/io/api/BufferedReader.h"
+#include "fbpcf/io/api/BufferedWriter.h"
 #include "fbpcf/io/api/FileReader.h"
+#include "fbpcf/io/api/FileWriter.h"
 
 #include "Constants.h"
 #include "Csv.h"
@@ -74,6 +77,33 @@ bool readCsv(
     readLine(header, parts);
   }
   inlineBufferedReader->close();
+  return true;
+}
+
+bool writeCsv(
+    const std::string& fileName,
+    const std::vector<std::string>& header,
+    const std::vector<std::vector<std::string>>& data) {
+  auto inlineWriter = std::make_unique<fbpcf::io::FileWriter>(fileName);
+  auto inlineBufferedWriter =
+      std::make_unique<fbpcf::io::BufferedWriter>(std::move(inlineWriter));
+
+  std::string newLine = "\n";
+
+  std::string outputLine;
+  folly::join(',', header, outputLine);
+
+  inlineBufferedWriter->writeString(outputLine);
+  inlineBufferedWriter->writeString(newLine);
+
+  for (auto& parts : data) {
+    folly::join(",", parts, outputLine);
+    inlineBufferedWriter->writeString(outputLine);
+    inlineBufferedWriter->writeString(newLine);
+  }
+
+  inlineBufferedWriter->close();
+
   return true;
 }
 

--- a/fbpcs/emp_games/common/Csv.h
+++ b/fbpcs/emp_games/common/Csv.h
@@ -34,4 +34,9 @@ bool readCsv(
     std::function<void(const std::vector<std::string>&)> processHeader =
         [](auto) {});
 
+bool writeCsv(
+    const std::string& fileName,
+    const std::vector<std::string>& header,
+    const std::vector<std::vector<std::string>>& data);
+
 } // namespace private_measurement::csv

--- a/fbpcs/emp_games/common/test/test_data/input.csv
+++ b/fbpcs/emp_games/common/test/test_data/input.csv
@@ -1,0 +1,3 @@
+id,field1,field2,field3
+1,foo,bubba,gas
+2,trio,[1,2,3],[4,5,6]

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -29,7 +29,11 @@ inline const std::vector<std::string> SECRET_SHARES_HEADER = {
     "id_",
     "opportunityTimestamps",
     "isValidOpportunityTimestamp",
+    "purchaseTimestamps",
+    "thresholdTimestamps",
     "anyValidPurchaseTimestamp",
+    "purchaseValues",
+    "purchaseValueSquared",
     "testReach"};
 
 template <int schedulerId>
@@ -63,12 +67,12 @@ struct LiftGameProcessedData {
  private:
   template <typename T>
   static std::string joinColumn(
-      std::vector<std::vector<T>> data,
+      const std::vector<std::vector<T>>& data,
       size_t columnIndex);
 
   template <typename T>
   static std::vector<T> extractColumn(
-      std::vector<std::vector<T>> data,
+      const std::vector<std::vector<T>>& data,
       size_t columnIndex);
 
   static std::vector<std::string> splitValueArray(const std::string& str);

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
+#include "folly/logging/xlog.h"
+
 namespace private_lift {
 
 template <int schedulerId>
@@ -32,6 +34,16 @@ struct LiftGameProcessedData {
   std::vector<SecValue<schedulerId>> purchaseValues;
   std::vector<SecValueSquared<schedulerId>> purchaseValueSquared;
   SecBit<schedulerId> testReach;
+
+  void writeToCSV(
+      const std::string& globalParamsOutputPath,
+      const std::string& secretSharesOutputPath) const;
+
+  static LiftGameProcessedData readFromCSV(
+      const std::string& globalParamsInputPath,
+      const std::string& secretSharesInputPath);
 };
 
 } // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -27,6 +27,8 @@ inline const std::vector<std::string> GLOBAL_PARAMS_HEADER = {
 
 inline const std::vector<std::string> SECRET_SHARES_HEADER = {
     "id_",
+    "indexShares",
+    "testIndexShares",
     "opportunityTimestamps",
     "isValidOpportunityTimestamp",
     "purchaseTimestamps",
@@ -74,6 +76,10 @@ struct LiftGameProcessedData {
   static std::vector<T> extractColumn(
       const std::vector<std::vector<T>>& data,
       size_t columnIndex);
+
+  template <typename T>
+  static std::vector<std::vector<T>> transpose(
+      const std::vector<std::vector<T>>& data);
 
   static std::vector<std::string> splitValueArray(const std::string& str);
 };

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -25,6 +25,13 @@ inline const std::vector<std::string> GLOBAL_PARAMS_HEADER = {
     "valueSquaredBits",
 };
 
+inline const std::vector<std::string> SECRET_SHARES_HEADER = {
+    "id_",
+    "opportunityTimestamps",
+    "isValidOpportunityTimestamp",
+    "anyValidPurchaseTimestamp",
+    "testReach"};
+
 template <int schedulerId>
 struct LiftGameProcessedData {
   int64_t numRows;
@@ -52,6 +59,19 @@ struct LiftGameProcessedData {
   static LiftGameProcessedData readFromCSV(
       const std::string& globalParamsInputPath,
       const std::string& secretSharesInputPath);
+
+ private:
+  template <typename T>
+  static std::string joinColumn(
+      std::vector<std::vector<T>> data,
+      size_t columnIndex);
+
+  template <typename T>
+  static std::vector<T> extractColumn(
+      std::vector<std::vector<T>> data,
+      size_t columnIndex);
+
+  static std::vector<std::string> splitValueArray(const std::string& str);
 };
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h
@@ -9,11 +9,21 @@
 
 #include <cstdint>
 #include <vector>
+#include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/Constants.h"
 
 #include "folly/logging/xlog.h"
 
 namespace private_lift {
+
+inline const std::vector<std::string> GLOBAL_PARAMS_HEADER = {
+    "numPartnerCohorts",
+    "numPublisherBreakdowns",
+    "numGroups",
+    "numTestGroups",
+    "valueBits",
+    "valueSquaredBits",
+};
 
 template <int schedulerId>
 struct LiftGameProcessedData {

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <stdexcept>
+#include <string>
+
 #include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
 
 namespace private_lift {
@@ -16,7 +17,16 @@ template <int schedulerId>
 void LiftGameProcessedData<schedulerId>::writeToCSV(
     const std::string& globalParamsOutputPath,
     const std::string& secretSharesOutputPath) const {
-  throw std::runtime_error("Unimplemented");
+  std::vector<std::vector<std::string>> globalParams = {
+      {std::to_string(numPartnerCohorts),
+       std::to_string(numPublisherBreakdowns),
+       std::to_string(numGroups),
+       std::to_string(numTestGroups),
+       std::to_string(valueBits),
+       std::to_string(valueSquaredBits)}};
+
+  private_measurement::csv::writeCsv(
+      globalParamsOutputPath, GLOBAL_PARAMS_HEADER, globalParams);
 }
 
 template <int schedulerId>
@@ -24,6 +34,35 @@ LiftGameProcessedData<schedulerId>
 LiftGameProcessedData<schedulerId>::readFromCSV(
     const std::string& globalParamsInputPath,
     const std::string& secretSharesInputPath) {
-  throw std::runtime_error("Unimplemented");
+  LiftGameProcessedData<schedulerId> result;
+  result.numRows = 0;
+
+  private_measurement::csv::readCsv(
+      globalParamsInputPath,
+      [&result](
+          const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        for (size_t i = 0; i < header.size(); i++) {
+          auto column = header[i];
+          auto value = parts[i];
+          if (column == "numPartnerCohorts") {
+            result.numPartnerCohorts = std::stoul(value);
+          } else if (column == "numPublisherBreakdowns") {
+            result.numPublisherBreakdowns = std::stoul(value);
+          } else if (column == "numGroups") {
+            result.numGroups = std::stoul(value);
+          } else if (column == "numTestGroups") {
+            result.numTestGroups = std::stoul(value);
+          } else if (column == "valueBits") {
+            result.valueBits = std::stoul(value);
+          } else if (column == "valueSquaredBits") {
+            result.valueSquaredBits = std::stoul(value);
+          } else {
+            LOG(WARNING) << "Warning: Unknown column in csv: " << column;
+          }
+        }
+      });
+
+  return result;
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -36,8 +36,40 @@ void LiftGameProcessedData<schedulerId>::writeToCSV(
       opportunityTimestamps.extractIntShare().getValue();
   std::vector<bool> isValidOpportunityTimestampShares =
       isValidOpportunityTimestamp.extractBit().getValue();
+  std::vector<std::vector<uint64_t>> purchaseTimestampShares;
+  std::transform(
+      purchaseTimestamps.begin(),
+      purchaseTimestamps.end(),
+      std::back_inserter(purchaseTimestampShares),
+      [](const SecTimestamp<schedulerId>& purchaseTimestamp) {
+        return purchaseTimestamp.extractIntShare().getValue();
+      });
+  std::vector<std::vector<uint64_t>> thresholdTimestampShares;
+  std::transform(
+      thresholdTimestamps.begin(),
+      thresholdTimestamps.end(),
+      std::back_inserter(thresholdTimestampShares),
+      [](const SecTimestamp<schedulerId>& thresholdTimestamp) {
+        return thresholdTimestamp.extractIntShare().getValue();
+      });
   std::vector<bool> anyValidPurchaseTimestampShares =
       anyValidPurchaseTimestamp.extractBit().getValue();
+  std::vector<std::vector<int64_t>> purchaseValueShares;
+  std::transform(
+      purchaseValues.begin(),
+      purchaseValues.end(),
+      std::back_inserter(purchaseValueShares),
+      [](const SecValue<schedulerId>& purchaseValue) {
+        return purchaseValue.extractIntShare().getValue();
+      });
+  std::vector<std::vector<int64_t>> purchaseValueSquaredShares;
+  std::transform(
+      purchaseValueSquared.begin(),
+      purchaseValueSquared.end(),
+      std::back_inserter(purchaseValueSquaredShares),
+      [](const SecValueSquared<schedulerId>& purchaseValueSquared) {
+        return purchaseValueSquared.extractIntShare().getValue();
+      });
   std::vector<bool> testReachShares = testReach.extractBit().getValue();
 
   for (size_t i = 0; i < numRows; i++) {
@@ -49,13 +81,50 @@ void LiftGameProcessedData<schedulerId>::writeToCSV(
     secretShares[i].push_back(std::to_string(opportunityTimestampsShares[i]));
     secretShares[i].push_back(
         std::to_string(isValidOpportunityTimestampShares[i]));
+    secretShares[i].push_back(joinColumn(purchaseTimestampShares, i));
+    secretShares[i].push_back(joinColumn(thresholdTimestampShares, i));
     secretShares[i].push_back(
         std::to_string(anyValidPurchaseTimestampShares[i]));
+    secretShares[i].push_back(joinColumn(purchaseValueShares, i));
+    secretShares[i].push_back(joinColumn(purchaseValueSquaredShares, i));
     secretShares[i].push_back(std::to_string(testReachShares[i]));
   }
 
   private_measurement::csv::writeCsv(
       secretSharesOutputPath, SECRET_SHARES_HEADER, secretShares);
+}
+
+template <int schedulerId>
+template <typename T>
+std::string LiftGameProcessedData<schedulerId>::joinColumn(
+    const std::vector<std::vector<T>>& data,
+    size_t columnIndex) {
+  if (data.size() == 0) {
+    return "[]";
+  } else if (data.size() == 1) {
+    return "[" + std::to_string(data[0][columnIndex]) + "]";
+  } else {
+    std::string result = "[";
+    for (size_t row = 0; row < data.size() - 1; row++) {
+      result += std::to_string(data[row][columnIndex]) + ",";
+    }
+
+    result += std::to_string(data[data.size() - 1][columnIndex]) + "]";
+    return result;
+  }
+}
+
+template <int schedulerId>
+template <typename T>
+std::vector<T> LiftGameProcessedData<schedulerId>::extractColumn(
+    const std::vector<std::vector<T>>& data,
+    size_t columnIndex) {
+  std::vector<T> result;
+  result.reserve(data.size());
+  for (size_t row = 0; row < data.size(); row++) {
+    result.push_back(data[row][columnIndex]);
+  }
+  return result;
 }
 
 template <int schedulerId>
@@ -93,7 +162,11 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
       });
   std::vector<uint64_t> opportunityTimestampsShares;
   std::vector<bool> isValidOpportunityTimestampShares;
+  std::vector<std::vector<uint64_t>> purchaseTimestampShares;
+  std::vector<std::vector<uint64_t>> thresholdTimestampShares;
   std::vector<bool> anyValidPurchaseTimestampShares;
+  std::vector<std::vector<int64_t>> purchaseValueShares;
+  std::vector<std::vector<int64_t>> purchaseValueSquaredShares;
   std::vector<bool> testReachShares;
 
   private_measurement::csv::readCsv(
@@ -101,7 +174,11 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
       [&result,
        &opportunityTimestampsShares,
        &isValidOpportunityTimestampShares,
+       &purchaseTimestampShares,
+       &thresholdTimestampShares,
        &anyValidPurchaseTimestampShares,
+       &purchaseValueShares,
+       &purchaseValueSquaredShares,
        &testReachShares](
           const std::vector<std::string>& header,
           const std::vector<std::string>& parts) {
@@ -113,8 +190,33 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
             opportunityTimestampsShares.push_back(std::stoull(value));
           } else if (column == "isValidOpportunityTimestamp") {
             isValidOpportunityTimestampShares.push_back(std::stoul(value));
+          } else if (column == "purchaseTimestamps") {
+            purchaseTimestampShares.emplace_back();
+            for (const auto& purchaseTimestampShare : splitValueArray(value)) {
+              purchaseTimestampShares.back().push_back(
+                  std::stoull(purchaseTimestampShare));
+            }
+          } else if (column == "thresholdTimestamps") {
+            thresholdTimestampShares.emplace_back();
+            for (const auto& thresholdTimestampShare : splitValueArray(value)) {
+              thresholdTimestampShares.back().push_back(
+                  std::stoull(thresholdTimestampShare));
+            }
           } else if (column == "anyValidPurchaseTimestamp") {
             anyValidPurchaseTimestampShares.push_back(std::stoul(value));
+          } else if (column == "purchaseValues") {
+            purchaseValueShares.emplace_back();
+            for (const auto& purchaseValueShare : splitValueArray(value)) {
+              purchaseValueShares.back().push_back(
+                  std::stoll(purchaseValueShare));
+            }
+          } else if (column == "purchaseValueSquared") {
+            purchaseValueSquaredShares.emplace_back();
+            for (const auto& purchaseValueSquaredShare :
+                 splitValueArray(value)) {
+              purchaseValueSquaredShares.back().push_back(
+                  std::stoll(purchaseValueSquaredShare));
+            }
           } else if (column == "testReach") {
             testReachShares.push_back(std::stoul(value));
           } else if (column != "id_") {
@@ -133,12 +235,55 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
   result.isValidOpportunityTimestamp =
       SecBit<schedulerId>(typename SecBit<schedulerId>::ExtractedBit(
           isValidOpportunityTimestampShares));
+
+  result.purchaseTimestamps = std::vector<SecTimestamp<schedulerId>>();
+  result.purchaseTimestamps.reserve(purchaseTimestampShares[0].size());
+  for (size_t i = 0; i < purchaseTimestampShares[0].size(); i++) {
+    result.purchaseTimestamps.push_back(SecTimestamp<schedulerId>(
+        typename SecTimestamp<schedulerId>::ExtractedInt(
+            extractColumn(purchaseTimestampShares, i))));
+  }
+
+  result.thresholdTimestamps = std::vector<SecTimestamp<schedulerId>>();
+  result.thresholdTimestamps.reserve(thresholdTimestampShares[0].size());
+  for (size_t i = 0; i < thresholdTimestampShares[0].size(); i++) {
+    result.thresholdTimestamps.push_back(SecTimestamp<schedulerId>(
+        typename SecTimestamp<schedulerId>::ExtractedInt(
+            extractColumn(thresholdTimestampShares, i))));
+  }
+
   result.anyValidPurchaseTimestamp =
       SecBit<schedulerId>(typename SecBit<schedulerId>::ExtractedBit(
           anyValidPurchaseTimestampShares));
+
+  result.purchaseValues = std::vector<SecValue<schedulerId>>();
+  result.purchaseValues.reserve(purchaseValueShares[0].size());
+  for (size_t i = 0; i < purchaseValueShares[0].size(); i++) {
+    result.purchaseValues.push_back(
+        SecValue<schedulerId>(typename SecValue<schedulerId>::ExtractedInt(
+            extractColumn(purchaseValueShares, i))));
+  }
+
+  result.purchaseValueSquared = std::vector<SecValueSquared<schedulerId>>();
+  result.purchaseValueSquared.reserve(purchaseValueSquaredShares[0].size());
+  for (size_t i = 0; i < purchaseValueSquaredShares[0].size(); i++) {
+    result.purchaseValueSquared.push_back(SecValueSquared<schedulerId>(
+        typename SecValueSquared<schedulerId>::ExtractedInt(
+            extractColumn(purchaseValueSquaredShares, i))));
+  }
+
   result.testReach = SecBit<schedulerId>(
       typename SecBit<schedulerId>::ExtractedBit(testReachShares));
 
   return result;
+}
+
+template <int schedulerId>
+std::vector<std::string> LiftGameProcessedData<schedulerId>::splitValueArray(
+    const std::string& str) {
+  auto innerString = str.substr(1, str.size() - 1);
+  std::vector<std::string> values =
+      private_measurement::csv::splitByComma(innerString, false);
+  return values;
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <iterator>
 #include <string>
 
 #include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
@@ -27,6 +29,33 @@ void LiftGameProcessedData<schedulerId>::writeToCSV(
 
   private_measurement::csv::writeCsv(
       globalParamsOutputPath, GLOBAL_PARAMS_HEADER, globalParams);
+
+  std::vector<std::vector<std::string>> secretShares(numRows);
+
+  std::vector<uint64_t> opportunityTimestampsShares =
+      opportunityTimestamps.extractIntShare().getValue();
+  std::vector<bool> isValidOpportunityTimestampShares =
+      isValidOpportunityTimestamp.extractBit().getValue();
+  std::vector<bool> anyValidPurchaseTimestampShares =
+      anyValidPurchaseTimestamp.extractBit().getValue();
+  std::vector<bool> testReachShares = testReach.extractBit().getValue();
+
+  for (size_t i = 0; i < numRows; i++) {
+    secretShares[i] = std::vector<std::string>();
+    secretShares[i].reserve(SECRET_SHARES_HEADER.size());
+
+    // id_ column
+    secretShares[i].push_back(std::to_string(i));
+    secretShares[i].push_back(std::to_string(opportunityTimestampsShares[i]));
+    secretShares[i].push_back(
+        std::to_string(isValidOpportunityTimestampShares[i]));
+    secretShares[i].push_back(
+        std::to_string(anyValidPurchaseTimestampShares[i]));
+    secretShares[i].push_back(std::to_string(testReachShares[i]));
+  }
+
+  private_measurement::csv::writeCsv(
+      secretSharesOutputPath, SECRET_SHARES_HEADER, secretShares);
 }
 
 template <int schedulerId>
@@ -62,6 +91,53 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
           }
         }
       });
+  std::vector<uint64_t> opportunityTimestampsShares;
+  std::vector<bool> isValidOpportunityTimestampShares;
+  std::vector<bool> anyValidPurchaseTimestampShares;
+  std::vector<bool> testReachShares;
+
+  private_measurement::csv::readCsv(
+      secretSharesInputPath,
+      [&result,
+       &opportunityTimestampsShares,
+       &isValidOpportunityTimestampShares,
+       &anyValidPurchaseTimestampShares,
+       &testReachShares](
+          const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        result.numRows++;
+        for (size_t i = 0; i < header.size(); i++) {
+          auto column = header[i];
+          auto value = parts[i];
+          if (column == "opportunityTimestamps") {
+            opportunityTimestampsShares.push_back(std::stoull(value));
+          } else if (column == "isValidOpportunityTimestamp") {
+            isValidOpportunityTimestampShares.push_back(std::stoul(value));
+          } else if (column == "anyValidPurchaseTimestamp") {
+            anyValidPurchaseTimestampShares.push_back(std::stoul(value));
+          } else if (column == "testReach") {
+            testReachShares.push_back(std::stoul(value));
+          } else if (column != "id_") {
+            LOG(WARNING) << "Warning: Unknown column in csv: " << column;
+          }
+        }
+      });
+
+  if (result.numRows == 0) {
+    XLOG(FATAL, "Lift Game shares file was empty");
+  }
+
+  result.opportunityTimestamps = SecTimestamp<schedulerId>(
+      typename SecTimestamp<schedulerId>::ExtractedInt(
+          opportunityTimestampsShares));
+  result.isValidOpportunityTimestamp =
+      SecBit<schedulerId>(typename SecBit<schedulerId>::ExtractedBit(
+          isValidOpportunityTimestampShares));
+  result.anyValidPurchaseTimestamp =
+      SecBit<schedulerId>(typename SecBit<schedulerId>::ExtractedBit(
+          anyValidPurchaseTimestampShares));
+  result.testReach = SecBit<schedulerId>(
+      typename SecBit<schedulerId>::ExtractedBit(testReachShares));
 
   return result;
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData_impl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcs/emp_games/lift/pcf2_calculator/LiftGameProcessedData.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+void LiftGameProcessedData<schedulerId>::writeToCSV(
+    const std::string& globalParamsOutputPath,
+    const std::string& secretSharesOutputPath) const {
+  throw std::runtime_error("Unimplemented");
+}
+
+template <int schedulerId>
+LiftGameProcessedData<schedulerId>
+LiftGameProcessedData<schedulerId>::readFromCSV(
+    const std::string& globalParamsInputPath,
+    const std::string& secretSharesInputPath) {
+  throw std::runtime_error("Unimplemented");
+}
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -311,6 +311,10 @@ TEST_P(InputProcessorTest, testIndexShares) {
   }
   auto groupIds = convertIndexSharesToGroupIds(publisherShares);
   EXPECT_EQ(expectGroupIds, groupIds);
+
+  auto deserializedGroupIds =
+      convertIndexSharesToGroupIds(publisherDeserialized_.indexShares);
+  EXPECT_EQ(groupIds, deserializedGroupIds);
 }
 
 TEST_P(InputProcessorTest, testTestIndexShares) {
@@ -329,6 +333,10 @@ TEST_P(InputProcessorTest, testTestIndexShares) {
   }
   auto testGroupIds = convertIndexSharesToGroupIds(publisherShares);
   EXPECT_EQ(expectTestGroupIds, testGroupIds);
+
+  auto deserializedTestGroupIds =
+      convertIndexSharesToGroupIds(publisherDeserialized_.testIndexShares);
+  EXPECT_EQ(testGroupIds, deserializedTestGroupIds);
 }
 
 TEST_P(InputProcessorTest, testOpportunityTimestamps) {

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/InputProcessorTest.cpp
@@ -154,13 +154,23 @@ class InputProcessorTest : public ::testing::TestWithParam<bool> {
     future3.get();
 
     cleanup(publisherGlobalParamsOutput);
+    cleanup(publisherSecretSharesOutput);
     cleanup(partnerGlobalParamsOutput);
+    cleanup(partnerSecretSharesOutput);
   }
 };
 
 TEST_P(InputProcessorTest, testNumRows) {
   EXPECT_EQ(publisherInputProcessor_.getLiftGameProcessedData().numRows, 33);
   EXPECT_EQ(partnerInputProcessor_.getLiftGameProcessedData().numRows, 33);
+
+  EXPECT_EQ(
+      publisherInputProcessor_.getLiftGameProcessedData().numRows,
+      publisherDeserialized_.numRows);
+
+  EXPECT_EQ(
+      partnerInputProcessor_.getLiftGameProcessedData().numRows,
+      partnerDeserialized_.numRows);
 }
 
 TEST_P(InputProcessorTest, testBitsForValues) {
@@ -333,12 +343,25 @@ TEST_P(InputProcessorTest, testOpportunityTimestamps) {
         .getValue();
   });
   auto opportunityTimestamps0 = future0.get();
-  auto opportunityTimestamps1 = future1.get();
+  future1.get();
   std::vector<uint64_t> expectOpportunityTimestamps = {
       0,   0,   0,   100, 100, 100, 100, 100, 100, 100, 100,
       100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
       100, 100, 0,   100, 100, 100, 100, 100, 100, 100, 100};
   EXPECT_EQ(opportunityTimestamps0, expectOpportunityTimestamps);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.opportunityTimestamps.openToParty(0)
+        .getValue();
+  });
+  auto future3 = std::async([&] {
+    return partnerDeserialized_.opportunityTimestamps.openToParty(0).getValue();
+  });
+
+  auto deserializedOpportunityTimestamps = future2.get();
+  future3.get();
+
+  EXPECT_EQ(opportunityTimestamps0, deserializedOpportunityTimestamps);
 }
 
 TEST_P(InputProcessorTest, testIsValidOpportunityTimestamp) {
@@ -353,11 +376,26 @@ TEST_P(InputProcessorTest, testIsValidOpportunityTimestamp) {
         .getValue();
   });
   auto isValidOpportunityTimestamp0 = future0.get();
-  auto isValidOpportunityTimestamp1 = future1.get();
+  future1.get();
   std::vector<bool> expectIsValidOpportunityTimestamp = {
       0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1,
       1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1};
   EXPECT_EQ(isValidOpportunityTimestamp0, expectIsValidOpportunityTimestamp);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.isValidOpportunityTimestamp.openToParty(0)
+        .getValue();
+  });
+  auto future3 = std::async([&] {
+    return partnerDeserialized_.isValidOpportunityTimestamp.openToParty(0)
+        .getValue();
+  });
+
+  auto deserializedIsValidOpportunityTimestamp = future2.get();
+  future3.get();
+
+  EXPECT_EQ(
+      isValidOpportunityTimestamp0, deserializedIsValidOpportunityTimestamp);
 }
 
 template <int schedulerId>
@@ -441,6 +479,20 @@ TEST_P(InputProcessorTest, testAnyValidPurchaseTimestamp) {
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   EXPECT_EQ(anyValidPurchaseTimestamp0, expectAnyValidPurchaseTimestamp);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.anyValidPurchaseTimestamp.openToParty(0)
+        .getValue();
+  });
+  auto future3 = std::async([&] {
+    return partnerDeserialized_.anyValidPurchaseTimestamp.openToParty(0)
+        .getValue();
+  });
+
+  auto anyValidPurchaseTimestampDeserialized = future2.get();
+  future3.get();
+
+  EXPECT_EQ(anyValidPurchaseTimestamp0, anyValidPurchaseTimestampDeserialized);
 }
 
 template <int schedulerId>
@@ -517,12 +569,23 @@ TEST_P(InputProcessorTest, testReach) {
         .getValue();
   });
   auto testReach0 = future0.get();
-  auto testReach1 = future1.get();
+  future1.get();
 
   std::vector<bool> expectTestReach = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                        0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0};
   EXPECT_EQ(testReach0, expectTestReach);
+
+  auto future2 = std::async([&] {
+    return publisherDeserialized_.testReach.openToParty(0).getValue();
+  });
+  auto future3 = std::async(
+      [&] { return partnerDeserialized_.testReach.openToParty(0).getValue(); });
+
+  auto testReachDeserialized = future2.get();
+  future3.get();
+
+  EXPECT_EQ(testReach0, testReachDeserialized);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Summary:
This diff adds serialization and deserialization of the following values in LiftGameProcessedData:

  std::vector<std::vector<bool>> indexShares;
  std::vector<std::vector<bool>> testIndexShares;

The output format for each row will be an array of groupId shares. The `numGroups` and `numTestGroups` variables determine the width of these shares. This data is used as part of the deserialization. (See test case logic in https://fburl.com/code/h0scxjaq)

Theoretically it should be possible to re-use the methods in previous diff D39547912 and just write the base 2 notation in array format. However this makes the storage cost equal to a single integer.

Differential Revision: D39547911

