### PR TITLE
Prune images on the test runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Print Tracker Hash
         run: echo ${{ github.event.inputs.tracker_hash }}
 
+      - name: Clean Up Docker Images
+        run: |
+          docker image prune -af
+
       - name: Cleanup ECS running tasks and previous running results
         run: |
           ./cleanup.sh


### PR DESCRIPTION
Summary:
The test runner ran out of space fairly quickly due to 85GB of docker images on the device.

https://pxl.cl/2h2Vv

Differential Revision: D40430327

