### PR TITLE
Add binary of UDP library main files

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+namespace unified_data_process {
+
+template <int PARTY>
+inline common::SchedulerStatistics startUdpProcessApp(
+    std::string serverIp,
+    int port,
+    int64_t numberOfRows,
+    int64_t sizeOfRow,
+    int64_t numberOfIntersection,
+    bool useXorEncryption) {
+  std::map<
+      int,
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
+          PartyInfo>
+      partyInfos({{0, {serverIp, port}}, {1, {serverIp, port}}});
+
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("udp_metrics");
+
+  auto communicationAgentFactory = std::make_shared<
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
+      PARTY, partyInfos, metricCollector);
+
+  auto udpGameFactory = std::make_unique<UdpProcessGameFactory<PARTY>>(
+      PARTY, *communicationAgentFactory);
+
+  UdpProcessApp<PARTY> app(
+      PARTY,
+      std::move(communicationAgentFactory),
+      std::move(metricCollector),
+      std::move(udpGameFactory),
+      numberOfRows,
+      sizeOfRow,
+      numberOfIntersection,
+      useXorEncryption);
+
+  app.run();
+  return app.getSchedulerStatistics();
+}
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessOptions.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessOptions.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessOptions.h"
+
+DEFINE_int32(party, 1, "1 = publisher, 2 = partner");
+DEFINE_bool(
+    use_xor_encryption,
+    true,
+    "Reveal output with XOR secret shares instead of in the clear to both parties");
+DEFINE_string(server_ip, "127.0.0.1", "Server's IP Address");
+DEFINE_int32(
+    port,
+    10000,
+    "Network port for establishing connection to other player");
+
+// UDP settings
+DEFINE_int64(row_number, 1000000, "Number of input rows");
+DEFINE_int64(row_size, 1000000, "Number of input rows");
+DEFINE_int64(intersection, 150000, "Size of intersection");
+
+// Logging flags
+DEFINE_string(
+    run_name,
+    "",
+    "A user given run name that will be used in s3 filename");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");
+DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(
+    log_cost_s3_region,
+    ".s3.us-west-2.amazonaws.com/",
+    "s3 region name");
+
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessOptions.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessOptions.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gflags/gflags.h>
+
+// MPC settings
+DECLARE_int32(party);
+DECLARE_bool(use_xor_encryption);
+DECLARE_string(server_ip);
+DECLARE_int32(port);
+
+// UDP settings
+DECLARE_int64(row_number);
+DECLARE_int64(row_size);
+DECLARE_int64(intersection);
+
+// Logging flags
+DECLARE_string(run_name);
+DECLARE_bool(log_cost);
+DECLARE_string(log_cost_s3_bucket);
+DECLARE_string(log_cost_s3_region);
+
+DECLARE_string(pc_feature_flags);

--- a/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "folly/init/Init.h"
+#include "folly/logging/xlog.h"
+
+#include "fbpcf/aws/AwsSdk.h"
+#include "fbpcs/performance_tools/CostEstimation.h"
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessOptions.h"
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  fbpcs::performance_tools::CostEstimation cost =
+      fbpcs::performance_tools::CostEstimation(
+          "data_processing_udp",
+          FLAGS_log_cost_s3_bucket,
+          FLAGS_log_cost_s3_region,
+          "pcf2");
+  cost.start();
+
+  fbpcf::AwsSdk::aquire();
+
+  XLOG(INFO) << "Running UDP library with settings:\n"
+             << "\tparty: " << FLAGS_party << "\n"
+             << "\tuse_xor_encryption: " << FLAGS_use_xor_encryption << "\n"
+             << "\tserver_ip_address: " << FLAGS_server_ip << "\n"
+             << "\tport: " << FLAGS_port << "\n"
+             << "\trow_number: " << FLAGS_row_number << "\n"
+             << "\trow_size: " << FLAGS_row_size << "\n"
+             << "\tintersection: " << FLAGS_intersection << "\n"
+             << "\trun_name: " << FLAGS_run_name << "\n"
+             << "\tlog cost: " << FLAGS_log_cost << "\n"
+             << "\ts3 bucket: " << FLAGS_log_cost_s3_bucket << "\n"
+             << "\ts3 region: " << FLAGS_log_cost_s3_region << "\n"
+             << "\tpc_feature_flags:" << FLAGS_pc_feature_flags;
+
+  FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner
+  // instead of 1 and 2
+
+  common::SchedulerStatistics schedulerStatistics;
+
+  XLOG(INFO) << "Start UDP Processing...";
+  if (FLAGS_party == common::PUBLISHER) {
+    XLOG(INFO)
+        << "Starting UDP Processing as Publisher, will wait for Partner...";
+    schedulerStatistics =
+        unified_data_process::startUdpProcessApp<common::PUBLISHER>(
+            FLAGS_server_ip,
+            FLAGS_port,
+            FLAGS_row_number,
+            FLAGS_row_size,
+            FLAGS_intersection,
+            FLAGS_use_xor_encryption);
+  } else if (FLAGS_party == common::PARTNER) {
+    XLOG(INFO)
+        << "Starting UDP Processing as Partner, will wait for Publisher...";
+    schedulerStatistics =
+        unified_data_process::startUdpProcessApp<common::PARTNER>(
+            FLAGS_server_ip,
+            FLAGS_port,
+            FLAGS_row_number,
+            FLAGS_row_size,
+            FLAGS_intersection,
+            FLAGS_use_xor_encryption);
+  } else {
+    XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
+  }
+
+  cost.end();
+  XLOG(INFO, cost.getEstimatedCostString());
+
+  XLOGF(
+      INFO,
+      "Non-free gate count = {}, Free gate count = {}",
+      schedulerStatistics.nonFreeGates,
+      schedulerStatistics.freeGates);
+
+  XLOGF(
+      INFO,
+      "Sent network traffic = {}, Received network traffic = {}",
+      schedulerStatistics.sentNetwork,
+      schedulerStatistics.receivedNetwork);
+
+  if (FLAGS_log_cost) {
+    bool run_name_specified = FLAGS_run_name != "";
+    auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
+    auto party = (FLAGS_party == common::PUBLISHER) ? "Publisher" : "Partner";
+
+    folly::dynamic extra_info = schedulerStatistics.details;
+
+    folly::dynamic costDict =
+        cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+    auto objectName = run_name_specified
+        ? run_name
+        : folly::to<std::string>(
+              FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+    XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
+  }
+
+  return 0;
+}

--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -26,6 +26,7 @@ namespace fbpcs::performance_tools {
 
 const std::unordered_map<std::string, std::string> SUPPORTED_APPLICATIONS(
     {{"data_processing", "dp-logs"},
+     {"data_processing_udp", "dp-logs"},
      {"attributor", "att-logs"},
      {"aggregator", "agg-logs"},
      {"lift", "pl-logs"},


### PR DESCRIPTION
Summary:
This diff adds main files to run the UDP process app added in D39939986 (https://github.com/facebookresearch/fbpcs/commit/02afb026a9643f6b211a2e4359d05bced5d4a862).
- adds `main.cpp` and `MainUtil.h` to run the UDP process App.
- adds a buck target to build the new binary, and `UdpProcessOptions.h` and `UdpProcessOptions.cpp` to define the flags.
- adds udp binary into to the costEstimation supported Apps

Reviewed By: robotal

Differential Revision: D40035530

