### PR TITLE
Add events crawler ARN to the policy

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/output.tf
@@ -2,3 +2,8 @@ output "firehose_stream_name" {
   value       = aws_kinesis_firehose_delivery_stream.extended_s3_stream.name
   description = "The Kinesis firehose stream name"
 }
+
+output "events_data_crawler_arn" {
+  value       = aws_glue_crawler.mpc_events_crawler.arn
+  description = "The events_data Glue crawler ARN"
+}

--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -303,6 +303,7 @@ deploy_aws_resources() {
     echo "######################## Deploy Data Ingestion Terraform scripts completed ########################"
     # store the outputs from data ingestion pipeline output into variables
     firehose_stream_name=$(terraform output firehose_stream_name | tr -d '"')
+    events_data_crawler_arn=$(terraform output events_data_crawler_arn | tr -d '"')
 
     if "$build_semi_automated_data_pipeline"
     then
@@ -374,7 +375,8 @@ deploy_aws_resources() {
         --database_name "$database_name" \
         --table_name "$table_name" \
         --cluster_name "$aws_ecs_cluster_name" \
-        --ecs_task_execution_role_name "$ecs_task_execution_role_name"
+        --ecs_task_execution_role_name "$ecs_task_execution_role_name" \
+        --events_data_crawler_arn "$events_data_crawler_arn"
     echo "######################## Finished deploy resources policy ########################"
     log_streaming_data "validating generated resoureces and policies..."
     # validate generated resources through PCE validator

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -295,6 +295,7 @@ class AwsDeploymentHelper:
             "DATEBASE_NAME": policy_params.database_name,
             "TABLE_NAME": policy_params.table_name,
             "DATA_INGESTION_LAMBDA_NAME": policy_params.data_ingestion_lambda_name,
+            "EVENTS_DATA_CRAWLER_ARN": policy_params.events_data_crawler_arn,
         }
 
         file_path = os.path.join(os.path.dirname(__file__), file_name)

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -49,6 +49,7 @@ class AwsDeploymentHelperTool:
                 cluster_name=self.cli_args.cluster_name,
                 ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
                 data_ingestion_lambda_name=self.cli_args.data_ingestion_lambda_name,
+                events_data_crawler_arn=self.cli_args.events_data_crawler_arn,
             )
             self.aws_deployment_helper_obj.create_policy(
                 policy_name=self.cli_args.policy_name, policy_params=policy_params

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
@@ -118,6 +118,13 @@ class AwsParserBuilder:
             help="Data ingestion Lambda name",
         )
 
+        iam_policy_command_group.add_argument(
+            "--events_data_crawler_arn",
+            type=str,
+            required=False,
+            help="The events_data Glue crawler ARN",
+        )
+
         return self
 
     def with_attach_iam_policy_parser_arguments(

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
@@ -41,7 +41,8 @@
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:database/${DATEBASE_NAME}",
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/${DATEBASE_NAME}/*",
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/${TABLE_NAME}",
-                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/events_data"
+                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/events_data",
+                "${EVENTS_DATA_CRAWLER_ARN}"
             ]
         },
         {

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
@@ -40,7 +40,8 @@
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:database/default",
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:database/${DATEBASE_NAME}",
                 "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/${DATEBASE_NAME}/*",
-                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/${TABLE_NAME}"
+                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/${TABLE_NAME}",
+                "arn:aws:glue:${REGION}:${ACCOUNT_ID}:table/default/events_data"
             ]
         },
         {

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -18,3 +18,4 @@ class PolicyParams:
     cluster_name: str
     ecs_task_execution_role_name: str
     data_ingestion_lambda_name: str
+    events_data_crawler_arn: str

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
@@ -31,6 +31,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
         test_cluster_name = "test-cluster"
         test_ecs_task_execution_role_name = "test-ecs-execution-role"
         test_data_ingestion_lambda_name = "test-di-lambda-name"
+        test_events_data_crawler_arn = "test-events-data-crawler-arn"
 
         with self.subTest("add_iam_user_basic"):
             cli_args = self.setup_cli_args_mock()
@@ -66,6 +67,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
             cli_args.cluster_name = test_cluster_name
             cli_args.ecs_task_execution_role_name = test_ecs_task_execution_role_name
             cli_args.data_ingestion_lambda_name = test_data_ingestion_lambda_name
+            cli_args.events_data_crawler_arn = test_events_data_crawler_arn
             aws_deployment_helper_tool = AwsDeploymentHelperTool(cli_args)
 
             aws_deployment_helper_tool.create()
@@ -81,6 +83,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
                     cluster_name=test_cluster_name,
                     ecs_task_execution_role_name=test_ecs_task_execution_role_name,
                     data_ingestion_lambda_name=test_data_ingestion_lambda_name,
+                    events_data_crawler_arn=test_events_data_crawler_arn,
                 ),
             )
 


### PR DESCRIPTION
Summary: So that the state of the Glue crawler can be read when using the policy.

Differential Revision: D39645636

