### PR TITLE
Adding cli changes to download data infra logs

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -113,6 +113,7 @@ class TestDownloadLogs(unittest.TestCase):
                     str(self._get_sample_log_path("container_ids.txt")),
                     "bucket-name",
                     "tag-name",
+                    "deployment_tag",
                     "--input_ids",
                 ]
             )


### PR DESCRIPTION
Summary:
**What**
This diff is part of the data infra pipeline logging project. In this diff `download_logs_cli` is changed to add options to enable data infra pipeline logging.

**Why**
`download_logs_cli` is called from computation UI when the computation run is completed. Right now it fetches only container logs and uploads on S3 is a zipped folder. With this change it will upload data infra pipeline logs as well.

**Context**
https://docs.google.com/document/d/1cMD9IQ8uF6MS1PRvOh8cr-1el7MO952SjUanAzAGJzw/edit?usp=sharing

Differential Revision: D40152846

