### PR TITLE
vpc automation, Fixed JQ query to dump JSON into a file during terraform deployment

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -206,6 +206,7 @@ undeploy_aws_resources() {
 
 deploy_aws_resources() {
     # first log, making sure the file is re-written fresh
+    echo "{}" > "$TF_RESOURCE_OUTPUT"
     log_streaming_data "starting to deploy resources..."
     log_streaming_data "validating inputs..."
     # validate all the inputs
@@ -278,7 +279,7 @@ deploy_aws_resources() {
     subnet_ids=$(terraform output subnets | tr -d '""[]\ \n')
     route_table_id=$(terraform output route_table_id | tr -d '"')
     aws_ecs_cluster_name=$(terraform output aws_ecs_cluster_name | tr -d '"')
-    log_resource_output resource_name "vpc_id" resource_value "$vpc_id"
+    log_resource_output "vpc_id" "$vpc_id"
     log_streaming_data "establishing vpc peering connection..."
     # Issue VPC Peering Connection to Publisher's VPC and add a route to the route table
     echo "########################Issue VPC Peering connection to Publisher's VPC########################"
@@ -305,7 +306,7 @@ deploy_aws_resources() {
     # Store the outputs into variables
     vpc_peering_connection_id=$(terraform output vpc_peering_connection_id | tr -d '"' )
     echo "VPC peering connection has been created. ID: $vpc_peering_connection_id"
-    log_resource_output resource_name "vpc_peering_connection_id" resource_value "$vpc_peering_connection_id"
+    log_resource_output "vpc_peering_connection_id" "$vpc_peering_connection_id"
 
     # Configure Data Ingestion Pipeline from CB to S3
     echo "########################Configure Data Ingestion Pipeline from CB to S3########################"

--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -106,8 +106,9 @@ log_streaming_data() {
 log_resource_output() {
     local resource_name=$1
     local resource_value=$2
-    echo "$(jq -n --arg key "$resource_name" --arg value "$resource_value" '{ ($key) : $value }' "$TF_RESOURCE_OUTPUT")" > "$TF_RESOURCE_OUTPUT"
+    echo "$(jq --arg key "$resource_name" --arg value "$resource_value" '. + { ($key) : $value }' "$TF_RESOURCE_OUTPUT")" > "$TF_RESOURCE_OUTPUT"
 }
+
 
 validateDeploymentResources () {
     local region=$1


### PR DESCRIPTION
Summary:
vpc automation, Fixed JQ query to dump JSON into a file during terraform deployment

Previous method somehow didn't append JSON content to a file which is a running JSON content file. The current diff addresses that:

1. Added a default JSON bracket to file at beginning to make sure contents are overridden during deployment start.

2. Changed JQ query to use ". + " to append.

Differential Revision: D40465838

