### PR TITLE
Use NetworkPlaintextScheduler in private attribution

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fbpcf/io/api/FileIOWrappers.h>
+#include <fbpcf/scheduler/NetworkPlaintextSchedulerFactory.h>
 #include <string>
 #include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
 #include "fbpcf/scheduler/LazySchedulerFactory.h"
@@ -20,6 +21,7 @@ template <
     int MY_ROLE,
     int schedulerId,
     bool usingBatch,
+    bool useXorEncryption,
     common::InputEncryption inputEncryption>
 class AttributionApp {
  public:
@@ -43,9 +45,13 @@ class AttributionApp {
         schedulerStatistics_{0, 0, 0, 0} {}
 
   void run() {
-    auto scheduler = fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
-                         MY_ROLE, *communicationAgentFactory_, metricCollector_)
-                         ->create();
+    auto scheduler = useXorEncryption
+        ? fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+              MY_ROLE, *communicationAgentFactory_, metricCollector_)
+              ->create()
+        : fbpcf::scheduler::NetworkPlaintextSchedulerFactory<false>(
+              MY_ROLE, *communicationAgentFactory_, metricCollector_)
+              .create();
 
     AttributionGame<schedulerId, usingBatch, inputEncryption> game(
         std::move(scheduler));

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -57,6 +57,7 @@ template <
     std::uint32_t PARTY,
     std::uint32_t index,
     bool usingBatch,
+    bool useXorEncryption,
     common::InputEncryption inputEncryption>
 inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     std::uint32_t startFileIndex,
@@ -101,6 +102,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
         PARTY,
         2 * index + PARTY,
         usingBatch,
+        useXorEncryption,
         inputEncryption>>(
         std::move(communicationAgentFactory),
         attributionRules,
@@ -121,6 +123,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
             PARTY,
             index + 1,
             usingBatch,
+            useXorEncryption,
             inputEncryption>(
             startFileIndex + numFiles,
             remainingThreads - 1,
@@ -139,7 +142,11 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
   return schedulerStatistics;
 }
 
-template <int PARTY, bool usingBatch, common::InputEncryption inputEncryption>
+template <
+    int PARTY,
+    bool usingBatch,
+    bool useXorEncryption,
+    common::InputEncryption inputEncryption>
 inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
     std::vector<std::string>& inputFilenames,
     std::vector<std::string>& outputFilenames,
@@ -157,6 +164,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
       PARTY,
       0U,
       usingBatch,
+      useXorEncryption,
       inputEncryption>(
       0U,
       numThreads,

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[]) {
 
   // use batched attribution by default
   const bool usingBatch = true;
-
+  const bool useXorEncryption = true;
   try {
     auto [inputFilenames, outputFilenames] = pcf2_attribution::getIOFilenames(
         FLAGS_num_files,
@@ -82,6 +82,7 @@ int main(int argc, char* argv[]) {
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
                 usingBatch,
+                useXorEncryption,
                 common::InputEncryption::PartnerXor>(
                 inputFilenames,
                 outputFilenames,
@@ -95,6 +96,7 @@ int main(int argc, char* argv[]) {
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
                 usingBatch,
+                useXorEncryption,
                 common::InputEncryption::Xor>(
                 inputFilenames,
                 outputFilenames,
@@ -108,6 +110,7 @@ int main(int argc, char* argv[]) {
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
                 usingBatch,
+                useXorEncryption,
                 common::InputEncryption::Plaintext>(
                 inputFilenames,
                 outputFilenames,
@@ -127,6 +130,7 @@ int main(int argc, char* argv[]) {
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
                 usingBatch,
+                useXorEncryption,
                 common::InputEncryption::PartnerXor>(
                 inputFilenames,
                 outputFilenames,
@@ -140,6 +144,7 @@ int main(int argc, char* argv[]) {
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
                 usingBatch,
+                useXorEncryption,
                 common::InputEncryption::Xor>(
                 inputFilenames,
                 outputFilenames,
@@ -154,6 +159,7 @@ int main(int argc, char* argv[]) {
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
                 usingBatch,
+                useXorEncryption,
                 common::InputEncryption::Plaintext>(
                 inputFilenames,
                 outputFilenames,


### PR DESCRIPTION
Summary: Modify the AttributionApp to use a NetworkPlaintextScheduler or the current LazyScheduler depending on the use_xor_encryption flag.

Differential Revision: D40401178

