### PR TITLE
adding GraphAPI version override support from pc-cli

### DIFF
--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -27,7 +27,9 @@ from fbpcs.private_computation.stage_flows.private_computation_stage_flow import
 )
 
 ACCESS_TOKEN = "access_token"
-URL = "https://graph.facebook.com/v13.0"
+GRAPHPI_BASE_URL = "https://graph.facebook.com"
+GRAPHAPI_DEFAULT_VERSION = "v13.0"
+URL = f"{GRAPHPI_BASE_URL}/{GRAPHAPI_DEFAULT_VERSION}"
 
 
 class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
@@ -37,6 +39,11 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
         config = {"access_token": ACCESS_TOKEN}
         self.test_client = BoltGraphAPIClient(config, mock_logger)
         self.test_client._check_err = MagicMock()
+
+    def test_customize_graphapi_version(self) -> None:
+        config = {"access_token": ACCESS_TOKEN}
+        test_client = BoltGraphAPIClient(config, self.mock_logger, "v15.0")
+        self.assertEqual(test_client.graphapi_url, f"{GRAPHPI_BASE_URL}/v15.0")
 
     def test_get_graph_api_token_from_env_empty_config(self) -> None:
         expected_token = "from_env"


### PR DESCRIPTION
Summary:
## Why
In sev S302843, App creation will required v15.0 to create.
One of the solution is that pc-cli support graph api version override that allow upstream like computation UI can custimize the graph api version
More detail can be found https://docs.google.com/document/d/1SYVTX3fdz9zozOC2v3EA34p55tbPQIBlrUmQlknaJWs/edit?usp=sharing
## What
* add pc-cli argument `graphapi_version` allow upstream to override it
* if not getting from argument, fallback to v13.0 default defined in hard code for backwarf compatible

Differential Revision: D40484920

