### PR TITLE
Add SS -> SS Input processor

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h
@@ -20,4 +20,13 @@ class IInputProcessor {
       const = 0;
 };
 
+template <int schedulerId>
+void writeToCSV(
+    const IInputProcessor<schedulerId>& inputProcessor,
+    const std::string& globalParamsPath,
+    const std::string& secretSharesPath) {
+  inputProcessor.getLiftGameProcessedData().writeToCSV(
+      globalParamsPath, secretSharesPath);
+}
+
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/SecretShareInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/SecretShareInputProcessor.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/IInputProcessor.h"
+
+#pragma once
+
+namespace private_lift {
+
+template <int schedulerId>
+class SecretShareInputProcessor : public IInputProcessor<schedulerId> {
+ public:
+  SecretShareInputProcessor(
+      const std::string& globalParamsPath,
+      const std::string& secretSharePath)
+      : liftGameProcessedData_{LiftGameProcessedData<schedulerId>::readFromCSV(
+            globalParamsPath,
+            secretSharePath)} {}
+
+  SecretShareInputProcessor() {}
+
+  const LiftGameProcessedData<schedulerId>& getLiftGameProcessedData() const {
+    return liftGameProcessedData_;
+  }
+
+ private:
+  LiftGameProcessedData<schedulerId> liftGameProcessedData_;
+};
+
+} // namespace private_lift


### PR DESCRIPTION
Summary: Adds an explicit Input Processor for reading secret shares locally. This will replace the current InputProcessor in the existing lift stage in the UDP flow

Differential Revision: D39638698

