### PR TITLE
StageStage server ips return None when failed

### DIFF
--- a/fbpcs/common/entity/stage_state_instance.py
+++ b/fbpcs/common/entity/stage_state_instance.py
@@ -42,6 +42,11 @@ class StageStateInstance(InstanceBase):
         if self.status in [
             StageStateInstanceStatus.UNKNOWN,
             StageStateInstanceStatus.CREATED,
+            # if a container fails during initialization, then it is possible for
+            # that container to have no server ip. If we do not include FAILED here,
+            # the checked cast will fail. We don't need to transmit server ips
+            # when in a FAILED state, so this should be fine.
+            StageStateInstanceStatus.FAILED,
         ]:
             return []
 


### PR DESCRIPTION
Summary:
## What

- don't return server ips when stage state status is failed

## Why

With the introduction of the initialized statuses, the thrift server no longer waits for the publisher containers to start.

This leads to update instance failure scenarios where containers may not have had an ip address assigned to them yet

```
"containers": [
  {
    "ip_address": null,
    "status": "UNKNOWN",
    ...
  },
  {
    "ip_address": "10.0.9.141",
    "status": "UNKNOWN",
  },
```

These containers will be assigned to the stage state, which causes errors in the thrift server when mapping a stage state dataclass to a stage state thrift instance

Differential Revision: D39919126

