### PR TITLE
Remove AesCircuitCtr_impl.h import from fbpcs

### DIFF
--- a/.github/workflows/build_fbpcs_images.yml
+++ b/.github/workflows/build_fbpcs_images.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  FBPCF_VERSION: 2.1.73  # Please also update line 29 in .github/workflows/docker-publish.yml
+  FBPCF_VERSION: 2.1.78  # Please also update line 29 in .github/workflows/docker-publish.yml
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.73  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
+  FBPCF_VERSION: 2.1.78  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
   PID_VERSION: 0.0.4
 
 jobs:

--- a/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h
@@ -10,7 +10,6 @@
 #include <emmintrin.h>
 #include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
 #include "fbpcf/engine/util/util.h"
-#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuit_impl.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/IAesCircuitCtr.h"
 #include "fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h"
 namespace unified_data_process::data_processor {

--- a/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h
+++ b/fbpcs/data_processing/unified_data_process/data_processor/DataProcessor_impl.h
@@ -9,7 +9,6 @@
 
 #include "fbpcf/engine/util/aes.h"
 #include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr.h"
-#include "fbpcf/mpc_std_lib/aes_circuit/AesCircuitCtr_impl.h"
 #include "fbpcs/data_processing/unified_data_process/data_processor/DataProcessor.h"
 
 namespace unified_data_process::data_processor {


### PR DESCRIPTION
Summary: Currently the header files `AesCircuitCtr.h` and  `AesCircuit.h` files do not include the relevant `_impl.h` files in them. Once D40525216 becomes the production version of `fbpcf` we should be good to remove these lines.

Differential Revision: D40525350

