### PR TITLE
Create main runner for C++ fake data generator

### DIFF
--- a/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.cpp
+++ b/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <unordered_map>
+
+static std::string genIdFor(int64_t n) {
+  auto c = std::to_string(n);
+  // I'm too lazy to do something better
+  // and md5 is a PITA without pulling in openssl
+  return c + c + c + c;
+}
+
+std::string FakeDataGenerator::genOneRow() const {
+  std::uniform_real_distribution<double> realDist{0, 1};
+  std::uniform_int_distribution<int8_t> binaryDist{0, 1};
+  // Used for impressions and clicks
+  std::uniform_int_distribution<int64_t> engagementDist{0, 10};
+  std::uniform_int_distribution<int64_t> valueDist{
+      params_.minValue, params_.maxValue};
+  std::uniform_int_distribution<int64_t> tsDist{params_.minTs, params_.maxTs};
+
+  // Shared stuff
+  auto id = params_.shouldUseComplexIds ? genIdFor(n_) : std::to_string(n_);
+  auto groupId = binaryDist(r_);
+
+  // Publisher stuff
+  auto hasOpp = realDist(r_) < params.opportunityRate ? 1 : 0;
+  auto oppTs = hasOpp * tsDist(r_);
+  auto isTest = hasOpp && realDist(r_) < params_.testRate ? 1 : 0;
+  // Engagement
+  auto impressions = isTest * engagementDist(r_);
+  auto clicks = std::min(impressions, engagementDist(r_));
+  auto spend = isTest * valueDist(r_);
+
+  // Partner stuff
+  auto hasPurchase = realDist(r_) < params_.purchaseRate ? 1 : 0;
+  auto eventTs = hasPurchase * tsDist(r_);
+  auto value = hasPurchase * valueDist(r_);
+
+  std::string res;
+  std::unordered_map<std::string, std::string> m{
+      {"id_", id},
+      {"opportunity_timestamp", std::to_string(oppTs)},
+      {"test_flag", std::to_string(isTest)},
+      {"num_impressions", std::to_string(impressions)},
+      {"num_clicks", std::to_string(clicks)},
+      {"total_spend", std::to_string(spend)},
+      {"breakdown_id", std::to_string(groupId)},
+      {"event_timestamp", std::to_string(eventTs)},
+      {"value", std::to_string(value)},
+      {"cohort_id", std::to_string(groupId)},
+  };
+
+  for (const auto& col : params_.header) {
+    res += m.at(col);
+    res += ','
+  }
+
+  // Get rid of the last ','
+  res.pop_back();
+
+  ++n;
+  return res;
+}

--- a/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h
+++ b/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h
@@ -13,22 +13,25 @@
 #include <string>
 #include <vector>
 
+enum class Role { Publisher, Partner };
+
 struct FakeDataGeneratorParams {
+  Role role;
   std::vector<std::string> header;
   double opportunityRate = 0.8;
-  double testRate = 0.5;
+  double testRate = 0.9;
   double purchaseRate = 0.1;
   // 2020-09-13 12:26:40 UTC
   // Just a nice round number near the current date
-  int64_t minTs = 1600000000;
+  int64_t minTs = 1'600'000'000;
   // 30 days after the default minTs
-  int64_t maxTs = 1600000000 + 86400 * 30;
+  int64_t maxTs = 1'600'000'000 + 86400 * 30;
   int64_t minValue = 100;
   int64_t maxValue = 10000;
   bool shouldUseComplexIds = true;
-  int16_t numConversions = 4;
 
-  FakeDataGenerator(std::vector<std::string> header_) : header{header_} {}
+  FakeDataGeneratorParams(Role role_, std::vector<std::string> header_)
+      : role{role_}, header{header_} {}
 
   FakeDataGeneratorParams& withOpportunityRate(double r) {
     opportunityRate = r;
@@ -54,6 +57,7 @@ struct FakeDataGeneratorParams {
     maxTs = ts;
     return *this;
   }
+
   FakeDataGeneratorParams& withMinValue(int64_t v) {
     minValue = v;
     return *this;
@@ -68,11 +72,6 @@ struct FakeDataGeneratorParams {
     shouldUseComplexIds = b;
     return *this;
   }
-
-  FakeDataGeneratorParams& withNumConversions(int16_t n) {
-    numConversions = n;
-    return *this;
-  }
 };
 
 class FakeDataGenerator {
@@ -80,12 +79,13 @@ class FakeDataGenerator {
   explicit FakeDataGenerator(FakeDataGeneratorParams params)
       : FakeDataGenerator{
             params,
-            std::chrono::system_clock::now().time_since_epoch().count()} {}
+            static_cast<uint32_t>(
+                std::chrono::system_clock::now().time_since_epoch().count())} {}
 
-  FakeDataGenerator(FakeDataGeneratorParams params, int64_t seed)
+  FakeDataGenerator(FakeDataGeneratorParams params, uint32_t seed)
       : params_{params}, r_{seed}, n_{0} {}
 
-  std::string genOneRow() const;
+  std::string genOneRow();
 
  private:
   FakeDataGeneratorParams params_;

--- a/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h
+++ b/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct FakeDataGeneratorParams {
+  std::vector<std::string> header;
+  double opportunityRate = 0.8;
+  double testRate = 0.5;
+  double purchaseRate = 0.1;
+  double incrementalityRate = 0.1;
+  // 2020-09-13 12:26:40 UTC
+  // Just a nice round number near the current date
+  int64_t minTs = 1600000000;
+  // 30 days after the default minTs
+  int64_t maxTs = 1600000000 + 86400 * 30;
+  bool shouldUseMd5Ids = true;
+  int16_t numConversions = 4;
+
+  FakeDataGenerator(std::vector<std::string> header_) : header{header_} {}
+
+  FakeDataGeneratorParams& withOpportunityRate(double r) {
+    opportunityRate = r;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withTestRate(double r) {
+    testRate = r;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withPurchaseRate(double r) {
+    purchaseRate = r;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withIncrementalityRate(double r) {
+    incrementalityRate = r;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withMinTs(int64_t ts) {
+    minTs = ts;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withMaxTs(int64_t ts) {
+    maxTs = ts;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withShouldUseMd5Ids(bool b) {
+    shouldUseMd5Ids = b;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withNumConversions(int16_t n) {
+    numConversions = n;
+    return *this;
+  }
+}

--- a/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h
+++ b/fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
+#include <chrono>
 #include <cstdint>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -14,13 +18,14 @@ struct FakeDataGeneratorParams {
   double opportunityRate = 0.8;
   double testRate = 0.5;
   double purchaseRate = 0.1;
-  double incrementalityRate = 0.1;
   // 2020-09-13 12:26:40 UTC
   // Just a nice round number near the current date
   int64_t minTs = 1600000000;
   // 30 days after the default minTs
   int64_t maxTs = 1600000000 + 86400 * 30;
-  bool shouldUseMd5Ids = true;
+  int64_t minValue = 100;
+  int64_t maxValue = 10000;
+  bool shouldUseComplexIds = true;
   int16_t numConversions = 4;
 
   FakeDataGenerator(std::vector<std::string> header_) : header{header_} {}
@@ -40,11 +45,6 @@ struct FakeDataGeneratorParams {
     return *this;
   }
 
-  FakeDataGeneratorParams& withIncrementalityRate(double r) {
-    incrementalityRate = r;
-    return *this;
-  }
-
   FakeDataGeneratorParams& withMinTs(int64_t ts) {
     minTs = ts;
     return *this;
@@ -54,9 +54,18 @@ struct FakeDataGeneratorParams {
     maxTs = ts;
     return *this;
   }
+  FakeDataGeneratorParams& withMinValue(int64_t v) {
+    minValue = v;
+    return *this;
+  }
 
-  FakeDataGeneratorParams& withShouldUseMd5Ids(bool b) {
-    shouldUseMd5Ids = b;
+  FakeDataGeneratorParams& withMaxValue(int64_t v) {
+    maxValue = v;
+    return *this;
+  }
+
+  FakeDataGeneratorParams& withShouldUseComplexIds(bool b) {
+    shouldUseComplexIds = b;
     return *this;
   }
 
@@ -64,4 +73,22 @@ struct FakeDataGeneratorParams {
     numConversions = n;
     return *this;
   }
-}
+};
+
+class FakeDataGenerator {
+ public:
+  explicit FakeDataGenerator(FakeDataGeneratorParams params)
+      : FakeDataGenerator{
+            params,
+            std::chrono::system_clock::now().time_since_epoch().count()} {}
+
+  FakeDataGenerator(FakeDataGeneratorParams params, int64_t seed)
+      : params_{params}, r_{seed}, n_{0} {}
+
+  std::string genOneRow() const;
+
+ private:
+  FakeDataGeneratorParams params_;
+  std::default_random_engine r_;
+  int64_t n_;
+};

--- a/fbpcs/data_processing/load_testing_utils/GenFakeData.cpp
+++ b/fbpcs/data_processing/load_testing_utils/GenFakeData.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h"
+
+DEFINE_string(output_filepath, "", "Path of the output file");
+DEFINE_string(
+    role,
+    "publisher",
+    "Whether this is a publisher or partner dataset");
+DEFINE_string(header, "", "Header defining the output to be generated");
+DEFINE_int32(n, 1'000'000, "How many lines to generate");
+DEFINE_int32(log_every_n, 1'000'000, "How frequently to log updates");
+DEFINE_string(
+    opportunity_rate,
+    "0.8",
+    "Rate of logged opportunities (as a double)");
+DEFINE_string(
+    test_rate,
+    "0.9",
+    "Proportion of opportunities logged to test group (as a double)");
+DEFINE_string(
+    purchase_rate,
+    "0.1",
+    "Proportion of users making a purchase (as a double)");
+DEFINE_int32(min_ts, 1'600'000'000, "Minimum timestamp possible");
+DEFINE_int32(max_ts, 1'600'000'000 + 86400 * 30, "Maximum timestamp possible");
+DEFINE_int32(min_value, 100, "Minimum value for generated purchases");
+DEFINE_int32(max_value, 10'000, "Maximum value for generated purchases");
+DEFINE_bool(
+    should_use_complex_ids,
+    true,
+    "Use complex IDs instead of simple integers");
+
+static Role parseRole(std::string role) {
+  std::transform(role.begin(), role.end(), role.begin(), [](unsigned char c) {
+    return std::tolower(c);
+  });
+  return role == "publisher" ? Role::Publisher : Role::Partner;
+}
+
+static std::vector<std::string> parseHeader(std::string header) {
+  std::vector<std::string> res;
+  std::size_t start = 0;
+  std::size_t i = 0;
+  while (start + i < header.size()) {
+    if (header.at(start + i) == ',') {
+      res.push_back(header.substr(start, i));
+      start += i + 1;
+      i = 0;
+    } else {
+      ++i;
+    }
+  }
+  res.push_back(header.substr(start));
+  return res;
+}
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  auto role = parseRole(FLAGS_role);
+  auto header = parseHeader(FLAGS_header);
+
+  FakeDataGeneratorParams params{role, header};
+
+  params = params.withOpportunityRate(std::stod(FLAGS_opportunity_rate))
+               .withTestRate(std::stod(FLAGS_test_rate))
+               .withPurchaseRate(std::stod(FLAGS_purchase_rate))
+               .withMinTs(FLAGS_min_ts)
+               .withMaxTs(FLAGS_max_ts)
+               .withMinValue(FLAGS_min_value)
+               .withMaxValue(FLAGS_max_value)
+               .withShouldUseComplexIds(FLAGS_should_use_complex_ids);
+
+  FakeDataGenerator g{params};
+
+  std::cout << "Writing output to " << FLAGS_output_filepath << '\n';
+  std::ofstream fOut{FLAGS_output_filepath};
+  fOut << FLAGS_header << '\n';
+  for (std::size_t i = 0; i < FLAGS_n; ++i) {
+    auto row = g.genOneRow();
+    if (!row.empty()) {
+      fOut << row << '\n';
+    }
+    if ((i + 1) % FLAGS_log_every_n == 0) {
+      std::cout << "Processed " << i + 1 << " lines\n";
+    }
+  }
+
+  std::cout << "Done.\n";
+  return 0;
+}

--- a/fbpcs/data_processing/test/load_testing_utils/TestFakeDataGenerator.cpp
+++ b/fbpcs/data_processing/test/load_testing_utils/TestFakeDataGenerator.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+TEST(TestFakeDataGeneratorParams, withOpportunityRate) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withOpportunityRate(1.23);
+  // TODO: Add validation for valid ranges of params
+  EXPECT_DOUBLE_EQ(params.opportunityRate, 1.23);
+}
+
+TEST(TestFakeDataGeneratorParams, withTestRate) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withTestRate(4.56);
+  // TODO: Add validation for valid ranges of params
+  EXPECT_DOUBLE_EQ(params.testRate, 4.56);
+}
+
+TEST(TestFakeDataGeneratorParams, withPurchaseRate) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withPurchaseRate(7.89);
+  // TODO: Add validation for valid ranges of params
+  EXPECT_DOUBLE_EQ(params.purchaseRate, 7.89);
+}
+
+TEST(TestFakeDataGeneratorParams, withIncrementalityRate) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withIncrementalityRate(0.12);
+  // TODO: Add validation for valid ranges of params
+  EXPECT_DOUBLE_EQ(params.incrementalityRate, 0.12);
+}
+
+TEST(TestFakeDataGeneratorParams, withMinTs) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withMinTs(123);
+  EXPECT_EQ(params.minTs, 123);
+}
+
+TEST(TestFakeDataGeneratorParams, withMaxTs) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withMaxTs(456);
+  EXPECT_EQ(params.maxTs, 456);
+}
+
+TEST(TestFakeDataGeneratorParams, withShouldUseMd5Ids) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withShouldUseMd5Ids(false);
+  EXPECT_FALSE(params.shouldUseMd5Ids);
+}
+
+TEST(TestFakeDataGeneratorParams, withNumConversions) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withNumConversions(111);
+  EXPECT_EQ(params.numConversions, 111);
+}

--- a/fbpcs/data_processing/test/load_testing_utils/TestFakeDataGenerator.cpp
+++ b/fbpcs/data_processing/test/load_testing_utils/TestFakeDataGenerator.cpp
@@ -5,10 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "fbpcs/data_processing/load_testing_utils/FakeDataGenerator.h"
+
 #include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
+
+constexpr int64_t SEED = 10182022;
 
 TEST(TestFakeDataGeneratorParams, withOpportunityRate) {
   const std::vector<std::string> header{"a", "b", "c"};
@@ -34,14 +38,6 @@ TEST(TestFakeDataGeneratorParams, withPurchaseRate) {
   EXPECT_DOUBLE_EQ(params.purchaseRate, 7.89);
 }
 
-TEST(TestFakeDataGeneratorParams, withIncrementalityRate) {
-  const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
-  params.withIncrementalityRate(0.12);
-  // TODO: Add validation for valid ranges of params
-  EXPECT_DOUBLE_EQ(params.incrementalityRate, 0.12);
-}
-
 TEST(TestFakeDataGeneratorParams, withMinTs) {
   const std::vector<std::string> header{"a", "b", "c"};
   FakeDataGeneratorParams params{header};
@@ -56,11 +52,25 @@ TEST(TestFakeDataGeneratorParams, withMaxTs) {
   EXPECT_EQ(params.maxTs, 456);
 }
 
-TEST(TestFakeDataGeneratorParams, withShouldUseMd5Ids) {
+TEST(TestFakeDataGeneratorParams, withMinValue) {
   const std::vector<std::string> header{"a", "b", "c"};
   FakeDataGeneratorParams params{header};
-  params.withShouldUseMd5Ids(false);
-  EXPECT_FALSE(params.shouldUseMd5Ids);
+  params.withMinValue(123);
+  EXPECT_EQ(params.minValue, 123);
+}
+
+TEST(TestFakeDataGeneratorParams, withMaxValue) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withMaxValue(456);
+  EXPECT_EQ(params.maxValue, 456);
+}
+
+TEST(TestFakeDataGeneratorParams, withShouldUseComplexIds) {
+  const std::vector<std::string> header{"a", "b", "c"};
+  FakeDataGeneratorParams params{header};
+  params.withShouldUseComplexIds(false);
+  EXPECT_FALSE(params.shouldUseComplexIds);
 }
 
 TEST(TestFakeDataGeneratorParams, withNumConversions) {
@@ -68,4 +78,31 @@ TEST(TestFakeDataGeneratorParams, withNumConversions) {
   FakeDataGeneratorParams params{header};
   params.withNumConversions(111);
   EXPECT_EQ(params.numConversions, 111);
+}
+
+TEST(TestFakeDataGenerator, genOneRowForPublisher) {
+  const std::vector<std::string> header{
+      "id_", "opportunity_timestamp", "test_flag", "breakdown_id"};
+  FakeDataGeneratorParams params{header};
+  FakeDataGenerator g{params, SEED};
+
+  auto row = g.genOneRow();
+  EXPECT_EQ(row, "");
+}
+
+TEST(TestFakeDataGenerator, genOneRowForPartner) {
+  const std::vector<std::string> header{"id_", "event_timestamp", "value"};
+  FakeDataGeneratorParams params{header};
+  FakeDataGenerator g{params, SEED};
+
+  auto row = g.genOneRow();
+  EXPECT_EQ(row, "");
+}
+TEST(TestFakeDataGenerator, genOneRowForInvalidHeader) {
+  const std::vector<std::string> header{"id_", "bad_column_name"};
+  FakeDataGeneratorParams params{header};
+  FakeDataGenerator g{params, SEED};
+
+  auto row = g.genOneRow();
+  EXPECT_EQ(row, "");
 }

--- a/fbpcs/data_processing/test/load_testing_utils/TestFakeDataGenerator.cpp
+++ b/fbpcs/data_processing/test/load_testing_utils/TestFakeDataGenerator.cpp
@@ -16,7 +16,7 @@ constexpr int64_t SEED = 10182022;
 
 TEST(TestFakeDataGeneratorParams, withOpportunityRate) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withOpportunityRate(1.23);
   // TODO: Add validation for valid ranges of params
   EXPECT_DOUBLE_EQ(params.opportunityRate, 1.23);
@@ -24,7 +24,7 @@ TEST(TestFakeDataGeneratorParams, withOpportunityRate) {
 
 TEST(TestFakeDataGeneratorParams, withTestRate) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withTestRate(4.56);
   // TODO: Add validation for valid ranges of params
   EXPECT_DOUBLE_EQ(params.testRate, 4.56);
@@ -32,7 +32,7 @@ TEST(TestFakeDataGeneratorParams, withTestRate) {
 
 TEST(TestFakeDataGeneratorParams, withPurchaseRate) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withPurchaseRate(7.89);
   // TODO: Add validation for valid ranges of params
   EXPECT_DOUBLE_EQ(params.purchaseRate, 7.89);
@@ -40,50 +40,55 @@ TEST(TestFakeDataGeneratorParams, withPurchaseRate) {
 
 TEST(TestFakeDataGeneratorParams, withMinTs) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withMinTs(123);
   EXPECT_EQ(params.minTs, 123);
 }
 
 TEST(TestFakeDataGeneratorParams, withMaxTs) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withMaxTs(456);
   EXPECT_EQ(params.maxTs, 456);
 }
 
 TEST(TestFakeDataGeneratorParams, withMinValue) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withMinValue(123);
   EXPECT_EQ(params.minValue, 123);
 }
 
 TEST(TestFakeDataGeneratorParams, withMaxValue) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withMaxValue(456);
   EXPECT_EQ(params.maxValue, 456);
 }
 
 TEST(TestFakeDataGeneratorParams, withShouldUseComplexIds) {
   const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   params.withShouldUseComplexIds(false);
   EXPECT_FALSE(params.shouldUseComplexIds);
-}
-
-TEST(TestFakeDataGeneratorParams, withNumConversions) {
-  const std::vector<std::string> header{"a", "b", "c"};
-  FakeDataGeneratorParams params{header};
-  params.withNumConversions(111);
-  EXPECT_EQ(params.numConversions, 111);
 }
 
 TEST(TestFakeDataGenerator, genOneRowForPublisher) {
   const std::vector<std::string> header{
       "id_", "opportunity_timestamp", "test_flag", "breakdown_id"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
+  params.purchaseRate = 1;
+  FakeDataGenerator g{params, SEED};
+
+  auto row = g.genOneRow();
+  EXPECT_EQ(row, "a10b2c30d40e5f6,1601902513,1,1");
+}
+
+TEST(TestFakeDataGenerator, genOneRowForPublisherNoOpportunity) {
+  const std::vector<std::string> header{
+      "id_", "opportunity_timestamp", "test_flag", "breakdown_id"};
+  FakeDataGeneratorParams params{Role::Publisher, header};
+  params.opportunityRate = 0;
   FakeDataGenerator g{params, SEED};
 
   auto row = g.genOneRow();
@@ -92,17 +97,28 @@ TEST(TestFakeDataGenerator, genOneRowForPublisher) {
 
 TEST(TestFakeDataGenerator, genOneRowForPartner) {
   const std::vector<std::string> header{"id_", "event_timestamp", "value"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Partner, header};
+  params.purchaseRate = 1;
+  FakeDataGenerator g{params, SEED};
+
+  auto row = g.genOneRow();
+  EXPECT_EQ(row, "a10b2c30d40e5f6,1602405690,4410");
+}
+
+TEST(TestFakeDataGenerator, genOneRowForPartnerNoPurchase) {
+  const std::vector<std::string> header{"id_", "event_timestamp", "value"};
+  FakeDataGeneratorParams params{Role::Partner, header};
+  params.purchaseRate = 0;
   FakeDataGenerator g{params, SEED};
 
   auto row = g.genOneRow();
   EXPECT_EQ(row, "");
 }
+
 TEST(TestFakeDataGenerator, genOneRowForInvalidHeader) {
   const std::vector<std::string> header{"id_", "bad_column_name"};
-  FakeDataGeneratorParams params{header};
+  FakeDataGeneratorParams params{Role::Publisher, header};
   FakeDataGenerator g{params, SEED};
 
-  auto row = g.genOneRow();
-  EXPECT_EQ(row, "");
+  EXPECT_THROW(g.genOneRow(), std::out_of_range);
 }


### PR DESCRIPTION
Summary:
# This stack
* Create a gen_fake_data script using C++ since the Python one takes ~12hr to process 1B rows
# This diff
* Add the entry point for this program by creating a thin main wrapper

Reviewed By: marksliva

Differential Revision: D40375165

