### PR TITLE
Fix incompactibility with buck2

### DIFF
--- a/fbpcs/emp_games/common/TestUtil.cpp
+++ b/fbpcs/emp_games/common/TestUtil.cpp
@@ -10,7 +10,14 @@
 namespace private_measurement::test_util {
 
 std::string getBaseDirFromPath(const std::string& filePath) {
-  return filePath.substr(0, filePath.rfind("/") + 1);
+  auto dir = filePath.substr(0, filePath.rfind("/") + 1);
+  std::string toErase = "fbcode/";
+  size_t pos = dir.find(toErase);
+  if (pos != std::string::npos) {
+    // If found then erase it from string
+    return dir.substr(pos + toErase.size());
+  }
+  return dir;
 }
 
 } // namespace private_measurement::test_util


### PR DESCRIPTION
Summary: After migrating to buck2, the value of `__FILE__` has changed (from not containing `fbcode/` to containing `fbcode/`). This change has broken tons of tests. This diff is to fhix this issue to make sure out tests works with both versions of buck.

Reviewed By: jrodal98

Differential Revision: D40235858

