### PR TITLE
fix get valid stage edge case

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -404,13 +404,13 @@ class BoltRunner(Generic[T, U]):
                 # if it's not a joint stage, the statuses don't matter at all since
                 # each party operates independently
                 # Example: publisher is RESHARD_FAILED, partner is RESHARD_COMPLETED
-                if not publisher_stage.is_joint_stage or (
+                if stage_flow.is_completed_status(partner_status) and (
+                    not publisher_stage.is_joint_stage
                     # it's fine if one party is completed and the other is started
                     # because the one with the started status just needs to call
                     # update_instance one more time
                     # Example: publisher is COMPUTATION_STARTED, partner is COMPUTATION_COMPLETED
-                    stage_flow.is_started_status(publisher_status)
-                    and stage_flow.is_completed_status(partner_status)
+                    or stage_flow.is_started_status(publisher_status)
                 ):
                     return publisher_stage
             elif partner_stage is publisher_stage.previous_stage:
@@ -421,10 +421,10 @@ class BoltRunner(Generic[T, U]):
                     await self.partner_client.update_instance(partner_id)
                 ).pc_instance_status
                 # Example: publisher is RESHARD_COMPLETED, partner is RESHARD_FAILED
-                if not partner_stage.is_joint_stage or (
+                if stage_flow.is_completed_status(publisher_status) and (
+                    not partner_stage.is_joint_stage
                     # Example: publisher is COMPUTATION_COMPLETED, partner is COMPUTATION_STARTED
-                    stage_flow.is_started_status(partner_status)
-                    and stage_flow.is_completed_status(publisher_status)
+                    or stage_flow.is_started_status(partner_status)
                 ):
                     return partner_stage
             # Example: partner is CREATED, publisher is PID_PREPARE_COMPLETED

--- a/fbpcs/bolt/test/test_bolt_runner.py
+++ b/fbpcs/bolt/test/test_bolt_runner.py
@@ -863,6 +863,18 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
                 PrivateComputationStageFlow.COMPUTE.completed_status,
                 PrivateComputationStageFlow.COMPUTE.next_stage,
             ),
+            (
+                PrivateComputationStageFlow.CREATED.completed_status,
+                PrivateComputationStageFlow.CREATED.next_stage,
+                PrivateComputationStageFlow.PID_SHARD.failed_status,
+                PrivateComputationStageFlow.PID_SHARD,
+            ),
+            (
+                PrivateComputationStageFlow.PID_SHARD.failed_status,
+                PrivateComputationStageFlow.PID_SHARD,
+                PrivateComputationStageFlow.CREATED.completed_status,
+                PrivateComputationStageFlow.CREATED.next_stage,
+            ),
         ]
 
 


### PR DESCRIPTION
Summary:
## What

- The problem...
  - `get_next_valid_stage` fetches the partner's next runnable stage and the publisher's next runnable stage
  - The simple case is that they are the same
  - There are complex scenarios, however, where the partner and publisher may have different next stages, but the run is still valid. e.g. partner has status PID_SHARD_FAILED, publisher has status PID_SHARD_COMPLETED. The partner's next stage is PID_SHARD, the publisher's next stage is PID_PREPARE. However, since PID_SHARD is a non-joint stage, we can retry PID_SHARD and simply not invoke the publisher on the retry
  - The previous implementation assumed that the earliest stage is always valid if it's a non joint stage and the publisher is only one stage ahead
  - However, this assumption is incorrect - the earliest stage is only valid if it's a non joint stage, the publisher is one stage ahead, AND the publisher hasn't attempted the next stage yet
  - This diff fixes this issue and adds tests for the edge case

## Why

- Bugs are bad
- If this logic wasn't buggy, we would have been able to fail fast on S301876

Differential Revision: D40357679

