### PR TITLE
Create InputProcessor to run UDP

### DIFF
--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGame.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGame.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGame.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class MetadataCompactorGame : public IMetadataCompactorGame<schedulerId>,
+                              public fbpcf::frontend::MpcGame<schedulerId> {
+ public:
+  MetadataCompactorGame<schedulerId>(
+      const int party,
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler)
+      : fbpcf::frontend::MpcGame<schedulerId>(std::move(scheduler)),
+        party_{party} {}
+
+  std::unique_ptr<IInputProcessor<schedulerId>> play(
+      InputData inputData,
+      int32_t numConversionPerUser) override {
+    throw std::runtime_error("Not implemented");
+  }
+
+ private:
+  const int party_;
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGameFactory.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGameFactory.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "fbpcs/emp_games/lift/metadata_compaction/IMetadataCompactorGameFactory.h"
+#include "fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGame.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+class MetadataCompactorGameFactory
+    : public IMetadataCompactorGameFactory<schedulerId> {
+ public:
+  std::unique_ptr<IMetadataCompactorGame<schedulerId>> create(
+      std::unique_ptr<fbpcf::scheduler::IScheduler> scheduler,
+      int partyId) {
+    return std::make_unique<MetadataCompactorGame<schedulerId>>(
+        partyId, std::move(scheduler));
+  }
+};
+
+} // namespace private_lift

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include "fbpcs/data_processing/unified_data_process/adapter/IAdapter.h"
+#include "fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h"
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/IInputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h"
+
+namespace private_lift {
+/**
+ * This class handles privately sharing all the input data in MPC. It will
+ * handle obliviously filtering out rows with dummy entries.
+ */
+template <int schedulerId>
+class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
+ public:
+  using SecString =
+      typename unified_data_process::data_processor::IDataProcessor<
+          schedulerId>::SecString;
+
+  CompactionBasedInputProcessor(
+      int myRole,
+      std::unique_ptr<unified_data_process::adapter::IAdapter> adapter,
+      std::unique_ptr<
+          unified_data_process::data_processor::IDataProcessor<schedulerId>>
+          dataProcessor,
+      InputData inputData,
+      int32_t numConversionsPerUser)
+      : myRole_{myRole},
+        adapter_{std::move(adapter)},
+        dataProcessor_{std::move(dataProcessor)},
+        inputData_{inputData},
+        numConversionsPerUser_{numConversionsPerUser} {
+    if (inputData.getNumRows() == 0) {
+      throw std::invalid_argument("Tried to process dataset with no rows");
+    }
+
+    auto unionMap = shuffleAndGetUnionMap();
+    auto intersectionMap = getIntersectionMap(unionMap);
+
+    auto plaintextData = preparePlaintextData();
+
+    compactData(intersectionMap, plaintextData);
+    extractCompactedData();
+  }
+
+ private:
+  // shuffles the input data and returns the union map
+  std::vector<int32_t> shuffleAndGetUnionMap();
+
+  // runs adapter algorithm to get intsersection map
+  std::vector<int32_t> getIntersectionMap(const std::vector<int32_t>& unionMap);
+
+  // Serializes input data into rows of fixed width. Different implementations
+  // for publisher and partner
+  std::vector<std::vector<unsigned char>> preparePlaintextData();
+
+  /* Runs data processor algorithm to get intersected secret share data
+   * intersectionMap is the map of other player. Results are stored in
+   * publisherDataShares_ and partnerDataShares_
+   */
+  void compactData(
+      const std::vector<int32_t>& intersectionMap,
+      const std::vector<std::vector<unsigned char>>& plaintextData);
+
+  // deserializes the compacted data into MPC structured values
+  void extractCompactedData();
+
+  int32_t myRole_;
+
+  std::unique_ptr<unified_data_process::adapter::IAdapter> adapter_;
+  std::unique_ptr<
+      unified_data_process::data_processor::IDataProcessor<schedulerId>>
+      dataProcessor_;
+
+  InputData inputData_;
+  int32_t numConversionsPerUser_;
+
+  SecString publisherDataShares_;
+  SecString partnerDataShares_;
+
+  LiftGameProcessedData<schedulerId> liftGameProcessedData_;
+};
+
+} // namespace private_lift
+
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <stdexcept>
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/IInputProcessor.h"
+
+namespace private_lift {
+
+template <int schedulerId>
+std::vector<int32_t>
+CompactionBasedInputProcessor<schedulerId>::shuffleAndGetUnionMap() {
+  // dummy implementation. Assume each PID is a match
+  std::vector<int32_t> unionMap(inputData_.getNumRows());
+  for (int32_t i = 0; i < unionMap.size(); i++) {
+    unionMap[i] = i;
+  }
+  return unionMap;
+}
+
+template <int schedulerId>
+std::vector<int32_t>
+CompactionBasedInputProcessor<schedulerId>::getIntersectionMap(
+    const std::vector<int32_t>& unionMap) {
+  return adapter_->adapt(unionMap);
+}
+
+template <int schedulerId>
+std::vector<std::vector<unsigned char>>
+CompactionBasedInputProcessor<schedulerId>::preparePlaintextData() {
+  throw std::runtime_error("Not implemented");
+}
+
+template <int schedulerId>
+void CompactionBasedInputProcessor<schedulerId>::compactData(
+    const std::vector<int32_t>& intersectionMap,
+    const std::vector<std::vector<unsigned char>>& plaintextData) {
+  int32_t myDataWidth = plaintextData[0].size();
+
+  auto publisherDataSize = common::shareIntFrom<
+      schedulerId,
+      sizeof(myDataWidth) * 8,
+      common::PUBLISHER,
+      common::PARTNER>(myRole_, myDataWidth);
+
+  auto partnerDataSize = common::shareIntFrom<
+      schedulerId,
+      sizeof(myDataWidth) * 8,
+      common::PARTNER,
+      common::PUBLISHER>(myRole_, myDataWidth);
+
+  if (myRole_ == common::PUBLISHER) {
+    publisherDataShares_ =
+        dataProcessor_->processMyData(plaintextData, intersectionMap.size());
+    partnerDataShares_ = dataProcessor_->processPeersData(
+        inputData_.getNumRows(), intersectionMap, partnerDataSize);
+  } else if (myRole_ == common::PARTNER) {
+    publisherDataShares_ = dataProcessor_->processPeersData(
+        inputData_.getNumRows(), intersectionMap, publisherDataSize);
+    partnerDataShares_ =
+        dataProcessor_->processMyData(plaintextData, intersectionMap.size());
+  }
+}
+
+template <int schedulerId>
+void CompactionBasedInputProcessor<schedulerId>::extractCompactedData() {
+  throw std::runtime_error("Not implemented");
+}
+
+} // namespace private_lift


### PR DESCRIPTION
Summary:
Creates the skeleton of the UDP "CompactionBasedInputProcessor" that will run in the real `MetadataCompactorGame`. The general outline is as follows:

1. (**shuffleAndGetUnionMap()**) The player will shuffler their input data (so as to prevent knowing the relative order of the adversaries intersection members. This will output a union map of the shuffler data
2. (**getIntersectionMap()**) The players will run the adapter algorithm based on union map from previous step
3. (**preparePlaintextData()**)The player will prepare their real plaintext inputs as a stream of bytes
4. (**compactData()**) The players will run the data processor algorithm, which will locally encrypt the data and then pass to the other player for filtering. The encrypted shares will be stored in two local MPC variables (one for publisher and partner plaintext data)
5. (**extractCompactedData()**) The secret shares from previous step will be deserialized into correct MPC variables in `liftGameProcessedData_`

Additionally I added some utility methods to DataProcessor and Adapter to create the production versions.

Differential Revision: D40402985

