### PR TITLE
Use NetworkPlaintextScheduler in private attribution (#1753)

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -59,6 +59,7 @@ template <
     bool usingBatch,
     common::InputEncryption inputEncryption>
 inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
+    bool useXorEncryption,
     std::uint32_t startFileIndex,
     std::uint32_t remainingThreads,
     std::string serverIp,
@@ -107,6 +108,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
         inputFilenames,
         outputFilenames,
         metricCollector,
+        useXorEncryption,
         startFileIndex,
         numFiles);
 
@@ -122,6 +124,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
             index + 1,
             usingBatch,
             inputEncryption>(
+            useXorEncryption,
             startFileIndex + numFiles,
             remainingThreads - 1,
             serverIp,
@@ -141,6 +144,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
 
 template <int PARTY, bool usingBatch, common::InputEncryption inputEncryption>
 inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
+    bool useXorEncryption,
     std::vector<std::string>& inputFilenames,
     std::vector<std::string>& outputFilenames,
     int16_t concurrency,
@@ -158,6 +162,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFiles(
       0U,
       usingBatch,
       inputEncryption>(
+      useXorEncryption,
       0U,
       numThreads,
       serverIp,

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[]) {
 
   // use batched attribution by default
   const bool usingBatch = true;
-
+  bool useXorEncryption = FLAGS_use_xor_encryption;
   try {
     auto [inputFilenames, outputFilenames] = pcf2_attribution::getIOFilenames(
         FLAGS_num_files,
@@ -83,6 +83,7 @@ int main(int argc, char* argv[]) {
                 common::PUBLISHER,
                 usingBatch,
                 common::InputEncryption::PartnerXor>(
+                useXorEncryption,
                 inputFilenames,
                 outputFilenames,
                 concurrency,
@@ -96,6 +97,7 @@ int main(int argc, char* argv[]) {
                 common::PUBLISHER,
                 usingBatch,
                 common::InputEncryption::Xor>(
+                useXorEncryption,
                 inputFilenames,
                 outputFilenames,
                 concurrency,
@@ -109,6 +111,7 @@ int main(int argc, char* argv[]) {
                 common::PUBLISHER,
                 usingBatch,
                 common::InputEncryption::Plaintext>(
+                useXorEncryption,
                 inputFilenames,
                 outputFilenames,
                 concurrency,
@@ -128,6 +131,7 @@ int main(int argc, char* argv[]) {
                 common::PARTNER,
                 usingBatch,
                 common::InputEncryption::PartnerXor>(
+                useXorEncryption,
                 inputFilenames,
                 outputFilenames,
                 concurrency,
@@ -141,6 +145,7 @@ int main(int argc, char* argv[]) {
                 common::PARTNER,
                 usingBatch,
                 common::InputEncryption::Xor>(
+                useXorEncryption,
                 inputFilenames,
                 outputFilenames,
                 concurrency,
@@ -155,6 +160,7 @@ int main(int argc, char* argv[]) {
                 common::PARTNER,
                 usingBatch,
                 common::InputEncryption::Plaintext>(
+                useXorEncryption,
                 inputFilenames,
                 outputFilenames,
                 concurrency,


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/fbpcs/pull/1753

Modify the AttributionApp to use a NetworkPlaintextScheduler or the current LazyScheduler depending on the use_xor_encryption flag.

Differential Revision: D40401178

