### PR TITLE
Re-write testWithJammedPort to be robust (#402)

### DIFF
--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
@@ -265,6 +265,45 @@ TEST_P(AggregationAppTest, TestCorrectness) {
           break;
       }
       break;
+    case 1:
+      switch (visibility) {
+        case common::Visibility::Publisher:
+          testCorrectnessAggregationAppWrapper<
+              1,
+              common::Visibility::Publisher>(useTls, useNewOutputFormat);
+          break;
+        case common::Visibility::Xor:
+          testCorrectnessAggregationAppWrapper<1, common::Visibility::Xor>(
+              useTls, useNewOutputFormat);
+          break;
+      }
+      break;
+    case 2:
+      switch (visibility) {
+        case common::Visibility::Publisher:
+          testCorrectnessAggregationAppWrapper<
+              2,
+              common::Visibility::Publisher>(useTls, useNewOutputFormat);
+          break;
+        case common::Visibility::Xor:
+          testCorrectnessAggregationAppWrapper<2, common::Visibility::Xor>(
+              useTls, useNewOutputFormat);
+          break;
+      }
+      break;
+    case 3:
+      switch (visibility) {
+        case common::Visibility::Publisher:
+          testCorrectnessAggregationAppWrapper<
+              3,
+              common::Visibility::Publisher>(useTls, useNewOutputFormat);
+          break;
+        case common::Visibility::Xor:
+          testCorrectnessAggregationAppWrapper<3, common::Visibility::Xor>(
+              useTls, useNewOutputFormat);
+          break;
+      }
+      break;
     default:
       break;
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcf/pull/402

This is another flaky test. It is also relying on a non-atomic version of determining a free port, which will fail stress tests.

Instead, I have rewritten the test to create a guaranteed set of agent factories (set up in a previous stack of diffs). When we create agents, it will automatically try to connect to port 1. This isn't allowed, so it should test our functionality. Then, I create agents and ensure it doesn't time out.

Reviewed By: nguytc

Differential Revision: D39682065

