### PR TITLE
Create a GraphAPI trace logging svc in Bolt

### DIFF
--- a/fbpcs/common/service/graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/graphapi_trace_logging_service.py
@@ -28,6 +28,7 @@ RESPONSE_TIMEOUT: float = 3.05
 
 class GraphApiTraceLoggingService(TraceLoggingService):
     def __init__(self, access_token: str, endpoint_url: str) -> None:
+        super().__init__()
         self.access_token = access_token
         self.endpoint_url = endpoint_url
 

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -270,6 +270,13 @@ async def run_bolt(
         logger: logger client
         job_list: The BoltJobs to execute
     """
+    if not job_list:
+        raise OneCommandRunnerBaseException(
+            "Expected at least one job",
+            "len(job_list) == 0",
+            "Submit at least one job to call this API",
+        )
+
     # create the runner
     runner = BoltRunner(
         publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -456,6 +456,7 @@ def _build_private_computation_service(
     pid_config: Dict[str, Any],
     pph_config: Dict[str, Any],
     pid_pph_config: Dict[str, Any],
+    trace_logging_svc: Optional[TraceLoggingService] = None,
 ) -> PrivateComputationService:
     instance_repository_config = pc_config["dependency"][
         "PrivateComputationInstanceRepository"
@@ -487,7 +488,7 @@ def _build_private_computation_service(
         workflow_service = None
 
     metric_svc = _build_metric_service(pc_config["dependency"].get("MetricService"))
-    trace_logging_svc = _build_trace_logging_service(
+    trace_logging_svc = trace_logging_svc or _build_trace_logging_service(
         pc_config["dependency"].get("TraceLoggingService")
     )
 


### PR DESCRIPTION
Summary:
# What
 * Title
# Why
 * For a Graph API-based logger, we need to know the study_id or dataset_id, but that information isn't available in the service wrapper. So we can create the trace logger in the runner and then pass it when building the service
# This stack
 * Use Graph API-based trace logger on partner side

Reviewed By: jrodal98, joe1234wu

Differential Revision: D40153143

