### PR TITLE
Fix missing PID configs on the partner

### DIFF
--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -215,6 +215,7 @@ def run_study(
                 stage_flow_cls=stage_flow_override,
                 result_visibility=result_visibility or ResultVisibility.PUBLIC,
                 pcs_features=pcs_features,
+                pid_configs=config["pid"],
                 run_id=run_id,
             )
         )


### PR DESCRIPTION
Summary:
With the new bolt client the partner side pid configs are not passed to pcs to create instance. This diff fixes this by passing constructor args to bolt args

TODO: We will set up end to end tests separately to test this scenario.

Reviewed By: wenqingren

Differential Revision: D40426049

