### PR TITLE
limit the PCE's full s3 access to the deployed data bucket

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -377,6 +377,7 @@ deploy_aws_resources() {
     python3 cli.py create aws \
         --add_iam_policy \
         --policy_name "$policy_name" \
+        --template_path "$fb_pc_iam_policy" \
         --region "$region" \
         --firehose_stream_name "$firehose_stream_name" \
         --data_ingestion_lambda_name "$data_ingestion_lambda_name" \
@@ -425,6 +426,7 @@ table_name=${s3_bucket_data_pipeline//-/_}
 data_upload_key_path="semi-automated-data-ingestion"
 query_results_key_path="query-results"
 data_ingestion_lambda_name="cb-data-ingestion-stream-processor${tag_postfix}"
+fb_pc_iam_policy="/terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json"
 
 if "$undeploy"
 then

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -124,16 +124,14 @@ class AwsDeploymentHelper:
     def create_policy(
         self,
         policy_name: str,
+        template_path: str,
         policy_params: PolicyParams,
         user_name: Optional[str] = None,
     ) -> None:
         self.log.info(f"Adding policy {policy_name}")
 
-        # directly reading the json file from iam_policies folder
-        # TODO: pass the policy to be added from cli.py when we need more granular control
-
         policy_json_data = self.read_json_file(
-            file_name="iam_policies/fb_pc_iam_policy.json", policy_params=policy_params
+            file_name=template_path, policy_params=policy_params
         )
 
         try:

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -52,7 +52,9 @@ class AwsDeploymentHelperTool:
                 events_data_crawler_arn=self.cli_args.events_data_crawler_arn,
             )
             self.aws_deployment_helper_obj.create_policy(
-                policy_name=self.cli_args.policy_name, policy_params=policy_params
+                policy_name=self.cli_args.policy_name,
+                template_path=self.cli_args.template_path,
+                policy_params=policy_params,
             )
 
         if self.cli_args.attach_iam_policy:

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
@@ -78,6 +78,13 @@ class AwsParserBuilder:
         )
 
         iam_policy_command_group.add_argument(
+            "--template_path",
+            type=str,
+            required=False,
+            help="Policy template file to use",
+        )
+
+        iam_policy_command_group.add_argument(
             "--firehose_stream_name",
             type=str,
             required=False,

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_data_bucket_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_data_bucket_policy.json
@@ -1,0 +1,43 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${DATA_BUCKET_NAME}",
+                "arn:aws:s3:::${DATA_BUCKET_NAME}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:Describe*",
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Deny",
+            "Action": [
+                "s3:*"
+            ],
+            "NotResource": [
+                "arn:aws:s3:::${DATA_BUCKET_NAME}",
+                "arn:aws:s3:::${DATA_BUCKET_NAME}/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "s3:ResourceAccount": [
+                        "${ACCOUNT_ID}"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
@@ -60,6 +60,7 @@ class TestAwsDeploymentHelper(unittest.TestCase):
         pass
 
     def test_create_policy(self) -> None:
+        template_path = "iam_policies/fb_pc_iam_policy.json"
         test_policy_name = "TestIamPolicyName"
         test_policy_params = {"test-key-1": "test-val-1"}
         test_user_name = "test-user-name"
@@ -73,11 +74,11 @@ class TestAwsDeploymentHelper(unittest.TestCase):
         with self.subTest("basic"):
             # Test
             self.aws_deployment_helper.create_policy(
-                test_policy_name, test_policy_params
+                test_policy_name, template_path, test_policy_params
             )
             # Assert
             self.aws_deployment_helper.read_json_file.assert_called_once_with(
-                file_name="iam_policies/fb_pc_iam_policy.json",
+                file_name=template_path,
                 policy_params=test_policy_params,
             )
             self.aws_deployment_helper.iam.create_policy.assert_called_once_with(
@@ -93,7 +94,7 @@ class TestAwsDeploymentHelper(unittest.TestCase):
             )
             # Test
             self.aws_deployment_helper.create_policy(
-                test_policy_name, test_policy_params
+                test_policy_name, "test_template_path", test_policy_params
             )
             # Assert
             self.aws_deployment_helper.iam.create_policy.assert_called_once_with(
@@ -111,7 +112,7 @@ class TestAwsDeploymentHelper(unittest.TestCase):
             )
             # Test
             self.aws_deployment_helper.create_policy(
-                test_policy_name, test_policy_params
+                test_policy_name, "test_template_path", test_policy_params
             )
             # Assert
             self.aws_deployment_helper.log.error.assert_called_once()
@@ -124,7 +125,10 @@ class TestAwsDeploymentHelper(unittest.TestCase):
             )
             # Test
             self.aws_deployment_helper.create_policy(
-                test_policy_name, test_policy_params, test_user_name
+                test_policy_name,
+                "test_template_path",
+                test_policy_params,
+                test_user_name,
             )
             # Assert
             self.aws_deployment_helper.log.error.assert_called_once()

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
@@ -22,6 +22,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
     def test_create(self, mock_aws_deployment_helper: MagicMock) -> None:
         test_user_name = "test-user"
         test_policy_name = "test-policy"
+        test_template_path = "test-template-path"
         test_region = "us-east-1"
         test_firehose_stream_name = "test-firehose"
         test_data_bucket_name = "test-data-bucket"
@@ -58,6 +59,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
             cli_args = self.setup_cli_args_mock()
             cli_args.add_iam_policy = True
             cli_args.policy_name = test_policy_name
+            cli_args.template_path = test_template_path
             cli_args.region = test_region
             cli_args.firehose_stream_name = test_firehose_stream_name
             cli_args.data_bucket_name = test_data_bucket_name
@@ -74,6 +76,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
 
             aws_deployment_helper_tool.aws_deployment_helper_obj.create_policy.assert_called_once_with(
                 policy_name=test_policy_name,
+                template_path=test_template_path,
                 policy_params=PolicyParams(
                     firehose_stream_name=test_firehose_stream_name,
                     data_bucket_name=test_data_bucket_name,

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/iam.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/iam.tf
@@ -51,5 +51,5 @@ resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-policy-attach
 
 resource "aws_iam_role_policy_attachment" "task_s3" {
   role       = aws_iam_role.onedocker_ecs_task_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  policy_arn = var.s3_access_arn
 }

--- a/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/variable.tf
+++ b/fbpcs/infra/pce/aws_terraform_template/common/pce_shared/variable.tf
@@ -22,3 +22,9 @@ variable "pce_id" {
   type        = string
   description = "The identifier for marking the cloud resources are in PCE"
 }
+
+variable "s3_access_arn" {
+  type        = string
+  description = "The s3 arn that the PCE can access"
+  default     = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}


### PR DESCRIPTION
Summary:
For partner side deployments. For other usages it will still default to the
current AmazonS3FullAccess arn for now.

Differential Revision: D40406015

