### PR TITLE
Add call to publisher cancel stage on rety of a joint stage.

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -272,14 +272,20 @@ class BoltRunner(Generic[T, U]):
                 in [fail_status, PrivateComputationInstanceStatus.TIMEOUT]
                 or partner_state.pc_instance_status is fail_status
             ):
-                # stage failed, cancel partner side only in joint stage
+                # stage failed, cancel publisher and partner side only in joint stage
                 if stage.is_joint_stage:
                     try:
                         logger.error(
-                            f"Publisher status: {publisher_state.pc_instance_status}. Canceling partner stage {stage.name}."
+                            f"Publisher status: {publisher_state.pc_instance_status}. Canceling publisher and partner stage {stage.name}."
                         )
-                        await self.partner_client.cancel_current_stage(
-                            instance_id=partner_id
+
+                        await asyncio.gather(
+                            self.publisher_client.cancel_current_stage(
+                                instance_id=publisher_id
+                            ),
+                            self.partner_client.cancel_current_stage(
+                                instance_id=partner_id
+                            ),
                         )
                     except Exception as e:
                         logger.error(

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -176,6 +176,21 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
             msg = "running next stage"
         self._check_err(r, msg)
 
+    async def cancel_current_stage(
+        self,
+        instance_id: str,
+        stage: Optional[PrivateComputationBaseStageFlow] = None,
+        server_ips: Optional[List[str]] = None,
+    ) -> None:
+        params = self.params.copy()
+        params["operation"] = "CANCEL"
+        r = requests.post(f"{URL}/{instance_id}", params=params)
+        if stage:
+            msg = f"cancel current stage {stage}."
+        else:
+            msg = "cancel current stage."
+        self._check_err(r, msg)
+
     async def update_instance(self, instance_id: str) -> BoltState:
         response = json.loads((await self.get_instance(instance_id)).text)
         response_status = response.get("status")

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -126,6 +126,20 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             await self.test_client.run_stage(instance_id="id", stage=stage)
             mock_post.assert_called_once_with(f"{URL}/id", params=expected_params)
 
+    @patch("fbpcs.pl_coordinator.bolt_graphapi_client.requests.post")
+    async def test_bolt_cancel_current_stage(self, mock_post) -> None:
+        expected_params = {
+            "access_token": ACCESS_TOKEN,
+            "operation": "CANCEL",
+        }
+        for stage in PrivateComputationStageFlow.ID_MATCH, None:
+            with self.subTest(stage=stage):
+                mock_post.reset_mock()
+                await self.test_client.cancel_current_stage(
+                    instance_id="id", stage=stage
+                )
+                mock_post.assert_called_once_with(f"{URL}/id", params=expected_params)
+
     @patch(
         "fbpcs.pl_coordinator.bolt_graphapi_client.BoltGraphAPIClient.get_instance",
         new_callable=AsyncMock,


### PR DESCRIPTION
Summary:
# Design document -
https://docs.google.com/document/d/1T87uFzfF1VepnxcUhiunb_5CkzO5gzJ8i9YlhvCBgL8/edit?usp=sharing

# Context:
As a follow up of SEV - S291746, we need to add co-ordinated retry logic between partner and publisher so that;  in case of a partner side joint stage spin up failure, the partner side first cancels the publisher side stage and then runs next.

# In this diff
Adding call to publisher - cancel_current_stage from bolt_runner when the partner side fails on a joint stage.

Differential Revision: D39996307

