### PR TITLE
Add support for cancel current in PC thrift.

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -557,10 +557,9 @@ class PrivateComputationService:
         if private_computation_instance.stage_flow.is_completed_status(
             private_computation_instance.infra_config.status
         ):
-            raise ValueError(
-                f"Instance {instance_id} has status {private_computation_instance.infra_config.status}. Nothing to cancel."
+            raise PrivateComputationServiceInvalidStageError(
+                f"Instance {instance_id} stage flow completed. (status: {private_computation_instance.infra_config.status}). Nothing to cancel."
             )
-            return private_computation_instance
 
         if not private_computation_instance.infra_config.instances:
             raise ValueError(


### PR DESCRIPTION
Summary:
# Design document -
https://docs.google.com/document/d/1T87uFzfF1VepnxcUhiunb_5CkzO5gzJ8i9YlhvCBgL8/edit?usp=sharing

# Context:
As a follow up of SEV - S291746, we need to add co-ordinated retry logic between partner and publisher so that;  in case of a partner side joint stage spin up failure, the partner side first cancels the publisher side stage and then runs next.

# In this diff
Adding support in thrift for existing cancel_current_stage method in PCS.

Differential Revision: D39800454

