### PR TITLE
Increase per-run client concurrency limit to 5

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -14,6 +14,8 @@ Types of changes
   [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased - 2.4.0] - put release date here
+### Changed
+* Client max concurrency increased from 3 to 5
 
 ## [2.3.0] - 2022-10-12
 

--- a/fbpcs/pl_coordinator/constants.py
+++ b/fbpcs/pl_coordinator/constants.py
@@ -29,7 +29,7 @@ MAX_TRIES = 2
 RETRY_INTERVAL = 60
 
 MIN_NUM_INSTANCES = 1
-MAX_NUM_INSTANCES = 3
+MAX_NUM_INSTANCES = 5
 PROCESS_WAIT = 1  # interval between starting processes.
 INSTANCE_SLA = 86400  # 16 hr instance sla, 2 tries per stage, total 24 hrs (since the Ent expires after 24 hours)
 


### PR DESCRIPTION
Summary:
# What
* Client concurrency: 3 -> 5
# Why
* Recent scalability tests show that we can handle concurrency of 100 runs easily, so we'll now bump our client concurrency to 5

Reviewed By: musebc

Differential Revision:
D40516233

LaMa Project: L416713

