### PR TITLE
Add PL UDP binary to build and release

### DIFF
--- a/binaries_out_lists/emp_games.txt
+++ b/binaries_out_lists/emp_games.txt
@@ -1,5 +1,6 @@
 lift_calculator
 pcf2_lift_calculator
+pcf2_lift_metadata_compaction
 pcf2_shard_combiner
 decoupled_attribution_calculator
 decoupled_aggregation_calculator

--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -143,6 +143,7 @@ target_link_libraries(
   perftools
   pcf2_lift_input_processing
 )
+install(TARGETS pcf2_lift_metadata_compaction DESTINATION bin)
 
 # pcf2_lift
 file(GLOB pcf2_lift_calculator_src

--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -65,6 +65,7 @@ if [ "$PACKAGE" = "emp_games" ]; then
 docker create -ti --name temp_container "${DOCKER_IMAGE_PATH}"
 docker cp temp_container:/usr/local/bin/lift_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/pcf2_lift_calculator "$SCRIPT_DIR/binaries_out/."
+docker cp temp_container:/usr/local/bin/pcf2_lift_metadata_compaction "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/decoupled_attribution_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/decoupled_aggregation_calculator "$SCRIPT_DIR/binaries_out/."
 docker cp temp_container:/usr/local/bin/pcf2_attribution_calculator "$SCRIPT_DIR/binaries_out/."

--- a/promote_scripts/promote_binaries.sh
+++ b/promote_scripts/promote_binaries.sh
@@ -21,6 +21,7 @@ fi
 binary_names=(
     'private_lift/lift'
     'private_lift/pcf2_lift'
+    'private_lift/pcf2_lift_metadata_compaction'
     'private_lift/aggregator'
     'private_attribution/decoupled_attribution'
     'private_attribution/decoupled_aggregation'

--- a/upload-binaries-to-s3-test.sh
+++ b/upload-binaries-to-s3-test.sh
@@ -32,6 +32,7 @@ shift
 one_docker_repo="one-docker-repository-custom"
 lift_package="s3://$one_docker_repo/private_lift/lift/${TAG}/lift"
 pcf2_lift_package="s3://$one_docker_repo/private_lift/pcf2_lift/${TAG}/pcf2_lift"
+pcf2_lift_metadata_compaction_package="s3://$one_docker_repo/private_lift/pcf2_lift_metadata_compaction/${TAG}/pcf2_lift_metadata_compaction"
 attribution_repo="s3://$one_docker_repo/private_attribution"
 decoupled_attribution="$attribution_repo/decoupled_attribution/${TAG}/decoupled_attribution"
 decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_aggregation"
@@ -47,6 +48,7 @@ if [ "$PACKAGE" = "emp_games" ]; then
 cd binaries_out || exit
 aws s3 cp lift_calculator "$lift_package"
 aws s3 cp pcf2_lift_calculator "$pcf2_lift_package"
+aws s3 cp pcf2_lift_metadata_compaction "$pcf2_lift_metadata_compaction_package"
 aws s3 cp decoupled_attribution_calculator "$decoupled_attribution"
 aws s3 cp decoupled_aggregation_calculator "$decoupled_aggregation"
 aws s3 cp pcf2_attribution_calculator "$pcf2_attribution"

--- a/upload-binaries-to-s3.sh
+++ b/upload-binaries-to-s3.sh
@@ -32,6 +32,7 @@ shift
 one_docker_repo="one-docker-repository-prod"
 lift_package="s3://$one_docker_repo/private_lift/lift/${TAG}/lift"
 pcf2_lift_package="s3://$one_docker_repo/private_lift/pcf2_lift/${TAG}/pcf2_lift"
+pcf2_lift_metadata_compaction_package="s3://$one_docker_repo/private_lift/pcf2_lift_metadata_compaction${TAG}/pcf2_lift_metadata_compaction"
 attribution_repo="s3://$one_docker_repo/private_attribution"
 decoupled_attribution="$attribution_repo/decoupled_attribution/${TAG}/decoupled_attribution"
 decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_aggregation"
@@ -47,6 +48,7 @@ if [ "$PACKAGE" = "emp_games" ]; then
 cd binaries_out || exit
 aws s3 cp lift_calculator "$lift_package"
 aws s3 cp pcf2_lift_calculator "$pcf2_lift_package"
+aws s3 cp pcf2_lift_metadata_compaction "$pcf2_lift_metadata_compaction_package"
 aws s3 cp decoupled_attribution_calculator "$decoupled_attribution"
 aws s3 cp decoupled_aggregation_calculator "$decoupled_aggregation"
 aws s3 cp pcf2_attribution_calculator "$pcf2_attribution"


### PR DESCRIPTION
Summary:
Following step 4 in https://www.internalfb.com/intern/wiki/Private_Computation_Infra/Private_Services_Infra/PCS_wikis/How_to_add_a_stage_to_PCS/Step_4:_Update_Github_CI/.

This extracts the binaries and uploads it to onedocker under private_lift/pcf2_lift_metadata_compaction

Differential Revision: D39749359

