### PR TITLE
Pin PID Version in FBPCS

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,8 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.73  # Please also update line 8 in .github/workflows/build_binary_images.yml
+  FBPCF_VERSION: 2.1.73  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
+  PID_VERSION: 0.0.4
 
 jobs:
   ### Build and publish rc/onedocker image
@@ -49,7 +50,7 @@ jobs:
 
       - name: Build onedocker image in rc
         run: |
-          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f -p linux/amd64 -v ${{ env.FBPCF_VERSION }}
+          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f -p linux/amd64 -v ${{ env.FBPCF_VERSION }} -i ${{ env.PID_VERSION }}
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -26,6 +26,7 @@ package:
 -t TAG: tags the image with the given tag (default: latest)
 -p PLATFORM: builds the image to target the given platform (default depends on local system) - requires Docker Engine API 1.40+
 -v FBPCF_VERSION: base FBPCF version to use
+-i PID_VERSION: The version of PID to use when building the OneDocker Container
 EOF
   exit 1
 }
@@ -46,7 +47,8 @@ FORCE_EXTERNAL=false
 USE_GCP=false
 PLATFORM=""
 FBPCF_VERSION="latest"
-while getopts "u,f,g,t:,p:,v:" o; do
+PID_VERSION="latest"
+while getopts "u,f,g,t:,p:,v:,i:" o; do
   case $o in
     (u) OS_VARIANT="ubuntu"
         OS_RELEASE=${UBUNTU_RELEASE}
@@ -56,6 +58,7 @@ while getopts "u,f,g,t:,p:,v:" o; do
     (t) TAG=$OPTARG;;
     (p) PLATFORM=$OPTARG;;
     (v) FBPCF_VERSION=$OPTARG;;
+    (i) PID_VERSION=$OPTARG;;
     (*) usage
   esac
 done
@@ -108,6 +111,7 @@ for P in $PACKAGE; do
     --build-arg tag="${TAG}" \
     --build-arg os_release="${OS_RELEASE}" \
     --build-arg fbpcf_image="${FBPCF_IMAGE}" \
+    --build-arg private_id_tag="${PID_VERSION}" \
     --compress \
     -t "${IMAGE_PREFIX}${DOCKER_PACKAGE}:${TAG}" -f "docker/${P}/Dockerfile${DOCKER_EXTENSION}" \
     "${opt_params[@]}" .

--- a/docker/onedocker/Dockerfile.ubuntu
+++ b/docker/onedocker/Dockerfile.ubuntu
@@ -4,10 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 ARG os_release="20.04"
 ARG tag="latest"
+ARG private_id_tag="latest"
 FROM fbpcs/data-processing:${tag} as data_processing
 FROM fbpcs/emp-games:${tag} as emp_games
-# Tag for private-id is always latest
-FROM ghcr.io/facebookresearch/private-id:latest as private_id
+FROM ghcr.io/facebookresearch/private-id:${private_id_tag} as private_id
 
 FROM ubuntu:${os_release}
 # Set the timezone

--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes
 ## [Unreleased - 2.4.0] - put release date here
 ### Changed
 * Client max concurrency increased from 3 to 5
+* PID Version pinned to 0.0.4
 
 ## [2.3.0] - 2022-10-12
 


### PR DESCRIPTION
Summary: Now that PID is being released with specific versions, we can pin to that version in PCS and reduce our risk of issues in hotfix situations.

Differential Revision: D40550550

