### PR TITLE
adding PL/PA product specific token validation rules

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -72,6 +72,16 @@ class OneCommandRunnerExitCode(Enum):
     ERROR_TOKEN_DATA_ACCESS_EXPIRY = 74
     ERROR_TOKEN_PERMISSIONS = 75
 
+    # PL validation specific error
+    ERROR_READ_STUDY = 80
+    ERROR_CREATE_PL_INSTANCE = 81
+    ERROR_READ_PL_INSTANCE = 82
+
+    # PA validation specific error
+    ERROR_READ_DATASET = 90
+    ERROR_CREATE_PA_INSTANCE = 91
+    ERROR_READ_PA_INSTANCE = 92
+
 
 class OneCommandRunnerBaseException(Exception):
     def __init__(
@@ -98,11 +108,32 @@ class OneCommandRunnerBaseException(Exception):
 
 
 class PCStudyValidationException(OneCommandRunnerBaseException, RuntimeError):
-    def __init__(self, cause: str, remediation: str) -> None:
+    def __init__(
+        self,
+        cause: str,
+        remediation: str,
+        exit_code: OneCommandRunnerExitCode = OneCommandRunnerExitCode.ERROR,
+    ) -> None:
         super().__init__(
             msg="PCStudyValidationException",
             cause=cause,
             remediation=remediation,
+            exit_code=exit_code,
+        )
+
+
+class PCAttributionValidationException(OneCommandRunnerBaseException, RuntimeError):
+    def __init__(
+        self,
+        cause: str,
+        remediation: str,
+        exit_code: OneCommandRunnerExitCode = OneCommandRunnerExitCode.ERROR,
+    ) -> None:
+        super().__init__(
+            msg="PCAttributionValidationException",
+            cause=cause,
+            remediation=remediation,
+            exit_code=exit_code,
         )
 
 


### PR DESCRIPTION
Summary:
## Why
As Sev S289834 follow-up task, we will need to have Access Token validation before trigger runs.
We will introduce two-level token validations.
1. common validation before trigger runners D39716726 (https://github.com/facebookresearch/fbpcs/commit/9233decb0522461819d21a951fbe0f106d51a414)
2. product-specific token validation (this diff)

Here is the detailed proposal doc [PC SEV Follow-up: Access Token Validations (Due date: 09/30)]
https://docs.google.com/document/d/1DOuNCYm9YAc_8r7-zWYxb1Dw-Dig2EJEbOGviJYJqX0/edit?usp=sharing
## What
* Add PL/PA Token rule enums
* Add PL/PA sys error code when validation failed
* note: it's not cover `get_pixel` yet, maybe in next diff

Differential Revision: D39826672

