### PR TITLE
fbpkg test failure due to compressionMapping json.

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -650,6 +650,11 @@ void testCorrectnessWithScheduler(
     auto outputReformatted =
         revealXORedReformattedResult(res0, res1, attributionRule);
     verifyOutput(outputReformatted, reformattedOutputJsonFileName);
+    if (std::filesystem::exists(
+            FLAGS_output_base_path + "compressionMapping.json")) {
+      std::filesystem::remove(
+          FLAGS_output_base_path + "compressionMapping.json");
+    }
   } else {
     // check against expected output
     auto output = revealXORedResult(res0, res1, attributionRule);


### PR DESCRIPTION
Summary:
During one of the unit tests for reformatted attribution format. We are creating a json file which gets created in root folder in this case (will be created in S3 in prod).
Due to this file creation, we are gettting error in fbpkg creation.
In this diff, removing the file if it exists after the test run.

Differential Revision: D39994394

