### PR TITLE
Add new PCS stage service to run metadata compaction (Lift UDP) binary

### DIFF
--- a/fbpcs/onedocker_binary_names.py
+++ b/fbpcs/onedocker_binary_names.py
@@ -34,5 +34,6 @@ class OneDockerBinaryNames(Enum):
 
     LIFT_COMPUTE = "private_lift/lift"
     PCF2_LIFT = "private_lift/pcf2_lift"
+    PCF2_LIFT_METADATA_COMPACTION = "private_lift/pcf2_lift_metadata_compaction"
 
     PC_PRE_VALIDATION = "validation/pc_pre_validation_cli"

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -231,6 +231,10 @@ class PrivateComputationInstance(InstanceBase):
         return self._get_stage_output_path("compute_stage", "json")
 
     @property
+    def pcf2_lift_metadata_compaction_output_base_path(self) -> str:
+        return self._get_stage_output_path("metadata_compaction_stage", "csv")
+
+    @property
     def pcf2_lift_stage_output_base_path(self) -> str:
         return self._get_stage_output_path("pcf2_lift_stage", "json")
 

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -19,6 +19,7 @@ from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 class GameNames(Enum):
     LIFT = "lift"
     PCF2_LIFT = "pcf2_lift"
+    PCF2_LIFT_METADATA_COMPACTION = "pcf2_lift_metadata_compaction"
     SHARD_AGGREGATOR = "shard_aggregator"
     PCF2_SHARD_COMBINER = "pcf2_shard_combiner"
     DECOUPLED_ATTRIBUTION = "decoupled_attribution"
@@ -59,10 +60,34 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="file_start_index", required=False),
             OneDockerArgument(name="num_files", required=True),
             OneDockerArgument(name="concurrency", required=True),
+            OneDockerArgument(name="epoch", required=False),
             OneDockerArgument(name="num_conversions_per_user", required=False),
+            OneDockerArgument(name="compute_publisher_breakdowns", required=False),
             OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="log_cost_s3_bucket", required=False),
+            OneDockerArgument(name="log_cost_s3_region", required=False),
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
+            OneDockerArgument(name="use_tls", required=False),
+            OneDockerArgument(name="ca_cert_path", required=False),
+            OneDockerArgument(name="server_cert_path", required=False),
+            OneDockerArgument(name="private_key_path", required=False),
+        ],
+    },
+    GameNames.PCF2_LIFT_METADATA_COMPACTION.value: {
+        "onedocker_package_name": OneDockerBinaryNames.PCF2_LIFT_METADATA_COMPACTION.value,
+        "arguments": [
+            OneDockerArgument(name="input_path", required=True),
+            OneDockerArgument(name="output_global_params_path", required=True),
+            OneDockerArgument(name="output_secret_shares_path", required=True),
+            OneDockerArgument(name="epoch", required=False),
+            OneDockerArgument(name="num_conversions_per_user", required=False),
+            OneDockerArgument(name="compute_publisher_breakdowns", required=False),
+            OneDockerArgument(name="run_name", required=False),
+            OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="log_cost_s3_bucket", required=False),
+            OneDockerArgument(name="log_cost_s3_region", required=False),
             OneDockerArgument(name="pc_feature_flags", required=False),
             OneDockerArgument(name="use_tls", required=False),
             OneDockerArgument(name="ca_cert_path", required=False),
@@ -80,6 +105,8 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="threshold", required=True),
             OneDockerArgument(name="first_shard_index", required=False),
             OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="log_cost_s3_bucket", required=False),
+            OneDockerArgument(name="log_cost_s3_region", required=False),
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="visibility", required=False),
             OneDockerArgument(name="run_id", required=False),
@@ -96,6 +123,8 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="threshold", required=True),
             OneDockerArgument(name="first_shard_index", required=False),
             OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="log_cost_s3_bucket", required=False),
+            OneDockerArgument(name="log_cost_s3_region", required=False),
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="visibility", required=False),
             OneDockerArgument(name="use_tls", required=False),
@@ -150,6 +179,8 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_xor_encryption", required=True),
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="log_cost_s3_bucket", required=False),
+            OneDockerArgument(name="log_cost_s3_region", required=False),
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="use_new_output_format", required=False),
             OneDockerArgument(name="run_id", required=False),
@@ -174,6 +205,8 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="use_xor_encryption", required=True),
             OneDockerArgument(name="use_postfix", required=True),
             OneDockerArgument(name="log_cost", required=False),
+            OneDockerArgument(name="log_cost_s3_bucket", required=False),
+            OneDockerArgument(name="log_cost_s3_region", required=False),
             OneDockerArgument(name="run_name", required=False),
             OneDockerArgument(name="use_new_output_format", required=False),
             OneDockerArgument(name="run_id", required=False),

--- a/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from typing import Any, DefaultDict, Dict, List, Optional
+
+from fbpcp.service.mpc import MPCService
+from fbpcp.util.typing import checked_cast
+from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+    PrivateComputationRole,
+)
+
+from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.argument_helper import get_tls_arguments
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_LOG_COST_TO_S3,
+    LIFT_DEFAULT_PADDING_SIZE,
+)
+
+from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
+from fbpcs.private_computation.service.private_computation_service_data import (
+    PrivateComputationServiceData,
+)
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+)
+
+from fbpcs.private_computation.service.utils import (
+    create_and_start_mpc_instance,
+    get_updated_pc_status_mpc_game,
+    map_private_computation_role_to_mpc_party,
+)
+
+
+class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
+    """
+    Handles business logic for the private computation PCF2.0 Metadata Compaction Stage (UDP for Lift)
+
+    Private attributed:
+        _onedocker_binary_config_map: Stores a mapping from mpc game to OneDockerBinaryConfig (binary version and tmp directory)
+        _mpc_svc: creates and runs MPC instances
+        _log_cost_to_s3: if money cost of the computation will be logged to S3
+        _container_timeout: optional duration in seconds before cloud containers timeout
+    """
+
+    def __init__(
+        self,
+        onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
+        mpc_service: MPCService,
+        padding_size: int = LIFT_DEFAULT_PADDING_SIZE,
+        log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
+        container_timeout: Optional[int] = None,
+    ) -> None:
+        self._onedocker_binary_config_map = onedocker_binary_config_map
+        self._mpc_service = mpc_service
+        self.padding_size = padding_size
+        self._log_cost_to_s3 = log_cost_to_s3
+        self._container_timeout = container_timeout
+
+    async def run_async(
+        self,
+        pc_instance: PrivateComputationInstance,
+        server_ips: Optional[List[str]] = None,
+    ) -> PrivateComputationInstance:
+        """
+        Args:
+            pc_instance: the private computation instance to run lift with
+            server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
+
+        Returns:
+            An updated version of pc_instance that stores an MPCInstance
+        """
+
+        game_args = self._get_lift_metadata_compaction_game_args(pc_instance)
+
+        # We do this check here because depends on how game_args is generated, len(game_args) could be different,
+        #   but we will always expect server_ips == len(game_args)
+        if server_ips and len(server_ips) != len(game_args):
+            raise ValueError(
+                f"Unable to rerun MPC compute because there is a mismatch between the number of server ips given ({len(server_ips)}) and the number of containers ({len(game_args)}) to be spawned."
+            )
+
+        logging.info(
+            "Starting to run MPC instance for PCF2.0 Lift Metadata Compaction."
+        )
+
+        stage_data = PrivateComputationServiceData.PCF2_LIFT_METADATA_COMPACTION_DATA
+        binary_name = stage_data.binary_name
+        game_name = checked_cast(str, stage_data.game_name)
+
+        binary_config = self._onedocker_binary_config_map[binary_name]
+        should_wait_spin_up: bool = (
+            pc_instance.infra_config.role is PrivateComputationRole.PARTNER
+        )
+        mpc_instance = await create_and_start_mpc_instance(
+            mpc_svc=self._mpc_service,
+            instance_id=pc_instance.infra_config.instance_id
+            + "_pcf_lift_metadata_compaction",
+            game_name=game_name,
+            mpc_party=map_private_computation_role_to_mpc_party(
+                pc_instance.infra_config.role
+            ),
+            num_containers=pc_instance.infra_config.num_pid_containers,
+            binary_version=binary_config.binary_version,
+            server_ips=server_ips,
+            game_args=game_args,
+            container_timeout=self._container_timeout,
+            repository_path=binary_config.repository_path,
+            wait_for_containers_to_start_up=should_wait_spin_up,
+        )
+
+        logging.info(
+            "MPC instance started running for PCF2.0 Lift Metadata Compaction."
+        )
+
+        # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
+        pc_instance.infra_config.instances.append(
+            PCSMPCInstance.from_mpc_instance(mpc_instance)
+        )
+
+        return pc_instance
+
+    def get_status(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> PrivateComputationInstanceStatus:
+        """Updates the MPCInstances and gets latest PrivateComputationInstance status
+
+        Arguments:
+            private_computation_instance: The PC instance that is being updated
+
+        Returns:
+            The latest status for private_computation_instance
+        """
+        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
+
+    def _get_lift_metadata_compaction_game_args(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> List[Dict[str, Any]]:
+        """Gets the game args passed to game binaries by onedocker
+
+        When onedocker spins up containers to run games, it unpacks a dictionary containing the
+        arguments required by the game binary being ran. This function prepares that dictionary.
+
+        Args:
+            pc_instance: the private computation instance to generate game args for
+
+        Returns:
+            MPC game args to be used by onedocker
+        """
+
+        id_combiner_output_path = pc_instance.data_processing_output_path + "_combine"
+        num_metadata_compaction_containers = pc_instance.infra_config.num_pid_containers
+        output_global_params_base_path = (
+            pc_instance.pcf2_lift_metadata_compaction_output_base_path
+            + "_global_params"
+        )
+        output_secret_shares_base_path = (
+            pc_instance.pcf2_lift_metadata_compaction_output_base_path
+            + "_secret_shares"
+        )
+
+        run_name_base = (
+            pc_instance.infra_config.instance_id
+            + "_"
+            + GameNames.PCF2_LIFT_METADATA_COMPACTION.value
+        )
+
+        tls_args = get_tls_arguments(pc_instance.has_feature(PCSFeature.PCF_TLS))
+
+        cmd_args_list = []
+        for shard in range(num_metadata_compaction_containers):
+            game_args: Dict[str, Any] = {
+                "input_path": get_sharded_filepath(id_combiner_output_path, shard),
+                "output_global_params_path": get_sharded_filepath(
+                    output_global_params_base_path, shard
+                ),
+                "output_secret_shares_path": get_sharded_filepath(
+                    output_secret_shares_base_path, shard
+                ),
+                "num_conversions_per_user": pc_instance.product_config.common.padding_size,
+                "run_name": f"{run_name_base}_{shard}" if self._log_cost_to_s3 else "",
+                "log_cost": self._log_cost_to_s3,
+                # TODO T133330151 Add run_id support to PL UDP binary
+                # "run_id": private_computation_instance.infra_config.run_id,
+                **tls_args,
+            }
+
+            if pc_instance.feature_flags is not None:
+                game_args["pc_feature_flags"] = pc_instance.feature_flags
+
+            if pc_instance.product_config.common.post_processing_data:
+                pc_instance.product_config.common.post_processing_data.s3_cost_export_output_paths.add(
+                    f"pl-logs/{run_name_base}_{shard}_{pc_instance.infra_config.role.value.title()}.json"
+                )
+
+            cmd_args_list.append(game_args)
+        return cmd_args_list

--- a/fbpcs/private_computation/service/private_computation_service_data.py
+++ b/fbpcs/private_computation/service/private_computation_service_data.py
@@ -109,6 +109,14 @@ class PrivateComputationServiceData:
         service=None,
     )
 
+    PCF2_LIFT_METADATA_COMPACTION_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.PCF2_LIFT_METADATA_COMPACTION.value,
+        game_name=BINARY_NAME_TO_GAME_NAME[
+            OneDockerBinaryNames.PCF2_LIFT_METADATA_COMPACTION.value
+        ],
+        service=None,
+    )
+
     PCF2_SHARD_COMBINE_STAGE_DATA: StageData = StageData(
         binary_name=OneDockerBinaryNames.PCF2_SHARD_COMBINER.value,
         game_name=BINARY_NAME_TO_GAME_NAME[

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from collections import defaultdict
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpcp.service.mpc import MPCService
+from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.entity.product_config import (
+    CommonProductConfig,
+    LiftConfig,
+    ProductConfig,
+)
+from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
+
+from fbpcs.private_computation.service.pcf2_lift_metadata_compaction_stage_service import (
+    PCF2LiftMetadataCompactionStageService,
+)
+
+
+class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
+    @patch("fbpcp.service.mpc.MPCService")
+    def setUp(self, mock_mpc_svc: MPCService) -> None:
+        self.mock_mpc_svc = mock_mpc_svc
+        self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())
+        self.mock_mpc_svc.create_instance = MagicMock()
+
+        onedocker_binary_config_map = defaultdict(
+            lambda: OneDockerBinaryConfig(
+                tmp_directory="/test_tmp_directory/",
+                binary_version="latest",
+                repository_path="test_path/",
+            )
+        )
+        self.stage_svc = PCF2LiftMetadataCompactionStageService(
+            onedocker_binary_config_map,
+            self.mock_mpc_svc,
+        )
+
+    async def test_run_async(self) -> None:
+        private_computation_instance = self._create_pc_instance()
+        mpc_instance = PCSMPCInstance.create_instance(
+            instance_id=private_computation_instance.infra_config.instance_id
+            + "_pcf2_lift_metadata_compaction",
+            game_name=GameNames.PCF2_LIFT_METADATA_COMPACTION.value,
+            mpc_party=MPCParty.CLIENT,
+            num_workers=private_computation_instance.infra_config.num_pid_containers,
+        )
+
+        self.mock_mpc_svc.start_instance_async = AsyncMock(return_value=mpc_instance)
+
+        test_server_ips = [
+            f"192.0.2.{i}"
+            for i in range(private_computation_instance.infra_config.num_pid_containers)
+        ]
+        await self.stage_svc.run_async(private_computation_instance, test_server_ips)
+
+        self.assertEqual(
+            mpc_instance, private_computation_instance.infra_config.instances[0]
+        )
+
+    def test_get_game_args(self) -> None:
+        private_computation_instance = self._create_pc_instance()
+        base_run_name = (
+            private_computation_instance.infra_config.instance_id
+            + "_"
+            + GameNames.PCF2_LIFT_METADATA_COMPACTION.value
+        )
+
+        test_game_args = [
+            {
+                "input_path": f"{private_computation_instance.data_processing_output_path}_combine_{i}",
+                "output_global_params_path": f"{private_computation_instance.pcf2_lift_metadata_compaction_output_base_path}_global_params_{i}",
+                "output_secret_shares_path": f"{private_computation_instance.pcf2_lift_metadata_compaction_output_base_path}_secret_shares_{i}",
+                "num_conversions_per_user": private_computation_instance.product_config.common.padding_size,
+                "run_name": f"{base_run_name}_{i}",
+                "log_cost": True,
+                "use_tls": False,
+                "ca_cert_path": "",
+                "server_cert_path": "",
+                "private_key_path": "",
+            }
+            for i in range(2)
+        ]
+
+        self.assertEqual(
+            test_game_args,
+            self.stage_svc._get_lift_metadata_compaction_game_args(
+                private_computation_instance
+            ),
+        )
+
+    def _create_pc_instance(self) -> PrivateComputationInstance:
+        infra_config: InfraConfig = InfraConfig(
+            instance_id="test_instance_123",
+            role=PrivateComputationRole.PARTNER,
+            status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+            status_update_ts=1600000000,
+            instances=[],
+            game_type=PrivateComputationGameType.LIFT,
+            num_pid_containers=2,
+            num_mpc_containers=2,
+            num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
+            status_updates=[],
+        )
+        common: CommonProductConfig = CommonProductConfig(
+            input_path="456",
+            output_dir="789",
+        )
+        product_config: ProductConfig = LiftConfig(
+            common=common,
+        )
+        return PrivateComputationInstance(
+            infra_config=infra_config,
+            product_config=product_config,
+        )


### PR DESCRIPTION
Summary:
Following step 2 in https://www.internalfb.com/intern/wiki/Private_Computation_Infra/Private_Services_Infra/PCS_wikis/How_to_add_a_stage_to_PCS/Step_2:_Add_a_stage_service/.

This adds the stage service to run Lift UDP.

The file inputs are passed from the lift ID spine combiner stage, and re-uses the same methods to calculate the file paths.

I also added some OneDocker arguments for other binaries that do not exist currently.

Differential Revision: D39747757

