### PR TITLE
Create transit gateway terraform deployment

### DIFF
--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  profile = "default"
+  region  = var.aws_region
+}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/output.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/output.tf
@@ -1,0 +1,4 @@
+output "transit_gateway_id" {
+  value       = aws_ec2_transit_gateway.interparty_transit_gateway.id
+  description = "The id of the inter-party transit gateway"
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/tgw.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/tgw.tf
@@ -1,0 +1,8 @@
+resource "aws_ec2_transit_gateway" "interparty_transit_gateway" {
+  description = "transit gateway for inter-party network connectivity"
+
+  auto_accept_shared_attachments = "enable"
+  tags = {
+    Name = "onedocker-tgw${var.tag_postfix}"
+  }
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/variable.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/variable.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  description = "region of the aws resources"
+  default     = "us-west-1"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}


### PR DESCRIPTION
Summary:
## Context
Following the [DH infra design](https://docs.google.com/document/d/1tldpSmSYM0kWs2lNDfZ4PP2Bd6jiZtV7kILtpyggiek/edit?usp=sharing), we want to create transit gateway on publisher side, this

## Summary
This diff is the terraform files for creating a transit gateway in a AWS region.

Differential Revision: D39756808

