### PR TITLE
Make build_private_computation_service logically public

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -15,6 +15,9 @@ Types of changes
 
 ## [Unreleased - 2.3.0] - put release date here
 
+### Changed
+* Made _build_private_computation_service a logically public method
+
 ## [2.2.0] - 2022-10-03
 ### Added
 

--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -15,7 +15,7 @@ from fbpcs.bolt.bolt_runner import BoltRunner
 from fbpcs.bolt.constants import DEFAULT_POLL_INTERVAL_SEC
 from fbpcs.bolt.oss_bolt_pcs import BoltPCSClient, BoltPCSCreateInstanceArgs
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    _build_private_computation_service,
+    build_private_computation_service,
 )
 from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
 
@@ -47,7 +47,7 @@ def create_bolt_runner(
         runner_config["partner_client_config"]
     )
     publisher_client = BoltPCSClient(
-        _build_private_computation_service(
+        build_private_computation_service(
             publisher_client_config["private_computation"],
             publisher_client_config["mpc"],
             publisher_client_config["pid"],
@@ -56,7 +56,7 @@ def create_bolt_runner(
         )
     )
     partner_client = BoltPCSClient(
-        _build_private_computation_service(
+        build_private_computation_service(
             partner_client_config["private_computation"],
             partner_client_config["mpc"],
             partner_client_config["pid"],

--- a/fbpcs/common/service/graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/graphapi_trace_logging_service.py
@@ -28,6 +28,7 @@ RESPONSE_TIMEOUT: float = 3.05
 
 class GraphApiTraceLoggingService(TraceLoggingService):
     def __init__(self, access_token: str, endpoint_url: str) -> None:
+        super().__init__()
         self.access_token = access_token
         self.endpoint_url = endpoint_url
 

--- a/fbpcs/common/service/graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/graphapi_trace_logging_service.py
@@ -25,7 +25,6 @@ from fbpcs.common.service.trace_logging_service import (
 # which is the default TCP packet retransmission window.
 RESPONSE_TIMEOUT: float = 3.05
 
-DEFAULT_RUN_ID = "anonymous_run_id"
 DEFAULT_COMPONENT_NAME = "pcservice"
 
 
@@ -54,7 +53,7 @@ class GraphApiTraceLoggingService(TraceLoggingService):
             scrubbed_checkpoint_data[scrubbed_key] = scrubbed_val
 
         params = {
-            "run_id": run_id or DEFAULT_RUN_ID,
+            "run_id": run_id,
             "instance_id": instance_id,
             "checkpoint_name": f"{checkpoint_name}_{status}",
             "access_token": self.access_token,

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -270,6 +270,13 @@ async def run_bolt(
         logger: logger client
         job_list: The BoltJobs to execute
     """
+    if not job_list:
+        raise OneCommandRunnerBaseException(
+            "Expected at least one job",
+            "len(job_list) == 0",
+            "Submit at least one job to call this API",
+        )
+
     # create the runner
     runner = BoltRunner(
         publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -48,7 +48,7 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    _build_private_computation_service,
+    build_private_computation_service,
     get_instance,
     get_tier,
 )
@@ -296,7 +296,7 @@ async def run_bolt(
     runner = BoltRunner(
         publisher_client=publisher_client,
         partner_client=BoltPCSClient(
-            _build_private_computation_service(
+            build_private_computation_service(
                 pc_config=config["private_computation"],
                 mpc_config=config["mpc"],
                 pid_config=config["pid"],

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -26,6 +26,7 @@ from fbpcs.pl_coordinator.constants import MAX_NUM_INSTANCES
 from fbpcs.pl_coordinator.exceptions import (
     GraphAPIGenericException,
     IncorrectVersionError,
+    OneCommandRunnerBaseException,
     OneCommandRunnerExitCode,
     PCAttributionValidationException,
     sys_exit_after,
@@ -270,6 +271,12 @@ async def run_bolt(
         logger: logger client
         job_list: The BoltJobs to execute
     """
+    if not job_list:
+        raise OneCommandRunnerBaseException(
+            "Expected at least one job",
+            "len(job_list) == 0",
+            "Submit at least one job to call this API",
+        )
 
     runner = BoltRunner(
         publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -18,9 +18,13 @@ from fbpcs.bolt.bolt_job import BoltJob, BoltPlayerArgs
 from fbpcs.bolt.bolt_runner import BoltRunner
 from fbpcs.bolt.oss_bolt_pcs import BoltPCSClient, BoltPCSCreateInstanceArgs
 from fbpcs.common.feature.pcs_feature_gate_utils import get_stage_flow
+from fbpcs.common.service.graphapi_trace_logging_service import (
+    GraphApiTraceLoggingService,
+)
 from fbpcs.pl_coordinator.bolt_graphapi_client import (
     BoltGraphAPIClient,
     BoltPAGraphAPICreateInstanceArgs,
+    URL,
 )
 from fbpcs.pl_coordinator.constants import MAX_NUM_INSTANCES
 from fbpcs.pl_coordinator.exceptions import (
@@ -278,15 +282,27 @@ async def run_bolt(
             "Submit at least one job to call this API",
         )
 
+    # We create the publisher_client here so we can reuse the access_token in our trace logger svc
+    publisher_client = BoltGraphAPIClient(config=config["graphapi"], logger=logger)
+
+    # Create a GraphApiTraceLoggingService specific for this study_id
+    dataset_id = job_list[0].publisher_bolt_args.create_instance_args.dataset_id
+    endpoint_url = f"{URL}/{dataset_id}/checkpoint"
+    graphapi_trace_logging_svc = GraphApiTraceLoggingService(
+        access_token=publisher_client.access_token,
+        endpoint_url=endpoint_url,
+    )
+
     runner = BoltRunner(
-        publisher_client=BoltGraphAPIClient(config=config["graphapi"], logger=logger),
+        publisher_client=publisher_client,
         partner_client=BoltPCSClient(
             _build_private_computation_service(
-                config["private_computation"],
-                config["mpc"],
-                config["pid"],
-                config.get("post_processing_handlers", {}),
-                config.get("pid_post_processing_handlers", {}),
+                pc_config=config["private_computation"],
+                mpc_config=config["mpc"],
+                pid_config=config["pid"],
+                pph_config=config.get("post_processing_handlers", {}),
+                pid_pph_config=config.get("pid_post_processing_handlers", {}),
+                trace_logging_svc=graphapi_trace_logging_svc,
             )
         ),
         logger=logger,

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -49,7 +49,7 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
     PrivateComputationBaseStageFlow,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    _build_private_computation_service,
+    build_private_computation_service,
     get_tier,
 )
 
@@ -296,7 +296,7 @@ async def run_bolt(
     runner = BoltRunner(
         publisher_client=publisher_client,
         partner_client=BoltPCSClient(
-            _build_private_computation_service(
+            build_private_computation_service(
                 pc_config=config["private_computation"],
                 mpc_config=config["mpc"],
                 pid_config=config["pid"],

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -24,7 +24,7 @@ from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    _build_private_computation_service,
+    build_private_computation_service,
 )
 
 
@@ -102,7 +102,7 @@ class PreValidateService:
         input_paths: List[str],
         logger: logging.Logger,
     ) -> None:
-        pc_service = _build_private_computation_service(
+        pc_service = build_private_computation_service(
             config["private_computation"],
             config["mpc"],
             config["pid"],

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -456,6 +456,7 @@ def _build_private_computation_service(
     pid_config: Dict[str, Any],
     pph_config: Dict[str, Any],
     pid_pph_config: Dict[str, Any],
+    trace_logging_svc: Optional[TraceLoggingService] = None,
 ) -> PrivateComputationService:
     instance_repository_config = pc_config["dependency"][
         "PrivateComputationInstanceRepository"
@@ -487,9 +488,14 @@ def _build_private_computation_service(
         workflow_service = None
 
     metric_svc = _build_metric_service(pc_config["dependency"].get("MetricService"))
-    trace_logging_svc = _build_trace_logging_service(
-        pc_config["dependency"].get("TraceLoggingService")
-    )
+
+    trace_logging_svc = trace_logging_svc
+    # If a trace_logging_svc exists in the config, use that instead
+    logging.info("Overriding default trace_logging_svc since settings found in config")
+    if trace_logging_svc is None or "TraceLoggingService" in pc_config["dependency"]:
+        trace_logging_svc = _build_trace_logging_service(
+            pc_config["dependency"].get("TraceLoggingService")
+        )
 
     return PrivateComputationService(
         instance_repository=repository_service,

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -76,7 +76,7 @@ def create_instance(
     pcs_features: Optional[List[str]] = None,
     run_id: Optional[str] = None,
 ) -> PrivateComputationInstance:
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -121,7 +121,7 @@ def validate(
     expected_result_path: str,
     aggregated_result_path: Optional[str] = None,
 ) -> None:
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -160,7 +160,7 @@ def run_next(
     server_ips: Optional[List[str]] = None,
 ) -> None:
 
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -187,7 +187,7 @@ def run_stage(
     dry_run: bool = False,
 ) -> None:
 
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -213,7 +213,7 @@ def update_input_path(
     """
     Update input path by given instance_id, currently only support partner instance override.
     """
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -233,7 +233,7 @@ def get_instance(
     MPCInstance to this pc instance. Because pc_service.update_instance() also writes to this pc instance, it could
     accidentally erase that PID or MPCInstance.
     """
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -249,7 +249,7 @@ def get_instance(
 def get_server_ips(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> List[str]:
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -299,7 +299,7 @@ def get_mpc(config: Dict[str, Any], instance_id: str, logger: logging.Logger) ->
 def cancel_current_stage(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> PrivateComputationInstance:
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -340,7 +340,7 @@ def print_log_urls(
     To print the log urls with id instance_id.
     Printing out by stages and correspondens log url
     """
-    pc_service = _build_private_computation_service(
+    pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
         config["pid"],
@@ -450,7 +450,7 @@ def _build_trace_logging_service(
     return reflect.get_instance(config, TraceLoggingService)
 
 
-def _build_private_computation_service(
+def build_private_computation_service(
     pc_config: Dict[str, Any],
     mpc_config: Dict[str, Any],
     pid_config: Dict[str, Any],

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -30,7 +30,7 @@ from fbpcs.private_computation.stage_flows.private_computation_stage_flow import
 )
 
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
-    _build_private_computation_service,
+    build_private_computation_service,
     cancel_current_stage,
     create_instance,
     get_instance,
@@ -98,7 +98,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         mock_reflect_get_instance,
         mock_reflect_get_class,
     ) -> None:
-        _build_private_computation_service(
+        build_private_computation_service(
             pc_config=self.config["private_computation"],
             mpc_config=self.config["mpc"],
             pid_config=self.config["pid"],
@@ -123,7 +123,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         )
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_create_instance(
         self,
@@ -166,7 +166,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         )
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_validate(self, mock_build_pcs) -> None:
         mock_build_pcs.return_value = self.mock_pcs
@@ -183,7 +183,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         )
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_run_next(self, mock_build_pcs) -> None:
         mock_build_pcs.return_value = self.mock_pcs
@@ -198,7 +198,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         )
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_run_stage(self, mock_build_pcs) -> None:
         mock_build_pcs.return_value = self.mock_pcs
@@ -217,7 +217,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         )
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_update_input_path(self, mock_build_pcs) -> None:
         mock_build_pcs.return_value = self.mock_pcs
@@ -232,7 +232,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         )
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_get_instance(self, mock_build_pcs) -> None:
         mock_build_pcs.return_value = self.mock_pcs
@@ -244,7 +244,7 @@ class TestPrivateComputationServiceWrapper(TestCase):
         self.mock_pcs.get_instance.assert_called_once_with(self.test_instance_id)
 
     @patch(
-        "fbpcs.private_computation_cli.private_computation_service_wrapper._build_private_computation_service"
+        "fbpcs.private_computation_cli.private_computation_service_wrapper.build_private_computation_service"
     )
     def test_cancel_current_stage(self, mock_build_pcs) -> None:
         mock_build_pcs.return_value = self.mock_pcs


### PR DESCRIPTION
Summary:
# What
* Title
# Why
* This function is imported in many places, so it's weird that we're trying to pretend that it's private. We should consider refactoring the entire file since many of the utilities in the wrapper file are used (or want to be used) in other places.

Differential Revision: D40208900

