### PR TITLE
use tlsInfo to disable TLS in UDP game

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
@@ -21,7 +21,9 @@ inline common::SchedulerStatistics startUdpProcessApp(
     int64_t numberOfRows,
     int64_t sizeOfRow,
     int64_t numberOfIntersection,
-    bool useXorEncryption) {
+    bool useXorEncryption,
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
+        tlsInfo) {
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -33,7 +35,7 @@ inline common::SchedulerStatistics startUdpProcessApp(
 
   auto communicationAgentFactory = std::make_shared<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      PARTY, partyInfos, metricCollector);
+      PARTY, partyInfos, tlsInfo, metricCollector);
 
   auto udpGameFactory = std::make_unique<UdpProcessGameFactory<PARTY>>(
       PARTY, *communicationAgentFactory);

--- a/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
@@ -48,6 +48,8 @@ int main(int argc, char** argv) {
   FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner
   // instead of 1 and 2
 
+  auto tlsInfo = common::getTlsInfoFromArgs(false, "", "", "", "");
+
   common::SchedulerStatistics schedulerStatistics;
 
   XLOG(INFO) << "Start UDP Processing...";
@@ -61,7 +63,8 @@ int main(int argc, char** argv) {
             FLAGS_row_number,
             FLAGS_row_size,
             FLAGS_intersection,
-            FLAGS_use_xor_encryption);
+            FLAGS_use_xor_encryption,
+            tlsInfo);
   } else if (FLAGS_party == common::PARTNER) {
     XLOG(INFO)
         << "Starting UDP Processing as Partner, will wait for Publisher...";
@@ -72,7 +75,8 @@ int main(int argc, char** argv) {
             FLAGS_row_number,
             FLAGS_row_size,
             FLAGS_intersection,
-            FLAGS_use_xor_encryption);
+            FLAGS_use_xor_encryption,
+            tlsInfo);
   } else {
     XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
   }


### PR DESCRIPTION
Summary: This diff added a `tlsInfo` structure in UDP game to properly disable the TLS support.

Reviewed By: adshastri

Differential Revision: D40525289

