### PR TITLE
adding ephemeral smc tier in pcs

### DIFF
--- a/fbpcs/private_computation/entity/pcs_tier.py
+++ b/fbpcs/private_computation/entity/pcs_tier.py
@@ -11,6 +11,7 @@ from enum import Enum
 
 class PCSTier(Enum):
     UNKNOWN = "unknown"
+    EPHEMERAL = "ephemeral"
     RC = "rc"
     CANARY = "canary"
     PROD = "latest"
@@ -20,6 +21,11 @@ class PCSTier(Enum):
         """maps str (possibly smc tier of deployed PCS thrift servers) to a PCSTier."""
 
         if tier_str in (
+            "ephemeral",
+            "private_measurement.private_computation_service_ephemeral",
+        ):
+            return PCSTier.EPHEMERAL
+        elif tier_str in (
             "rc",
             "private_measurement.private_computation_service_rc",
         ):


### PR DESCRIPTION
Summary:
## Why
In draft diff D40191019, we were exploring supporting ephemeral fbpkg to start tupperware job.
This new env could help us to support ephemeral fbpkg builds before changes land, and provide more real work integration tests.

- SMC: https://www.internalfb.com/intern/smc/overview/?tier_name=private_measurement.private_computation_service_ephemeral
- TW job: https://www.internalfb.com/tupperware/job/summary?handle=tsp_global%2Fprivate_lift%2FPrivateComputationServiceEphemeralHackery

## What
- adding ephemeral smc tier in pcs

Reviewed By: musebc

Differential Revision: D40240402

