### PR TITLE
publisher side thrift to skip continer warm up when call stages

### DIFF
--- a/fbpcs/common/entity/stage_state_instance.py
+++ b/fbpcs/common/entity/stage_state_instance.py
@@ -40,7 +40,9 @@ class StageStateInstance(InstanceBase):
     @property
     def server_ips(self) -> List[str]:
         return [
-            checked_cast(str, container.ip_address) for container in self.containers
+            checked_cast(str, container.ip_address)
+            for container in self.containers
+            if container.ip_address is not None
         ]
 
     @property
@@ -63,10 +65,10 @@ class StageStateInstance(InstanceBase):
         elif all(status is ContainerInstanceStatus.COMPLETED for status in statuses):
             self.status = StageStateInstanceStatus.COMPLETED
             self.end_ts = int(time.time())
+        elif ContainerInstanceStatus.UNKNOWN in statuses:
+            self.status = StageStateInstanceStatus.UNKNOWN
         elif ContainerInstanceStatus.STARTED in statuses:
             self.status = StageStateInstanceStatus.STARTED
-        else:
-            self.status = StageStateInstanceStatus.UNKNOWN
 
         return self.status
 

--- a/fbpcs/common/tests/test_stage_state_instance.py
+++ b/fbpcs/common/tests/test_stage_state_instance.py
@@ -32,13 +32,18 @@ class TestStageStateInstance(unittest.TestCase):
                     ip_address="192.0.2.5",
                     status=ContainerInstanceStatus.COMPLETED,
                 ),
+                ContainerInstance(
+                    instance_id="test_container_instance_3",
+                    ip_address=None,
+                    status=ContainerInstanceStatus.FAILED,
+                ),
             ],
             creation_ts=1646642432,
             end_ts=1646642432 + 5,
         )
 
     def test_server_ips(self) -> None:
-        self.assertEqual(len(self.stage_state_instance.containers), 2)
+        self.assertEqual(len(self.stage_state_instance.containers), 3)
         self.assertEqual(
             self.stage_state_instance.server_ips, ["192.0.2.4", "192.0.2.5"]
         )
@@ -68,8 +73,94 @@ class TestStageStateInstance(unittest.TestCase):
                         self.stage_state_instance.stop_containers(mock_onedocker_svc)
 
                 mock_onedocker_svc.stop_containers.assert_called_with(
-                    ["test_container_instance_1", "test_container_instance_2"]
+                    [
+                        "test_container_instance_1",
+                        "test_container_instance_2",
+                        "test_container_instance_3",
+                    ]
                 )
+
+    @patch("fbpcp.service.onedocker.OneDockerService")
+    @patch(
+        "fbpcs.common.entity.stage_state_instance.StageStateInstance._update_containers"
+    )
+    def test_update_status_translation(
+        self, mock_update_containers, mock_onedocker_svc
+    ) -> None:
+        with self.subTest("test all containers started"):
+            mock_update_containers.return_value = [
+                ContainerInstance(
+                    instance_id="test_container_instance_100",
+                    status=ContainerInstanceStatus.STARTED,
+                ),
+                ContainerInstance(
+                    instance_id="test_container_instance_101",
+                    status=ContainerInstanceStatus.STARTED,
+                ),
+            ]
+
+            status = self.stage_state_instance.update_status(mock_onedocker_svc)
+            self.assertEqual(status, StageStateInstanceStatus.STARTED)
+
+        with self.subTest("test some container completed"):
+            mock_update_containers.return_value = [
+                ContainerInstance(
+                    instance_id="test_container_instance_100",
+                    status=ContainerInstanceStatus.COMPLETED,
+                ),
+                ContainerInstance(
+                    instance_id="test_container_instance_101",
+                    status=ContainerInstanceStatus.STARTED,
+                ),
+            ]
+
+            status = self.stage_state_instance.update_status(mock_onedocker_svc)
+            self.assertEqual(status, StageStateInstanceStatus.STARTED)
+
+        with self.subTest("test all containers completed"):
+            mock_update_containers.return_value = [
+                ContainerInstance(
+                    instance_id="test_container_instance_100",
+                    status=ContainerInstanceStatus.COMPLETED,
+                ),
+                ContainerInstance(
+                    instance_id="test_container_instance_101",
+                    status=ContainerInstanceStatus.COMPLETED,
+                ),
+            ]
+
+            status = self.stage_state_instance.update_status(mock_onedocker_svc)
+            self.assertEqual(status, StageStateInstanceStatus.COMPLETED)
+
+        with self.subTest("test container had failed"):
+            mock_update_containers.return_value = [
+                ContainerInstance(
+                    instance_id="test_container_instance_100",
+                    status=ContainerInstanceStatus.FAILED,
+                ),
+                ContainerInstance(
+                    instance_id="test_container_instance_101",
+                    status=ContainerInstanceStatus.COMPLETED,
+                ),
+            ]
+
+            status = self.stage_state_instance.update_status(mock_onedocker_svc)
+            self.assertEqual(status, StageStateInstanceStatus.FAILED)
+
+        with self.subTest("test container had unknown"):
+            mock_update_containers.return_value = [
+                ContainerInstance(
+                    instance_id="test_container_instance_100",
+                    status=ContainerInstanceStatus.COMPLETED,
+                ),
+                ContainerInstance(
+                    instance_id="test_container_instance_101",
+                    status=ContainerInstanceStatus.UNKNOWN,
+                ),
+            ]
+
+            status = self.stage_state_instance.update_status(mock_onedocker_svc)
+            self.assertEqual(status, StageStateInstanceStatus.UNKNOWN)
 
     @patch("fbpcp.service.onedocker.OneDockerService")
     def test_update_status(self, mock_onedocker_svc) -> None:
@@ -96,6 +187,7 @@ class TestStageStateInstance(unittest.TestCase):
             [
                 ContainerInstanceStatus.FAILED,
                 ContainerInstanceStatus.COMPLETED,
+                ContainerInstanceStatus.FAILED,
                 ContainerInstanceStatus.FAILED,
             ],
         )

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AttributionConfig,
@@ -161,6 +162,9 @@ class AggregateShardsStageService(PrivateComputationStageService):
             for arg in game_args:
                 arg["visibility"] = result_visibility
 
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -176,6 +180,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
         # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
         pc_instance.infra_config.instances.append(

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -19,6 +19,7 @@ from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
@@ -122,6 +123,9 @@ class ComputeMetricsStageService(PrivateComputationStageService):
 
         binary_config = self._onedocker_binary_config_map[binary_name]
         retry_counter_str = str(pc_instance.infra_config.retry_counter)
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -137,6 +141,7 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running.")

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
@@ -98,6 +99,9 @@ class AggregationStageService(PrivateComputationStageService):
 
         binary_config = self._onedocker_binary_config_map[binary_name]
         retry_counter_str = str(pc_instance.infra_config.retry_counter)
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -113,6 +117,7 @@ class AggregationStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running for decoupled aggregation stage.")

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AttributionConfig,
@@ -96,6 +97,9 @@ class AttributionStageService(PrivateComputationStageService):
 
         binary_config = self._onedocker_binary_config_map[binary_name]
         retry_counter_str = str(pc_instance.infra_config.retry_counter)
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -111,6 +115,7 @@ class AttributionStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running for decoupled attribution.")

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -17,6 +17,7 @@ from fbpcs.private_computation.entity.pid_mr_config import Protocol
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 
@@ -75,6 +76,9 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
 
         # TODO: we will write log_cost_to_s3 to the instance, so this function interface
         #   will get simplified
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         container_instances = await start_combiner_service(
             pc_instance,
             self._onedocker_svc,
@@ -83,6 +87,7 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
             log_cost_to_s3=self._log_cost_to_s3,
             max_id_column_count=pc_instance.product_config.common.pid_max_column_count,
             protocol_type=self.protocol_type,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
         self._logger.info("Finished running CombinerService")
 

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -113,13 +113,17 @@ class PCPreValidationStageService(PrivateComputationStageService):
         if binary_config.repository_path:
             env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
 
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         container_instances = await RunBinaryBaseService().start_containers(
-            [cmd_args],
-            self._onedocker_svc,
-            binary_config.binary_version,
-            binary_name,
+            cmd_args_list=[cmd_args],
+            onedocker_svc=self._onedocker_svc,
+            binary_version=binary_config.binary_version,
+            binary_name=binary_name,
             timeout=PRE_VALIDATION_CHECKS_TIMEOUT,
             env_vars=env_vars,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         stage_state = StageStateInstance(

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
@@ -99,6 +100,9 @@ class PCF2AggregationStageService(PrivateComputationStageService):
 
         binary_config = self._onedocker_binary_config_map[binary_name]
         retry_counter_str = str(pc_instance.infra_config.retry_counter)
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -115,6 +119,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running for pcf2.0 based aggregation stage.")

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AttributionConfig,
@@ -97,6 +98,9 @@ class PCF2AttributionStageService(PrivateComputationStageService):
 
         binary_config = self._onedocker_binary_config_map[binary_name]
         retry_counter_str = str(pc_instance.infra_config.retry_counter)
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -112,6 +116,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running for pcf2.0 attribution.")

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -18,6 +18,7 @@ from fbpcs.private_computation.entity.infra_config import PrivateComputationGame
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AggregationType,
@@ -104,6 +105,9 @@ class PCF2LiftStageService(PrivateComputationStageService):
 
         binary_config = self._onedocker_binary_config_map[binary_name]
         retry_counter_str = str(pc_instance.infra_config.retry_counter)
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -119,6 +123,7 @@ class PCF2LiftStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running for PCF2.0 Lift.")

--- a/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
@@ -19,6 +19,7 @@ from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.product_config import (
     AttributionConfig,
@@ -149,6 +150,9 @@ class ShardCombinerStageService(PrivateComputationStageService):
             for arg in game_args:
                 arg["visibility"] = result_visibility
 
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         mpc_instance = await create_and_start_mpc_instance(
             mpc_svc=self._mpc_service,
             instance_id=pc_instance.infra_config.instance_id
@@ -164,6 +168,7 @@ class ShardCombinerStageService(PrivateComputationStageService):
             game_args=game_args,
             container_timeout=self._container_timeout,
             repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
         logging.info("MPC instance started running for PCF2.0 Shard Combiner.")

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -23,6 +23,7 @@ from fbpcs.onedocker_binary_config import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
 from fbpcs.private_computation.service.private_computation_stage_service import (
@@ -133,6 +134,9 @@ class PIDPrepareStageService(PrivateComputationStageService):
             ] = onedocker_binary_config.repository_path
 
         pid_prepare_binary_service = PIDPrepareBinaryService()
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         return await pid_prepare_binary_service.start_containers(
             cmd_args_list=args_list,
             onedocker_svc=self._onedocker_svc,
@@ -140,6 +144,7 @@ class PIDPrepareStageService(PrivateComputationStageService):
             binary_name=binary_name,
             timeout=self._container_timeout,
             env_vars=env_vars,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
     def stop_service(

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -147,12 +147,16 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
                 ONEDOCKER_REPOSITORY_PATH
             ] = onedocker_binary_config.repository_path
 
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         return await pid_run_protocol_binary_service.start_containers(
             cmd_args_list=args_list,
             onedocker_svc=self._onedocker_svc,
             binary_version=onedocker_binary_config.binary_version,
             binary_name=binary_name,
             env_vars=env_vars,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
     @classmethod

--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -20,6 +20,7 @@ from fbpcs.onedocker_binary_config import (
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -122,6 +123,9 @@ class PIDShardStageService(PrivateComputationStageService):
                 ONEDOCKER_REPOSITORY_PATH
             ] = onedocker_binary_config.repository_path
 
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         return await sharding_binary_service.start_containers(
             cmd_args_list=[args],
             onedocker_svc=self._onedocker_svc,
@@ -129,6 +133,7 @@ class PIDShardStageService(PrivateComputationStageService):
             binary_name=binary_name,
             timeout=self._container_timeout,
             env_vars=env_vars,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
 
     def stop_service(

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -31,6 +31,7 @@ class RunBinaryBaseService:
         timeout: Optional[int] = None,
         wait_for_containers_to_finish: bool = False,
         env_vars: Optional[Dict[str, str]] = None,
+        wait_for_containers_to_start_up: bool = True,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
@@ -43,6 +44,9 @@ class RunBinaryBaseService:
             timeout=timeout,
             env_vars=env_vars,
         )
+        if not wait_for_containers_to_start_up:
+            logger.info("Skipped container warm up")
+            return pending_containers
 
         with RetryHandler(
             ThrottlingError, logger=logger, backoff_seconds=30

--- a/fbpcs/private_computation/service/shard_stage_service.py
+++ b/fbpcs/private_computation/service/shard_stage_service.py
@@ -16,6 +16,7 @@ from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
+    PrivateComputationRole,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
@@ -67,11 +68,15 @@ class ShardStageService(PrivateComputationStageService):
         #     note we need each file to be sharded into the same # of files
         #     because we want to keep the data of each existing file to run
         #     on the same container
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
         container_instances = await start_sharder_service(
             pc_instance,
             self._onedocker_svc,
             self._onedocker_binary_config_map,
             combine_output_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
         )
         self._logger.info("All sharding coroutines finished")
 

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -200,6 +200,7 @@ def get_pc_status_from_stage_state(
     # calling onedocker_svc to update newest containers in StageState
     stage_state_instance_status = stage_instance.update_status(onedocker_svc)
     current_stage = private_computation_instance.current_stage
+    # only update when StageStateInstanceStatus transit to Started/Completed/Failed, or remain the current status
     if stage_state_instance_status is StageStateInstanceStatus.STARTED:
         status = current_stage.started_status
     elif stage_state_instance_status is StageStateInstanceStatus.COMPLETED:

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -65,6 +65,7 @@ async def create_and_start_mpc_instance(
     container_timeout: Optional[int] = None,
     repository_path: Optional[str] = None,
     certificate_request: Optional[CertificateRequest] = None,
+    wait_for_containers_to_start_up: bool = True,
 ) -> MPCInstance:
     """Creates an MPC instance and runs MPC service with it
 
@@ -102,6 +103,7 @@ async def create_and_start_mpc_instance(
         version=binary_version,
         env_vars=env_vars,
         certificate_request=certificate_request,
+        wait_for_containers_to_start_up=wait_for_containers_to_start_up,
     )
 
 
@@ -222,6 +224,7 @@ async def start_combiner_service(
     wait_for_containers: bool = False,
     max_id_column_count: int = 1,
     protocol_type: str = Protocol.PID_PROTOCOL.value,
+    wait_for_containers_to_start_up: bool = True,
 ) -> List[ContainerInstance]:
     """Run combiner service and return those container instances
 
@@ -305,6 +308,7 @@ async def start_combiner_service(
         timeout=None,
         wait_for_containers_to_finish=wait_for_containers,
         env_vars=env_vars,
+        wait_for_containers_to_start_up=wait_for_containers_to_start_up,
     )
 
 
@@ -316,6 +320,7 @@ async def start_sharder_service(
     onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
     combine_output_path: str,
     wait_for_containers: bool = False,
+    wait_for_containers_to_start_up: bool = True,
 ) -> List[ContainerInstance]:
     """Run combiner service and return those container instances
 
@@ -374,6 +379,7 @@ async def start_sharder_service(
         timeout=None,
         wait_for_containers_to_finish=wait_for_containers,
         env_vars=env_vars,
+        wait_for_containers_to_start_up=wait_for_containers_to_start_up,
     )
 
 

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -129,12 +129,13 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
 
         env_vars = {ONEDOCKER_REPOSITORY_PATH: "test_path/"}
         mock_run_binary_base_service_start_containers.assert_called_with(
-            [expected_cmd_args],
-            mock_onedocker_svc,
-            "latest",
-            OneDockerBinaryNames.PC_PRE_VALIDATION.value,
+            cmd_args_list=[expected_cmd_args],
+            onedocker_svc=mock_onedocker_svc,
+            binary_version="latest",
+            binary_name=OneDockerBinaryNames.PC_PRE_VALIDATION.value,
             timeout=1200,
             env_vars=env_vars,
+            wait_for_containers_to_start_up=True,
         )
 
         mock_stage_state_instance.assert_called_with(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -851,6 +851,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 version=binary_version,
                 env_vars=env_vars,
                 certificate_request=None,
+                wait_for_containers_to_start_up=True,
             ),
             mock_mpc_svc.start_instance_async.call_args,
         )


### PR DESCRIPTION
Summary:
## Why
In this Diff stack series, I'm going to introduce new status call "initialzed" in each stage.
The reason of adding new status is to decouple containers warm up time in the run_next api, to reduce api latency.

To better understanding what my goal is. Here is the current state transitions looks like
https://pxl.cl/2cRlQ

as you see in above diagram, it's waiting for "all" containers spin-up then return the request to API.

Here is the goal of this diff stack changes.

https://pxl.cl/2cRmf

We will be adding new status "initialized" that we can return API requests sooner, then leverage our current update mehod (chronos JOB) to transit the status to start.
Which will save the API latency a ton based on my previous [investigation](https://fb.workplace.com/groups/164332244998024/permalink/873521087412466/) by 60s + to <1.5 s

## What
* This is the series of diff stack
* Only change in `publisher` side to skip container start up time within api level to reduce api latency
* `Partner` side still remain existing logic to wait for container start up

## Result
We've improved latency from **70s** to only **1~2s** (based on the local dev thrift server). **16x** latency improvement based on MPC stage (5x # of containers to PID stages)
We will have stress test to see the final improvement when this diff land on RC tier

**Before**
```
====================
publisher_joewu_1663300026_0:PC_PRE_VALIDATION = 1.91s
publisher_joewu_1663300026_0:PID_SHARD = 39.06s
publisher_joewu_1663300026_0:PID_PREPARE = 40.82s
publisher_joewu_1663300026_0:ID_MATCH = 52.93s
publisher_joewu_1663300026_0:ID_MATCH_POST_PROCESS = 2.78s
publisher_joewu_1663300026_0:ID_SPINE_COMBINER = 48.24s
publisher_joewu_1663300026_0:RESHARD = 52.60s
publisher_joewu_1663300026_0:COMPUTE = 74.57s
publisher_joewu_1663300026_0:AGGREGATE = 39.88s
publisher_joewu_1663300026_0:POST_PROCESSING_HANDLERS = 2.42s
====================
Max: 74.57s. min: 1.91s. avg: 35.52s
```

**After This Diff**
```
====================
publisher_joewu_1663298469_0:PC_PRE_VALIDATION = 1.86s
publisher_joewu_1663298469_0:PID_SHARD = 2.45s
publisher_joewu_1663298469_0:PID_PREPARE = 2.38s
publisher_joewu_1663298469_0:ID_MATCH = 2.45s
publisher_joewu_1663298469_0:ID_MATCH_POST_PROCESS = 2.67s
publisher_joewu_1663298469_0:ID_SPINE_COMBINER = 2.45s
publisher_joewu_1663298469_0:RESHARD = 2.72s
publisher_joewu_1663298469_0:COMPUTE = 4.55s
publisher_joewu_1663298469_0:AGGREGATE = 2.95s
publisher_joewu_1663298469_0:POST_PROCESSING_HANDLERS = 2.05s
====================
Max: 4.55s. min: 1.86s. avg: 2.65s
```

Differential Revision: D39551133

