### PR TITLE
Force remove S3 bucket when we run undeploy terraform script

### DIFF
--- a/fbpcs/infra/pid/aws_terraform_template/partner/s3_bucket.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/partner/s3_bucket.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "mrpid_partner_intermediate_bucket" {
   bucket = "mrpid-partner-${var.md5hash_aws_account_id}"
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "mrpid_block_public_access" {
@@ -71,6 +72,7 @@ EOF
 
 resource "aws_s3_bucket" "mrpid_partner_confs_bucket" {
   bucket = "mrpid-partner-${var.md5hash_aws_account_id}-confs"
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "mrpid_confs_block_public_access" {

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/s3_bucket.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/s3_bucket.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "mrpid_publisher_intermediate_bucket" {
   bucket = "mrpid-publisher-${var.md5hash_partner_account_id}"
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "mrpid_block_public_access" {
@@ -13,6 +14,7 @@ resource "aws_s3_bucket_public_access_block" "mrpid_block_public_access" {
 
 resource "aws_s3_bucket" "mrpid_publisher_confs_bucket" {
   bucket = "mrpid-publisher-${var.md5hash_partner_account_id}-confs"
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "mrpid_confs_block_public_access" {


### PR DESCRIPTION
Summary: Force remove S3 bucket when we run undeploy terraform script, if S3 intermedaite bucket already contains data.

Reviewed By: Pradeepnitw

Differential Revision: D40286126

