### PR TITLE
Fix the ability to build binaries based on the local FBPCF image.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
+  FBPCF_VERSION: 2.1.73
 
 jobs:
   ### Build and publish rc/onedocker image
@@ -48,7 +49,7 @@ jobs:
 
       - name: Build onedocker image in rc
         run: |
-          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f -p linux/amd64
+          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f -p linux/amd64 -v ${{ env.FBPCF_VERSION }}
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -14,7 +14,7 @@ FBPCF_VERSION="2.1.73"
 PROG_NAME=$0
 usage() {
   cat << EOF >&2
-Usage: $PROG_NAME <package: emp_games|data_processing|pce_deployment|onedocker> [-u] [-g] [-t TAG] [-p PLATFORM]
+Usage: $PROG_NAME <package: emp_games|data_processing|pce_deployment|onedocker> [-u] [-g] [-t TAG] [-p PLATFORM] [-v FBPCF_VERSION]
 
 package:
   emp_games - builds the emp-games docker image
@@ -26,6 +26,7 @@ package:
 -g Only used for the pce_deployment package to build the GCP docker image instead of the AWS image
 -t TAG: tags the image with the given tag (default: latest)
 -p PLATFORM: builds the image to target the given platform (default depends on local system) - requires Docker Engine API 1.40+
+-v FBPCF_VERSION: base FBPCF version to use
 EOF
   exit 1
 }
@@ -45,7 +46,8 @@ TAG="latest"
 FORCE_EXTERNAL=false
 USE_GCP=false
 PLATFORM=""
-while getopts "u,f,g,t:,p:" o; do
+FBPCF_VERSION="latest"
+while getopts "u,f,g,t:,p,v:" o; do
   case $o in
     (u) OS_VARIANT="ubuntu"
         OS_RELEASE=${UBUNTU_RELEASE}
@@ -54,6 +56,7 @@ while getopts "u,f,g,t:,p:" o; do
     (g) USE_GCP=true;;
     (t) TAG=$OPTARG;;
     (p) PLATFORM=$OPTARG;;
+    (v) FBPCF_VERSION=$OPTARG;;
     (*) usage
   esac
 done


### PR DESCRIPTION
Summary: There was a bug in the code that pinned the FBPCF version which made it impossible to test with local FBPCF changes. This commit adds a new version flag which allows you to specify the FBPCF version, and defaults it to latest for developers who are testing. This commit also updates the build and release system to pin the FBPCF version for releases.

Differential Revision: D40285359

