### PR TITLE
Unittest for DotproductGame with multiple scheduler types

### DIFF
--- a/fbpcs/emp_games/dotproduct/DotproductApp.h
+++ b/fbpcs/emp_games/dotproduct/DotproductApp.h
@@ -90,9 +90,9 @@ class DotproductApp {
     return schedulerStatistics_;
   }
 
- protected:
-  std::tuple<std::vector<std::vector<double>>, std::vector<std::vector<bool>>>
-  readCSVInput(std::string inputPath, int labelWidth, int numFeatures) {
+  static std::
+      tuple<std::vector<std::vector<double>>, std::vector<std::vector<bool>>>
+      readCSVInput(std::string inputPath, int labelWidth, int numFeatures) {
     std::vector<std::vector<double>> allFeatures;
     std::vector<std::vector<bool>> allLabels;
     auto lineNo = 0;
@@ -116,7 +116,7 @@ class DotproductApp {
     return {allFeatures, transposeLabels(allLabels, labelWidth)};
   }
 
-  std::tuple<std::vector<double>, std::vector<bool>> parseLine(
+  static std::tuple<std::vector<double>, std::vector<bool>> parseLine(
       const int lineNo,
       const std::vector<std::string>& header,
       const std::vector<std::string>& parts,
@@ -146,7 +146,7 @@ class DotproductApp {
     return {features, labels};
   }
 
-  inline std::vector<std::vector<bool>> transposeLabels(
+  static inline std::vector<std::vector<bool>> transposeLabels(
       std::vector<std::vector<bool>> labels,
       int labelWidth) {
     std::vector<std::vector<bool>> transposedLabels(

--- a/fbpcs/emp_games/dotproduct/test/DotproductAppTest.cpp
+++ b/fbpcs/emp_games/dotproduct/test/DotproductAppTest.cpp
@@ -21,6 +21,7 @@
 
 #include "fbpcs/emp_games/common/TestUtil.h"
 #include "fbpcs/emp_games/dotproduct/DotproductApp.h"
+#include "fbpcs/emp_games/dotproduct/test/DotproductTestUtils.h"
 
 namespace pcf2_dotproduct {
 
@@ -51,44 +52,6 @@ static void runGame(
       debugMode);
 
   app->run();
-}
-
-// verify the dotproduct output
-bool verifyOutput(
-    std::vector<double> result,
-    std::vector<double> expectedResult) {
-  return std::equal(
-      result.begin(),
-      result.end(),
-      expectedResult.begin(),
-      [](double value1, double value2) {
-        constexpr double epsilon = 0.00001;
-        return std::fabs(value1 - value2) < epsilon;
-      });
-}
-
-std::vector<double> parseResult(std::string filePath) {
-  std::ifstream result;
-  std::string line;
-
-  result.open(filePath);
-  std::getline(result, line);
-
-  const auto left = line.find('[');
-  const auto right = line.find(']');
-
-  std::string valsString = line.substr(left + 1, right - (left + 1));
-
-  std::vector<double> v;
-
-  std::stringstream ss(valsString);
-
-  while (ss.good()) {
-    string substr;
-    getline(ss, substr, ',');
-    v.push_back(std::stod(substr));
-  }
-  return v;
 }
 
 // helper function for executing MPC game and verifying corresponding output

--- a/fbpcs/emp_games/dotproduct/test/DotproductTestUtils.h
+++ b/fbpcs/emp_games/dotproduct/test/DotproductTestUtils.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcf/io/api/FileIOWrappers.h>
+#include <filesystem>
+#include <string>
+
+#include <gtest/gtest.h>
+#include "folly/Format.h"
+#include "folly/Random.h"
+#include "folly/logging/xlog.h"
+
+namespace pcf2_dotproduct {
+
+// result is expected to be in a one line list format (e.g., [0.3, 0.75, 0.1])
+inline std::vector<double> parseResult(std::string filePath) {
+  std::ifstream result;
+  std::string line;
+
+  result.open(filePath);
+  std::getline(result, line);
+
+  const auto left = line.find('[');
+  const auto right = line.find(']');
+
+  std::string valsString = line.substr(left + 1, right - (left + 1));
+
+  std::vector<double> v;
+
+  std::stringstream ss(valsString);
+
+  while (ss.good()) {
+    string substr;
+    getline(ss, substr, ',');
+    v.push_back(std::stod(substr));
+  }
+  return v;
+}
+
+// verify the dotproduct output with expected results, value difference should
+// be smaller than 1e-7.
+inline bool verifyOutput(
+    std::vector<double> result,
+    std::vector<double> expectedResult) {
+  return std::equal(
+      result.begin(),
+      result.end(),
+      expectedResult.begin(),
+      [](double value1, double value2) {
+        return std::fabs(value1 - value2) < 1e-7;
+      });
+}
+
+} // namespace pcf2_dotproduct


### PR DESCRIPTION
Summary:
This diff adds test for DotproductGame using multiple scheduler types (Plaintext, eager, Lazy). Adding this test require changing multiple files:

- **DotproductTestUtils.h**: This file is added to have functions used by multiple test files (e.g., reading the result of the dotproduct)
- **DotproductAppTest.cpp**: The previous test cases are modified to use DotproductTestUtils.h
- **DotproductGameTest**: The new test case is added here which includes running dotproduct game for publisher & partner, and reading the result back
- **DotproductApp.h**: This file was modified to make the functions  readCSVInput a static function to be called from the test case without initializing an object.

Differential Revision: D39696388

