### PR TITLE
Use Adapter and DataProcessor factory utility methods in tests

### DIFF
--- a/fbpcs/data_processing/unified_data_process/adapter/test/AdapterTest.cpp
+++ b/fbpcs/data_processing/unified_data_process/adapter/test/AdapterTest.cpp
@@ -14,10 +14,6 @@
 #include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/mpc_std_lib/permuter/AsWaksmanPermuterFactory.h"
-#include "fbpcf/mpc_std_lib/permuter/DummyPermuterFactory.h"
-#include "fbpcf/mpc_std_lib/shuffler/NonShufflerFactory.h"
-#include "fbpcf/mpc_std_lib/shuffler/PermuteBasedShufflerFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 #include "fbpcs/data_processing/unified_data_process/adapter/AdapterFactory.h"
@@ -116,93 +112,31 @@ TEST(AdapterTest, testAdapterWithNonShuffler) {
   auto agentFactories =
       fbpcf::engine::communication::getInMemoryAgentFactory(2);
   fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
-  AdapterFactory<0> factory0(
-      true,
-      0,
-      1,
-      std::make_unique<
-          fbpcf::mpc_std_lib::shuffler::insecure::NonShufflerFactory<
-              fbpcf::frontend::BitString<true, 0, true>>>());
+  auto factory0 = getAdapterFactoryWithNonShuffler<0>(true, 0, 1);
+  auto factory1 = getAdapterFactoryWithNonShuffler<1>(false, 1, 0);
 
-  AdapterFactory<1> factory1(
-      false,
-      0,
-      1,
-      std::make_unique<
-          fbpcf::mpc_std_lib::shuffler::insecure::NonShufflerFactory<
-              fbpcf::frontend::BitString<true, 1, true>>>());
-
-  adapterTest(factory0.create(), factory1.create());
+  adapterTest(factory0->create(), factory1->create());
 }
 
 TEST(AdapterTest, testAdapterWithPermuteBasedShufflerAndDummyPermuter) {
   auto agentFactories =
       fbpcf::engine::communication::getInMemoryAgentFactory(2);
   fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
-  AdapterFactory<0> factory0(
-      true,
-      0,
-      1,
-      std::make_unique<
-          fbpcf::mpc_std_lib::shuffler::PermuteBasedShufflerFactory<
-              fbpcf::frontend::BitString<true, 0, true>>>(
-          0,
-          1,
-          std::make_unique<fbpcf::mpc_std_lib::permuter::insecure::
-                               DummyPermuterFactory<std::vector<bool>, 0>>(
-              0, 1),
-          std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
 
-  AdapterFactory<1> factory1(
-      false,
-      0,
-      1,
-      std::make_unique<
-          fbpcf::mpc_std_lib::shuffler::PermuteBasedShufflerFactory<
-              fbpcf::frontend::BitString<true, 1, true>>>(
-          1,
-          0,
-          std::make_unique<fbpcf::mpc_std_lib::permuter::insecure::
-                               DummyPermuterFactory<std::vector<bool>, 1>>(
-              1, 0),
-          std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
+  auto factory0 = getAdapterFactoryWithInsecureShuffler<0>(true, 0, 1);
+  auto factory1 = getAdapterFactoryWithInsecureShuffler<1>(false, 1, 0);
 
-  adapterTest(factory0.create(), factory1.create());
+  adapterTest(factory0->create(), factory1->create());
 }
 
 TEST(AdapterTest, testAdapterWithSecurePermuteBasedShuffler) {
   auto agentFactories =
       fbpcf::engine::communication::getInMemoryAgentFactory(2);
   fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
-  AdapterFactory<0> factory0(
-      true,
-      0,
-      1,
-      std::make_unique<
-          fbpcf::mpc_std_lib::shuffler::PermuteBasedShufflerFactory<
-              fbpcf::frontend::BitString<true, 0, true>>>(
-          0,
-          1,
-          std::make_unique<fbpcf::mpc_std_lib::permuter::
-                               AsWaksmanPermuterFactory<std::vector<bool>, 0>>(
-              0, 1),
-          std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
+  auto factory0 = getAdapterFactoryWithAsWaksmanBasedShuffler<0>(true, 0, 1);
+  auto factory1 = getAdapterFactoryWithAsWaksmanBasedShuffler<1>(false, 1, 0);
 
-  AdapterFactory<1> factory1(
-      false,
-      0,
-      1,
-      std::make_unique<
-          fbpcf::mpc_std_lib::shuffler::PermuteBasedShufflerFactory<
-              fbpcf::frontend::BitString<true, 1, true>>>(
-          1,
-          0,
-          std::make_unique<fbpcf::mpc_std_lib::permuter::
-                               AsWaksmanPermuterFactory<std::vector<bool>, 1>>(
-              1, 0),
-          std::make_unique<fbpcf::engine::util::AesPrgFactory>()));
-
-  adapterTest(factory0.create(), factory1.create());
+  adapterTest(factory0->create(), factory1->create());
 }
 
 } // namespace unified_data_process::adapter

--- a/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h
@@ -88,3 +88,5 @@ class DataProcessor final : public IDataProcessor<schedulerId> {
 };
 
 } // namespace unified_data_process::data_processor
+
+#include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h"

--- a/fbpcs/data_processing/unified_data_process/data_processor/DataProcessorFactory.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DataProcessorFactory.h
@@ -48,4 +48,19 @@ class DataProcessorFactory final : public IDataProcessorFactory<schedulerId> {
   std::unique_ptr<AesCtrFactory> aesCtrFactory_;
 };
 
+template <int schedulerId>
+inline std::unique_ptr<DataProcessorFactory<schedulerId>>
+getDataProcessorFactoryWithAesCtr(
+    int myId,
+    int partnerId,
+    fbpcf::engine::communication::IPartyCommunicationAgentFactory&
+        agentFactory) {
+  return std::make_unique<DataProcessorFactory<schedulerId>>(
+      myId,
+      partnerId,
+      agentFactory,
+      std::make_unique<fbpcf::mpc_std_lib::aes_circuit::AesCircuitCtrFactory<
+          typename IDataProcessor<schedulerId>::SecBit>>());
+}
+
 } // namespace unified_data_process::data_processor

--- a/fbpcs/data_processing/unified_data_process/data_processor/test/DataProcessorTest.cpp
+++ b/fbpcs/data_processing/unified_data_process/data_processor/test/DataProcessorTest.cpp
@@ -14,7 +14,6 @@
 #include <unordered_map>
 
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtrFactory.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 #include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h"
@@ -120,19 +119,12 @@ TEST(DataProcessor, testDataProcessor) {
   auto agentFactories =
       fbpcf::engine::communication::getInMemoryAgentFactory(2);
   fbpcf::setupRealBackend<0, 1>(*agentFactories[0], *agentFactories[1]);
-  DataProcessorFactory<0> factory0(
-      0,
-      1,
-      *agentFactories[0],
-      std::make_unique<fbpcf::mpc_std_lib::aes_circuit::AesCircuitCtrFactory<
-          typename IDataProcessor<0>::SecBit>>());
-  DataProcessorFactory<1> factory1(
-      1,
-      0,
-      *agentFactories[1],
-      std::make_unique<fbpcf::mpc_std_lib::aes_circuit::AesCircuitCtrFactory<
-          typename IDataProcessor<1>::SecBit>>());
-  testDataProcessor(factory0.create(), factory1.create());
+  auto factory0 =
+      getDataProcessorFactoryWithAesCtr<0>(0, 1, *agentFactories[0]);
+  auto factory1 =
+      getDataProcessorFactoryWithAesCtr<1>(1, 0, *agentFactories[1]);
+
+  testDataProcessor(factory0->create(), factory1->create());
 }
 
 } // namespace unified_data_process::data_processor

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
@@ -12,10 +12,8 @@
 #include <vector>
 
 #include "fbpcs/data_processing/unified_data_process/adapter/Adapter.h"
-#include "fbpcs/data_processing/unified_data_process/adapter/Adapter_impl.h"
 #include "fbpcs/data_processing/unified_data_process/adapter/IAdapter.h"
 #include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h"
-#include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h"
 #include "fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
 


### PR DESCRIPTION
Summary: Refactored Adapter and DataProcessor tests to use utility methods in Factory classes.

Differential Revision: D40438439

