### PR TITLE
Adding log_cost_bucket param to infra_config.

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -155,6 +155,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     )
     pce_config: Optional[PCEConfig] = None
     run_id: Optional[str] = immutable_field(default=None)
+    log_cost_bucket: Optional[str] = immutable_field(default=None)
 
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -177,6 +177,7 @@ class PrivateComputationService:
         pid_configs: Optional[Dict[str, Any]] = None,
         pcs_features: Optional[List[str]] = None,
         run_id: Optional[str] = None,
+        log_cost_bucket: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
         self.metric_svc.bump_entity_key(PCSERVICE_ENTITY_NAME, "create_instance")
@@ -229,6 +230,7 @@ class PrivateComputationService:
             mpc_compute_concurrency=concurrency or DEFAULT_CONCURRENCY,
             status_updates=[],
             run_id=run_id,
+            log_cost_bucket=log_cost_bucket,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -186,6 +186,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         self.test_output_dir = "out_dir"
         self.test_game_type = PrivateComputationGameType.LIFT
         self.test_concurrency = 1
+        self.log_cost_bucket = "test_log_bucket"
         self.test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
 
     @mock.patch("time.time", new=mock.MagicMock(return_value=1))
@@ -1144,6 +1145,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             mpc_compute_concurrency=self.test_concurrency,
             status_updates=[],
+            log_cost_bucket=self.log_cost_bucket,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.test_input_path,


### PR DESCRIPTION
Summary:
Current cost estimation is broken for RC, canary and prod runs. Thus in this diff stack adding functionality to log cost estimation to correct buckets as per the tier.

In diff, adding log_cost_bucket param to infra config.

Differential Revision: D40422199

