### PR TITLE
Add build scripts for the Data Processing and EMP game images.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# Build and Release Pipelines
+
+## Overview of the Pipeline architecture
+Coming Soon!
+
+## Updating the FBPCF version in FBPCS
+As part of an ongoing effort to improve the FBPCS build and release, we are making some changes to how we build the images and publish them to the GitHub container registry. As part of this, for a temporary time, the FBPCF version is contained in 2 different files. You can find it in [build_binary_images.yml](build_binary_images.yml) on line 8 and [docker_publish.yml](docker_publish.yml) on line 29. Please make sure to update it in both locations whenever you are commiting a version change. To find the version of FBPCF that you want to pin, you can look at their [releases page](https://github.com/facebookresearch/fbpcf/releases) and pick either the latest version released, or whatever version you are looking for.

--- a/.github/workflows/build_binary_images.yml
+++ b/.github/workflows/build_binary_images.yml
@@ -1,0 +1,34 @@
+name: Build and Publish Data Processing and EMP Games Docker Images
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  FBPCF_VERSION: 2.1.73  # Please also update line 29 in .github/workflows/docker-publish.yml
+
+jobs:
+  output_version:
+    runs-on: ubuntu-latest
+    name: Set FBPCF version
+    outputs:
+      fbpcf_version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - id: set_version
+        run: echo "version=${{ env.FBPCF_VERSION }}" >> $GITHUB_OUTPUT
+
+  build_and_publish_data_processing_image:
+    name: Build and Publish Data Processing Image
+    needs: output_version
+    uses: ./.github/workflows/build_data_processing_image.yml
+    with:
+      tag: latest
+      fbpcf_version: ${{needs.output_version.outputs.fbpcf_version}}
+
+  build_and_publish_emp_games_image:
+    name: Build and Publish EMP Games Image
+    needs: output_version
+    uses: ./.github/workflows/build_emp_games_image.yml
+    with:
+      tag: latest
+      fbpcf_version: ${{needs.output_version.outputs.fbpcf_version}}

--- a/.github/workflows/build_data_processing_image.yml
+++ b/.github/workflows/build_data_processing_image.yml
@@ -1,0 +1,78 @@
+name: Build and Publish Data Processing Image
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: The docker tag to publish with
+        required: true
+        default: latest
+        type: string
+      fbpcf_version:
+        description: The FBPCF version to build with
+        required: true
+        default: latest
+        type: string
+
+env:
+  DISTRO: ubuntu
+  REGISTRY: ghcr.io
+  RC_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/rc/data_processing
+
+jobs:
+  build_data_processing_image:
+    name: Build Data Processing Image
+    runs-on: [self-hosted, fbpcs-build]
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-data-processing-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-data-processing
+
+      - name: Pull FBPCF Image
+        run: docker pull ghcr.io/facebookresearch/fbpcf/ubuntu:${{ inputs.fbpcf_version }}
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Publish Data Processing Docker Image to GHCR
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/data_processing/Dockerfile.ubuntu
+          tags: |
+            ${{ env.RC_REGISTRY_IMAGE_NAME }}:latest
+            ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            tag=latest
+            os_release=20.04
+            fbpcf_image=ghcr.io/facebookresearch/fbpcf/ubuntu:${{ inputs.fbpcf_version }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # This ugly bit is necessary or else our cache will grow forever
+      # until it hits GitHub's limit of 5GB.
+      # Temp fix: T135482742
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build_emp_games_image.yml
+++ b/.github/workflows/build_emp_games_image.yml
@@ -1,0 +1,78 @@
+name: Build and Publish EMP Games Image
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: The docker tag to publish with
+        required: true
+        default: latest
+        type: string
+      fbpcf_version:
+        description: The FBPCF version to build with
+        required: true
+        default: latest
+        type: string
+
+env:
+  DISTRO: ubuntu
+  REGISTRY: ghcr.io
+  RC_REGISTRY_IMAGE_NAME: ghcr.io/${{ github.repository }}/rc/emp_games
+
+jobs:
+  build_emp_games_image:
+    name: Build EMP Games Image
+    runs-on: [self-hosted, fbpcs-build]
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-emp-games-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-emp-games
+
+      - name: Pull FBPCF Image
+        run: docker pull ghcr.io/facebookresearch/fbpcf/ubuntu:${{ inputs.fbpcf_version }}
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Publish EMP Games image to GHCR
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/emp_games/Dockerfile.ubuntu
+          tags: |
+            ${{ env.RC_REGISTRY_IMAGE_NAME }}:latest
+            ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            tag=latest
+            os_release=20.04
+            fbpcf_image=ghcr.io/facebookresearch/fbpcf/ubuntu:${{ inputs.fbpcf_version }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # This ugly bit is necessary or else our cache will grow forever
+      # until it hits GitHub's limit of 5GB.
+      # Temp fix: T135482742
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.73
+  FBPCF_VERSION: 2.1.73  # Please also update line 8 in .github/workflows/build_binary_images.yml
 
 jobs:
   ### Build and publish rc/onedocker image

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -8,7 +8,6 @@ set -e
 
 UBUNTU_RELEASE="20.04"
 GITHUB_PACKAGES="ghcr.io/facebookresearch"
-FBPCF_VERSION="2.1.73"
 
 
 PROG_NAME=$0


### PR DESCRIPTION
Summary:
## Background
Now that we can reliably re-build the emp-games and data processing docker images on each commit, we can move the build to being more of a push methodology rather than a pull one at conveyor build time. This will help us to save time on each bundle creation.

## This commit
This change adds new jobs that run on every push to main. They build the EMP Games and Data Processing docker images and publish them to the GitHub container registry with the latest and sha tags. This is the first step in allowing us to cut out a 30 minute build process on every bundle we create.

Differential Revision: D40384201

