### PR TITLE
(partial) partial container retry

### DIFF
--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -22,6 +22,48 @@ DEFAULT_WAIT_FOR_CONTAINER_POLL = 5
 
 
 class RunBinaryBaseService:
+    @classmethod
+    def _get_containers_to_start(
+        cls,
+        cmd_args_list: List[str],
+        existing_containers: Optional[List[ContainerInstance]] = None,
+    ) -> List[int]:
+        if existing_containers is None:
+            # if there are no existing containers, we need to spin containers up for
+            # every command
+            return list(range(len(cmd_args_list)))
+
+        if len(cmd_args_list) != len(existing_containers):
+            raise ValueError(
+                "Cannot retry stage - list of container arguments and list of existing containers have different lengths"
+            )
+
+        # only start containers that previously failed
+        return [
+            i
+            for i, container in enumerate(existing_containers)
+            if container.status is ContainerInstanceStatus.FAILED
+        ]
+
+    @classmethod
+    def _get_pending_containers(
+        cls,
+        new_pending_containers: List[ContainerInstance],
+        containers_to_start: List[int],
+        existing_containers: Optional[List[ContainerInstance]] = None,
+    ) -> List[ContainerInstance]:
+        if not existing_containers:
+            return new_pending_containers
+
+        pending_containers = existing_containers.copy()
+        for i, new_pending_container in zip(
+            containers_to_start, new_pending_containers
+        ):
+            # replace existing container with the new pending container
+            pending_containers[i] = new_pending_container
+
+        return pending_containers
+
     async def start_containers(
         self,
         cmd_args_list: List[str],
@@ -32,18 +74,30 @@ class RunBinaryBaseService:
         wait_for_containers_to_finish: bool = False,
         env_vars: Optional[Dict[str, str]] = None,
         wait_for_containers_to_start_up: bool = True,
+        existing_containers: Optional[List[ContainerInstance]] = None,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
         timeout = timeout or DEFAULT_CONTAINER_TIMEOUT_IN_SEC
 
-        pending_containers = onedocker_svc.start_containers(
+        containers_to_start = self._get_containers_to_start(
+            cmd_args_list, existing_containers
+        )
+        logger.info(f"Spinning up {len(containers_to_start)} containers")
+        logger.info(f"Containers to start: {containers_to_start}")
+
+        new_pending_containers = onedocker_svc.start_containers(
             package_name=binary_name,
             version=binary_version,
-            cmd_args_list=cmd_args_list,
+            cmd_args_list=[cmd_args_list[i] for i in containers_to_start],
             timeout=timeout,
             env_vars=env_vars,
         )
+
+        pending_containers = self._get_pending_containers(
+            new_pending_containers, containers_to_start, existing_containers
+        )
+
         if not wait_for_containers_to_start_up:
             logger.info("Skipped container warm up")
             return pending_containers

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -71,9 +71,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 onedocker_binary_config_map=self.onedocker_binary_config_map,
                 container_timeout=self.container_timeout,
             )
-            containers = [
-                self.create_container_instance() for _ in range(test_num_containers)
-            ]
+            containers = [self.create_container_instance()]
             self.mock_onedocker_svc.start_containers = MagicMock(
                 return_value=containers
             )

--- a/fbpcs/private_computation/test/service/test_run_binary_base_service.py
+++ b/fbpcs/private_computation/test/service/test_run_binary_base_service.py
@@ -14,11 +14,94 @@ from fbpcs.private_computation.service.run_binary_base_service import (
 )
 
 
-class TestWaitForContainersAsync(IsolatedAsyncioTestCase):
+class TestRunBinaryBaseService(IsolatedAsyncioTestCase):
     @patch("fbpcp.service.container.ContainerService")
     def setUp(self, MockContainerService) -> None:
         self.container_svc = MockContainerService()
         self.onedocker_svc = OneDockerService(self.container_svc, "task_def")
+
+    def test_get_containers_to_start_no_existing_containers(self) -> None:
+        for num_containers in range(2):
+            with self.subTest(num_containers=num_containers):
+                containers_to_start = RunBinaryBaseService._get_containers_to_start(
+                    ["arg"] * num_containers
+                )
+                self.assertEqual(containers_to_start, list(range(num_containers)))
+
+    def test_get_containers_to_start_existing_containers(self) -> None:
+        for existing_statuses in (
+            (ContainerInstanceStatus.FAILED,),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.FAILED,
+            ),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.COMPLETED,
+            ),
+            (
+                ContainerInstanceStatus.STARTED,
+                ContainerInstanceStatus.FAILED,
+            ),
+        ):
+            # expect to start only the failed containers
+            expected_result = [
+                i
+                for i, status in enumerate(existing_statuses)
+                if status is ContainerInstanceStatus.FAILED
+            ]
+            with self.subTest(
+                existing_statuses=existing_statuses, expected_result=expected_result
+            ):
+                containers_to_start = RunBinaryBaseService._get_containers_to_start(
+                    ["arg"] * len(existing_statuses),
+                    [
+                        ContainerInstance("id", "ip", status)
+                        for status in existing_statuses
+                    ],
+                )
+                self.assertEqual(containers_to_start, expected_result)
+
+    def test_get_containers_to_start_invalid_args(self) -> None:
+        # expect failure because num of command arguments != number existing containers
+        with self.assertRaises(ValueError):
+            RunBinaryBaseService._get_containers_to_start(
+                ["arg"] * 2,
+                [
+                    ContainerInstance("id", "ip", ContainerInstanceStatus.FAILED),
+                ],
+            )
+
+    def test_get_pending_containers(self) -> None:
+        for existing_statuses, containers_to_start in (
+            # no existing containers case
+            ((), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.FAILED), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.STARTED), [0]),
+            ((ContainerInstanceStatus.STARTED, ContainerInstanceStatus.FAILED), [1]),
+        ):
+            existing_containers = [
+                ContainerInstance(str(i), "ip", status)
+                for i, status in enumerate(existing_statuses)
+            ]
+            new_pending_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in containers_to_start
+            ]
+            expected_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in range(2)
+            ]
+
+            with self.subTest(
+                new_pending_containers=new_pending_containers,
+                containers_to_start=containers_to_start,
+                existing_containers=existing_containers,
+            ):
+                pending_containers = RunBinaryBaseService._get_pending_containers(
+                    new_pending_containers, containers_to_start, existing_containers
+                )
+                self.assertEqual(pending_containers, expected_containers)
 
     @mock.patch("fbpcp.service.onedocker.OneDockerService.get_containers")
     async def test_wait_for_containers_success(self, get_containers) -> None:


### PR DESCRIPTION
Summary:
## What

- RunBinaryBaseService now optionally takes existing containers
- If existing containers are passed, then RunBinaryBaseService will only retry containers that previously failed

## Why

- It's this kind of month
  - S296317
  - S291746
  - S293193

- For all non joint stages:
    - This enables full partial container retry for both publisher and partner! This means that, if some container(s) fail during start-up or in the middle of the stage, we only retry the failed container(s).
- For ID match:
    - This enables partial partial container retry for both publisher and partner. This means that, if some container(s) fail during start-up, we will only retry the failed container(s) are recover (mitigates S296317).
        - This does NOT handle scenarios where containers fail in the middle of the stage. The retry logic will NOT work in that scenario (just like in prod today, so no regression).

Differential Revision: D39876436

