### PR TITLE
Create transit gateway resource share deployment

### DIFF
--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  profile = "default"
+  region  = var.aws_region
+}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/output.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/output.tf
@@ -1,0 +1,4 @@
+output "transit_gateway_id" {
+  value       = aws_ec2_transit_gateway.interparty_transit_gateway.id
+  description = "The id of the inter-party transit gateway"
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/tgw.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/tgw.tf
@@ -1,0 +1,8 @@
+resource "aws_ec2_transit_gateway" "interparty_transit_gateway" {
+  description = "transit gateway for inter-party network connectivity"
+
+  auto_accept_shared_attachments = "enable"
+  tags = {
+    Name = "onedocker-tgw${var.tag_postfix}"
+  }
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/variable.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/network/variable.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  description = "region of the aws resources"
+  default     = "us-west-1"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/main.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  profile = "default"
+  region  = var.aws_region
+}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/output.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/output.tf
@@ -1,0 +1,4 @@
+output "transit_gateway_resource_share_id" {
+  value       = aws_ram_resource_share.tgw_resource_share.id
+  description = "The id of the transit gateway resource share"
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/tgw_ram.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/tgw_ram.tf
@@ -1,0 +1,14 @@
+resource "aws_ram_resource_share" "tgw_resource_share" {
+  name                      = "transit_gateway_resource_share${var.tag_postfix}"
+  allow_external_principals = true
+}
+
+resource "aws_ram_resource_association" "aws_ram_resource_tgw_association" {
+  resource_arn       = var.transit_gateway_arn
+  resource_share_arn = aws_ram_resource_share.tgw_resource_share.arn
+}
+
+resource "aws_ram_principal_association" "aws_ram_principal_tgw_association" {
+  principal          = var.principal
+  resource_share_arn = aws_ram_resource_share.tgw_resource_share.arn
+}

--- a/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/variable.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/inter_party_connect/publisher/ram/variable.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "region of the aws resources"
+  default     = "us-west-1"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}
+
+variable "transit_gateway_arn" {
+  description = "Amazon Resource Name (ARN) of the transit gateway to associate with the RAM Resource Share"
+}
+
+variable "principal" {
+  description = "The principal to associate with the resource share. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN"
+}


### PR DESCRIPTION
Summary:
## Context
Following last diff, after publisher deploys a transit gateway, it needs to be shared with other parties so others can attach VPCs to it

## Summary
This diff creates transit gateway resource share component

Differential Revision: D39757506

