### PR TITLE
adding PL/PA read pixel validations

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -82,6 +82,9 @@ class OneCommandRunnerExitCode(Enum):
     ERROR_CREATE_PA_INSTANCE = 91
     ERROR_READ_PA_INSTANCE = 92
 
+    # Product common validation error
+    ERROR_READ_ADSPIXELS = 100
+
 
 class OneCommandRunnerBaseException(Exception):
     def __init__(

--- a/fbpcs/pl_coordinator/pc_graphapi_utils.py
+++ b/fbpcs/pl_coordinator/pc_graphapi_utils.py
@@ -188,6 +188,13 @@ class PCGraphAPIClient:
         self._check_err(r, "getting study data")
         return r
 
+    def get_adspixels(self, adspixels_id: str, fields: List[str]) -> requests.Response:
+        params = self.params.copy()
+        params["fields"] = ",".join(fields)
+        r = requests.get(f"{URL}/{adspixels_id}", params=params)
+        self._check_err(r, "getting adspixels data")
+        return r
+
     def get_attribution_dataset_info(
         self, dataset_id: str, fields: List[str]
     ) -> requests.Response:


### PR DESCRIPTION
Summary:
## Why
As Sev S289834 follow-up task, we will need to have Access Token validation before trigger runs.
We will introduce two-level token validations.
1. common validation before trigger runners D39716726 (https://github.com/facebookresearch/fbpcs/commit/9233decb0522461819d21a951fbe0f106d51a414)
2. product-specific token validation  - get pixel validation (this diff)

Here is the detailed proposal doc [PC SEV Follow-up: Access Token Validations (Due date: 09/30)]
https://docs.google.com/document/d/1DOuNCYm9YAc_8r7-zWYxb1Dw-Dig2EJEbOGviJYJqX0/edit?usp=sharing

## What
* PL read adspixel on id [codeptr](https://www.internalfb.com/code/www/[aee2e3b4eef8af8a08bbb8918a0d320a477a32fe]/flib/platform/graph/resources/ads/study/GraphAdStudyObjectiveNode.php?lines=435-467)
* PA read adspixel on target_id [codeptr](https://www.internalfb.com/code/www/[76399913ece62963b7be598075afa3a7fc82702d]/flib/entity/private_measurement/private_attribution/EntPrivateAttributionDatasetSchema.php?lines=156-164)
* Add PL/PA sys error code when get pixel validation failed
* Raise customized exception & error code when validation failed

Differential Revision: D39982009

