### PR TITLE
T133639006: Limit getRandomPermutation input size to 32 bits. Remove last loop iteration

### DIFF
--- a/fbpcs/emp_games/compactor/AttributionOutput.h
+++ b/fbpcs/emp_games/compactor/AttributionOutput.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <filesystem>
+
 #include "fbpcf/frontend/Bit.h"
 #include "fbpcf/frontend/Int.h"
 #include "fbpcs/emp_games/common/Csv.h"

--- a/fbpcs/emp_games/compactor/CompactorGame.h
+++ b/fbpcs/emp_games/compactor/CompactorGame.h
@@ -41,7 +41,7 @@ class BaseCompactorGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   SecretAttributionOutput<schedulerId> play(
       const SecretAttributionOutput<schedulerId>& secret,
-      size_t size,
+      uint32_t size,
       bool shouldRevealSize) {
     auto compactor = getCompactor(myId_, partnerId_);
     auto [rstMetadata, rstLabel] = compactor->compaction(


### PR DESCRIPTION
Summary:
Implementing suggestions from NCC security review (T133639006). If the size of the vector passed to shuffler is `>2^32-1` then the permutation indexes will overflow and cause invalid result. I don't think we can expect this to support 4.3 billion rows anytime soon so I have opted to update the interface to require `sizeof(size_t) < 32`

It seems that PCS codebase still compiles with this change as compactor game test will continue to compile even without the changes I made to the diff in it. (See below where I ran `buck test //fbpcs/emp_games:compactor_test`, this was without the changes to CompactorGame.

Differential Revision: D40244828

