### PR TITLE
pl_study_runner add run_study_async

### DIFF
--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
 import calendar
 import copy
 import datetime
@@ -237,8 +238,10 @@ class TestPlStudyRunner(TestCase):
         self.mock_graph_api_client.get_instance.return_value = (
             self._get_graph_api_output("CREATED", expected_features)
         )
-        tested_features = pl_study_runner._get_pcs_features(
-            self.cell_obj_instances, self.mock_graph_api_client
+        tested_features = asyncio.run(
+            pl_study_runner._get_pcs_features(
+                self.cell_obj_instances, self.mock_graph_api_client
+            )
         )
         self.assertEqual(tested_features, expected_features)
 


### PR DESCRIPTION
Summary:
## What

- Make the existing `run_study` async and rename it to `run_study_async`
- Make a few functions that call `asyncio.run` async instead
- Make `run_study` a function that just calls `run_study_async` with `asyncio.run`

## Why

- This is cleaner than having multiple asyncio.run throughout the file
- This makes it possible to call run study from an async context. Previously, this would fail because asyncio.run cannot be used if there is already an event loop (or something like this, I don't remember the error message).
- This will be used to enable PL graph API experiments on the experimentation platform

Differential Revision: D40453809

