### PR TITLE
Add new Paralellized End to End test runners.

### DIFF
--- a/.github/workflows/e2e_tests/one_command_runner_test.yml
+++ b/.github/workflows/e2e_tests/one_command_runner_test.yml
@@ -1,0 +1,93 @@
+name: One command runner test
+
+on:
+  workflow_call:
+    inputs:
+      lift_study_id:
+        description: Lift study id
+        required: true
+        default: 32102205110410
+      lift_objective_id:
+        description: Lift objective id
+        required: true
+        default: 23502204952992
+      lift_input_path:
+        description: S3 path to synthetic data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
+      lift_expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json
+      tag:
+        description: Version tag to use
+        required: true
+        default: rc
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
+
+env:
+  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
+  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
+  CONSOLE_OUTPUT_FILE: /tmp/output.txt
+
+jobs:
+  ### Private Lift E2E tests
+  pl_test:
+    name: Private Lift E2E Tests
+    runs-on: [self-hosted, fbpcs-e2e-test-runner]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash}}
+
+      - name: One command runner
+        id: runner
+        continue-on-error: true
+        run: |
+          ./fbpcs/scripts/run_fbpcs.sh run_study \
+          ${{ github.event.inputs.study_id }} \
+          --objective_ids=${{ github.event.inputs.objective_id }} \
+          --input_paths=${{ github.event.inputs.input_path }} \
+          --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
+          -- \
+          --version=${{ github.event.inputs.tag }} > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
+
+      - name: Print runner console output
+        continue-on-error: true
+        run: |
+          cat ${{env.CONSOLE_OUTPUT_FILE}}
+
+      - name: Abort when runner failed
+        if: steps.runner.outcome != 'success'
+        run: |
+          echo "Please check the runner console output in the above step." ; \
+          exit 1
+
+      - name: Validate Results
+        # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
+        # the fbpcs_instances directory is where instances are written to (feature of run_fbpcs.sh)
+        # the config.yml specifies that /fbpcs_instances is the instance repo, which is the source of the "/{}"
+        run: |
+          find fbpcs_instances -regex 'fbpcs_instances/[0-9]+' | xargs -I {} ./fbpcs/scripts/run_fbpcs.sh \
+          validate \
+          "/{}" \
+          --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
+          --expected_result_path=${{ github.event.inputs.expected_result_path }} \
+          -- \
+          --version=${{ github.event.inputs.tag }}
+
+      - name: Validate runner logs
+        # First command extracts the pc-cli log lines starting with "... ! Command line: ..." into a file.
+        run: |
+          sed -n '/^.* ! Command line: .*/,$p' < ${{env.CONSOLE_OUTPUT_FILE}} > ${{env.CONSOLE_OUTPUT_FILE}}.extracted
+          docker run --rm -v "${{env.CONSOLE_OUTPUT_FILE}}.extracted:${{env.CONSOLE_OUTPUT_FILE}}" ${{env.FBPCS_CONTAINER_REPO_URL}}/${{env.FBPCS_IMAGE_NAME}}:${{github.event.inputs.tag}} \
+          python -m fbpcs.infra.logging_service.log_analyzer.log_analyzer ${{env.CONSOLE_OUTPUT_FILE}} --validate_one_runner_logs

--- a/.github/workflows/e2e_tests/pa_one_command_runner_test.yml
+++ b/.github/workflows/e2e_tests/pa_one_command_runner_test.yml
@@ -1,0 +1,73 @@
+name: PA One command runner test
+
+on:
+  workflow_call:
+    inputs:
+      attribution_dataset_id:
+        description: Attribution Dataset id
+        required: true
+        default: 1127612294482487
+      attribution_input_path:
+        description: S3 path to synthetic attribution data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/partner_e2e_input.csv
+      attribution_expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result_last_click.json
+      tag:
+        description: Version tag to use
+        required: true
+        default: rc
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
+
+env:
+  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
+  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
+
+jobs:
+  ### Private Attribution E2E tests
+
+  pa_test:
+    name: Private Attribution E2E Tests
+    runs-on: [self-hosted, fbpcs-e2e-test-runner]
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash}}
+
+      - name: One Command runner
+        run: |
+          ./fbpcs/scripts/run_fbpcs.sh run_attribution \
+          --dataset_id=${{ github.event.inputs.dataset_id}} \
+          --attribution_rule="last_click_1d" \
+          --input_path=${{ github.event.inputs.input_path}} \
+          --aggregation_type="measurement" \
+          --concurrency=4 \
+          --num_files_per_mpc_container=4 \
+          --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
+          --timestamp="1646870400" \
+          --k_anonymity_threshold=0 \
+          -- \
+          --version=${{ github.event.inputs.tag }}
+      - name: Validate Results
+        # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
+        # the fbpcs_instances directory is where instances are written to (feature of run_fbpcs.sh)
+        # the config.yml specifies that /fbpcs_instances is the instance repo, which is the source of the "/{}"
+        run: |
+          find fbpcs_instances -regex 'fbpcs_instances/[0-9]+' | xargs -I {} ./fbpcs/scripts/run_fbpcs.sh \
+          validate \
+          "/{}" \
+          --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
+          --expected_result_path=${{ github.event.inputs.expected_result_path }} \
+          -- \
+          --version=${{ github.event.inputs.tag }}

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -1,0 +1,110 @@
+name: End To End Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      lift_study_id:
+        description: Lift study id
+        required: true
+        default: 32102205110410
+      lift_objective_id:
+        description: Lift objective id
+        required: true
+        default: 40202203600681
+      lift_input_path:
+        description: S3 path to synthetic data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
+      lift_expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json
+      multi_key_lift_study_id:
+        description: Lift study id
+        required: true
+        default: 38402205691678
+      multi_key_lift_objective_id:
+        description: Lift objective id
+        required: true
+        default: 43702205627286
+      multi_key_lift_input_path:
+        description: S3 path to synthetic data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
+      multi_key_lift_expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json
+      attribution_dataset_id:
+        description: Attribution Dataset id
+        required: true
+        default: 1127612294482487
+      attribution_input_path:
+        description: S3 path to synthetic attribution data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/partner_e2e_input.csv
+      attribution_expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result_last_click.json
+      multi_key_attribution_dataset_id:
+        description: Attribution Dataset id
+        required: true
+        default: 3204590196477122
+      multi_key_attribution_input_path:
+        description: S3 path to synthetic attribution data
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/partner_e2e_input.csv
+      multi_key_attribution_expected_result_path:
+        description: S3 path to expected results from synthetic run
+        required: true
+        default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result_last_click.json
+      tag:
+        description: Version tag to use
+        required: true
+        default: rc
+      tracker_hash:
+        description: '[Internal usage] Used for tracking workflow job status within Meta infra'
+        required: false
+        type: str
+
+env:
+  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
+  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
+  CONSOLE_OUTPUT_FILE: /tmp/output.txt
+
+jobs:
+  lift_test:
+    name: Private Lift E2E test
+    steps:
+      - name: Private Lift E2E test
+        uses: ./.github/workflows/e2e_tests/one_command_runner_test.yml
+  attribution_test:
+    name: Private Attribution E2E test
+    steps:
+      - name: Private Attribution E2E test
+        uses: ./.github/workflows/e2e_tests/pa_one_command_runner_test.yml
+  multi_key_lift_test:
+    name: Multi Key Private Lift E2E test
+    steps:
+      - name: Multi Key Private Lift E2E test
+        uses: ./.github/workflows/e2e_tests/one_command_runner_test.yml
+        with:
+          lift_study_id: ${{ github.event.inputs.multi_key_lift_study_id }}
+          lift_objective_id: ${{ github.event.inputs.multi_key_lift_objective_id }}
+          lift_input_path: ${{ github.event.inputs.multi_key_lift_input_path }}
+          lift_expected_result_path: ${{ github.event.inputs.multi_key_lift_expected_result_path }}
+          tag: ${{ github.event.inputs.tag }}
+          tracker_hash: ${{ github.event.inputs.tracker_hash }}
+  multi_key_attribution_test:
+    name: Multi Key Private Attribution E2E test
+    steps:
+      - name: Multi Key Private Attribution E2E test
+        uses: ./.github/workflows/e2e_tests/pa_one_command_runner_test.yml
+        with:
+          attribution_dataset_id: ${{ github.event.inputs.multi_key_attribution_dataset_id }}
+          attribution_input_path: ${{ github.event.inputs.multi_key_attribution_input_path }}
+          attribution_expected_result_path: ${{ github.event.inputs.multi_key_attribution_expected_result_path }}
+          tag: ${{ github.event.inputs.tag }}
+          tracker_hash: ${{ github.event.inputs.tracker_hash }}


### PR DESCRIPTION
Summary:
## Background
Right now, we run all of the E2E tests in serial, even though they are unrelated to each other. On average, this takes around 3.5 hours. The longest individual test takes around 1 hour to execute. To improve our release times, we want to parallelize the E2E tests.

# This Diff
This diff adds new E2E test action yamls that can be used to parallelize the testing.

Differential Revision: D40241478

