### PR TITLE
Dot product Output with high precision

### DIFF
--- a/fbpcs/emp_games/dotproduct/DotproductApp.h
+++ b/fbpcs/emp_games/dotproduct/DotproductApp.h
@@ -159,11 +159,14 @@ class DotproductApp {
   void writeOutputData(
       const std::vector<double> dotproduct,
       std::string outputPath) {
-    std::string outputString = "[";
-    for (auto& v : dotproduct) {
-      outputString = outputString + std::to_string(v) + ",";
+    std::stringstream ss;
+    ss.precision(10);
+    ss << "[";
+    for (const auto& v : dotproduct) {
+      ss << v << ',';
     }
     // replace the comma with bracket to end the list
+    std::string outputString = ss.str();
     outputString[outputString.size() - 1] = ']';
     XLOG(INFO, outputString);
     fbpcf::io::FileIOWrappers::writeFile(outputPath, outputString);


### PR DESCRIPTION
Summary:
Dotproduct output was using std::to_string(v) to convert double to string. However, this function defaults to 6 decimal places which results in reduced percision.

In order to maintain high precision, we use stringstream which allows to specify the right precision.

Differential Revision: D40012913

