### PR TITLE
Update the EMP and Data Processing Docker Images to use a pinned version of FBPCF and the Ubuntu OS

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -8,6 +8,7 @@ set -e
 
 UBUNTU_RELEASE="20.04"
 GITHUB_PACKAGES="ghcr.io/facebookresearch"
+FBPCF_VERSION="2.1.66"
 
 
 PROG_NAME=$0
@@ -62,7 +63,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Docker build must run from the root folder, so all the relative paths work inside the Dockerfile's
 cd "$SCRIPT_DIR" || exit
 
-FBPCF_IMAGE="fbpcf/${OS_VARIANT}:latest"
+FBPCF_IMAGE="fbpcf/${OS_VARIANT}:${FBPCF_VERSION}"
 if [[ " $FBPCF_DEPENDENCY " =~ $PACKAGE ]]; then # Not all packages require fbpcf
   IMAGE_PREFIX="fbpcs/" # Current all FBPCF Dependent images are tagged with "fbpcs" prefix
   if [ "${FORCE_EXTERNAL}" == false ] && docker image inspect "${FBPCF_IMAGE}" >/dev/null 2>&1; then

--- a/docker/data_processing/Dockerfile.ubuntu
+++ b/docker/data_processing/Dockerfile.ubuntu
@@ -2,8 +2,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-ARG os_release="latest"
-ARG fbpcf_image="fbpcf/ubuntu:latest"
+ARG os_release="20.04"
+ARG fbpcf_image
 
 FROM ${fbpcf_image} as dev
 

--- a/docker/emp_games/Dockerfile.ubuntu
+++ b/docker/emp_games/Dockerfile.ubuntu
@@ -2,8 +2,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-ARG os_release="latest"
-ARG fbpcf_image="fbpcf/ubuntu:latest"
+ARG os_release="20.04"
+ARG fbpcf_image
 
 FROM ${fbpcf_image} as dev
 

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-ARG os_release="latest"
+ARG os_release="20.04"
 ARG tag="latest"
 FROM fbpcs/data-processing:${tag} as data_processing
 FROM fbpcs/emp-games:${tag} as emp_games


### PR DESCRIPTION
Summary: See title.

Reviewed By: gitfish77

Differential Revision: D40074501

