### PR TITLE
Add arguments to PCF2 compute stage for reading from secret share results

### DIFF
--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -57,6 +57,7 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
         "arguments": [
             OneDockerArgument(name="input_base_path", required=True),
             OneDockerArgument(name="output_base_path", required=True),
+            OneDockerArgument(name="input_global_params_path", required=False),
             OneDockerArgument(name="file_start_index", required=False),
             OneDockerArgument(name="num_files", required=True),
             OneDockerArgument(name="concurrency", required=True),

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -238,6 +238,19 @@ class PCF2LiftStageService(PrivateComputationStageService):
         Returns:
             MPC game args to be used by onedocker
         """
+
+        if private_computation_instance.has_feature(
+            PCSFeature.PRIVATE_LIFT_UNIFIED_DATA_PROCESS
+        ):
+            common_compute_game_args[
+                "input_base_path"
+            ] = (
+                private_computation_instance.pcf2_lift_metadata_compaction_output_base_path
+            )
+            common_compute_game_args[
+                "input_global_params_path"
+            ] = f"{private_computation_instance.pcf2_lift_metadata_compaction_output_base_path}_global_params_0"
+
         game_args = [
             {
                 **common_compute_game_args,


### PR DESCRIPTION
Summary: The last step for the new UDP flow is passing the global parameters output from the UDP stage into the PCS stage. The feature flag will automatically control the behavior of the binary to read from secret shares.

Differential Revision: D39941419

