### PR TITLE
Use Factory pattern to create MetadataCompactorGame

### DIFF
--- a/fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGame.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGame.h
@@ -33,16 +33,4 @@ class DummyMetadataCompactorGame
   const int party_;
 };
 
-template <int schedulerId>
-std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
-    std::unique_ptr<fbpcf::scheduler::IScheduler>,
-    int)>
-getDummyMetadataCompactorGameCreator() {
-  return
-      [](std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler, int partyId) {
-        return std::make_unique<DummyMetadataCompactorGame<schedulerId>>(
-            partyId, std::move(scheduler));
-      };
-}
-
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGame.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGame.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class DummyMetadataCompactorGame
+    : public IMetadataCompactorGame<schedulerId>,
+      public fbpcf::frontend::MpcGame<schedulerId> {
+ public:
+  DummyMetadataCompactorGame(
+      const int party,
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler)
+      : fbpcf::frontend::MpcGame<schedulerId>(std::move(scheduler)),
+        party_{party} {}
+
+  std::unique_ptr<IInputProcessor<schedulerId>> play(
+      InputData inputData,
+      int32_t numConversionPerUser) override {
+    return std::make_unique<InputProcessor<schedulerId>>(
+        party_, inputData, numConversionPerUser);
+  }
+
+ private:
+  const int party_;
+};
+
+template <int schedulerId>
+std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
+    std::unique_ptr<fbpcf::scheduler::IScheduler>,
+    int)>
+getDummyMetadataCompactorGameCreator() {
+  return
+      [](std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler, int partyId) {
+        return std::make_unique<DummyMetadataCompactorGame<schedulerId>>(
+            partyId, std::move(scheduler));
+      };
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGameFactory.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGameFactory.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGame.h"
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGameFactory.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class DummyMetadataCompactorGameFactory
+    : public IMetadataCompactorGameFactory<schedulerId> {
+ public:
+  std::unique_ptr<IMetadataCompactorGame<schedulerId>> create(
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler,
+      int partyId) {
+    return std::make_unique<DummyMetadataCompactorGame<schedulerId>>(
+        partyId, std::move(scheduler));
+  }
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "fbpcf/frontend/mpcGame.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class IMetadataCompactorGame {
+ public:
+  virtual ~IMetadataCompactorGame() = default;
+
+  virtual std::unique_ptr<IInputProcessor<schedulerId>> play(
+      InputData inputData,
+      int32_t numConversionPerUser) = 0;
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGameFactory.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGameFactory.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class IMetadataCompactorGameFactory {
+ public:
+  virtual ~IMetadataCompactorGameFactory() = default;
+
+  virtual std::unique_ptr<IMetadataCompactorGame<schedulerId>> create(
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler,
+      int partyId) = 0;
+
+ private:
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcs/emp_games/common/SchedulerStatistics.h"
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class MetadataCompactorApp {
+ public:
+  MetadataCompactorApp(
+      int party,
+      std::unique_ptr<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+          communicationAgentFactory,
+      int numConversionsPerUser,
+      bool computePublisherBreakdowns,
+      int epoch,
+      const std::string& inputPath,
+      const std::string& outputGlobalParamsPath,
+      const std::string& outputSecretSharesPath,
+      bool useXorEncryption = true)
+      : party_{party},
+        communicationAgentFactory_{std::move(communicationAgentFactory)},
+        numConversionsPerUser_{numConversionsPerUser},
+        computePublisherBreakdowns_{computePublisherBreakdowns},
+        epoch_{epoch},
+        inputPath_{inputPath},
+        outputGlobalParamsPath_{outputGlobalParamsPath},
+        outputSecretSharesPath_{outputSecretSharesPath},
+        useXorEncryption_{useXorEncryption} {}
+
+  void run(std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
+               std::unique_ptr<fbpcf::scheduler::IScheduler>,
+               int)> metadataCompactorGameCreator);
+
+ protected:
+  std::unique_ptr<fbpcf::scheduler::IScheduler> createScheduler();
+
+ private:
+  int party_;
+  std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
+      std::unique_ptr<fbpcf::scheduler::IScheduler>,
+      int)>
+      metadataCompactorGameCreator_;
+  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+      communicationAgentFactory_;
+  int numConversionsPerUser_;
+  bool computePublisherBreakdowns_;
+  int epoch_;
+  std::string inputPath_;
+  std::string outputGlobalParamsPath_;
+  std::string outputSecretSharesPath_;
+  bool useXorEncryption_;
+};
+
+} // namespace private_lift
+
+#include "fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h"

--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp.h
@@ -11,6 +11,7 @@
 #include "fbpcf/scheduler/IScheduler.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h"
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGameFactory.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h"
 
 namespace private_lift {
@@ -23,6 +24,8 @@ class MetadataCompactorApp {
       std::unique_ptr<
           fbpcf::engine::communication::IPartyCommunicationAgentFactory>
           communicationAgentFactory,
+      std::unique_ptr<IMetadataCompactorGameFactory<schedulerId>>
+          compactorGameFactory,
       int numConversionsPerUser,
       bool computePublisherBreakdowns,
       int epoch,
@@ -32,6 +35,7 @@ class MetadataCompactorApp {
       bool useXorEncryption = true)
       : party_{party},
         communicationAgentFactory_{std::move(communicationAgentFactory)},
+        compactorGameFactory_{std::move(compactorGameFactory)},
         numConversionsPerUser_{numConversionsPerUser},
         computePublisherBreakdowns_{computePublisherBreakdowns},
         epoch_{epoch},
@@ -40,9 +44,7 @@ class MetadataCompactorApp {
         outputSecretSharesPath_{outputSecretSharesPath},
         useXorEncryption_{useXorEncryption} {}
 
-  void run(std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
-               std::unique_ptr<fbpcf::scheduler::IScheduler>,
-               int)> metadataCompactorGameCreator);
+  void run();
 
  protected:
   std::unique_ptr<fbpcf::scheduler::IScheduler> createScheduler();
@@ -55,6 +57,8 @@ class MetadataCompactorApp {
       metadataCompactorGameCreator_;
   std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
       communicationAgentFactory_;
+  std::unique_ptr<IMetadataCompactorGameFactory<schedulerId>>
+      compactorGameFactory_;
   int numConversionsPerUser_;
   bool computePublisherBreakdowns_;
   int epoch_;

--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h
@@ -17,10 +17,7 @@
 namespace private_lift {
 
 template <int schedulerId>
-void MetadataCompactorApp<schedulerId>::run(
-    std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
-        std::unique_ptr<fbpcf::scheduler::IScheduler>,
-        int)> metadataCompactorGameCreator) {
+void MetadataCompactorApp<schedulerId>::run() {
   auto scheduler = createScheduler();
 
   InputData inputData(
@@ -31,7 +28,7 @@ void MetadataCompactorApp<schedulerId>::run(
       numConversionsPerUser_);
 
   auto metadataCompactorGame =
-      metadataCompactorGameCreator(std::move(scheduler), party_);
+      compactorGameFactory_->create(std::move(scheduler), party_);
 
   auto inputProcessor =
       metadataCompactorGame->play(inputData, numConversionsPerUser_);

--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp.h"
+
+#include <fbpcf/scheduler/LazySchedulerFactory.h>
+#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/IInputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+void MetadataCompactorApp<schedulerId>::run(
+    std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
+        std::unique_ptr<fbpcf::scheduler::IScheduler>,
+        int)> metadataCompactorGameCreator) {
+  auto scheduler = createScheduler();
+
+  InputData inputData(
+      inputPath_,
+      InputData::LiftMPCType::Standard,
+      computePublisherBreakdowns_,
+      epoch_,
+      numConversionsPerUser_);
+
+  auto metadataCompactorGame =
+      metadataCompactorGameCreator(std::move(scheduler), party_);
+
+  auto inputProcessor =
+      metadataCompactorGame->play(inputData, numConversionsPerUser_);
+  writeToCSV(*inputProcessor, outputGlobalParamsPath_, outputSecretSharesPath_);
+}
+
+template <int schedulerId>
+std::unique_ptr<fbpcf::scheduler::IScheduler>
+MetadataCompactorApp<schedulerId>::createScheduler() {
+  return useXorEncryption_
+      ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+            party_, *communicationAgentFactory_)
+            ->create()
+      : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
+            party_, *communicationAgentFactory_)
+            .create();
+}
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/test/MetadataCompactionAppTest.cpp
+++ b/fbpcs/emp_games/lift/metadata_compaction/test/MetadataCompactionAppTest.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <memory>
+#include "folly/Format.h"
+#include "folly/Random.h"
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/scheduler/ISchedulerFactory.h"
+
+#include "fbpcs/emp_games/lift/metadata_compaction/DummyMetadataCompactorGame.h"
+#include "fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/SecretShareInputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.h"
+
+namespace private_lift {
+template <int schedulerId>
+void runMetadataCompactionApp(
+    int myId,
+    int numConversionsPerUser,
+    bool computePublisherBreakdowns,
+    int epoch,
+    const std::string& inputPath,
+    const std::string& outputGlobalParamsPath,
+    const std::string& outputSecretSharesPath,
+    bool useXorEncryption,
+    std::unique_ptr<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+        communicationAgentFactory,
+    std::function<std::unique_ptr<IMetadataCompactorGame<schedulerId>>(
+        std::unique_ptr<fbpcf::scheduler::IScheduler>,
+        int)> metadataCompactorGameCreator) {
+  auto app = std::make_unique<MetadataCompactorApp<schedulerId>>(
+      myId,
+      std::move(communicationAgentFactory),
+      numConversionsPerUser,
+      computePublisherBreakdowns,
+      epoch,
+      inputPath,
+      outputGlobalParamsPath,
+      outputSecretSharesPath,
+      useXorEncryption);
+
+  app->run(metadataCompactorGameCreator);
+}
+
+template <int schedulerId>
+std::unique_ptr<IInputProcessor<schedulerId>> createInputProcessorWithScheduler(
+    int myId,
+    bool useXorEncryption,
+    std::string globalParamsPath,
+    std::string secretSharesPath,
+    std::unique_ptr<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+        communicationAgentFactory) {
+  auto scheduler = useXorEncryption
+      ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+            myId, *communicationAgentFactory)
+            ->create()
+      : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
+            myId, *communicationAgentFactory)
+            .create();
+
+  fbpcf::scheduler::SchedulerKeeper<schedulerId>::setScheduler(
+      std::move(scheduler));
+
+  return std::make_unique<SecretShareInputProcessor<schedulerId>>(
+      globalParamsPath, secretSharesPath);
+}
+
+class MetadataCompactionAppTestFixture
+    : public ::testing::TestWithParam<std::tuple<bool, bool>> {
+ protected:
+  std::string publisherInputPath_;
+  std::string partnerInputPath_;
+  std::string publisherGlobalParamsOutputPath_;
+  std::string publisherSecretSharesOutputPath_;
+  std::string partnerGlobalParamsOutputPath_;
+  std::string partnerSecretSharesOutputPath_;
+
+  void SetUp() override {
+    std::string tempDir = std::filesystem::temp_directory_path();
+    publisherInputPath_ = folly::sformat(
+        "{}/publisher_{}.csv", tempDir, folly::Random::secureRand64());
+    partnerInputPath_ = folly::sformat(
+        "{}/partner_{}.csv", tempDir, folly::Random::secureRand64());
+    publisherGlobalParamsOutputPath_ = folly::sformat(
+        "{}/publisher_global_params_output_{}",
+        tempDir,
+        folly::Random::secureRand64());
+    publisherSecretSharesOutputPath_ = folly::sformat(
+        "{}/publisher_secret_shares_output_{}",
+        tempDir,
+        folly::Random::secureRand64());
+    partnerGlobalParamsOutputPath_ = folly::sformat(
+        "{}/partner_global_params_output_{}",
+        tempDir,
+        folly::Random::secureRand64());
+    partnerSecretSharesOutputPath_ = folly::sformat(
+        "{}/partner_secret_shares_output_{}",
+        tempDir,
+        folly::Random::secureRand64());
+  }
+
+  void TearDown() override {
+    std::filesystem::remove(publisherInputPath_);
+    std::filesystem::remove(partnerInputPath_);
+    std::filesystem::remove(publisherGlobalParamsOutputPath_);
+    std::filesystem::remove(publisherSecretSharesOutputPath_);
+    std::filesystem::remove(partnerGlobalParamsOutputPath_);
+    std::filesystem::remove(partnerSecretSharesOutputPath_);
+  }
+
+  std::pair<
+      std::unique_ptr<IInputProcessor<2>>,
+      std::unique_ptr<IInputProcessor<3>>>
+  runTest(
+      const std::string& publisherInputPath,
+      const std::string& partnerInputPath,
+      const std::string& publisherGlobalParamsOutputPath,
+      const std::string& publisherSecretSharesOutputPath,
+      const std::string& partnerGlobalParamsOutputPath,
+      const std::string& partnerSecretSharesOutputPath,
+      int numConversionsPerUser,
+      bool computePublisherBreakdowns,
+      bool useXorEncryption,
+      std::function<std::unique_ptr<IMetadataCompactorGame<0>>(
+          std::unique_ptr<fbpcf::scheduler::IScheduler>,
+          int)> publisherGameCreator,
+      std::function<std::unique_ptr<IMetadataCompactorGame<1>>(
+          std::unique_ptr<fbpcf::scheduler::IScheduler>,
+          int)> partnerGameCreator) {
+    auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+    int epoch = 1546300800;
+    auto future0 = std::async(
+        runMetadataCompactionApp<0>,
+        0,
+        numConversionsPerUser,
+        computePublisherBreakdowns,
+        epoch,
+        publisherInputPath,
+        publisherGlobalParamsOutputPath,
+        publisherSecretSharesOutputPath,
+        useXorEncryption,
+        std::move(factories[0]),
+        publisherGameCreator);
+
+    auto future1 = std::async(
+        runMetadataCompactionApp<1>,
+        1,
+        numConversionsPerUser,
+        computePublisherBreakdowns,
+        epoch,
+        partnerInputPath,
+        partnerGlobalParamsOutputPath,
+        partnerSecretSharesOutputPath,
+        useXorEncryption,
+        std::move(factories[1]),
+        partnerGameCreator);
+
+    future0.get();
+    future1.get();
+
+    factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
+
+    auto future2 = std::async(
+        createInputProcessorWithScheduler<2>,
+        0,
+        useXorEncryption,
+        publisherGlobalParamsOutputPath,
+        publisherSecretSharesOutputPath,
+        std::move(factories[0]));
+
+    auto future3 = std::async(
+        createInputProcessorWithScheduler<3>,
+        1,
+        useXorEncryption,
+        partnerGlobalParamsOutputPath,
+        partnerSecretSharesOutputPath,
+        std::move(factories[1]));
+
+    auto publisherResults = future2.get();
+    auto partnerResults = future3.get();
+
+    return std::make_pair<
+        std::unique_ptr<IInputProcessor<2>>,
+        std::unique_ptr<IInputProcessor<3>>>(
+        std::move(publisherResults), std::move(partnerResults));
+  }
+};
+
+TEST_P(
+    MetadataCompactionAppTestFixture,
+    TestRandomOutputWithDummyCompactorGame) {
+  int numConversionsPerUser = 25;
+  GenFakeData testDataGenerator;
+  LiftFakeDataParams params;
+  params.setNumRows(100)
+      .setOpportunityRate(.5)
+      .setTestRate(.5)
+      .setPurchaseRate(.5)
+      .setIncrementalityRate(0.0)
+      .setEpoch(1546300800)
+      .setNumConversions(numConversionsPerUser);
+  testDataGenerator.genFakePublisherInputFile(publisherInputPath_, params);
+  testDataGenerator.genFakePartnerInputFile(partnerInputPath_, params);
+
+  bool useXorEncryption = std::get<0>(GetParam());
+  bool computePublisherBreakdowns = std::get<1>(GetParam());
+
+  auto res = runTest(
+      publisherInputPath_,
+      partnerInputPath_,
+      publisherGlobalParamsOutputPath_,
+      publisherSecretSharesOutputPath_,
+      partnerGlobalParamsOutputPath_,
+      partnerSecretSharesOutputPath_,
+      numConversionsPerUser,
+      computePublisherBreakdowns,
+      useXorEncryption,
+      getDummyMetadataCompactorGameCreator<0>(),
+      getDummyMetadataCompactorGameCreator<1>());
+
+  std::unique_ptr<IInputProcessor<2>> publisherResults =
+      std::move(std::get<0>(res));
+
+  std::unique_ptr<IInputProcessor<3>> partnerResults =
+      std::move(std::get<1>(res));
+
+  EXPECT_EQ(publisherResults->getLiftGameProcessedData().numRows, 100);
+  EXPECT_EQ(partnerResults->getLiftGameProcessedData().numRows, 100);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MetadataCompactionAppTest,
+    MetadataCompactionAppTestFixture,
+    ::testing::Combine(::testing::Bool(), ::testing::Bool()),
+    [](const testing::TestParamInfo<
+        MetadataCompactionAppTestFixture::ParamType>& info) {
+      std::string useXorEncryption = std::get<0>(info.param) ? "True" : "False";
+      std::string computePublisherBreakdowns =
+          std::get<1>(info.param) ? "True" : "False";
+
+      std::string name = "UseXor_" + useXorEncryption +
+          "_ComputePublisherBreakdowns_" + computePublisherBreakdowns;
+      return name;
+    });
+
+} // namespace private_lift


### PR DESCRIPTION
Summary:
The current way to instantiate different UDP stage implementations is through a Game creator function that accepts a pcf scheduler and party ID.

This is basically the same thing but using Factory pattern instead. We can start working on M3 before M2 is finished by essentially creating a new "MetadataCompactorGame" that actually runs the UDP library.

Differential Revision: D39736927

