### PR TITLE
Add PCS Feature enum for feature gating

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -14,6 +14,7 @@ class PCSFeature(Enum):
 
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
+    PRIVATE_LIFT_UNIFIED_DATA_PROCESS = "private_lift_unified_data_process"
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"
     PCF_TLS = "pcf_tls"


### PR DESCRIPTION
Summary:
This will be used to gate the following

- Execution of UDP stage in the existing PCF2 Lift Stage Flow
- In the existing PCF2_LIFT stage, this feature flag will determine the input processing performed on the files. i.e. plaintext inputs vs. secret shared
- In the reshard stage service, the input files will change from ID_SPINE_COMBINER stage output to PCF2_LIFT_METADATA_COMPACTION_STAGE output

Differential Revision: D39914919

