### PR TITLE
Add memory usage measurement in costEstimation library

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <memory>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
@@ -21,6 +20,7 @@ inline common::SchedulerStatistics startUdpProcessApp(
     int64_t numberOfRows,
     int64_t sizeOfRow,
     int64_t numberOfIntersection,
+    std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst,
     bool useXorEncryption) {
   std::map<
       int,
@@ -46,6 +46,7 @@ inline common::SchedulerStatistics startUdpProcessApp(
       numberOfRows,
       sizeOfRow,
       numberOfIntersection,
+      costEst,
       useXorEncryption);
 
   app.run();

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
@@ -13,6 +13,7 @@
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+#include "fbpcs/performance_tools/CostEstimation.h"
 
 namespace unified_data_process {
 
@@ -29,6 +30,7 @@ class UdpProcessApp {
       int32_t numberOfRows,
       int64_t sizeOfRow,
       int32_t numberOfIntersection,
+      std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst,
       bool useXorEncryption = true)
       : party_{party},
         communicationAgentFactory_{std::move(communicationAgentFactory)},
@@ -37,6 +39,7 @@ class UdpProcessApp {
         numberOfRows_{numberOfRows},
         sizeOfRow_{sizeOfRow},
         numberOfIntersection_{numberOfIntersection},
+        costEst_{costEst},
         useXorEncryption_{useXorEncryption} {}
 
   // return the extracted shares of intersected metadata from publiser and
@@ -63,6 +66,7 @@ class UdpProcessApp {
   int64_t numberOfRows_;
   int64_t sizeOfRow_;
   int64_t numberOfIntersection_;
+  std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst_;
   bool useXorEncryption_;
   common::SchedulerStatistics schedulerStatistics_;
 };

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
@@ -26,11 +26,11 @@ UdpProcessApp<schedulerId>::run() {
   auto& unionMap = std::get<0>(testData);
   auto& metaData = std::get<1>(testData);
   auto udpProcessGame = udpGameFactory_->create(std::move(scheduler));
-
+  costEst_->addCheckPoint("computation preparation");
   XLOGF(
       INFO, "Start to run Adapter with a unionMap of size {}", unionMap.size());
   auto indexes = udpProcessGame->playAdapter(unionMap);
-
+  costEst_->addCheckPoint("Adapter done");
   XLOGF(
       INFO,
       "Start to run DataProcessor with a metaData of size {} and intersection size of {}",
@@ -38,7 +38,7 @@ UdpProcessApp<schedulerId>::run() {
       indexes.size());
   auto shares = udpProcessGame->playDataProcessor(
       metaData, indexes, metaData.size(), sizeOfRow_);
-
+  costEst_->addCheckPoint("DataProcessor done");
   auto publisherShares = std::get<0>(shares);
   auto partnerShares = std::get<1>(shares);
 

--- a/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
@@ -16,6 +16,7 @@
 #include "fbpcf/test/TestHelper.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+#include "fbpcs/performance_tools/CostEstimation.h"
 
 namespace unified_data_process {
 template <int schedulerId>
@@ -25,6 +26,7 @@ runUdpProcessApp(
     int32_t rowNumber,
     int32_t rowSize,
     int32_t intersectionSize,
+    std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst,
     std::shared_ptr<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory>
         communicationAgentFactory,
@@ -37,7 +39,8 @@ runUdpProcessApp(
       std::move(udpGameFactory),
       rowNumber,
       rowSize,
-      intersectionSize);
+      intersectionSize,
+      costEst);
   return app.run();
 }
 
@@ -107,12 +110,20 @@ TEST(UdpProcessApp, testUdpProcessApp) {
   auto metricCollector1 =
       std::make_shared<fbpcf::util::MetricCollector>("attribution_test_1");
 
+  auto costEst0 = std::make_shared<fbpcs::performance_tools::CostEstimation>(
+      "data_processing_udp", "test_bucket", "test_s3_region", "pcf2");
+  costEst0->start();
+  auto costEst1 = std::make_shared<fbpcs::performance_tools::CostEstimation>(
+      "data_processing_udp", "test_bucket", "test_s3_region", "pcf2");
+  costEst1->start();
+
   auto future0 = std::async(
       runUdpProcessApp<0>,
       0,
       rowNumber,
       rowSize,
       intersectionSize,
+      costEst0,
       std::move(agentFactories[0]),
       std::move(metricCollector0),
       std::move(udpGameFactory0));
@@ -122,6 +133,7 @@ TEST(UdpProcessApp, testUdpProcessApp) {
       rowNumber,
       rowSize,
       intersectionSize,
+      costEst1,
       std::move(agentFactories[1]),
       std::move(metricCollector1),
       std::move(udpGameFactory1));

--- a/fbpcs/performance_tools/CostEstimation.h
+++ b/fbpcs/performance_tools/CostEstimation.h
@@ -34,11 +34,14 @@ class CostEstimation {
     double networkRxBytes;
     double networkTxBytes;
     double cost;
+    size_t peakRSS;
+    size_t curRSS;
 
     folly::dynamic toDynamic() const {
       folly::dynamic res = folly::dynamic::object("runtime", runtime)(
           "networkRxBytes", networkRxBytes)(
-          "networkTxBytes", networkTxBytes)("cost", cost);
+          "networkTxBytes",
+          networkTxBytes)("cost", cost)("peak mem", peakRSS)("current mem", curRSS);
       return res;
     }
   };
@@ -53,11 +56,14 @@ class CostEstimation {
   long networkTXBytes_; // Network Transmit bytes
   std::chrono::time_point<std::chrono::system_clock> start_time_;
   std::chrono::time_point<std::chrono::system_clock> end_time_;
+  size_t peakRSS_; // maximum virtual memory space used by the process, in kB
   std::unordered_map<std::string, CheckPointMetrics> checkPointMetrics_;
   std::vector<std::string> checkPointName_;
   int checkPoints_ = 0;
   void calculateCostCheckPoints();
   std::unordered_map<std::string, long> readNetworkSnapshot();
+  size_t getPeakRSS();
+  size_t getCurrentRSS();
 
  public:
   explicit CostEstimation(


### PR DESCRIPTION
Summary:
This diff adds memory usage measurement in costEstimation library. We plan to use costEstimation library to measure the memory usage (maximum memory used) of emp games. So, the following methods/variable are added.

1. add a `getPeakRSS()` to read the peak memory usage for the current process. In this method, we use `getrusage()` to get the usage statistics for the calling process which is the sum of resources used by all threads in the process. From the returned usage summary, we take out and return `ru_maxrss` which represents the maximum memory usage for the calling process.
2. add `getCurrentRSS()` to read the current memory usage. This method reads `/proc/self/statm` to get information about memory usage, which includes the current memory usage.
3. add `peakRSS_` to record the peak memory usage. This will record the peak memory usage that is captured after the game execution.
4. revise the checkpoint structure to record the memory metrics at a checkpoint.

`getrusage()`: https://man7.org/linux/man-pages/man2/getrusage.2.html

Differential Revision: D40252412

