### PR TITLE
apply LogAdaptor in thrift server log for each instance to better tw log triage

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -104,6 +104,7 @@ class PrivateComputationService:
         workflow_svc: Optional[WorkflowService] = None,
         metric_svc: Optional[MetricService] = None,
         trace_logging_svc: Optional[TraceLoggingService] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Constructor of PrivateComputationService
         instance_repository -- repository to CRUD PrivateComputationInstance
@@ -140,7 +141,9 @@ class PrivateComputationService:
             self.metric_svc,
             self.trace_logging_svc,
         )
-        self.logger: logging.Logger = logging.getLogger(__name__)
+        self.logger: logging.Logger = (
+            logging.getLogger(__name__) if logger is None else logger
+        )
 
     # TODO T88759390: make an async version of this function
     def create_instance(


### PR DESCRIPTION
Summary:
## Why
In thrift server, we have only central logger to emit all instances logs.
During looking up logs, it's hard to triage which instance is it. This diff is to leverage `LogAdaptor` in pcs to add `instance_id ` as log prefix
* the LogAdaptor code ptr D38359871 (https://github.com/facebookresearch/fbpcs/commit/327092a79db7df4ad70747dd04a307fc66e310ae)
* Example usage on the partner side D38359997 (https://github.com/facebookresearch/fbpcs/commit/4b18ef42861572323779e6891bdfc17dc66e98a0)

## What
* Apply `LogAdaptor` in thrift server
* Adapt instance id as prefix to logger
* passing logger to `_build_private_computation_svc`

Differential Revision: D39987609

