### PR TITLE
Bolt token reader support no graph API section

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -207,6 +207,7 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
             GraphAPITokenNotFound: graph api token not in config.yml and not in env var
         """
         try:
+            config = config.get("graphapi", config)
             if not isinstance(config, ConfigYamlDict):
                 config = ConfigYamlDict.from_dict(config)
             self.logger.info("attempting to read graph api token from config.yml file")

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -98,7 +98,7 @@ def run_study(
 
     # obtain study information
     client: BoltGraphAPIClient[BoltPLGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
-        config["graphapi"], logger
+        config, logger
     )
     try:
         study_data = _get_study_data(study_id, client)
@@ -283,7 +283,7 @@ async def run_bolt(
         )
 
     # We create the publisher_client here so we can reuse the access_token in our trace logger svc
-    publisher_client = BoltGraphAPIClient(config=config["graphapi"], logger=logger)
+    publisher_client = BoltGraphAPIClient(config=config, logger=logger)
 
     # Create a GraphApiTraceLoggingService specific for this study_id
     study_id = job_list[0].publisher_bolt_args.create_instance_args.study_id

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -38,6 +38,26 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
         self.test_client = BoltGraphAPIClient(config, mock_logger)
         self.test_client._check_err = MagicMock()
 
+    def test_get_graph_api_token_from_env_empty_config(self) -> None:
+        expected_token = "from_env"
+        with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: expected_token}):
+            config = {}
+            actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+            self.assertEqual(expected_token, actual_token)
+
+    def test_get_graph_api_token_from_env_full_config_todo(self) -> None:
+        expected_token = "from_env"
+        with patch.dict("os.environ", {FBPCS_GRAPH_API_TOKEN: expected_token}):
+            config = {"graphapi": {"access_token": "TODO"}}
+            actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+            self.assertEqual(expected_token, actual_token)
+
+    def test_get_graph_api_token_from_dict_full_config(self) -> None:
+        expected_token = "from_dict"
+        config = {"graphapi": {"access_token": expected_token}}
+        actual_token = BoltGraphAPIClient(config, self.mock_logger).access_token
+        self.assertEqual(expected_token, actual_token)
+
     def test_get_graph_api_token_from_dict(self) -> None:
         expected_token = "from_dict"
         config = {"access_token": expected_token}

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -105,7 +105,7 @@ def run_attribution(
     ## Step 1: Validation. Function arguments and  for private attribution run.
     # obtain the values in the dataset info vector.
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
-        config["graphapi"], logger
+        config, logger
     )
     try:
         datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
@@ -283,7 +283,7 @@ async def run_bolt(
         )
 
     # We create the publisher_client here so we can reuse the access_token in our trace logger svc
-    publisher_client = BoltGraphAPIClient(config=config["graphapi"], logger=logger)
+    publisher_client = BoltGraphAPIClient(config=config, logger=logger)
 
     # Create a GraphApiTraceLoggingService specific for this study_id
     dataset_id = job_list[0].publisher_bolt_args.create_instance_args.dataset_id
@@ -385,7 +385,7 @@ def get_attribution_dataset_info(
     config: Dict[str, Any], dataset_id: str, logger: logging.Logger
 ) -> str:
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
-        config["graphapi"], logger
+        config, logger
     )
 
     return json.loads(

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -315,7 +315,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     # validate token before run study/attribution
     if arguments["run_attribution"] or arguments["run_study"]:
-        graph_client = BoltGraphAPIClient(config=config["graphapi"], logger=logger)
+        graph_client = BoltGraphAPIClient(config=config, logger=logger)
         token_validator = TokenValidator(client=graph_client)
         token_validator.validate_common_rules()
 

--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -49,7 +49,7 @@ class TestPlStudyRunner(TestCase):
         mock_graph_api_client,
         mock_logger,
     ) -> None:
-        self.config = {"graphapi": {"access_token": "access_token"}}
+        self.config = {}
         self.test_logger = logging.getLogger(__name__)
         self.client_mock = MagicMock()
         valid_start_date = datetime.datetime.now() - datetime.timedelta(hours=1)


### PR DESCRIPTION
Summary:
## What

- Bolt can now operate on either a full config yml dict or just the "graphapi section"

Reviewed By: anthonyzhang25

Differential Revision: D40442207

