### PR TITLE
Create a GraphAPI trace logging svc in Bolt for attribution

### DIFF
--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -270,6 +270,13 @@ async def run_bolt(
         logger: logger client
         job_list: The BoltJobs to execute
     """
+    if not job_list:
+        raise OneCommandRunnerBaseException(
+            "Expected at least one job",
+            "len(job_list) == 0",
+            "Submit at least one job to call this API",
+        )
+
     # create the runner
     runner = BoltRunner(
         publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -26,6 +26,7 @@ from fbpcs.pl_coordinator.constants import MAX_NUM_INSTANCES
 from fbpcs.pl_coordinator.exceptions import (
     GraphAPIGenericException,
     IncorrectVersionError,
+    OneCommandRunnerBaseException,
     OneCommandRunnerExitCode,
     PCAttributionValidationException,
     sys_exit_after,
@@ -270,6 +271,12 @@ async def run_bolt(
         logger: logger client
         job_list: The BoltJobs to execute
     """
+    if not job_list:
+        raise OneCommandRunnerBaseException(
+            "Expected at least one job",
+            "len(job_list) == 0",
+            "Submit at least one job to call this API",
+        )
 
     runner = BoltRunner(
         publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -18,9 +18,13 @@ from fbpcs.bolt.bolt_job import BoltJob, BoltPlayerArgs
 from fbpcs.bolt.bolt_runner import BoltRunner
 from fbpcs.bolt.oss_bolt_pcs import BoltPCSClient, BoltPCSCreateInstanceArgs
 from fbpcs.common.feature.pcs_feature_gate_utils import get_stage_flow
+from fbpcs.common.service.graphapi_trace_logging_service import (
+    GraphApiTraceLoggingService,
+)
 from fbpcs.pl_coordinator.bolt_graphapi_client import (
     BoltGraphAPIClient,
     BoltPAGraphAPICreateInstanceArgs,
+    URL,
 )
 from fbpcs.pl_coordinator.constants import MAX_NUM_INSTANCES
 from fbpcs.pl_coordinator.exceptions import (
@@ -278,15 +282,27 @@ async def run_bolt(
             "Submit at least one job to call this API",
         )
 
+    # We create the publisher_client here so we can reuse the access_token in our trace logger svc
+    publisher_client = BoltGraphAPIClient(config=config["graphapi"], logger=logger)
+
+    # Create a GraphApiTraceLoggingService specific for this study_id
+    dataset_id = job_list[0].publisher_bolt_args.create_instance_args.dataset_id
+    endpoint_url = f"{URL}/{dataset_id}/checkpoint"
+    graphapi_trace_logging_svc = GraphApiTraceLoggingService(
+        access_token=publisher_client.access_token,
+        endpoint_url=endpoint_url,
+    )
+
     runner = BoltRunner(
-        publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),
+        publisher_client=publisher_client,
         partner_client=BoltPCSClient(
             _build_private_computation_service(
-                config["private_computation"],
-                config["mpc"],
-                config["pid"],
-                config.get("post_processing_handlers", {}),
-                config.get("pid_post_processing_handlers", {}),
+                pc_config=config["private_computation"],
+                mpc_config=config["mpc"],
+                pid_config=config["pid"],
+                pph_config=config.get("post_processing_handlers", {}),
+                pid_pph_config=config.get("pid_post_processing_handlers", {}),
+                trace_logging_svc=graphapi_trace_logging_svc,
             )
         ),
         logger=logger,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -456,6 +456,7 @@ def _build_private_computation_service(
     pid_config: Dict[str, Any],
     pph_config: Dict[str, Any],
     pid_pph_config: Dict[str, Any],
+    trace_logging_svc: Optional[TraceLoggingService] = None,
 ) -> PrivateComputationService:
     instance_repository_config = pc_config["dependency"][
         "PrivateComputationInstanceRepository"
@@ -487,7 +488,7 @@ def _build_private_computation_service(
         workflow_service = None
 
     metric_svc = _build_metric_service(pc_config["dependency"].get("MetricService"))
-    trace_logging_svc = _build_trace_logging_service(
+    trace_logging_svc = trace_logging_svc or _build_trace_logging_service(
         pc_config["dependency"].get("TraceLoggingService")
     )
 


### PR DESCRIPTION
Summary:
# What
 * Title
# Why
 * For a Graph API-based logger, we need to know the study_id or dataset_id, but that information isn't available in the service wrapper. So we can create the trace logger in the runner and then pass it when building the service
# This stack
 * Use Graph API-based trace logger on partner side

Reviewed By: jrodal98

Differential Revision: D40153490

