### PR TITLE
Remove unused num_containers from PA create method.

### DIFF
--- a/fbpcs/pl_coordinator/pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pc_graphapi_utils.py
@@ -157,7 +157,6 @@ class PCGraphAPIClient:
         dataset_id: str,
         timestamp: int,
         attribution_rule: str,
-        num_containers: int,
     ) -> requests.Response:
         params = self.params.copy()
         params["attribution_rule"] = attribution_rule

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -244,7 +244,6 @@ def _create_new_instance(
             dataset_id,
             timestamp,
             attribution_rule,
-            2,
         ).text
     )["id"]
     logger.info(


### PR DESCRIPTION
Summary: the num_containers parameter is not send to PA publisher when creating the PA instance Thus cleaning up this unused parameter

Differential Revision: D39744625

