### PR TITLE
Store the event_id for the semi-automated pipeline

### DIFF
--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
@@ -132,6 +132,7 @@ expected_column_list = [
     "conversion_value",
     "event_type",
     "action_source",
+    "event_id",
 ]
 for column_name in expected_column_list:
     if column_name not in listColumns:


### PR DESCRIPTION
Summary:
The event_id is an optional field that will be used for deduplication in the
future.

https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event#event-id

Differential Revision:
D40277860

LaMa Project: L416713

