### PR TITLE
Actually set the TLS info based on the binary arguments

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
@@ -73,7 +73,9 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
     int numConversionsPerUser,
     bool computePublisherBreakdowns,
     int epoch,
-    bool useXorEncryption) {
+    bool useXorEncryption,
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
+        tlsInfo) {
   // aggregate scheduler statistics across apps
   common::SchedulerStatistics schedulerStatistics{
       0, 0, 0, 0, folly::dynamic::object()};
@@ -92,13 +94,6 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
         partyInfos(
             {{0, {serverIp, port + index * 100}},
              {1, {serverIp, port + index * 100}}});
-
-    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo
-        tlsInfo;
-    tlsInfo.certPath = "";
-    tlsInfo.keyPath = "";
-    tlsInfo.passphrasePath = "";
-    tlsInfo.useTls = false;
 
     auto metricCollector = std::make_shared<fbpcf::util::MetricCollector>(
         "lift_metrics_for_thread_" + std::to_string(index));
@@ -147,7 +142,8 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFilesHelper(
                 numConversionsPerUser,
                 computePublisherBreakdowns,
                 epoch,
-                useXorEncryption);
+                useXorEncryption,
+                tlsInfo);
         schedulerStatistics.add(remainingStats);
       }
     }
@@ -169,7 +165,9 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFiles(
     int numConversionsPerUser,
     bool computePublisherBreakdowns,
     int epoch,
-    bool useXorEncryption) {
+    bool useXorEncryption,
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
+        tlsInfo) {
   // use only as many threads as the number of files
   auto numThreads = std::min((int)inputFilepaths.size(), (int)concurrency);
 
@@ -186,7 +184,8 @@ inline common::SchedulerStatistics startCalculatorAppsForShardedFiles(
       numConversionsPerUser,
       computePublisherBreakdowns,
       epoch,
-      useXorEncryption);
+      useXorEncryption,
+      tlsInfo);
 }
 
 } // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -152,6 +152,13 @@ int main(int argc, char** argv) {
   auto inputFilepaths = filepaths.first;
   auto outputFilepaths = filepaths.second;
 
+  auto tlsInfo = common::getTlsInfoFromArgs(
+      FLAGS_use_tls,
+      FLAGS_ca_cert_path,
+      FLAGS_server_cert_path,
+      FLAGS_private_key_path,
+      "");
+
   std::vector<std::string> enabledFeatureFlags;
   folly::split(',', FLAGS_pc_feature_flags, enabledFeatureFlags);
   bool readInputFromSecretShares = std::any_of(
@@ -208,7 +215,8 @@ int main(int argc, char** argv) {
             FLAGS_num_conversions_per_user,
             FLAGS_compute_publisher_breakdowns,
             FLAGS_epoch,
-            FLAGS_use_xor_encryption);
+            FLAGS_use_xor_encryption,
+            tlsInfo);
   } else if (FLAGS_party == common::PARTNER) {
     XLOG(INFO)
         << "Starting Private Lift as Partner, will wait for Publisher...";
@@ -224,7 +232,8 @@ int main(int argc, char** argv) {
             FLAGS_num_conversions_per_user,
             FLAGS_compute_publisher_breakdowns,
             FLAGS_epoch,
-            FLAGS_use_xor_encryption);
+            FLAGS_use_xor_encryption,
+            tlsInfo);
   } else {
     XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
   }


### PR DESCRIPTION
Summary: We are doing what we did in D39643733 (https://github.com/facebookresearch/fbpcs/commit/d3f93dc0ae58a89836264252821189067d1f8d40). But I forgot to do it for lift, for some reason. Doing it in this diff now.

Differential Revision: D40285234

