### PR TITLE
refactor token rule checker to embed to rules

### DIFF
--- a/fbpcs/pl_coordinator/token_validation_rules.py
+++ b/fbpcs/pl_coordinator/token_validation_rules.py
@@ -7,11 +7,31 @@
 # pyre-strict
 
 
+import time
 from dataclasses import dataclass, field
 from enum import auto, Enum
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from dataclasses_json import dataclass_json
+
+from fbpcs.pl_coordinator.constants import INSTANCE_SLA
+
+"""
+required token scopes defined here:
+https://github.com/facebookresearch/fbpcs/blob/main/docs/PCS_Partner_Playbook_UI.pdf
+(see Step 3: generating 60 days access token)
+"""
+REQUIRED_TOKEN_SCOPES = {
+    "ads_management",
+    "ads_read",
+    "business_management",
+    "private_computation_access",
+}
+
+
+"""
+data models define here
+"""
 
 
 @dataclass_json
@@ -30,34 +50,85 @@ class TokenValidationRuleType(Enum):
     PRIVATE_ATTRIBUTION = auto()
 
 
+"""
+Token validation rule data model
+"""
+
+
 @dataclass(frozen=True)
 class TokenValidationRuleData:
     rule_name: str
     rule_type: TokenValidationRuleType
+    rule_checker: Callable[[DebugTokenData], bool]
+
+
+"""
+rule checkers
+"""
+user_type_checker: Callable[[DebugTokenData], bool] = lambda data: data.type == "USER"
+valid_checker: Callable[[DebugTokenData], bool] = lambda data: data.is_valid
+
+
+def expiry_checker(data: DebugTokenData) -> bool:
+    expires_at = data.expires_at
+    if expires_at is None:
+        return False
+
+    return expires_at == 0 or (
+        expires_at > 0 and expires_at - int(time.time()) >= INSTANCE_SLA
+    )
+
+
+def data_access_expiry_checker(data: DebugTokenData) -> bool:
+    expires_at = data.data_access_expires_at
+    if expires_at is None:
+        return False
+
+    return expires_at == 0 or (
+        expires_at > 0 and expires_at - int(time.time()) >= INSTANCE_SLA
+    )
+
+
+def permission_checker(data: DebugTokenData) -> bool:
+    if data.scopes is None:
+        return False
+
+    return set(data.scopes).issuperset(REQUIRED_TOKEN_SCOPES)
+
+
+"""
+Rule definitions
+"""
 
 
 class TokenValidationRule(Enum):
     TOKEN_USER_TYPE = TokenValidationRuleData(
         rule_name="TOKEN_USER_TYPE",
         rule_type=TokenValidationRuleType.COMMON,
+        rule_checker=user_type_checker,
     )
     TOKEN_VALID = TokenValidationRuleData(
         rule_name="TOKEN_VALID",
         rule_type=TokenValidationRuleType.COMMON,
+        rule_checker=valid_checker,
     )
     TOKEN_EXPIRY = TokenValidationRuleData(
         rule_name="TOKEN_EXPIRY",
         rule_type=TokenValidationRuleType.COMMON,
+        rule_checker=expiry_checker,
     )
     TOKEN_DATA_ACCESS_EXPIRY = TokenValidationRuleData(
         rule_name="TOKEN_DATA_ACCESS_EXPIRY",
         rule_type=TokenValidationRuleType.COMMON,
+        rule_checker=data_access_expiry_checker,
     )
     TOKEN_PERMISSIONS = TokenValidationRuleData(
         rule_name="TOKEN_PERMISSIONS",
         rule_type=TokenValidationRuleType.COMMON,
+        rule_checker=permission_checker,
     )
 
     def __init__(self, data: TokenValidationRuleData) -> None:
         super().__init__()
         self.rule_type: TokenValidationRuleType = data.rule_type
+        self.rule_checker: Callable[[DebugTokenData], bool] = data.rule_checker


### PR DESCRIPTION
Summary:
## Why
In previous diff D39716726 (https://github.com/facebookresearch/fbpcs/commit/9233decb0522461819d21a951fbe0f106d51a414), we added token rule validator before trigger PL/PA runs.
One of the follow up is to refactor the diff to move checker embed to rule data itself
## What
* refactor rule checker to rules

Reviewed By: ztlbells

Differential Revision: D39823239

