### PR TITLE
vpc peering automation

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -258,6 +258,7 @@ deploy_aws_resources() {
     subnet_ids=$(terraform output subnets | tr -d '""[]\ \n')
     route_table_id=$(terraform output route_table_id | tr -d '"')
     aws_ecs_cluster_name=$(terraform output aws_ecs_cluster_name | tr -d '"')
+    log_resource_output resource_name "vpc_id" resource_value "$vpc_id"
     log_streaming_data "establishing vpc peering connection..."
     # Issue VPC Peering Connection to Publisher's VPC and add a route to the route table
     echo "########################Issue VPC Peering connection to Publisher's VPC########################"
@@ -284,6 +285,7 @@ deploy_aws_resources() {
     # Store the outputs into variables
     vpc_peering_connection_id=$(terraform output vpc_peering_connection_id | tr -d '"' )
     echo "VPC peering connection has been created. ID: $vpc_peering_connection_id"
+    log_resource_output resource_name "vpc_peering_connection_id" resource_value "$vpc_peering_connection_id"
 
     # Configure Data Ingestion Pipeline from CB to S3
     echo "########################Configure Data Ingestion Pipeline from CB to S3########################"

--- a/fbpcs/infra/cloud_bridge/server/build.gradle
+++ b/fbpcs/infra/cloud_bridge/server/build.gradle
@@ -30,6 +30,7 @@ repositories {
 
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   implementation 'com.amazonaws:aws-java-sdk-sts'
   implementation 'com.amazonaws:aws-java-sdk-ec2'

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Constants.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Constants.java
@@ -10,4 +10,5 @@ package com.facebook.business.cloudbridge.pl.server;
 public final class Constants {
   public static final String DEPLOYMENT_STREAMING_LOG_FILE = "/tmp/deploymentStream.log";
   public static final String PCE_VALIDATOR_LOG_STREAMING = "/tmp/pceValidatorStream.log";
+  public static final String DEPLOYMENT_RESOURCE_OUTPUT_FILE = "/tmp/resourceOutput.log";
 }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -125,6 +125,7 @@ public class DeploymentRunner extends Thread {
       environmentVariables.put("AWS_SESSION_TOKEN", deployment.awsSessionToken);
     }
     environmentVariables.put("TF_LOG_STREAMING", Constants.DEPLOYMENT_STREAMING_LOG_FILE);
+    environmentVariables.put("TF_RESOURCE_OUTPUT", Constants.DEPLOYMENT_RESOURCE_OUTPUT_FILE);
     if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
       if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
       environmentVariables.put("TF_LOG", deployment.logLevel.getLevel());

--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -103,6 +103,12 @@ log_streaming_data() {
     echo "$(date +"%M:%S") -> $text" >> "$TF_LOG_STREAMING"
 }
 
+log_resource_output() {
+    local resource_name=$1
+    local resource_value=$2
+    echo "$(jq -n --arg key "$resource_name" --arg value "$resource_value" '{ ($key) : $value }' "$TF_RESOURCE_OUTPUT")" > "$TF_RESOURCE_OUTPUT"
+}
+
 validateDeploymentResources () {
     local region=$1
     local pce_id=$2


### PR DESCRIPTION
Summary:
Overall design doc: https://docs.google.com/document/d/1Arz_FjBTEVj96G1fZfHC8SfIrHUpCNKjKnA-PvsKobU/edit#

Note to reviewers:
There will be a series of diffs spread across , frontend, backend, database, kotlin layer, java layer. so please read below on what is here and what's coming ?

This diff:

1. creates a graphQL end point to validate aws credentials inline

What's coming:
1.handle more user friendly error messages if required (subject to content team approval)

2. Integrate overall flow for API#2 in design

3. More error handling logic for expiry token etc

4. fetch metadata from deployment metadata table.

5. connect deployment client to meta peer pce client

6. create DB entry to store vpc connection id and partner vpc id

7. Parse tarraform vpc output details in kotlin layer and store in DB.

8. frontend changes for api #1, integrate UX.

9. Feature gate integration to hide under a feature.

10. add inlien validation result.

11. change modal stepper order..

... etc

Differential Revision: D40198362

