### PR TITLE
Update FBPCS build pipeline to explicitly target amd64 when building images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build onedocker image in rc
         run: |
-          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f
+          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f -p linux/amd64
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1


### PR DESCRIPTION
Summary:
From task:

In a recent change, we added an argument to the FBPCS build script build-docker.sh to allow the caller to explicitly pass a platform to target (-p PLATFORM) when building an image.  Previously, we were implicitly targeting the platform that build was running on: amd64. However, we always require amd64 images to run in our cloud deployment.
This task is to update our build system to pass this new argument and explicitly target amd64 or linux/amd64. This will require our build system to run Docker Engine 1.40+.

Reviewed By: musebc, gitfish77

Differential Revision: D40026703

