### PR TITLE
Adding Athena configs and logs to S3 with other data infra resources

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/cloud_error/cloud_error.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud_error/cloud_error.py
@@ -10,6 +10,10 @@ class AwsException(Exception):
     pass
 
 
+class AwsInvalidCredentials(AwsException):
+    pass
+
+
 class AwsCloudwatchException(AwsException):
     pass
 

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -121,7 +121,8 @@ class TestDownloadLogs(unittest.TestCase):
             ],
             cli.container_ids,
         )
-        self.assertIsNotNone(cli.aws_container_logs)
+        # This will be none because aws_cloud raises exception
+        self.assertIsNone(cli.aws_container_logs)
 
     #######################################
     # Tests for logically private methods #

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -141,6 +141,7 @@ class StringFormatter(str, Enum):
     LAMBDA_LOG_GROUP_NAME = "/aws/lambda/{}"
     GLUE_CRAWLER_NAME = "mpc-events-crawler-{}"
     GLUE_ETL_NAME = "glue-ETL-{}"
+    ATHENA_DATABASE = "mpc-events-db-{}"
 
 
 @dataclass

--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -12,7 +12,7 @@ import shutil
 from dataclasses import dataclass
 from enum import Enum
 from pprint import pprint
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from fbpcs.infra.logging_service.download_logs.cloud_error.utils_error import (
     NotSupportedContentType,
@@ -126,7 +126,7 @@ class Utils:
         return file_name
 
     @staticmethod
-    def string_formatter(preset_string: str, *args: str) -> str:
+    def string_formatter(preset_string: str, *args: Optional[str]) -> str:
         return preset_string.format(*args)
 
 
@@ -139,6 +139,8 @@ class StringFormatter(str, Enum):
     ZIPPED_FOLDER_NAME = "{}.zip"
     KINESIS_FIREHOSE_DELIVERY_STREAM = "cb-data-ingestion-stream-{}"
     LAMBDA_LOG_GROUP_NAME = "/aws/lambda/{}"
+    GLUE_CRAWLER_NAME = "mpc-events-crawler-{}"
+    GLUE_ETL_NAME = "glue-ETL-{}"
 
 
 @dataclass


### PR DESCRIPTION
Summary:
**What**
This diff is part of the data infra pipeline logging project. In data infra pipeline Athena is used to query the data. This diff addresses,
1. Getting Athena configs for a given data catalog and database name
2. Fetching recent queries
3. Getting Query results

**Why**
This will help in debugging Athena related failures in data infra pipeline

**Context**
https://docs.google.com/document/d/1cMD9IQ8uF6MS1PRvOh8cr-1el7MO952SjUanAzAGJzw/edit?usp=sharing

Differential Revision: D39714844

