### PR TITLE
remove num MPC container > num PID container error

### DIFF
--- a/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_instance_local.py
@@ -75,24 +75,6 @@ class TestLocalPrivateComputationInstanceRepository(unittest.TestCase):
         )
         self.repo.delete(instance_id)
 
-    def test_create_with_invalid_num_containers(self) -> None:
-        instance_id = self._get_random_id()
-
-        with self.assertRaises(ValueError):
-            InfraConfig(
-                instance_id=instance_id,
-                role=PrivateComputationRole.PUBLISHER,
-                status=PrivateComputationInstanceStatus.CREATED,
-                status_update_ts=1600000000,
-                instances=[self.test_mpc_instance],
-                game_type=PrivateComputationGameType.LIFT,
-                num_pid_containers=8,
-                num_mpc_containers=4,
-                num_files_per_mpc_container=40,
-                mpc_compute_concurrency=1,
-                status_updates=[],
-            )
-
     def test_update(self) -> None:
         instance_id = self._get_random_id()
         infra_config: InfraConfig = InfraConfig(


### PR DESCRIPTION
Summary:
We saw a failure due to the check of `num MPC container > num PID container`. This is not always true because PID is gating SNMK by number of containers, so PID can have 2 containers to use single-key protocol while MPC can have only single container. Also, we should completely decouple PID and MPC containers, so we are removing this condition.

After D40399873 (https://github.com/facebookresearch/fbpcs/commit/fa6d7d89547068b64be905f64f7a173f07d6e64e), we will be mutating num MPC containers based on actual spine file size. Therefore, I'm going to remove this condition.

According to D32117843 (https://github.com/facebookresearch/fbpcs/commit/cf41f83ead91fcc943b435e8e6d91fe54501c684), this check was added because "we make a few assumptions in the codebase when we shard. In theory we could support sharding the other way around but in general we expect the pid code to be much cheaper and require smaller capacity than the mpc code". So we believe it is safe to remove this change for decoupling effort.

Differential Revision: D40532167

