### PR TITLE
update filepath trace to get the right file

### DIFF
--- a/fbpcs/common/service/trace_logging_service.py
+++ b/fbpcs/common/service/trace_logging_service.py
@@ -68,7 +68,7 @@ class TraceLoggingService(abc.ABC):
     def _extract_caller_info(self) -> Dict[str, str]:
         res = {}
         try:
-            frame = inspect.stack()[1]
+            frame = inspect.stack()[2]
             res["filepath"] = f"{frame.filename}:{frame.lineno}"
         except Exception as e:
             logging.warning(f"Failed to extract caller info: {e}")


### PR DESCRIPTION
Summary:
I noticed that the filepath in checkpoint data was always grabbing trace_logging_service.py

this diff grabs one frame up

Reviewed By: gorel, gitfish77

Differential Revision: D39554947

