### PR TITLE
Add binary of UDP library

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/scheduler/IScheduler.h"
+#include "fbpcs/emp_games/common/SchedulerStatistics.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h"
+
+namespace unified_data_process {
+
+template <int schedulerId>
+class UdpProcessApp {
+ public:
+  UdpProcessApp(
+      int party,
+      std::shared_ptr<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+          communicationAgentFactory,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector,
+      std::unique_ptr<UdpProcessGameFactory<schedulerId>> udpGameFactory,
+      int64_t numberOfRows,
+      int64_t sizeOfRow,
+      int64_t numberOfIntersection,
+      bool useXorEncryption = true)
+      : party_{party},
+        communicationAgentFactory_{std::move(communicationAgentFactory)},
+        metricCollector_{std::move(metricCollector)},
+        udpGameFactory_{std::move(udpGameFactory)},
+        numberOfRows_{numberOfRows},
+        sizeOfRow_{sizeOfRow},
+        numberOfIntersection_{numberOfIntersection},
+        useXorEncryption_{useXorEncryption} {}
+
+  // return the extracted shares of intersected metadata from publiser and
+  // partner
+  std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
+  run();
+
+  common::SchedulerStatistics getSchedulerStatistics() {
+    return schedulerStatistics_;
+  }
+
+ protected:
+  std::unique_ptr<fbpcf::scheduler::IScheduler> createScheduler();
+
+  std::tuple<std::vector<int64_t>, std::vector<std::vector<unsigned char>>>
+  dataGeneration();
+
+ private:
+  int party_;
+  std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+      communicationAgentFactory_;
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
+  std::unique_ptr<UdpProcessGameFactory<schedulerId>> udpGameFactory_;
+  int64_t numberOfRows_;
+  int64_t sizeOfRow_;
+  int64_t numberOfIntersection_;
+  bool useXorEncryption_;
+  common::SchedulerStatistics schedulerStatistics_;
+};
+
+} // namespace unified_data_process
+
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h"

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
+
+#include <fbpcf/scheduler/LazySchedulerFactory.h>
+#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
+#include <cstddef>
+
+namespace unified_data_process {
+
+template <int schedulerId>
+std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
+UdpProcessApp<schedulerId>::run() {
+  auto scheduler = createScheduler();
+
+  XLOG(INFO) << "Start generating random data...";
+  auto testData = dataGeneration();
+  XLOG(INFO) << "Finsihed generating random data...";
+  auto& unionMap = std::get<0>(testData);
+  auto& metaData = std::get<1>(testData);
+  auto udpProcessGame = udpGameFactory_->create(std::move(scheduler));
+
+  XLOGF(
+      INFO, "Start to run Adapter with a unionMap of size {}", unionMap.size());
+  auto indexes = udpProcessGame->playAdapter(unionMap);
+
+  XLOGF(
+      INFO,
+      "Start to run DataProcessor with a metaData of size {} and intersection size of {}",
+      metaData.size(),
+      indexes.size());
+  auto shares = udpProcessGame->playDataProcessor(
+      metaData, indexes, metaData.size(), sizeOfRow_);
+
+  auto publisherShares = std::get<0>(shares);
+  auto partnerShares = std::get<1>(shares);
+
+  XLOGF(
+      INFO,
+      "Finished UDP library with publisher shares (batch size {} and bitlength {}) and partner shares (batch size {} and bitlength {})",
+      publisherShares.at(0).size(),
+      publisherShares.size(),
+      partnerShares.at(0).size(),
+      partnerShares.size());
+
+  auto gateStatistics =
+      fbpcf::scheduler::SchedulerKeeper<schedulerId>::getGateStatistics();
+
+  XLOGF(
+      INFO,
+      "Non-free gate count = {}, Free gate count = {}",
+      gateStatistics.first,
+      gateStatistics.second);
+
+  auto trafficStatistics =
+      fbpcf::scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+  XLOGF(
+      INFO,
+      "Sent network traffic = {}, Received network traffic = {}",
+      trafficStatistics.first,
+      trafficStatistics.second);
+
+  schedulerStatistics_.nonFreeGates = gateStatistics.first;
+  schedulerStatistics_.freeGates = gateStatistics.second;
+  schedulerStatistics_.sentNetwork = trafficStatistics.first;
+  schedulerStatistics_.receivedNetwork = trafficStatistics.second;
+  schedulerStatistics_.details = metricCollector_->collectMetrics();
+
+  return {publisherShares, partnerShares};
+}
+
+template <int schedulerId>
+std::unique_ptr<fbpcf::scheduler::IScheduler>
+UdpProcessApp<schedulerId>::createScheduler() {
+  return useXorEncryption_
+      ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+            party_, *communicationAgentFactory_, metricCollector_)
+            ->create()
+      : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
+            party_, *communicationAgentFactory_, metricCollector_)
+            .create();
+}
+
+template <int schedulerId>
+std::tuple<std::vector<int64_t>, std::vector<std::vector<unsigned char>>>
+UdpProcessApp<schedulerId>::dataGeneration() {
+  std::vector<int64_t> unionMap(numberOfRows_, -1);
+  std::vector<std::vector<unsigned char>> metaData(
+      (numberOfRows_ - numberOfIntersection_) / 2 + numberOfIntersection_,
+      std::vector<unsigned char>(sizeOfRow_));
+
+  for (size_t i = 0; i < numberOfIntersection_; ++i) {
+    unionMap[i] = i;
+    for (size_t j = 0; j < sizeOfRow_; ++j) {
+      metaData[i][j] = i % 256;
+    }
+  }
+  for (size_t i = numberOfIntersection_; i < unionMap.size(); ++i) {
+    // If an entry is non-match, it means that only one party has a match.
+    // We use -party_ to represents a non-match entry so that publisher has 0
+    // (match) but partner has -1 (non-match)
+    unionMap[i] = -party_;
+  }
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<uint8_t> dist(0, 255);
+  for (size_t i = numberOfIntersection_; i < metaData.size(); ++i) {
+    for (size_t j = 0; j < sizeOfRow_; ++j) {
+      metaData[i][j] = dist(e);
+    }
+  }
+  return {unionMap, metaData};
+}
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "fbpcf/frontend/mpcGame.h"
+#include "fbpcs/data_processing/unified_data_process/adapter/IAdapterFactory.h"
+#include "fbpcs/data_processing/unified_data_process/data_processor/IDataProcessorFactory.h"
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+
+namespace unified_data_process {
+
+template <int schedulerId>
+class UdpProcessGame : public fbpcf::frontend::MpcGame<schedulerId> {
+ public:
+  using SecString = fbpcf::frontend::BitString<true, schedulerId, true>;
+  using PubString = fbpcf::frontend::BitString<false, schedulerId, true>;
+  using SecBit = fbpcf::frontend::Bit<true, schedulerId, true>;
+  explicit UdpProcessGame(
+      int32_t myId,
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler,
+      std::unique_ptr<unified_data_process::adapter::IAdapterFactory>
+          adapterFactory,
+      std::unique_ptr<
+          unified_data_process::data_processor::IDataProcessorFactory<
+              schedulerId>> dataProcessorFactory)
+      : fbpcf::frontend::MpcGame<schedulerId>(std::move(scheduler)),
+        myId_(myId),
+        adapterFactory_(std::move(adapterFactory)),
+        dataProcessorFactory_(std::move(dataProcessorFactory)) {}
+
+  std::vector<int64_t> playAdapter(const std::vector<int64_t>& unionMap);
+  std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
+  playDataProcessor(
+      const std::vector<std::vector<unsigned char>>& metaData,
+      const std::vector<int64_t>& indexes,
+      size_t peersDataSize,
+      size_t peersDataWidth);
+
+ private:
+  int32_t myId_;
+  std::unique_ptr<unified_data_process::adapter::IAdapterFactory>
+      adapterFactory_;
+  std::unique_ptr<
+      unified_data_process::data_processor::IDataProcessorFactory<schedulerId>>
+      dataProcessorFactory_;
+};
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/permuter/IPermuterFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/IShuffler.h"
+#include "fbpcf/mpc_std_lib/shuffler/IShufflerFactory.h"
+#include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
+#include "fbpcs/data_processing/unified_data_process/adapter/AdapterFactory.h"
+#include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessorFactory.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
+
+namespace unified_data_process {
+
+template <int schedulerId>
+class UdpProcessGameFactory {
+ public:
+  explicit UdpProcessGameFactory(
+      int partyId,
+      fbpcf::engine::communication::IPartyCommunicationAgentFactory&
+          communicationAgentFactory)
+      : partyId_(partyId),
+        communicationAgentFactory_(communicationAgentFactory) {}
+
+  std::unique_ptr<UdpProcessGame<schedulerId>> create(
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler) {
+    auto adapterFactory = std::make_unique<
+        unified_data_process::adapter::AdapterFactory<schedulerId>>(
+        partyId_ == common::PUBLISHER,
+        0,
+        1,
+        std::make_unique<
+            fbpcf::mpc_std_lib::shuffler::PermuteBasedShufflerFactory<
+                fbpcf::frontend::BitString<true, schedulerId, true>>>(
+            partyId_,
+            1 - partyId_,
+            std::make_unique<
+                fbpcf::mpc_std_lib::permuter::
+                    AsWaksmanPermuterFactory<std::vector<bool>, schedulerId>>(
+                partyId_, 1 - partyId_),
+            std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
+    auto dataProcessorFactory = std::make_unique<
+        unified_data_process::data_processor::DataProcessorFactory<
+            schedulerId>>(
+        partyId_,
+        1 - partyId_,
+        communicationAgentFactory_,
+        std::make_unique<fbpcf::mpc_std_lib::aes_circuit::AesCircuitCtrFactory<
+            typename UdpProcessGame<schedulerId>::SecBit>>());
+    return std::make_unique<UdpProcessGame<schedulerId>>(
+        partyId_,
+        std::move(scheduler),
+        std::move(adapterFactory),
+        std::move(dataProcessorFactory));
+  }
+
+ private:
+  int partyId_;
+  fbpcf::engine::communication::IPartyCommunicationAgentFactory&
+      communicationAgentFactory_;
+};
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "fbpcs/data_processing/unified_data_process/adapter/Adapter.h"
+#include "fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h"
+#include "fbpcs/data_processing/unified_data_process/adapter/IAdapter.h"
+#include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h"
+#include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h"
+#include "fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
+
+namespace unified_data_process {
+
+template <int schedulerId>
+std::vector<int64_t> UdpProcessGame<schedulerId>::playAdapter(
+    const std::vector<int64_t>& unionMap) {
+  auto adapter = adapterFactory_->create();
+  return adapter->adapt(unionMap);
+}
+
+template <int schedulerId>
+std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
+UdpProcessGame<schedulerId>::playDataProcessor(
+    const std::vector<std::vector<unsigned char>>& metaData,
+    const std::vector<int64_t>& indexes,
+    size_t peersDataSize,
+    size_t peersDataWidth) {
+  size_t intersectionSize = indexes.size();
+  auto dataProcessor = dataProcessorFactory_->create();
+  typename UdpProcessGame<schedulerId>::SecString publisherShares;
+  typename UdpProcessGame<schedulerId>::SecString advertiserShares;
+  if (myId_ == common::PUBLISHER) {
+    XLOG(INFO) << "Start to process my data...";
+    publisherShares = dataProcessor->processMyData(metaData, intersectionSize);
+    XLOG(INFO) << "Start to process peer's data...";
+    advertiserShares =
+        dataProcessor->processPeersData(peersDataSize, indexes, peersDataWidth);
+  } else {
+    XLOG(INFO) << "Start to process peer's data...";
+    publisherShares =
+        dataProcessor->processPeersData(peersDataSize, indexes, peersDataWidth);
+    XLOG(INFO) << "Start to process my data...";
+    advertiserShares = dataProcessor->processMyData(metaData, intersectionSize);
+  }
+  std::vector<std::vector<bool>> publisherRawShare(
+      publisherShares.size(),
+      std::vector<bool>(publisherShares.getBatchSize()));
+  std::vector<std::vector<bool>> advertiserRawShare(
+      advertiserShares.size(),
+      std::vector<bool>(advertiserShares.getBatchSize()));
+
+  auto extractPublisherString = publisherShares.extractStringShare();
+  auto extractAdvertiserString = advertiserShares.extractStringShare();
+
+  for (size_t i = 0; i < extractPublisherString.size(); ++i) {
+    publisherRawShare[i] = extractPublisherString[i].getValue();
+  }
+  for (size_t i = 0; i < extractAdvertiserString.size(); ++i) {
+    advertiserRawShare[i] = extractAdvertiserString[i].getValue();
+  }
+
+  return {publisherRawShare, advertiserRawShare};
+}
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <memory>
+#include "folly/Format.h"
+#include "folly/Random.h"
+
+#include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
+#include "fbpcf/scheduler/ISchedulerFactory.h"
+#include "fbpcf/test/TestHelper.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+
+namespace unified_data_process {
+template <int schedulerId>
+std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
+runUdpProcessApp(
+    int myId,
+    int64_t rowNumber,
+    int64_t rowSize,
+    int64_t intersectionSize,
+    std::shared_ptr<
+        fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+        communicationAgentFactory,
+    std::shared_ptr<fbpcf::util::MetricCollector> metricCollector,
+    std::unique_ptr<UdpProcessGameFactory<schedulerId>> udpGameFactory) {
+  UdpProcessApp<schedulerId> app(
+      myId,
+      std::move(communicationAgentFactory),
+      std::move(metricCollector),
+      std::move(udpGameFactory),
+      rowNumber,
+      rowSize,
+      intersectionSize);
+  return app.run();
+}
+
+std::vector<std::vector<uint8_t>> reconstructResults(
+    std::vector<std::vector<bool>>& booleanShares0,
+    std::vector<std::vector<bool>>& booleanShares1) {
+  std::vector<std::vector<bool>> booleanShares(
+      booleanShares0.size(), std::vector<bool>(booleanShares0.at(0).size()));
+  for (size_t i = 0; i < booleanShares0.size(); ++i) {
+    for (size_t j = 0; j < booleanShares0.at(0).size(); ++j) {
+      booleanShares[i][j] = booleanShares0[i][j] ^ booleanShares1[i][j];
+    }
+  }
+  std::vector<std::vector<uint8_t>> reconstructedData(
+      booleanShares.at(0).size(),
+      std::vector<uint8_t>(booleanShares.size() / 8));
+
+  for (size_t i = 0; i < booleanShares.size() / 8; i++) {
+    for (uint8_t j = 0; j < 8; j++) {
+      for (size_t k = 0; k < booleanShares.at(0).size(); k++) {
+        reconstructedData[k][i] += (booleanShares.at(i * 8 + j).at(k) << j);
+      }
+    }
+  }
+
+  return reconstructedData;
+}
+
+void checkOutput(
+    const std::vector<std::vector<uint8_t>>& publisherData,
+    const std::vector<std::vector<uint8_t>>& partnerData,
+    int64_t row_size,
+    int64_t intersectionSize) {
+  ASSERT_EQ(publisherData.size(), intersectionSize);
+  ASSERT_EQ(partnerData.size(), intersectionSize);
+  ASSERT_EQ(publisherData.at(0).size(), row_size);
+  ASSERT_EQ(partnerData.at(0).size(), row_size);
+
+  // The intersected meta data on both
+  // party were set to be the same for the ease of
+  // correctness verification.
+  EXPECT_EQ(publisherData, partnerData);
+}
+
+TEST(UdpProcessApp, testUdpProcessApp) {
+  std::random_device rd;
+  std::mt19937_64 e(rd());
+  std::uniform_int_distribution<int32_t> randomRowNum(100, 0xFF);
+  std::uniform_int_distribution<int32_t> randomRowSize(64, 80);
+  std::uniform_int_distribution<uint8_t> randomRate(1, 20);
+  int64_t rowNumber = randomRowNum(e);
+  int64_t rowSize = randomRowSize(e);
+  double intsectionRate = randomRate(e);
+  int64_t intersectionSize = (intsectionRate / 100) * rowNumber;
+
+  auto agentFactories =
+      fbpcf::engine::communication::getInMemoryAgentFactory(2);
+  fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
+  auto udpGameFactory0 =
+      std::make_unique<UdpProcessGameFactory<0>>(0, *agentFactories[0]);
+  auto udpGameFactory1 =
+      std::make_unique<UdpProcessGameFactory<1>>(1, *agentFactories[1]);
+
+  auto metricCollector0 =
+      std::make_shared<fbpcf::util::MetricCollector>("attribution_test_0");
+
+  auto metricCollector1 =
+      std::make_shared<fbpcf::util::MetricCollector>("attribution_test_1");
+
+  auto future0 = std::async(
+      runUdpProcessApp<0>,
+      0,
+      rowNumber,
+      rowSize,
+      intersectionSize,
+      std::move(agentFactories[0]),
+      std::move(metricCollector0),
+      std::move(udpGameFactory0));
+  auto future1 = std::async(
+      runUdpProcessApp<1>,
+      1,
+      rowNumber,
+      rowSize,
+      intersectionSize,
+      std::move(agentFactories[1]),
+      std::move(metricCollector1),
+      std::move(udpGameFactory1));
+
+  auto sharesOutput0 = future0.get();
+  auto sharesOutput1 = future1.get();
+
+  auto& publisherDataShares0 = std::get<0>(sharesOutput0);
+  auto& partnerDataShares0 = std::get<1>(sharesOutput0);
+
+  auto& publisherDataShares1 = std::get<0>(sharesOutput1);
+  auto& partnerDataShares1 = std::get<1>(sharesOutput1);
+
+  auto publisherData =
+      reconstructResults(publisherDataShares0, publisherDataShares1);
+  auto partnerData = reconstructResults(partnerDataShares0, partnerDataShares1);
+  checkOutput(publisherData, partnerData, rowSize, intersectionSize);
+}
+
+} // namespace unified_data_process


### PR DESCRIPTION
Summary:
This diff added the binary of UDP library as an emp game under ``//fbpcs/emp_games/data_processing/unified_data_process``.
 1. adds `UdpProcessGame.h` and `UdpProcessGame_impl.h` to implement a game for udp adapter and data processor.
2. adds `UdpProcessGameFactory.h` to create `UdpProcessGame`.
3. adds `UdpProcessApp.h` and `UdpProcessApp_impl.h` to wrap the `UdpProcessGame`.
4. adds a test file to test the `UdpProcessApp`

This game mainly expect four input parameters: ``party`` to indicate whether running the game as publisher or partner; ``row_number`` represents the size of ``unionMap`` from PID stage. ``row_size`` reoresents the number of bytes in a row of metadata. ``intersection`` represents the number of instersection in the ``unionMap``.

The ``UdpProcessApp`` will generate some random data based on the above input parameters and feed them into the ``UdpProcessGame``. In more detail, the ``dataGeneration()`` methods will generate a ``unionMap`` to simulate the results from PID stage and ``metadata`` to simulate each party's meta data.

``unionMap`` will be an integer vector with size ``row_number``. On publisher side, the first ``intersection`` rows in the ``unionMap`` will be positive indexes and the rest will be 0. On the partner side, the first ``intersection`` rows in the ``unionMap`` will be positive indexes and the rest will be -1. In this way, the top ``intersection`` rows in the ``unionMap`` represents the intersection.

Reviewed By: robotal

Differential Revision: D39939986

