### PR TITLE
Change adapter and data processor types to int32_t

### DIFF
--- a/fbpcs/data_processing/unified_data_process/adapter/Adapter.h
+++ b/fbpcs/data_processing/unified_data_process/adapter/Adapter.h
@@ -31,8 +31,8 @@ class Adapter final : public IAdapter {
         party1Id_(party1Id),
         shuffler_(std::move(shuffler)) {}
 
-  std::vector<int64_t> adapt(
-      const std::vector<int64_t>& unionMap) const override;
+  std::vector<int32_t> adapt(
+      const std::vector<int32_t>& unionMap) const override;
 
  private:
   bool amIParty0_;

--- a/fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h
+++ b/fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h
@@ -14,8 +14,8 @@
 namespace unified_data_process::adapter {
 
 template <int schedulerId>
-std::vector<int64_t> Adapter<schedulerId>::adapt(
-    const std::vector<int64_t>& unionMap) const {
+std::vector<int32_t> Adapter<schedulerId>::adapt(
+    const std::vector<int32_t>& unionMap) const {
   auto unionSize = unionMap.size();
 
   if (unionSize == 0) {
@@ -26,7 +26,7 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
   SecString ids(2 * indexWidth + 1);
 
   std::vector<bool> hasValue(unionSize);
-  std::vector<uint64_t> myMap(unionSize);
+  std::vector<uint32_t> myMap(unionSize);
 
   for (size_t i = 0; i < unionSize; i++) {
     hasValue[i] = unionMap.at(i) >= 0;
@@ -51,7 +51,7 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
   auto match1 = shuffledIds[0].openToParty(party1Id_);
   auto matchResult =
       amIParty0_ ? std::move(match0).getValue() : std::move(match1).getValue();
-  int64_t intersectionSize = 0;
+  int32_t intersectionSize = 0;
   for (auto item : matchResult) {
     intersectionSize += item;
   }
@@ -81,7 +81,7 @@ std::vector<int64_t> Adapter<schedulerId>::adapt(
   auto myShare = amIParty0_ ? std::move(myShare1).getValue()
                             : std::move(myShare0).getValue();
 
-  std::vector<int64_t> rst(intersectionSize, 0);
+  std::vector<int32_t> rst(intersectionSize, 0);
   for (size_t i = 0; i < intersectionSize; i++) {
     for (size_t j = 0; j < indexWidth; j++) {
       rst[i] += (myShare.at(j).at(i)) << j;

--- a/fbpcs/data_processing/unified_data_process/adapter/IAdapter.h
+++ b/fbpcs/data_processing/unified_data_process/adapter/IAdapter.h
@@ -30,8 +30,8 @@ class IAdapter {
    * in the output represents the index of peer's element that corresponds to
    * the i-th element in the intersection.
    */
-  virtual std::vector<int64_t> adapt(
-      const std::vector<int64_t>& unionMap) const = 0;
+  virtual std::vector<int32_t> adapt(
+      const std::vector<int32_t>& unionMap) const = 0;
 };
 
 } // namespace unified_data_process::adapter

--- a/fbpcs/data_processing/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcs/data_processing/unified_data_process/adapter/test/AdapterTest.cpp
@@ -24,8 +24,8 @@
 
 namespace unified_data_process::adapter {
 
-std::vector<int64_t> generateShuffledIndex(size_t size) {
-  std::vector<int64_t> rst(size);
+std::vector<int32_t> generateShuffledIndex(size_t size) {
+  std::vector<int32_t> rst(size);
   for (size_t i = 0; i < size; i++) {
     rst[i] = i;
   }
@@ -34,9 +34,9 @@ std::vector<int64_t> generateShuffledIndex(size_t size) {
 }
 
 std::tuple<
-    std::vector<int64_t>,
-    std::vector<int64_t>,
-    std::unordered_map<int64_t, int64_t>>
+    std::vector<int32_t>,
+    std::vector<int32_t>,
+    std::unordered_map<int32_t, int32_t>>
 generateAdapterTestData() {
   std::random_device rd;
   std::mt19937_64 e(rd());
@@ -57,13 +57,13 @@ generateAdapterTestData() {
     }
   }
 
-  std::vector<int64_t> p0Data = generateShuffledIndex(p0InputSize);
-  std::vector<int64_t> p1Data = generateShuffledIndex(p1InputSize);
-  std::vector<int64_t> p0Input(unionSize);
-  std::vector<int64_t> p1Input(unionSize);
+  std::vector<int32_t> p0Data = generateShuffledIndex(p0InputSize);
+  std::vector<int32_t> p1Data = generateShuffledIndex(p1InputSize);
+  std::vector<int32_t> p0Input(unionSize);
+  std::vector<int32_t> p1Input(unionSize);
   size_t p0Index = 0;
   size_t p1Index = 0;
-  std::unordered_map<int64_t, int64_t> expectedOutput;
+  std::unordered_map<int32_t, int32_t> expectedOutput;
   for (size_t i = 0; i < unionSize; i++) {
     if (u.at(i) == 2) {
       expectedOutput[p0Data.at(p0Index)] = p1Data.at(p1Index);
@@ -86,9 +86,9 @@ generateAdapterTestData() {
 }
 
 void checkOutput(
-    const std::vector<int64_t>& p0Output,
-    const std::vector<int64_t>& p1Output,
-    const std::unordered_map<int64_t, int64_t>& expectedOutput) {
+    const std::vector<int32_t>& p0Output,
+    const std::vector<int32_t>& p1Output,
+    const std::unordered_map<int32_t, int32_t>& expectedOutput) {
   ASSERT_EQ(p0Output.size(), expectedOutput.size());
   ASSERT_EQ(p1Output.size(), expectedOutput.size());
   for (size_t i = 0; i < p0Output.size(); i++) {
@@ -102,7 +102,7 @@ void adapterTest(
     std::unique_ptr<IAdapter> adapter1) {
   auto [p0Input, p1Input, expectedOutput] = generateAdapterTestData();
   auto task = [](std::unique_ptr<IAdapter> adapter,
-                 const std::vector<int64_t>& input) {
+                 const std::vector<int32_t>& input) {
     return adapter->adapt(input);
   };
   auto future0 = std::async(task, std::move(adapter0), p0Input);

--- a/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h
@@ -47,7 +47,7 @@ class DataProcessor final : public IDataProcessor<schedulerId> {
    */
   typename IDataProcessor<schedulerId>::SecString processPeersData(
       size_t dataSize,
-      const std::vector<int64_t>& indexes,
+      const std::vector<int32_t>& indexes,
       size_t dataWidth) override;
 
  private:

--- a/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h
@@ -74,7 +74,7 @@ template <int schedulerId>
 typename IDataProcessor<schedulerId>::SecString
 DataProcessor<schedulerId>::processPeersData(
     size_t dataSize,
-    const std::vector<int64_t>& indexes,
+    const std::vector<int32_t>& indexes,
     size_t dataWidth) {
   // 1a. (peer)encrypt my data locally
   // 2a. (peer)send encryted data to peer

--- a/fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessor.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessor.h
@@ -38,7 +38,7 @@ class DummyDataProcessor final : public IDataProcessor<schedulerId> {
    */
   typename IDataProcessor<schedulerId>::SecString processPeersData(
       size_t dataSize,
-      const std::vector<int64_t>& indexes,
+      const std::vector<int32_t>& indexes,
       size_t dataWidth) override;
 
  private:

--- a/fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessor_impl.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessor_impl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "fbpcs/data_processing/unified_data_process/data_processor/DummyDataProcessor.h"
+
 namespace unified_data_process::data_processor::insecure {
 
 template <int schedulerId>
@@ -33,7 +35,7 @@ template <int schedulerId>
 typename IDataProcessor<schedulerId>::SecString
 DummyDataProcessor<schedulerId>::processPeersData(
     size_t dataSize,
-    const std::vector<int64_t>& indexes,
+    const std::vector<int32_t>& indexes,
     size_t dataWidth) {
   std::vector<std::vector<unsigned char>> plaintext;
   for (size_t i = 0; i < dataSize; i++) {

--- a/fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h
@@ -48,7 +48,7 @@ class IDataProcessor {
    */
   virtual SecString processPeersData(
       size_t dataSize,
-      const std::vector<int64_t>& indexes,
+      const std::vector<int32_t>& indexes,
       size_t dataWidth) = 0;
 };
 

--- a/fbpcs/data_processing/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcs/data_processing/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -27,7 +27,7 @@ namespace unified_data_process::data_processor {
 
 std::tuple<
     std::vector<std::vector<uint8_t>>,
-    std::vector<int64_t>,
+    std::vector<int32_t>,
     std::vector<std::vector<uint8_t>>>
 generateDataProcessorTestData() {
   std::random_device rd;
@@ -46,7 +46,7 @@ generateDataProcessorTestData() {
       data = randomData(e);
     }
   }
-  std::vector<int64_t> index(inputSize);
+  std::vector<int32_t> index(inputSize);
   for (size_t i = 0; i < inputSize; i++) {
     index[i] = i;
   }
@@ -88,7 +88,7 @@ void testDataProcessor(
   };
   auto task1 = [](std::unique_ptr<IDataProcessor<1>> processor,
                   size_t dataSize,
-                  const std::vector<int64_t>& indexes,
+                  const std::vector<int32_t>& indexes,
                   size_t dataWidth) {
     auto secretSharedOutput =
         processor->processPeersData(dataSize, indexes, dataWidth);

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
@@ -13,7 +13,6 @@
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
-#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h"
 
 namespace unified_data_process {
 
@@ -27,9 +26,9 @@ class UdpProcessApp {
           communicationAgentFactory,
       std::shared_ptr<fbpcf::util::MetricCollector> metricCollector,
       std::unique_ptr<UdpProcessGameFactory<schedulerId>> udpGameFactory,
-      int64_t numberOfRows,
+      int32_t numberOfRows,
       int64_t sizeOfRow,
-      int64_t numberOfIntersection,
+      int32_t numberOfIntersection,
       bool useXorEncryption = true)
       : party_{party},
         communicationAgentFactory_{std::move(communicationAgentFactory)},
@@ -52,7 +51,7 @@ class UdpProcessApp {
  protected:
   std::unique_ptr<fbpcf::scheduler::IScheduler> createScheduler();
 
-  std::tuple<std::vector<int64_t>, std::vector<std::vector<unsigned char>>>
+  std::tuple<std::vector<int32_t>, std::vector<std::vector<unsigned char>>>
   dataGeneration();
 
  private:

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
@@ -89,9 +89,9 @@ UdpProcessApp<schedulerId>::createScheduler() {
 }
 
 template <int schedulerId>
-std::tuple<std::vector<int64_t>, std::vector<std::vector<unsigned char>>>
+std::tuple<std::vector<int32_t>, std::vector<std::vector<unsigned char>>>
 UdpProcessApp<schedulerId>::dataGeneration() {
-  std::vector<int64_t> unionMap(numberOfRows_, -1);
+  std::vector<int32_t> unionMap(numberOfRows_, -1);
   std::vector<std::vector<unsigned char>> metaData(
       (numberOfRows_ - numberOfIntersection_) / 2 + numberOfIntersection_,
       std::vector<unsigned char>(sizeOfRow_));

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h
@@ -36,11 +36,11 @@ class UdpProcessGame : public fbpcf::frontend::MpcGame<schedulerId> {
         adapterFactory_(std::move(adapterFactory)),
         dataProcessorFactory_(std::move(dataProcessorFactory)) {}
 
-  std::vector<int64_t> playAdapter(const std::vector<int64_t>& unionMap);
+  std::vector<int32_t> playAdapter(const std::vector<int32_t>& unionMap);
   std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
   playDataProcessor(
       const std::vector<std::vector<unsigned char>>& metaData,
-      const std::vector<int64_t>& indexes,
+      const std::vector<int32_t>& indexes,
       size_t peersDataSize,
       size_t peersDataWidth);
 
@@ -54,3 +54,5 @@ class UdpProcessGame : public fbpcf::frontend::MpcGame<schedulerId> {
 };
 
 } // namespace unified_data_process
+
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h"

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
@@ -22,8 +22,8 @@
 namespace unified_data_process {
 
 template <int schedulerId>
-std::vector<int64_t> UdpProcessGame<schedulerId>::playAdapter(
-    const std::vector<int64_t>& unionMap) {
+std::vector<int32_t> UdpProcessGame<schedulerId>::playAdapter(
+    const std::vector<int32_t>& unionMap) {
   auto adapter = adapterFactory_->create();
   return adapter->adapt(unionMap);
 }
@@ -32,7 +32,7 @@ template <int schedulerId>
 std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
 UdpProcessGame<schedulerId>::playDataProcessor(
     const std::vector<std::vector<unsigned char>>& metaData,
-    const std::vector<int64_t>& indexes,
+    const std::vector<int32_t>& indexes,
     size_t peersDataSize,
     size_t peersDataWidth) {
   size_t intersectionSize = indexes.size();

--- a/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
@@ -22,9 +22,9 @@ template <int schedulerId>
 std::tuple<std::vector<std::vector<bool>>, std::vector<std::vector<bool>>>
 runUdpProcessApp(
     int myId,
-    int64_t rowNumber,
-    int64_t rowSize,
-    int64_t intersectionSize,
+    int32_t rowNumber,
+    int32_t rowSize,
+    int32_t intersectionSize,
     std::shared_ptr<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory>
         communicationAgentFactory,
@@ -69,8 +69,8 @@ std::vector<std::vector<uint8_t>> reconstructResults(
 void checkOutput(
     const std::vector<std::vector<uint8_t>>& publisherData,
     const std::vector<std::vector<uint8_t>>& partnerData,
-    int64_t row_size,
-    int64_t intersectionSize) {
+    int32_t row_size,
+    int32_t intersectionSize) {
   ASSERT_EQ(publisherData.size(), intersectionSize);
   ASSERT_EQ(partnerData.size(), intersectionSize);
   ASSERT_EQ(publisherData.at(0).size(), row_size);
@@ -88,10 +88,10 @@ TEST(UdpProcessApp, testUdpProcessApp) {
   std::uniform_int_distribution<int32_t> randomRowNum(100, 0xFF);
   std::uniform_int_distribution<int32_t> randomRowSize(64, 80);
   std::uniform_int_distribution<uint8_t> randomRate(1, 20);
-  int64_t rowNumber = randomRowNum(e);
-  int64_t rowSize = randomRowSize(e);
-  double intsectionRate = randomRate(e);
-  int64_t intersectionSize = (intsectionRate / 100) * rowNumber;
+  int32_t rowNumber = randomRowNum(e);
+  int32_t rowSize = randomRowSize(e);
+  double intersectionRate = randomRate(e);
+  int32_t intersectionSize = (intersectionRate / 100) * rowNumber;
 
   auto agentFactories =
       fbpcf::engine::communication::getInMemoryAgentFactory(2);


### PR DESCRIPTION
Summary: The shuffler only supports permutations of size 32_bits (see D40244828 (https://github.com/facebookresearch/fbpcs/commit/4322220c5cd14a7bef64832baf15d9ba34bf9ab0)). We should correct the adapter API to reflect this.

Reviewed By: RuiyuZhu

Differential Revision: D40317771

