### PR TITLE
Pass metric collectors into apps (#410)

### DIFF
--- a/fbpcs/emp_games/compactor/main.cpp
+++ b/fbpcs/emp_games/compactor/main.cpp
@@ -114,13 +114,17 @@ int main(int argc, char** argv) {
       partyInfos{
           {{PUBLISHER_ROLE, {FLAGS_host, FLAGS_port}},
            {PARTNER_ROLE, {FLAGS_host, FLAGS_port}}}};
+
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("compactor");
+
   auto commAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      FLAGS_party, std::move(partyInfos), tlsInfo, "compactor_traffic");
+      FLAGS_party, std::move(partyInfos), tlsInfo, metricCollector);
 
   XLOG(INFO) << "Creating scheduler\n";
   auto scheduler = fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-                       FLAGS_party, *commAgentFactory)
+                       FLAGS_party, *commAgentFactory, metricCollector)
                        ->create();
 
   XLOG(INFO) << "Starting game\n";

--- a/fbpcs/emp_games/dotproduct/MainUtil.h
+++ b/fbpcs/emp_games/dotproduct/MainUtil.h
@@ -36,9 +36,12 @@ inline common::SchedulerStatistics startDotProductApp(
   tlsInfo.passphrasePath = "";
   tlsInfo.useTls = false;
 
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("dotproduct");
+
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      PARTY, partyInfos, tlsInfo, "dotproduct_traffic");
+      PARTY, partyInfos, tlsInfo, metricCollector);
 
   auto app = std::make_unique<pcf2_dotproduct::DotproductApp<PARTY, PARTY>>(
       std::move(communicationAgentFactory),
@@ -46,6 +49,7 @@ inline common::SchedulerStatistics startDotProductApp(
       outFilePath,
       numFeatures,
       labelWidth,
+      metricCollector,
       debugMode);
 
   app->run();

--- a/fbpcs/emp_games/dotproduct/test/DotproductAppTest.cpp
+++ b/fbpcs/emp_games/dotproduct/test/DotproductAppTest.cpp
@@ -41,6 +41,9 @@ static void runGame(
           PartyInfo>
       partyInfos({{0, {serverIp, port}}, {1, {serverIp, port}}});
 
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("dotproduct_test");
+
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
       PARTY, partyInfos, useTls, tlsDir, "dotproduct_traffic_test");
@@ -51,6 +54,7 @@ static void runGame(
       outputFilePath,
       numFeatures,
       labelWidth,
+      metricCollector,
       debugMode);
 
   app->run();

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp.h
@@ -34,6 +34,7 @@ class CalculatorApp {
       const int epoch,
       const std::vector<std::string>& inputPaths,
       const std::vector<std::string>& outputPaths,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector,
       const int startFileIndex = 0,
       const int numFiles = 1,
       const bool useXorEncryption = true)
@@ -44,6 +45,7 @@ class CalculatorApp {
         epoch_(epoch),
         inputPaths_(inputPaths),
         outputPaths_(outputPaths),
+        metricCollector_(metricCollector),
         startFileIndex_(startFileIndex),
         numFiles_(numFiles),
         useXorEncryption_(useXorEncryption) {}
@@ -70,6 +72,7 @@ class CalculatorApp {
   int epoch_;
   std::vector<std::string> inputPaths_;
   std::vector<std::string> outputPaths_;
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
   int startFileIndex_;
   int numFiles_;
   bool useXorEncryption_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorApp_impl.h
@@ -19,7 +19,6 @@ void CalculatorApp<schedulerId>::run() {
   // Run calculator game sequentially on numFiles files, starting from
   // startFileIndex
   auto scheduler = createScheduler();
-  auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
   CalculatorGame<schedulerId> game{
       party_, std::move(scheduler), std::move(communicationAgentFactory_)};
 
@@ -62,7 +61,7 @@ void CalculatorApp<schedulerId>::run() {
   schedulerStatistics_.freeGates = gateStatistics.second;
   schedulerStatistics_.sentNetwork = trafficStatistics.first;
   schedulerStatistics_.receivedNetwork = trafficStatistics.second;
-  schedulerStatistics_.details = metricsCollector->collectMetrics();
+  schedulerStatistics_.details = metricCollector_->collectMetrics();
 };
 
 template <int schedulerId>
@@ -93,10 +92,10 @@ std::unique_ptr<fbpcf::scheduler::IScheduler>
 CalculatorApp<schedulerId>::createScheduler() {
   return useXorEncryption_
       ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-            party_, *communicationAgentFactory_)
+            party_, *communicationAgentFactory_, metricCollector_)
             ->create()
       : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
-            party_, *communicationAgentFactory_)
+            party_, *communicationAgentFactory_, metricCollector_)
             .create();
 }
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
@@ -98,12 +98,12 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
     tlsInfo.passphrasePath = "";
     tlsInfo.useTls = false;
 
+    auto metricCollector = std::make_shared<fbpcf::util::MetricCollector>(
+        "lift_metrics_for_thread_" + std::to_string(index));
+
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-        PARTY,
-        partyInfos,
-        tlsInfo,
-        "lift_traffic_for_thread_" + std::to_string(index));
+        PARTY, partyInfos, tlsInfo, metricCollector);
 
     // Each CalculatorApp runs numFiles sequentially on a single thread
     // Publisher uses even schedulerId and partner uses odd schedulerId
@@ -115,6 +115,7 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
         epoch,
         inputFilepaths,
         outputFilepaths,
+        metricCollector,
         startFileIndex,
         numFiles,
         useXorEncryption);

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -41,6 +41,9 @@ void runCalculatorApp(
     std::unique_ptr<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory>
         communicationAgentFactory) {
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("calculator_test");
+
   auto app = std::make_unique<CalculatorApp<schedulerId>>(
       myId,
       std::move(communicationAgentFactory),
@@ -49,6 +52,7 @@ void runCalculatorApp(
       epoch,
       std::vector<std::string>{inputPath},
       std::vector<std::string>{outputPath},
+      metricCollector,
       0,
       1,
       useXorEncryption);

--- a/fbpcs/emp_games/pcf2_aggregation/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_aggregation/MainUtil.h
@@ -84,12 +84,12 @@ inline common::SchedulerStatistics startAggregationAppsForShardedFilesHelper(
     tlsInfo.passphrasePath = "";
     tlsInfo.useTls = false;
 
+    auto metricCollector = std::make_shared<fbpcf::util::MetricCollector>(
+        "aggregation_metrics_for_thread_" + std::to_string(index));
+
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-        PARTY,
-        partyInfos,
-        tlsInfo,
-        "aggregation_traffic_for_thread_" + std::to_string(index));
+        PARTY, partyInfos, tlsInfo, metricCollector);
 
     // Each AggregationApp runs numFiles sequentially on a single thread
     // Publisher uses even schedulerId and partner uses odd schedulerId
@@ -102,6 +102,7 @@ inline common::SchedulerStatistics startAggregationAppsForShardedFilesHelper(
         inputSecretShareFilenames,
         inputClearTextFilenames,
         outputFilenames,
+        metricCollector,
         startFileIndex,
         numFiles,
         numThreads);

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
@@ -49,6 +49,9 @@ static void runGame(
         communicationAgentFactory) {
   FLAGS_use_new_output_format = useNewOutputFormat;
 
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("aggregation_test");
+
   AggregationApp<PARTY, schedulerId>(
       inputEncryption,
       outputVisibility,
@@ -56,7 +59,8 @@ static void runGame(
       aggregationFormat,
       std::vector<std::string>{inputSecretSharePath},
       std::vector<std::string>{inputClearTextPath},
-      std::vector<std::string>{outputPath})
+      std::vector<std::string>{outputPath},
+      metricCollector)
       .run();
 }
 

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -93,12 +93,12 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     tlsInfo.passphrasePath = "";
     tlsInfo.useTls = false;
 
+    auto metricCollector = std::make_shared<fbpcf::util::MetricCollector>(
+        "attribution_metrics_for_thread_" + std::to_string(index));
+
     auto communicationAgentFactory = std::make_unique<
         fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-        PARTY,
-        partyInfos,
-        tlsInfo,
-        "attribution_traffic_for_thread_" + std::to_string(index));
+        PARTY, partyInfos, tlsInfo, metricCollector);
 
     // Each AttributionApp runs numFiles sequentially on a single thread
     // Publisher uses even schedulerId and partner uses odd schedulerId
@@ -111,6 +111,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
         attributionRules,
         inputFilenames,
         outputFilenames,
+        metricCollector,
         startFileIndex,
         numFiles);
 

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
@@ -37,11 +37,14 @@ static void runGame(
     std::unique_ptr<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory>
         communicationAgentFactory) {
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("attribution_test");
   AttributionApp<PARTY, schedulerId, usingBatch, inputEncryption>(
       std::move(communicationAgentFactory),
       attributionRules,
       std::vector<string>{inputPath},
-      std::vector<string>{outputPath})
+      std::vector<string>{outputPath},
+      metricCollector)
       .run();
 }
 

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
@@ -157,6 +157,8 @@ class ShardCombinerAppTestFixture
       std::unique_ptr<
           fbpcf::engine::communication::IPartyCommunicationAgentFactory>
           communicationAgentFactory) {
+    auto metricCollector =
+        std::make_shared<fbpcf::util::MetricCollector>("shard_combiner_test");
     ShardCombinerApp<shardSchemaType, schedulerId, usingBatch, inputEncryption>(
         std::move(communicationAgentFactory),
         numShards,
@@ -166,7 +168,8 @@ class ShardCombinerAppTestFixture
         outputPath,
         threshold,
         xorEncrypted,
-        resultVisibility)
+        resultVisibility,
+        metricCollector)
         .run();
   }
 

--- a/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
@@ -12,13 +12,13 @@
 
 #include <gflags/gflags.h>
 
-#include <folly/Synchronized.h>
-#include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
-
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/exception/ExceptionBase.h>
 #include <fbpcf/exception/exceptions.h>
+#include <folly/Synchronized.h>
+#include <folly/init/Init.h>
+#include <folly/json.h>
+#include <folly/logging/xlog.h>
 
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
@@ -160,6 +160,10 @@ int main(int argc, char* argv[]) {
 
   cost.end();
   XLOG(INFO) << cost.getEstimatedCostString();
+  XLOGF(
+      INFO,
+      "MPC Traffic Details: {}",
+      folly::toPrettyJson(schedulerStatistics.details));
   if (FLAGS_log_cost) {
     std::string party_str =
         (FLAGS_party == static_cast<int32_t>(common::PUBLISHER)) ? "Publisher"

--- a/fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/util/MainUtil.h
@@ -63,9 +63,12 @@ common::SchedulerStatistics runApp(
       partyInfos(
           {{common::PUBLISHER, {ip, port}}, {common::PARTNER, {ip, port}}});
 
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("shard_combiner");
+
   auto communicationAgentFactory = std::make_unique<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      schedulerId, partyInfos, tlsInfo, "shard_combiner_traffic");
+      schedulerId, partyInfos, tlsInfo, metricCollector);
 
   common::SchedulerStatistics schedulerStats;
   if (schedulerId == common::PUBLISHER) {
@@ -83,7 +86,8 @@ common::SchedulerStatistics runApp(
           outputPath,
           threshold,
           useXorEncryption,
-          resultVisibility);
+          resultVisibility,
+          metricCollector);
       app->run();
       return app->getSchedulerStatistics();
     } else {
@@ -100,7 +104,8 @@ common::SchedulerStatistics runApp(
           outputPath,
           threshold,
           useXorEncryption,
-          resultVisibility);
+          resultVisibility,
+          metricCollector);
       app->run();
       return app->getSchedulerStatistics();
     }
@@ -119,7 +124,8 @@ common::SchedulerStatistics runApp(
           outputPath,
           threshold,
           useXorEncryption,
-          resultVisibility);
+          resultVisibility,
+          metricCollector);
       app->run();
       return app->getSchedulerStatistics();
     } else {
@@ -136,7 +142,8 @@ common::SchedulerStatistics runApp(
           outputPath,
           threshold,
           useXorEncryption,
-          resultVisibility);
+          resultVisibility,
+          metricCollector);
       app->run();
       return app->getSchedulerStatistics();
     }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcf/pull/410

- Pass metric collectors into the apps: shard combiner, aggregation, attribution, and calculator
- Remove callsites to old SocketPartyCommunicationAgent constructors that takes a string "myname" as argument
- mark the old constructors as deprecated
-

Reviewed By: adshastri

Differential Revision: D39591456

