### PR TITLE
Add LogRetriever configs to CI/CD config.yml files

### DIFF
--- a/fbpcs/tests/github/config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/config_one_command_runner_test.yml
@@ -29,6 +29,15 @@ private_computation:
     OneDockerServiceConfig:
       constructor:
         task_definition: onedocker-task-pc-e2e-test:1#onedocker-container-pc-e2e-test
+    LogRetriever:
+      class: fbpcs.experimental.cloud_logs.aws_log_retriever.AWSLogRetriever
+      constructor:
+        cloudwatch_log_service_args:
+          kls: fbpcp.service.log_cloudwatch.CloudWatchLogService
+          args:
+            region: us-west-2
+            access_key_id:
+            access_key_data:
 pid:
   dependency:
 mpc:

--- a/fbpcs/tests/github/fbpcs_e2e_aws.yml
+++ b/fbpcs/tests/github/fbpcs_e2e_aws.yml
@@ -30,6 +30,15 @@ private_computation:
     OneDockerServiceConfig:
       constructor:
         task_definition: fbpcs-github-cicd:4#fbpcs-github-cicd
+    LogRetriever:
+      class: fbpcs.experimental.cloud_logs.aws_log_retriever.AWSLogRetriever
+      constructor:
+        cloudwatch_log_service_args:
+          kls: fbpcp.service.log_cloudwatch.CloudWatchLogService
+          args:
+            region: us-west-2
+            access_key_id:
+            access_key_data:
 pid:
   dependency:
   skip_aggregation_step: true


### PR DESCRIPTION
Summary:
## What

- Add log retriever configs to CI/CD yml files

## Why

- So we can get cloudwatch logs directly inside the PCS logs and through the trace logging table

Differential Revision: D40350710

