### PR TITLE
bolt log failed containers API

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -126,3 +126,6 @@ class BoltClient(ABC, Generic[T]):
                 f"instance {instance_args.instance_id} does not exist - creating"
             )
             return await self.create_instance(instance_args)
+
+    async def log_failed_containers(self, instance_id: str) -> None:
+        pass

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -273,6 +273,13 @@ class BoltRunner(Generic[T, U]):
                 in [fail_status, PrivateComputationInstanceStatus.TIMEOUT]
                 or partner_state.pc_instance_status is fail_status
             ):
+                try:
+                    await asyncio.gather(
+                        self.publisher_client.log_failed_containers(publisher_id),
+                        self.partner_client.log_failed_containers(partner_id),
+                    )
+                except Exception as e:
+                    logger.debug(e)
                 # stage failed, cancel publisher and partner side only in joint stage
                 if stage.is_joint_stage:
                     try:

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -230,3 +230,7 @@ class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
         instance_id = await super().get_or_create_instance(instance_args)
         self.pcs.update_input_path(instance_id, instance_args.input_path)
         return instance_id
+
+    async def log_failed_containers(self, instance_id: str) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self.pcs.log_failed_containers, instance_id)


### PR DESCRIPTION
Summary:
# What

- Add log_failed_containers` API to BoltClient

# Why

-  This will be used to log containers on failure

Reviewed By: joe1234wu

Differential Revision: D40241663

