### PR TITLE
Update BitString constructor

### DIFF
--- a/fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h
+++ b/fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h
@@ -84,7 +84,7 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
   std::vector<int64_t> rst(intersectionSize, 0);
   for (size_t i = 0; i < intersectionSize; i++) {
     for (size_t j = 0; j < indexWidth; j++) {
-      rst[i] += (myShare.at(i).at(j)) << j;
+      rst[i] += (myShare.at(j).at(i)) << j;
     }
   }
   return rst;


### PR DESCRIPTION
Summary:
See D35122217 (https://github.com/facebookresearch/fbpcs/commit/81f46c753c1f61f8d9f5370a64f37eecac12b3eb)

Currently the BitString constructor is treating the input as each vector is a batch of bits with agreed upon length.

# Argument against this change:
This doesn't follow the convention of MPC engine batching where the type describes a compile time restriction, and the batch size can be input at a later point.

For example, a Bit types UnitType is represented by a single Bit. If we have a std::vector<UnitType> then the length of that vector is the `batchSize`. Currently that is also true, each element is a std::vector<> of the agreed length, and there are `batchSize` total vectors.

# Argument for this change
Let us imagine the following code snippet
```
BitStringBatched str;
std::vector<std::vector<bool>> openedValues1 = str.openToParty(0).getValues()

std::vector<std::vector<bool>> openedValues2;
for (BitBatched b : str) {
openedValues2.push_back(b.openToParty(0).getValues()
}

BitStringBatched str2(openedValues1)
BitStringBatched str3(openedValues2)
```

In this example, the second way of extracting the values would only work with the convention in this diff.

Differential Revision: D39579926

