### PR TITLE
adding token common validation in cli before trigger runners

### DIFF
--- a/fbpcs/pl_coordinator/pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pc_graphapi_utils.py
@@ -129,6 +129,13 @@ class PCGraphAPIClient:
             )
         return token
 
+    def get_debug_token_data(self) -> requests.Response:
+        params = self.params.copy()
+        params["input_token"] = self.access_token
+        r = requests.get(f"{URL}/debug_token", params=params)
+        self._check_err(r, "getting debug token data")
+        return r
+
     def get_instance(self, instance_id: str) -> requests.Response:
         r = requests.get(
             f"{URL}/{instance_id}",

--- a/fbpcs/pl_coordinator/tests/test_token_validator.py
+++ b/fbpcs/pl_coordinator/tests/test_token_validator.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import json
+from datetime import datetime, timedelta
+from typing import Any, Dict
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock
+
+import requests
+
+from fbpcs.pl_coordinator.constants import INSTANCE_SLA
+from fbpcs.pl_coordinator.exceptions import GraphAPITokenValidationError
+
+from fbpcs.pl_coordinator.pc_graphapi_utils import PCGraphAPIClient
+from fbpcs.pl_coordinator.token_validation_rules import TokenValidationRule
+from fbpcs.pl_coordinator.token_validator import TokenValidator
+
+
+class TestTokenValidator(TestCase):
+    def setUp(self) -> None:
+        self.client = MagicMock(spec=PCGraphAPIClient)
+        self.validator = TokenValidator(self.client)
+
+    def test_token_common_rules(self) -> None:
+        mock_response = {
+            "data": {
+                "type": "USER",
+                "expires_at": int(
+                    datetime.timestamp(
+                        datetime.now() + timedelta(seconds=INSTANCE_SLA + 100)
+                    )
+                ),
+                "data_access_expires_at": int(
+                    datetime.timestamp(
+                        datetime.now() + timedelta(seconds=INSTANCE_SLA + 100)
+                    )
+                ),
+                "is_valid": True,
+                "scopes": [
+                    "ads_management",
+                    "ads_read",
+                    "business_management",
+                    "private_computation_access",
+                ],
+            }
+        }
+        with self.subTest("Token match all validation"):
+            self.client.reset_mock()
+            self.client.get_debug_token_data.return_value = self._get_graph_api_output(
+                mock_response
+            )
+            self.validator.validate_common_rules()
+
+    def test_token_single_common_rule(self) -> None:
+        for (
+            sub_test_title,
+            test_rule,
+            debug_data,
+            is_valid,
+        ) in self.get_token_common_test_data():
+            with self.subTest(
+                sub_test_title,
+                test_rule=test_rule,
+                debug_data=debug_data,
+                is_valid=is_valid,
+            ):
+                self.validator.debug_token_data = None
+                self.client.reset_mock()
+                self.client.get_debug_token_data.return_value = (
+                    self._get_graph_api_output(debug_data)
+                )
+                if is_valid:
+                    self.validator.validate_rule(test_rule)
+                else:
+                    with self.assertRaises(GraphAPITokenValidationError):
+                        self.validator.validate_rule(test_rule)
+
+    def get_token_common_test_data(self):
+        # sub_test_title, test_rule, debug_data, is_valid
+        return (
+            (
+                "Token valid during computation",
+                TokenValidationRule.TOKEN_EXPIRY,
+                self._gen_debug_data(
+                    expires_at=int(
+                        datetime.timestamp(
+                            datetime.now() + timedelta(seconds=INSTANCE_SLA + 100)
+                        )
+                    )
+                ),
+                True,
+            ),
+            (
+                "Token never expired",
+                TokenValidationRule.TOKEN_EXPIRY,
+                self._gen_debug_data(expires_at=0),
+                True,
+            ),
+            (
+                "Token never expire data access",
+                TokenValidationRule.TOKEN_DATA_ACCESS_EXPIRY,
+                self._gen_debug_data(data_access_expires_at=0),
+                True,
+            ),
+            (
+                "Token miss User type",
+                TokenValidationRule.TOKEN_USER_TYPE,
+                self._gen_debug_data(type=None),
+                False,
+            ),
+            (
+                "Token expire soon",
+                TokenValidationRule.TOKEN_EXPIRY,
+                self._gen_debug_data(
+                    expires_at=int(
+                        datetime.timestamp(datetime.now() + timedelta(seconds=100))
+                    )
+                ),
+                False,
+            ),
+            (
+                "Token data access valid during computation",
+                TokenValidationRule.TOKEN_DATA_ACCESS_EXPIRY,
+                self._gen_debug_data(
+                    data_access_expires_at=int(
+                        datetime.timestamp(
+                            datetime.now() + timedelta(seconds=INSTANCE_SLA + 100)
+                        )
+                    )
+                ),
+                True,
+            ),
+            (
+                "Token data access expire soon",
+                TokenValidationRule.TOKEN_DATA_ACCESS_EXPIRY,
+                self._gen_debug_data(
+                    data_access_expires_at=int(
+                        datetime.timestamp(datetime.now() + timedelta(seconds=100))
+                    )
+                ),
+                False,
+            ),
+            (
+                "Token not valid",
+                TokenValidationRule.TOKEN_VALID,
+                self._gen_debug_data(is_valid=False),
+                False,
+            ),
+            (
+                "Token not meet permission",
+                TokenValidationRule.TOKEN_VALID,
+                self._gen_debug_data(is_valid=False),
+                False,
+            ),
+        )
+
+    def _gen_debug_data(self, **kwargs) -> Dict[str, Any]:
+        mock_response = {"data": {}}
+        for k, v in kwargs.items():
+            mock_response["data"][k] = v
+
+        return mock_response
+
+    def _get_graph_api_output(self, text: Any) -> requests.Response:
+        r = requests.Response()
+        r.status_code = 200
+        # pyre-ignore
+        type(r).text = PropertyMock(return_value=json.dumps(text))
+
+        def json_func(**kwargs) -> Any:
+            return text
+
+        r.json = json_func
+        return r

--- a/fbpcs/pl_coordinator/token_validation_rules.py
+++ b/fbpcs/pl_coordinator/token_validation_rules.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from dataclasses import dataclass, field
+from enum import auto, Enum
+from typing import List, Optional
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass
+class DebugTokenData:
+    type: Optional[str] = field(default=None)
+    is_valid: Optional[bool] = field(default=None)
+    expires_at: Optional[int] = field(default=None)
+    data_access_expires_at: Optional[int] = field(default=None)
+    scopes: Optional[List[str]] = field(default=None)
+
+
+class TokenValidationRuleType(Enum):
+    COMMON = auto()
+    PRIVATE_LIFT = auto()
+    PRIVATE_ATTRIBUTION = auto()
+
+
+@dataclass(frozen=True)
+class TokenValidationRuleData:
+    rule_name: str
+    rule_type: TokenValidationRuleType
+
+
+class TokenValidationRule(Enum):
+    TOKEN_USER_TYPE = TokenValidationRuleData(
+        rule_name="TOKEN_USER_TYPE",
+        rule_type=TokenValidationRuleType.COMMON,
+    )
+    TOKEN_VALID = TokenValidationRuleData(
+        rule_name="TOKEN_VALID",
+        rule_type=TokenValidationRuleType.COMMON,
+    )
+    TOKEN_EXPIRY = TokenValidationRuleData(
+        rule_name="TOKEN_EXPIRY",
+        rule_type=TokenValidationRuleType.COMMON,
+    )
+    TOKEN_DATA_ACCESS_EXPIRY = TokenValidationRuleData(
+        rule_name="TOKEN_DATA_ACCESS_EXPIRY",
+        rule_type=TokenValidationRuleType.COMMON,
+    )
+    TOKEN_PERMISSIONS = TokenValidationRuleData(
+        rule_name="TOKEN_PERMISSIONS",
+        rule_type=TokenValidationRuleType.COMMON,
+    )
+
+    def __init__(self, data: TokenValidationRuleData) -> None:
+        super().__init__()
+        self.rule_type: TokenValidationRuleType = data.rule_type

--- a/fbpcs/pl_coordinator/token_validator.py
+++ b/fbpcs/pl_coordinator/token_validator.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+import time
+from typing import Optional, Tuple
+
+from fbpcs.pl_coordinator.constants import INSTANCE_SLA
+
+from fbpcs.pl_coordinator.exceptions import GraphAPITokenValidationError
+
+from fbpcs.pl_coordinator.pc_graphapi_utils import PCGraphAPIClient
+
+from fbpcs.pl_coordinator.token_validation_rules import (
+    DebugTokenData,
+    TokenValidationRule,
+    TokenValidationRuleType,
+)
+
+
+"""
+required token scopes defined here:
+https://github.com/facebookresearch/fbpcs/blob/main/docs/PCS_Partner_Playbook_UI.pdf
+(see Step 3: generating 60 days access token)
+"""
+REQUIRED_TOKEN_SCOPES = {
+    "ads_management",
+    "ads_read",
+    "business_management",
+    "private_computation_access",
+}
+COMMON_RULES: Tuple[TokenValidationRule, ...] = (
+    TokenValidationRule.TOKEN_USER_TYPE,
+    TokenValidationRule.TOKEN_VALID,
+    TokenValidationRule.TOKEN_EXPIRY,
+    TokenValidationRule.TOKEN_DATA_ACCESS_EXPIRY,
+    TokenValidationRule.TOKEN_PERMISSIONS,
+)
+
+
+class TokenValidator:
+    def __init__(self, client: PCGraphAPIClient) -> None:
+        self.client = client
+        self.debug_token_data: Optional[DebugTokenData] = None
+
+    def _load_data(self, rule: TokenValidationRule) -> None:
+        if (
+            rule.rule_type is TokenValidationRuleType.COMMON
+            and self.debug_token_data is None
+        ):
+            _debug_token_data = json.loads(self.client.get_debug_token_data().text).get(
+                "data"
+            )
+            # pyre-ignore[16]
+            self.debug_token_data = DebugTokenData.from_dict(_debug_token_data)
+
+    def validate_common_rules(self) -> None:
+        for rule in COMMON_RULES:
+            self.validate_rule(rule)
+
+    def validate_rule(self, rule: TokenValidationRule) -> None:
+        ## prepare data
+        self._load_data(rule=rule)
+        if rule is TokenValidationRule.TOKEN_USER_TYPE:
+            # pyre-ignore[16]
+            if self.debug_token_data.type == "USER":
+                return
+        elif rule is TokenValidationRule.TOKEN_VALID:
+            # pyre-ignore[16]
+            if self.debug_token_data.is_valid:
+                return
+        elif rule is TokenValidationRule.TOKEN_EXPIRY:
+            # pyre-ignore[16]
+            expires_at = self.debug_token_data.expires_at
+            if expires_at == 0 or (
+                expires_at > 0 and expires_at - int(time.time()) >= INSTANCE_SLA
+            ):  # 24hours
+                return
+        elif rule is TokenValidationRule.TOKEN_DATA_ACCESS_EXPIRY:
+            # pyre-ignore[16]
+            expires_at = self.debug_token_data.data_access_expires_at
+            if expires_at == 0 or (
+                expires_at > 0 and expires_at - int(time.time()) >= INSTANCE_SLA
+            ):  # 24hours
+                return
+        elif rule is TokenValidationRule.TOKEN_PERMISSIONS:
+            # pyre-ignore[16]
+            scopes = set(self.debug_token_data.scopes)
+            if scopes.issuperset(REQUIRED_TOKEN_SCOPES):
+                return
+
+        raise GraphAPITokenValidationError.make_error(rule)

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -188,8 +188,12 @@ class TestPrivateComputationCli(TestCase):
             pc_cli.main(argv)
             create_mock.assert_called_once()
 
+    @patch("fbpcs.private_computation_cli.private_computation_cli.TokenValidator")
+    @patch("fbpcs.private_computation_cli.private_computation_cli.PCGraphAPIClient")
     @patch("fbpcs.private_computation_cli.private_computation_cli.run_attribution")
-    def test_run_attribution(self, create_mock) -> None:
+    def test_run_attribution(
+        self, create_mock, graph_client_mock, token_validator_mock
+    ) -> None:
         argv = [
             "run_attribution",
             "--dataset_id=43423422232",
@@ -292,8 +296,12 @@ class TestPrivateComputationCli(TestCase):
         pc_cli.main(argv)
         get_mpc_mock.assert_called_once()
 
+    @patch("fbpcs.private_computation_cli.private_computation_cli.TokenValidator")
+    @patch("fbpcs.private_computation_cli.private_computation_cli.PCGraphAPIClient")
     @patch("fbpcs.private_computation_cli.private_computation_cli.run_study")
-    def test_run_study(self, run_study_mock) -> None:
+    def test_run_study(
+        self, run_study_mock, graph_client_mock, token_validator_mock
+    ) -> None:
         argv = [
             "run_study",
             "12345",


### PR DESCRIPTION
Summary:
## Why
As Sev follow-up task, we will need to have Access Token validation before trigger runs.
We will introduce two-level token validations.
1. common validation (this diff) before trigger runners
2. product-specific token validation (next Diffs )

Here is the detailed proposal doc [PC SEV Follow-up: Access Token Validations (Due date: 09/30)]
https://docs.google.com/document/d/1DOuNCYm9YAc_8r7-zWYxb1Dw-Dig2EJEbOGviJYJqX0/edit?usp=sharing
## What
* Add Token rule enums, support next diff in product specific token validation extension
* Add Token validator
* Define sys error code when validation failed

Differential Revision: D39716726

