### PR TITLE
Add num MPC container mutation

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -17,6 +17,7 @@ class PCSFeature(Enum):
     PRIVATE_LIFT_UNIFIED_DATA_PROCESS = "private_lift_unified_data_process"
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"
+    NUM_MPC_CONTAINER_MUTATION = "num_mpc_container_mutation"
     PCF_TLS = "pcf_tls"
     UNKNOWN = "unknown"
 

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -42,3 +42,7 @@ FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"
 CA_CERT_PATH = "tls/ca_cert.pem"
 SERVER_CERT_PATH = "tls/server_cert.pem"
 PRIVATE_KEY_PATH = "tls/private_key.pem"
+
+# TODO: pass number of rows per shard in arg instead of hardcoding
+NUM_ROWS_PER_MPC_SHARD_PL = 1000000
+NUM_ROWS_PER_MPC_SHARD_PA = 200000

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_pid_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_pid_pcf2_lift_stage_flow.py
@@ -126,6 +126,7 @@ class PrivateComputationMrPidPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
             return PIDMRStageService(args.workflow_svc)
         elif self is self.ID_SPINE_COMBINER:
             return IdSpineCombinerStageService(
+                args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
                 protocol_type=Protocol.MR_PID_PROTOCOL.value,

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
@@ -135,6 +135,7 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
             return PIDMRStageService(args.workflow_svc)
         elif self is self.ID_SPINE_COMBINER:
             return IdSpineCombinerStageService(
+                args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
                 protocol_type=Protocol.MR_PID_PROTOCOL.value,

--- a/fbpcs/private_computation/stage_flows/stage_selector.py
+++ b/fbpcs/private_computation/stage_flows/stage_selector.py
@@ -81,6 +81,7 @@ class StageSelector:
             )
         elif stage_flow.name == "ID_SPINE_COMBINER":
             return IdSpineCombinerStageService(
+                args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
             )

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -32,8 +32,10 @@ from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
 
 
 class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
+    @patch("fbpcp.service.storage.StorageService")
     @patch("fbpcp.service.onedocker.OneDockerService")
-    def setUp(self, onedocker_service) -> None:
+    def setUp(self, onedocker_service, storage_svc) -> None:
+        self.storage_svc = storage_svc
         self.onedocker_service = onedocker_service
         self.test_num_containers = 2
 
@@ -45,7 +47,7 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
             )
         )
         self.stage_svc = IdSpineCombinerStageService(
-            self.onedocker_service, self.onedocker_binary_config_map
+            self.storage_svc, self.onedocker_service, self.onedocker_binary_config_map
         )
 
     async def test_id_spine_combiner(self) -> None:


### PR DESCRIPTION
Summary:
# Context
In this diff, we are adding logic to mutate num MPC container based on PID spine file size. Please see [the doc](https://fb.workplace.com/groups/pidmatchingxfn/posts/518728833410109) for more details on the context.

# Details
We implemented a logic to read a metrics file and mutate num MPC containers in the beginning of ID combiner. If metrics file does not exist, it would raise exception and fail immediately.

Later, if there are discrepancy in the shard size on both side, it would fail in the check of num MPC containers and number of server IPs at https://fburl.com/code/v749paw6.

Differential Revision: D40399873

