### PR TITLE
Update E2E test to run on the specified E2E test runners

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,7 +73,7 @@ jobs:
 
   e2e_test:
     name: Run End to End Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, fbpcs-e2e-test-runner]
     needs: build_image
     permissions:
       contents: read
@@ -102,7 +102,6 @@ jobs:
         run: |
           docker run --rm -v "instances":"/instances" -v "$(realpath fbpcs_e2e_aws.yml):/home/pcs/pl_coordinator_env/fbpcs_e2e_aws.yml" -v "$(realpath bolt_config.yml):/home/pcs/pl_coordinator_env/bolt_config.yml" ${{ env.COORDINATOR_IMAGE }}:${{ github.event.inputs.new_tag }} python3.8 -m fbpcs.private_computation_cli.private_computation_cli bolt_e2e --bolt_config="bolt_config.yml"
         working-directory: ./fbpcs/tests/github/
-
 
       - name: Pull image from rc registry
         run: |

--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -38,7 +38,7 @@ jobs:
   ### Private Lift E2E tests
   pl_test:
     name: Private Lift E2E Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, fbpcs-e2e-test-runner]
     timeout-minutes: 90
     permissions:
       contents: read

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -34,7 +34,7 @@ jobs:
 
   pa_test:
     name: Private Attribution E2E Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, fbpcs-e2e-test-runner]
     timeout-minutes: 90
     permissions:
       contents: read

--- a/.github/workflows/rc_one_command_runner_test.yml
+++ b/.github/workflows/rc_one_command_runner_test.yml
@@ -37,7 +37,7 @@ jobs:
   ### Private Lift E2E tests
   pl_test:
     name: Private Lift E2E Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, fbpcs-e2e-test-runner]
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
Summary: This commit updates all E2E tests to only run on the E2E test runners. These runners will stay in the fb-ads-crypto-dev cloud account where all the configuration is set up and maintained. This will enable me to move the build runner to the meta-pci-aws-dev cloud project so it is under PSI On-Call ownership for debugging issues. It will also allow us to easily scale the test runners to support parallel tests.

Differential Revision: D40241460

