### PR TITLE
Enable to configure output location for one command runner

### DIFF
--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -90,6 +90,7 @@ def run_study(
     result_visibility: Optional[ResultVisibility] = None,
     final_stage: Optional[PrivateComputationBaseStageFlow] = None,
     run_id: Optional[str] = None,
+    output_dir: Optional[str] = None,
 ) -> None:
 
     ## Step 1: Validation. Function arguments and study metadata must be valid for private lift run.
@@ -180,6 +181,7 @@ def run_study(
                 role=PrivateComputationRole.PARTNER,
                 game_type=PrivateComputationGameType.LIFT,
                 input_path=input_path,
+                output_dir=output_dir if output_dir else "",
                 num_pid_containers=int(num_shards),
                 num_mpc_containers=int(num_shards),
                 stage_flow_cls=stage_flow_override,

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -17,7 +17,7 @@ Usage:
     pc-cli get_instance <instance_id> --config=<config_file> [options]
     pc-cli get_server_ips <instance_id> --config=<config_file> [options]
     pc-cli get_mpc <instance_id> --config=<config_file> [options]
-    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --dry_run] [options]
+    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--output_dir=<output_dir> --tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --dry_run] [options]
     pc-cli pre_validate [<study_id>] --config=<config_file> [--objective_ids=<objective_ids>] --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
@@ -391,6 +391,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             result_visibility=arguments["--result_visibility"],
             run_id=arguments["--run_id"],
             final_stage=PrivateComputationStageFlow.AGGREGATE,
+            output_dir=arguments["--output_dir"],
         )
     elif arguments["run_attribution"]:
         stage_flow = PrivateComputationPCF2StageFlow

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -310,6 +310,7 @@ class TestPrivateComputationCli(TestCase):
             [
                 "--tries_per_stage=789",
                 "--dry_run",
+                f"--output_dir={self.temp_dir_path}",
             ]
         )
         pc_cli.main(argv)


### PR DESCRIPTION
Summary: We want to publish PL results to a specified s3 bucket location (an ask from amazon). Currently output_dir is always inferred from input_path in the pl one command runner (the `run_study` cmd in private computation cli).

Differential Revision: D39560388

