### PR TITLE
Set each stage timeout & Set EMR cluster auto-termination timeout

### DIFF
--- a/fbpcs/infra/pid/aws_terraform_template/partner/sfn_definition.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/partner/sfn_definition.tf
@@ -17,7 +17,7 @@ data "template_file" "partner_sfn_definition" {
       "Parameters": {
         "Name": "AdvWorkflowCluster",
         "VisibleToAllUsers": true,
-        "ReleaseLabel": "emr-6.7.0",
+        "ReleaseLabel": "emr-6.8.0",
         "Applications": [
           {
             "Name": "Hadoop"
@@ -28,6 +28,9 @@ data "template_file" "partner_sfn_definition" {
         ],
         "ServiceRole": "${aws_iam_role.mrpid_partner_emr_role.id}",
         "JobFlowRole": "${aws_iam_role.mrpid_partner_ec2_role.id}",
+        "AutoTerminationPolicy": {
+          "IdleTimeout": 14400
+        },
         "ManagedScalingPolicy": {
           "ComputeLimits": {
             "MinimumCapacityUnits": 2,
@@ -137,6 +140,7 @@ data "template_file" "partner_sfn_definition" {
         }
       },
       "ResultPath": null,
+      "TimeoutSeconds": 14400,
       "Catch": [
         {
           "ErrorEquals": [
@@ -161,7 +165,7 @@ data "template_file" "partner_sfn_definition" {
             "States.ALL"
           ],
           "IntervalSeconds": 30,
-          "MaxAttempts": 360,
+          "MaxAttempts": 480,
           "BackoffRate": 1
         }
       ],
@@ -192,6 +196,7 @@ data "template_file" "partner_sfn_definition" {
         }
       },
       "ResultPath": null,
+      "TimeoutSeconds": 10800,
       "Catch": [
         {
           "ErrorEquals": [

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/sfn_definition.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/sfn_definition.tf
@@ -17,7 +17,7 @@ data "template_file" "publisher_sfn_definition" {
       "Parameters": {
         "Name": "MetaWorkflowCluster",
         "VisibleToAllUsers": true,
-        "ReleaseLabel": "emr-6.7.0",
+        "ReleaseLabel": "emr-6.8.0",
         "Applications": [
           {
             "Name": "Hadoop"
@@ -28,6 +28,9 @@ data "template_file" "publisher_sfn_definition" {
         ],
         "ServiceRole": "${aws_iam_role.mrpid_publisher_emr_role.id}",
         "JobFlowRole": "${aws_iam_role.mrpid_publisher_ec2_role.id}",
+        "AutoTerminationPolicy": {
+          "IdleTimeout": 14400
+        },
         "ManagedScalingPolicy": {
           "ComputeLimits": {
             "MinimumCapacityUnits": 2,
@@ -108,6 +111,7 @@ data "template_file" "publisher_sfn_definition" {
         }
       },
       "ResultPath": null,
+      "TimeoutSeconds": 7200,
       "Catch": [
         {
           "ErrorEquals": [
@@ -133,7 +137,7 @@ data "template_file" "publisher_sfn_definition" {
             "States.ALL"
           ],
           "IntervalSeconds": 30,
-          "MaxAttempts": 360,
+          "MaxAttempts": 480,
           "BackoffRate": 1
         }
       ],
@@ -163,6 +167,7 @@ data "template_file" "publisher_sfn_definition" {
         }
       },
       "ResultPath": null,
+      "TimeoutSeconds": 14400,
       "Catch": [
         {
           "ErrorEquals": [
@@ -218,6 +223,7 @@ data "template_file" "publisher_sfn_definition" {
         }
       },
       "ResultPath": null,
+      "TimeoutSeconds": 10800,
       "Catch": [
         {
           "ErrorEquals": [


### PR DESCRIPTION
Summary:
Set each stage timeout to be double of execution time of 1B data:
PubStageOne execution 1 hour (timeout 7200)
PubStageTwo execution 1:44  (timeout 14400)
PubStageThree execution 1:20 (timeout 10800)

PartnerStageOne execution 1:35 (timeout 14400)
PartnerStageTwo execution 1:30 (timeout 10800)

Set whole EMR idle auto-termination to 4 hours (double of stage max execution time of 1B data)

Reviewed By: Pradeepnitw

Differential Revision: D40435829

