### PR TITLE
Add tracker hash so we can track the status.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Print Tracker Hash
         run: echo ${{ github.event.inputs.tracker_hash }}
 
@@ -64,6 +65,7 @@ jobs:
           # (fbpcs-github-cicd:4 https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/taskDefinitions/fbpcs-github-cicd/4)
           # points at :rc instead of latest-build
           docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{github.event.inputs.new_tag}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:rc
+
       - name: Push image to rc registry
         run: |
           docker push --all-tags ${{ env.RC_REGISTRY_IMAGE_NAME }}
@@ -77,6 +79,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash }}
+
       - name: Cleanup ECS running tasks and previous running results
         run: |
           ./cleanup.sh


### PR DESCRIPTION
Summary: MacGyver looks for a job that inlcudes the tracker hash in the log and fails if the workflow isn't complete and we can't find a job with the hash.

Reviewed By: gorel

Differential Revision: D40316140

