### PR TITLE
update stage services to pass existing containers

### DIFF
--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -219,9 +219,10 @@ class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
                 )
                 return True
 
-    async def cancel_current_stage(self, instance_id: str) -> None:
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self.pcs.cancel_current_stage, instance_id)
+    # canceling stages is not properly supported
+    # async def cancel_current_stage(self, instance_id: str) -> None:
+    #     loop = asyncio.get_running_loop()
+    #     await loop.run_in_executor(None, self.pcs.cancel_current_stage, instance_id)
 
     async def get_or_create_instance(
         self, instance_args: BoltPCSCreateInstanceArgs

--- a/fbpcs/common/entity/stage_state_instance.py
+++ b/fbpcs/common/entity/stage_state_instance.py
@@ -42,6 +42,11 @@ class StageStateInstance(InstanceBase):
         if self.status in [
             StageStateInstanceStatus.UNKNOWN,
             StageStateInstanceStatus.CREATED,
+            # if a container fails during initialization, then it is possible for
+            # that container to have no server ip. If we do not include FAILED here,
+            # the checked cast will fail. We don't need to transmit server ips
+            # when in a FAILED state, so this should be fine.
+            StageStateInstanceStatus.FAILED,
         ]:
             return []
 

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 import marshmallow
-
 from dataclasses_json.mm import SchemaType
 
 if TYPE_CHECKING:
@@ -26,6 +25,7 @@ if TYPE_CHECKING:
 
 from pathlib import Path
 
+from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.entity.mpc_instance import MPCInstanceStatus
 from fbpcs.common.entity.instance_base import InstanceBase
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
@@ -328,6 +328,22 @@ class PrivateComputationInstance(InstanceBase):
                     return stage_instance
 
         return None
+
+    def get_existing_containers_for_retry(
+        self,
+    ) -> Optional[List[ContainerInstance]]:
+        if self.infra_config.retry_counter == 0:
+            return None
+
+        instances = self.infra_config.instances
+        if not instances:
+            return None
+
+        last_instance = instances[-1]
+        if isinstance(last_instance, (PCSMPCInstance, StageStateInstance)):
+            return last_instance.containers
+        else:
+            return None
 
     def has_feature(self, feature: PCSFeature) -> bool:
         if feature is PCSFeature.UNKNOWN:

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -124,6 +124,7 @@ class PCPreValidationStageService(PrivateComputationStageService):
             timeout=PRE_VALIDATION_CHECKS_TIMEOUT,
             env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
 
         stage_state = StageStateInstance(

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -145,6 +145,7 @@ class PIDPrepareStageService(PrivateComputationStageService):
             timeout=self._container_timeout,
             env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
 
     def stop_service(

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -157,6 +157,7 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
             binary_name=binary_name,
             env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
 
     @classmethod

--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -134,6 +134,7 @@ class PIDShardStageService(PrivateComputationStageService):
             timeout=self._container_timeout,
             env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
 
     def stop_service(

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -13,7 +13,6 @@ from typing import DefaultDict, Dict, List, Optional
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
-
 from fbpcs.common.service.metric_service import MetricService
 from fbpcs.common.service.trace_logging_service import TraceLoggingService
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -309,6 +309,7 @@ async def start_combiner_service(
         wait_for_containers_to_finish=wait_for_containers,
         env_vars=env_vars,
         wait_for_containers_to_start_up=wait_for_containers_to_start_up,
+        existing_containers=private_computation_instance.get_existing_containers_for_retry(),
     )
 
 
@@ -380,6 +381,7 @@ async def start_sharder_service(
         wait_for_containers_to_finish=wait_for_containers,
         env_vars=env_vars,
         wait_for_containers_to_start_up=wait_for_containers_to_start_up,
+        existing_containers=private_computation_instance.get_existing_containers_for_retry(),
     )
 
 

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -69,7 +69,7 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -77,7 +77,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -63,7 +63,7 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
@@ -72,7 +72,7 @@ class PrivateComputationPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
@@ -69,7 +69,7 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -76,7 +76,7 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -72,7 +72,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
-        is_retryable=False,
+        is_retryable=True,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -136,6 +136,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             timeout=1200,
             env_vars=env_vars,
             wait_for_containers_to_start_up=True,
+            existing_containers=None,
         )
 
         mock_stage_state_instance.assert_called_with(

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -71,9 +71,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 onedocker_binary_config_map=self.onedocker_binary_config_map,
                 container_timeout=self.container_timeout,
             )
-            containers = [
-                self.create_container_instance() for _ in range(test_num_containers)
-            ]
+            containers = [self.create_container_instance()]
             self.mock_onedocker_svc.start_containers = MagicMock(
                 return_value=containers
             )

--- a/fbpcs/private_computation/test/service/test_run_binary_base_service.py
+++ b/fbpcs/private_computation/test/service/test_run_binary_base_service.py
@@ -14,11 +14,94 @@ from fbpcs.private_computation.service.run_binary_base_service import (
 )
 
 
-class TestWaitForContainersAsync(IsolatedAsyncioTestCase):
+class TestRunBinaryBaseService(IsolatedAsyncioTestCase):
     @patch("fbpcp.service.container.ContainerService")
     def setUp(self, MockContainerService) -> None:
         self.container_svc = MockContainerService()
         self.onedocker_svc = OneDockerService(self.container_svc, "task_def")
+
+    def test_get_containers_to_start_no_existing_containers(self) -> None:
+        for num_containers in range(2):
+            with self.subTest(num_containers=num_containers):
+                containers_to_start = RunBinaryBaseService._get_containers_to_start(
+                    ["arg"] * num_containers
+                )
+                self.assertEqual(containers_to_start, list(range(num_containers)))
+
+    def test_get_containers_to_start_existing_containers(self) -> None:
+        for existing_statuses in (
+            (ContainerInstanceStatus.FAILED,),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.FAILED,
+            ),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.COMPLETED,
+            ),
+            (
+                ContainerInstanceStatus.STARTED,
+                ContainerInstanceStatus.FAILED,
+            ),
+        ):
+            # expect to start only the failed containers
+            expected_result = [
+                i
+                for i, status in enumerate(existing_statuses)
+                if status is ContainerInstanceStatus.FAILED
+            ]
+            with self.subTest(
+                existing_statuses=existing_statuses, expected_result=expected_result
+            ):
+                containers_to_start = RunBinaryBaseService._get_containers_to_start(
+                    ["arg"] * len(existing_statuses),
+                    [
+                        ContainerInstance("id", "ip", status)
+                        for status in existing_statuses
+                    ],
+                )
+                self.assertEqual(containers_to_start, expected_result)
+
+    def test_get_containers_to_start_invalid_args(self) -> None:
+        # expect failure because num of command arguments != number existing containers
+        with self.assertRaises(ValueError):
+            RunBinaryBaseService._get_containers_to_start(
+                ["arg"] * 2,
+                [
+                    ContainerInstance("id", "ip", ContainerInstanceStatus.FAILED),
+                ],
+            )
+
+    def test_get_pending_containers(self) -> None:
+        for existing_statuses, containers_to_start in (
+            # no existing containers case
+            ((), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.FAILED), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.STARTED), [0]),
+            ((ContainerInstanceStatus.STARTED, ContainerInstanceStatus.FAILED), [1]),
+        ):
+            existing_containers = [
+                ContainerInstance(str(i), "ip", status)
+                for i, status in enumerate(existing_statuses)
+            ]
+            new_pending_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in containers_to_start
+            ]
+            expected_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in range(2)
+            ]
+
+            with self.subTest(
+                new_pending_containers=new_pending_containers,
+                containers_to_start=containers_to_start,
+                existing_containers=existing_containers,
+            ):
+                pending_containers = RunBinaryBaseService._get_pending_containers(
+                    new_pending_containers, containers_to_start, existing_containers
+                )
+                self.assertEqual(pending_containers, expected_containers)
 
     @mock.patch("fbpcp.service.onedocker.OneDockerService.get_containers")
     async def test_wait_for_containers_success(self, get_containers) -> None:


### PR DESCRIPTION
Summary:
## What

- Pass existing containers to stage services that use stage state
- Make ID match stage retry-able
- Disable "cancel_stage" in partner Bolt client
    - It is now unnecessary for non-joint stages
    - It doesn't work for joint stages (because we need coordination between parties)

## Why

- It's this kind of month
  - S296317
  - S291746
  - S293193

- For all non joint stages:
    - This enables full partial container retry for both publisher and partner! This means that, if some container(s) fail during start-up or in the middle of the stage, we only retry the failed container(s).
- For ID match:
    - This enables partial partial container retry for both publisher and partner. This means that, if some container(s) fail during start-up, we will only retry the failed container(s) are recover (mitigates S296317).
        - This does NOT handle scenarios where containers fail in the middle of the stage. The retry logic will NOT work in that scenario (just like in prod today, so no regression).

Differential Revision: D39920065

