### PR TITLE
better cloudwatch URL retrieval

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -9,15 +9,14 @@
 from typing import Dict, List, Optional
 
 from fbpcp.entity.cluster_instance import Cluster
-
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.container import ContainerService
 from fbpcp.service.container_aws import AWSContainerService
 from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
-from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
-
+from fbpcs.experimental.cloud_logs.aws_log_retriever import AWSLogRetriever
+from fbpcs.experimental.cloud_logs.log_retriever import LogRetriever
 from fbpcs.private_computation.service.utils import deprecated
 
 
@@ -26,7 +25,7 @@ class PCSContainerService(ContainerService):
         self.inner_container_service: ContainerService = inner_container_service
         self.log_retriever: Optional[LogRetriever] = None
         if isinstance(self.inner_container_service, AWSContainerService):
-            self.log_retriever = LogRetriever(CloudProvider.AWS)
+            self.log_retriever = AWSLogRetriever()
 
     def get_region(
         self,

--- a/fbpcs/experimental/cloud_logs/aws_log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/aws_log_retriever.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from enum import auto, Enum
+from typing import Optional
+
+from fbpcs.experimental.cloud_logs.log_retriever import LogRetriever
+
+
+class LogGroupGuessStrategy(Enum):
+    FROM_PCE_SERVICE = auto()
+    FROM_ARN = auto()
+
+
+class AWSLogRetriever(LogRetriever):
+    def __init__(
+        self,
+        awslogs_stream_prefix: str = "ecs",
+        awslogs_group: Optional[str] = None,
+        awslogs_region: Optional[str] = None,
+        # from arn is the default because partner PCEs seem to have use it, and
+        # it's easy for us to change the guess strategy for the publisher
+        log_group_guess_strategy: Enum = LogGroupGuessStrategy.FROM_ARN,
+    ) -> None:
+        self.awslogs_stream_prefix = awslogs_stream_prefix
+        self.awslogs_group = awslogs_group
+        self.awslogs_region = awslogs_region
+        self.log_group_guess_strategy = log_group_guess_strategy
+
+    def get_log_url(self, container_id: str) -> str:
+        """Get the log url for a container
+
+        Args:
+            container_id: ARN identifier for container for which the log URL should be retrieved
+
+        Returns:
+            return: The log URL for said container
+
+        Raises
+            IndexError: if container_id is not well-formed
+        """
+
+        container_id_info = container_id.split(":")
+        awslogs_region = self.awslogs_region or container_id_info[3]
+        cluster_name = container_id_info[-1].split("/")[1]
+
+        awslogs_group = self._get_log_group_name(awslogs_region, cluster_name)
+        log_stream_name = self._get_log_stream_name(container_id, awslogs_group)
+
+        return (
+            f"https://{awslogs_region}.console.aws.amazon.com/cloudwatch/home?"
+            f"region={awslogs_region}#logsV2:log-groups/"
+            f"log-group/{self._aws_encode(awslogs_group)}/"
+            f"log-events/{self._aws_encode(log_stream_name)}"
+        )
+
+    def _get_log_group_name(self, region: str, cluster: str) -> str:
+        if self.awslogs_group:
+            return self.awslogs_group
+        elif self.log_group_guess_strategy is LogGroupGuessStrategy.FROM_PCE_SERVICE:
+            return f"/ecs/onedocker-container-shared-{region}"
+        elif self.log_group_guess_strategy is LogGroupGuessStrategy.FROM_ARN:
+            return f"/ecs/{cluster.replace('-cluster', '-container')}"
+        else:
+            raise ValueError("Cannot guess log group name")
+
+    def _get_log_stream_name(self, container_id: str, log_group_name: str) -> str:
+        container_name = log_group_name.split("/")[-1]
+        task_id = container_id.split("/")[-1]
+
+        # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
+        # search for awslogs-stream-prefix
+        return f"{self.awslogs_stream_prefix}/{container_name}/{task_id}"
+
+    @classmethod
+    def _aws_encode(cls, s: str) -> str:
+        return s.replace("/", "$252F")

--- a/fbpcs/experimental/cloud_logs/dummy_log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/dummy_log_retriever.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from fbpcs.experimental.cloud_logs.log_retriever import LogRetriever
+
+
+class DummyLogRetriever(LogRetriever):
+    def get_log_url(self, container_id: str) -> str:
+        return ""

--- a/fbpcs/experimental/cloud_logs/log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/log_retriever.py
@@ -4,21 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import re
-
-from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+from abc import ABC, abstractmethod
 
 
-class LogRetriever:
-    """Retrieves logs for containers under a specific cloud provider.
+class LogRetriever(ABC):
+    """Retrieves logs for containers under a specific cloud provider."""
 
-    Private attributes:
-        _cloud_provider: Cloud Provider for which this log retriever was initialized
-    """
-
-    def __init__(self, cloud_provider: CloudProvider) -> None:
-        self._cloud_provider = cloud_provider
-
+    @abstractmethod
     def get_log_url(self, container_id: str) -> str:
         """Get the log url for a container
 
@@ -27,72 +19,5 @@ class LogRetriever:
 
         Returns:
             return: The log URL for said container
-
-        Raises:
-            IndexError: can be raised when using CloudProvider.AWS
-            NotImplementedError: if anything other than CloudProvider.AWS is used
         """
-        if self._cloud_provider is CloudProvider.AWS:
-            return self._get_aws_cloudwatch_log_url(container_id)
-        else:
-            raise NotImplementedError(
-                f"Retrieving log URLs for {self._cloud_provider} is not yet supported."
-            )
-
-    def _get_aws_cloudwatch_log_url(self, container_id: str) -> str:
-        """Return a CloudWatch URL given a container id.
-
-        Args:
-            container_id: AWS arn of a container run in ECS
-
-        Returns:
-            return: The Cloudwatch URL for said container
-
-        Raises:
-            IndexError: if container_id is not well-formed
-        """
-        container_id_info = container_id.split(":")
-        log_region = container_id_info[3]
-        task_id_info = container_id_info[-1].split("/")
-        cluster_name = task_id_info[1]
-        container_name = self._get_container_name(cluster_name, log_region)
-        task_id = task_id_info[-1]
-        log_group_name = f"$252Fecs$252F{container_name}"
-        log_stream_name = f"ecs$252F{container_name}$252F{task_id}"
-
-        return (
-            f"https://{log_region}.console.aws.amazon.com/cloudwatch/home?"
-            f"region={log_region}#logsV2:log-groups/"
-            f"log-group/{log_group_name}/"
-            f"log-events/{log_stream_name}"
-        )
-
-    def _get_container_name(self, cluster_name: str, log_region: str) -> str:
-        """Get the container_name. For publisher side log group, if it's created by PCE service,
-        it will be changed to format "onedocker-container-shared-<region>"
-        Args:
-            cluster_name: the name of cluster in format "onedocker-cluster-<tag>"
-            log_region: the AWS region
-
-        Returns:
-            return: The container_name
-
-        Raises:
-            IndexError: if container_name is not well-formed
-        """
-        container_name = cluster_name.replace("-cluster", "-container").replace(
-            # This log group doesn't exist in the experiment platform aws account.
-            # Replace it with a 32 digit string to trick subsequent string replacement
-            # into thinking it was deployed with PCE Service. Improvise. Adapt. Overcome
-            "mpc-aem-exp-platform-publisher",
-            "0" * 32,
-        )
-        container_name_parts = container_name.split("-")
-
-        # If the name does not have a 32 bit random string inside, return directly
-        # Otherwise, it means it's a container created by the PCE service,
-        # and it should be replaced with "-shared-<region>"
-        if not re.search(r"[0-9a-f]{32}", container_name_parts[-1]):
-            return container_name
-
-        return f"{container_name.rsplit('-', 1)[0]}-shared-{log_region}"
+        ...

--- a/fbpcs/experimental/cloud_logs/test/test_log_retriever.py
+++ b/fbpcs/experimental/cloud_logs/test/test_log_retriever.py
@@ -6,57 +6,40 @@
 
 import unittest
 
-from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
+from fbpcs.experimental.cloud_logs.aws_log_retriever import (
+    AWSLogRetriever,
+    LogGroupGuessStrategy,
+)
 
 
 class TestLogRetriever(unittest.TestCase):
-    def test_get_aws_cloudwatch_log_url(self) -> None:
-        retriever = LogRetriever(CloudProvider.AWS)
-        container_id = "arn:aws:ecs:us-west-2:539290649537:task/onedocker-cluster-fake-amazon/3a5e4213036b4456a6c16695b938b361"
-        expected = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-fake-amazon/log-events/ecs$252Fonedocker-container-fake-amazon$252F3a5e4213036b4456a6c16695b938b361"
-        actual = retriever._get_aws_cloudwatch_log_url(container_id)
-        self.assertEqual(expected, actual)
-
-        with self.assertRaises(IndexError):
-            retriever._get_aws_cloudwatch_log_url("aaaaaaaaaaaaaaa")
-
-    def test_get_log_url_aws_provider(self) -> None:
-        retriever = LogRetriever(CloudProvider.AWS)
-        container_id = "arn:aws:ecs:us-west-2:539290649537:task/onedocker-cluster-fake-amazon/3a5e4213036b4456a6c16695b938b361"
-        expected = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-fake-amazon/log-events/ecs$252Fonedocker-container-fake-amazon$252F3a5e4213036b4456a6c16695b938b361"
-        actual = retriever.get_log_url(container_id)
-        self.assertEqual(expected, actual)
+    def test_aws_invalid_container_id(self) -> None:
+        retriever = AWSLogRetriever()
 
         with self.assertRaises(IndexError):
             retriever.get_log_url("aaaaaaaaaaaaaaa")
 
-    def test_get_log_url_gcp_provider(self) -> None:
-        retriever = LogRetriever(CloudProvider.GCP)
-        container_id = "fancy_container"
-        with self.assertRaises(NotImplementedError):
-            retriever.get_log_url(container_id)
-
     def test_get_log_url_shared_log_group_on_publisher(self) -> None:
-        retriever = LogRetriever(CloudProvider.AWS)
+        retriever = AWSLogRetriever(
+            log_group_guess_strategy=LogGroupGuessStrategy.FROM_PCE_SERVICE
+        )
         container_id = "arn:aws:ecs:us-west-2:539290649537:task/onedocker-cluster-ee9bc805f22e40f9bbc107d5f006b6e1/3a5e4213036b4456a6c16695b938b361"
         expected = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-shared-us-west-2/log-events/ecs$252Fonedocker-container-shared-us-west-2$252F3a5e4213036b4456a6c16695b938b361"
         actual = retriever.get_log_url(container_id)
         self.assertEqual(expected, actual)
 
-    def test_get_log_url_exp_platform(self) -> None:
-        retriever = LogRetriever(CloudProvider.AWS)
-        for container_id, expected_url in (
-            # partner
-            (
-                "arn:aws:ecs:us-west-2:119557546360:task/onedocker-cluster-mpc-aem-exp-platform-partner/dc4fdf05e7684165b639b4e1831872c8",
-                "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-mpc-aem-exp-platform-partner/log-events/ecs$252Fonedocker-container-mpc-aem-exp-platform-partner$252Fdc4fdf05e7684165b639b4e1831872c8",
-            ),
-            # publisher
-            (
-                "arn:aws:ecs:us-west-2:119557546360:task/onedocker-cluster-mpc-aem-exp-platform-publisher/aeb6151d016046dab698b988e04018d4",
-                "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-shared-us-west-2/log-events/ecs$252Fonedocker-container-shared-us-west-2$252Faeb6151d016046dab698b988e04018d4",
-            ),
-        ):
-            with self.subTest(container_id=container_id, expected_url=expected_url):
-                actual = retriever.get_log_url(container_id)
-                self.assertEqual(expected_url, actual)
+    def test_ep_publisher(self) -> None:
+        retriever = AWSLogRetriever(
+            awslogs_group="/ecs/onedocker-container-shared-us-west-2"
+        )
+        container_id = "arn:aws:ecs:us-west-2:119557546360:task/onedocker-cluster-mpc-aem-exp-platform-publisher/aeb6151d016046dab698b988e04018d4"
+        expected_url = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-shared-us-west-2/log-events/ecs$252Fonedocker-container-shared-us-west-2$252Faeb6151d016046dab698b988e04018d4"
+        actual = retriever.get_log_url(container_id)
+        self.assertEqual(expected_url, actual)
+
+    def test_ep_partner(self) -> None:
+        retriever = AWSLogRetriever()
+        container_id = "arn:aws:ecs:us-west-2:119557546360:task/onedocker-cluster-mpc-aem-exp-platform-partner/dc4fdf05e7684165b639b4e1831872c8"
+        expected_url = "https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-mpc-aem-exp-platform-partner/log-events/ecs$252Fonedocker-container-mpc-aem-exp-platform-partner$252Fdc4fdf05e7684165b639b4e1831872c8"
+        actual = retriever.get_log_url(container_id)
+        self.assertEqual(expected_url, actual)

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -15,7 +15,6 @@ from fbpcp.error.pcp import ThrottlingError
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.service.retry_handler import RetryHandler
-from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
 from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
 
 DEFAULT_WAIT_FOR_CONTAINER_POLL = 5
@@ -74,18 +73,6 @@ class RunBinaryBaseService:
                 onedocker_svc.wait_for_pending_containers,
                 [container.instance_id for container in pending_containers],
             )
-
-        # Log the URL once... since the DataProcessingStage doesn't expose the
-        # containers, we handle the logic directly in each stage like so.
-        # It's kind of weird. T107574607 is tracking this.
-        # Hope we're using AWS!
-        log_retriever = LogRetriever(CloudProvider.AWS)
-        for i, container in enumerate(containers):
-            try:
-                log_url = log_retriever.get_log_url(container.instance_id)
-                logger.info(f"Container[{i}] URL -> {log_url}")
-            except Exception:
-                logger.warning(f"Could not look up URL for container[{i}]")
 
         logger.info("Task started")
         if wait_for_containers_to_finish:

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -15,7 +15,6 @@ import warnings
 from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.certificate_request import CertificateRequest
-
 from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
@@ -25,9 +24,8 @@ from fbpcs.common.entity.stage_state_instance import (
     StageStateInstance,
     StageStateInstanceStatus,
 )
-from fbpcs.experimental.cloud_logs.log_retriever import CloudProvider, LogRetriever
+from fbpcs.experimental.cloud_logs.aws_log_retriever import AWSLogRetriever
 from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
-
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -217,7 +215,7 @@ def get_log_urls(
     last_instance = private_computation_instance.infra_config.instances[-1]
 
     # TODO - hope we're using AWS!
-    log_retriever = LogRetriever(CloudProvider.AWS)
+    log_retriever = AWSLogRetriever()
 
     res = {}
     if isinstance(last_instance, PCSMPCInstance) or isinstance(


### PR DESCRIPTION
Summary:
## What

- Create abstract class for LogRetriever
- Create clearer and configurable "guessing" rules for determining URLs
- Enable (optional) configuration of aws logging settings if you don't want to guess or if the guessing sucks
    - awslogs_stream_prefix
    - awslogs_group
    - awslogs_region

Differential Revision: D40109396

