### PR TITLE
Push both console & yarn logs to cloudwatch for Spark jobs

### DIFF
--- a/fbpcs/infra/pid/aws_terraform_template/partner/s3_bucket.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/partner/s3_bucket.tf
@@ -112,15 +112,27 @@ sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /de
       "files": {
         "collect_list": [
           {
-            "file_path": "/mnt/var/log/spark/PartnerStageOne.log",
+            "file_path": "/mnt/var/log/spark/PartnerStageOneConsole.log",
             "log_group_name": "mrpid-partner-ec2-log-group",
-            "log_stream_name": "partner_stage_one_log",
+            "log_stream_name": "partner_stage_one_console_log",
             "timezone": "UTC"
           },
           {
-            "file_path": "/mnt/var/log/spark/PartnerStageTwo.log",
+            "file_path": "/mnt/var/log/spark/PartnerStageTwoConsole.log",
             "log_group_name": "mrpid-partner-ec2-log-group",
-            "log_stream_name": "partner_stage_two_log",
+            "log_stream_name": "partner_stage_two_console_log",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/mnt/var/log/spark/PartnerStageOneYarn.log",
+            "log_group_name": "mrpid-partner-ec2-log-group",
+            "log_stream_name": "partner_stage_one_yarn_log",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/mnt/var/log/spark/PartnerStageTwoYarn.log",
+            "log_group_name": "mrpid-partner-ec2-log-group",
+            "log_stream_name": "partner_stage_two_yarn_log",
             "timezone": "UTC"
           }
         ]

--- a/fbpcs/infra/pid/aws_terraform_template/partner/sfn_definition.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/partner/sfn_definition.tf
@@ -135,7 +135,7 @@ data "template_file" "partner_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.partner.PartnerStageOne {} s3://mrpid-publisher-${var.md5hash_aws_account_id}/{} s3://mrpid-partner-${var.md5hash_aws_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PartnerStageOne.log', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.instanceId, $.outputPath, $.inputPath))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.partner.PartnerStageOne {} s3://mrpid-publisher-${var.md5hash_aws_account_id}/{} s3://mrpid-partner-${var.md5hash_aws_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PartnerStageOneConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PartnerStageOneConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PartnerStageOneYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.instanceId, $.outputPath, $.inputPath))"
           }
         }
       },
@@ -191,7 +191,7 @@ data "template_file" "partner_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.partner.PartnerStageTwo {} s3://mrpid-publisher-${var.md5hash_aws_account_id}/{} s3://mrpid-partner-${var.md5hash_aws_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PartnerStageTwo.log', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.instanceId, $.outputPath, $.numPidContainers))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.partner.PartnerStageTwo {} s3://mrpid-publisher-${var.md5hash_aws_account_id}/{} s3://mrpid-partner-${var.md5hash_aws_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PartnerStageTwoConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PartnerStageTwoConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PartnerStageTwoYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.instanceId, $.outputPath, $.numPidContainers))"
           }
         }
       },

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/s3_bucket.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/s3_bucket.tf
@@ -54,21 +54,39 @@ sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /de
       "files": {
         "collect_list": [
           {
-            "file_path": "/mnt/var/log/spark/PubStageOne.log",
+            "file_path": "/mnt/var/log/spark/PubStageOneConsole.log",
             "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
-            "log_stream_name": "publisher_stage_one_log",
+            "log_stream_name": "publisher_stage_one_console_log",
             "timezone": "UTC"
           },
           {
-            "file_path": "/mnt/var/log/spark/PubStageTwo.log",
+            "file_path": "/mnt/var/log/spark/PubStageTwoConsole.log",
             "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
-            "log_stream_name": "publisher_stage_two_log",
+            "log_stream_name": "publisher_stage_two_console_log",
             "timezone": "UTC"
           },
           {
-            "file_path": "/mnt/var/log/spark/PubStageThree.log",
+            "file_path": "/mnt/var/log/spark/PubStageThreeConsole.log",
             "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
-            "log_stream_name": "publisher_stage_three_log",
+            "log_stream_name": "publisher_stage_three_console_log",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/mnt/var/log/spark/PubStageOneYarn.log",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_stream_name": "publisher_stage_one_yarn_log",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/mnt/var/log/spark/PubStageTwoYarn.log",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_stream_name": "publisher_stage_two_yarn_log",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/mnt/var/log/spark/PubStageThreeYarn.log",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_stream_name": "publisher_stage_three_yarn_log",
             "timezone": "UTC"
           }
         ]

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/sfn_definition.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/sfn_definition.tf
@@ -106,7 +106,7 @@ data "template_file" "publisher_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageOne {} s3://mrpid-publisher-${var.md5hash_partner_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageOne.log', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.inputPath))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageOne {} s3://mrpid-publisher-${var.md5hash_partner_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageOneConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageOneConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageOneYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.inputPath))"
           }
         }
       },
@@ -162,7 +162,7 @@ data "template_file" "publisher_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageTwo {} s3://mrpid-publisher-${var.md5hash_partner_account_id}/{} {} s3://mrpid-partner-${var.md5hash_partner_account_id}/{} 2>&1 | sudo tee /mnt/var/log/spark/PubStageTwo.log', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.instanceId))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageTwo {} s3://mrpid-publisher-${var.md5hash_partner_account_id}/{} {} s3://mrpid-partner-${var.md5hash_partner_account_id}/{} 2>&1 | sudo tee /mnt/var/log/spark/PubStageTwoConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageTwoConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageTwoYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.instanceId))"
           }
         }
       },
@@ -218,7 +218,7 @@ data "template_file" "publisher_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageThree {} {} s3://mrpid-partner-${var.md5hash_partner_account_id}/{} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageThree.log', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.outputPath, $.instanceId, $.numPidContainers))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageThree {} {} s3://mrpid-partner-${var.md5hash_partner_account_id}/{} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageThreeConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageThreeConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageThreeYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.outputPath, $.instanceId, $.numPidContainers))"
           }
         }
       },


### PR DESCRIPTION
Summary:
```
set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars s3://one-docker-repository-prod/pid/private-id-mr/latest/pid-mr-multikey.jar --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=1 --class com.meta.mr.multikey.publisher.PubStageOne s3://one-docker-repository-prod/pid/private-id-mr/latest/pid-mr-multikey.jar s3://mrpid-publisher-3e5adccb76c4baaff7b85f288780fcf8/46702208643902 s3://test-opportunities/35802205951975_31702207300999/o/ds=2022-06-18/46702208643902_out_dir/pid_mr s3://test-opportunities/35802205951975_31702207300999/o/ds=2022-06-18/test_private_lift_annotated_opportunities_multikey_hashed_pii_test-opportunities_539290649537_35802205951975_31702207300999._2022-06-18.csv 2>&1 | sudo tee /mnt/var/log/spark/PubStageOneConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageOneConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageOneYarn.log;test $exit_status -eq 0
```
Above is the example command run for each stage, it will push both console and yarn logs into local log files and map to cloudwatch by cloudwatch agent

Reviewed By: Pradeepnitw

Differential Revision: D40481025

