### PR TITLE
Store the event_id for each event

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -82,6 +82,7 @@ def lambda_handler(
         action_source = row_data.get("action_source")
         timestamp = row_data.get("event_time")
         event_type = row_data.get("event_name")
+        event_id = row_data.get("event_id")
         pc_test_event_code = row_data.get("pc_test_event_code")
         dummy_dict = {}
         currency_type = row_data.get("custom_data", dummy_dict).get("currency")
@@ -150,6 +151,8 @@ def lambda_handler(
         data["conversion_value"] = conversion_value
         data["event_type"] = event_type
         data["action_source"] = action_source
+        if event_id:
+            data["event_id"] = event_id
         if pc_test_event_code:
             data["pc_test_event_code"] = pc_test_event_code
         if email:


### PR DESCRIPTION
Summary:
The event_id is an optional field that will be used for deduplication in the
future.

https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event#event-id

Reviewed By: wenhaizhu

Differential Revision:
D40246545

LaMa Project: L1109689

