### PR TITLE
Pass TLS arguments into onedocker

### DIFF
--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -15,6 +15,7 @@ from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -26,6 +27,7 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
@@ -183,6 +185,9 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "use_new_output_format": False,
             "run_id": private_computation_instance.infra_config.run_id,
         }
+        tls_args = get_tls_arguments(
+            private_computation_instance.has_feature(PCSFeature.PCF_TLS)
+        )
         if private_computation_instance.feature_flags is not None:
             common_game_args[
                 "pc_feature_flags"
@@ -195,6 +200,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
                     "file_start_index": i
                     * private_computation_instance.infra_config.num_files_per_mpc_container,
                 },
+                **tls_args,
             }
             for i in range(private_computation_instance.infra_config.num_mpc_containers)
         ]

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -15,6 +15,7 @@ from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -25,6 +26,7 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
@@ -192,7 +194,9 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             common_game_args[
                 "pc_feature_flags"
             ] = private_computation_instance.feature_flags
-
+        tls_args = get_tls_arguments(
+            private_computation_instance.has_feature(PCSFeature.PCF_TLS)
+        )
         game_args = [
             {
                 **common_game_args,
@@ -200,6 +204,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
                     "file_start_index": i
                     * private_computation_instance.infra_config.num_files_per_mpc_container,
                 },
+                **tls_args,
             }
             for i in range(private_computation_instance.infra_config.num_mpc_containers)
         ]

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -15,6 +15,7 @@ from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -26,6 +27,7 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
+from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import (
     DEFAULT_LOG_COST_TO_S3,
     LIFT_DEFAULT_PADDING_SIZE,
@@ -190,6 +192,11 @@ class PCF2LiftStageService(PrivateComputationStageService):
             common_compute_game_args[
                 "pc_feature_flags"
             ] = private_computation_instance.feature_flags
+        tls_args = get_tls_arguments(
+            private_computation_instance.has_feature(PCSFeature.PCF_TLS)
+        )
+
+        common_compute_game_args.update(tls_args)
 
         game_args = []
 

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -101,6 +101,10 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             "log_cost": True,
             "use_new_output_format": False,
             "run_id": self.run_id,
+            "use_tls": False,
+            "ca_cert_path": "",
+            "server_cert_path": "",
+            "private_key_path": "",
         }
         test_game_args = [
             {

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -94,6 +94,10 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             "use_postfix": True,
             "log_cost": True,
             "run_id": self.run_id,
+            "use_tls": False,
+            "ca_cert_path": "",
+            "server_cert_path": "",
+            "private_key_path": "",
         }
         test_game_args = [
             {

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -96,6 +96,10 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             "run_name": run_name,
             "log_cost": True,
             "run_id": self.run_id,
+            "use_tls": False,
+            "ca_cert_path": "",
+            "server_cert_path": "",
+            "private_key_path": "",
         }
         test_game_args = [
             {

--- a/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
@@ -85,6 +85,10 @@ class TestShardCombinerStageService(IsolatedAsyncioTestCase):
                 if self.stage_svc._log_cost_to_s3
                 else "",
                 "log_cost": True,
+                "use_tls": False,
+                "ca_cert_path": "",
+                "server_cert_path": "",
+                "private_key_path": "",
             }
         ]
 


### PR DESCRIPTION
Summary:
See previous diffs for context.

In this diff, we are connecting the feature gate to onedocker. We are passing the necessary arguments from previous diffs into onedocker. These arguments will be ignored by the binaries.

Reviewed By: danbunnell, ajitfb

Differential Revision: D39638509

