### PR TITLE
adding System User on token validation rule TOKEN_USER_TYPE

### DIFF
--- a/fbpcs/pl_coordinator/tests/test_token_validator.py
+++ b/fbpcs/pl_coordinator/tests/test_token_validator.py
@@ -112,6 +112,18 @@ class TestTokenValidator(TestCase):
                 False,
             ),
             (
+                "Token is User type",
+                TokenValidationRule.TOKEN_USER_TYPE,
+                self._gen_debug_data(type="USER"),
+                True,
+            ),
+            (
+                "Token is System User type",
+                TokenValidationRule.TOKEN_USER_TYPE,
+                self._gen_debug_data(type="SYSTEM_USER"),
+                True,
+            ),
+            (
                 "Token expire soon",
                 TokenValidationRule.TOKEN_EXPIRY,
                 self._gen_debug_data(

--- a/fbpcs/pl_coordinator/token_validation_rules.py
+++ b/fbpcs/pl_coordinator/token_validation_rules.py
@@ -65,7 +65,11 @@ class TokenValidationRuleData:
 """
 rule checkers
 """
-user_type_checker: Callable[[DebugTokenData], bool] = lambda data: data.type == "USER"
+user_type_checker: Callable[[DebugTokenData], bool] = lambda data: data.type in (
+    "USER",
+    "SYSTEM_USER",
+)
+
 valid_checker: Callable[[DebugTokenData], bool] = lambda data: data.is_valid
 
 


### PR DESCRIPTION
Summary:
## Why
Amazon is using a System User token for triggering pc run
more details here: https://fb.workplace.com/groups/331044242148818/permalink/591902292729677/
## What
- Adding System User Token in the validation rule
- Adding UT to cover the cases

example token return
{F780937355}

Reviewed By: ztlbells

Differential Revision: D40364918

