### PR TITLE
Add checkPoints in costEsimation to measure performance of UDP components

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
@@ -21,7 +21,9 @@ inline common::SchedulerStatistics startUdpProcessApp(
     int64_t numberOfRows,
     int64_t sizeOfRow,
     int64_t numberOfIntersection,
-    bool useXorEncryption) {
+    bool useXorEncryption,
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
+        tlsInfo) {
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -33,7 +35,7 @@ inline common::SchedulerStatistics startUdpProcessApp(
 
   auto communicationAgentFactory = std::make_shared<
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
-      PARTY, partyInfos, metricCollector);
+      PARTY, partyInfos, tlsInfo, metricCollector);
 
   auto udpGameFactory = std::make_unique<UdpProcessGameFactory<PARTY>>(
       PARTY, *communicationAgentFactory);

--- a/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/MainUtil.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <memory>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
@@ -21,6 +20,7 @@ inline common::SchedulerStatistics startUdpProcessApp(
     int64_t numberOfRows,
     int64_t sizeOfRow,
     int64_t numberOfIntersection,
+    std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst,
     bool useXorEncryption,
     fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
         tlsInfo) {
@@ -48,6 +48,7 @@ inline common::SchedulerStatistics startUdpProcessApp(
       numberOfRows,
       sizeOfRow,
       numberOfIntersection,
+      costEst,
       useXorEncryption);
 
   app.run();

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h
@@ -13,6 +13,7 @@
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+#include "fbpcs/performance_tools/CostEstimation.h"
 
 namespace unified_data_process {
 
@@ -29,6 +30,7 @@ class UdpProcessApp {
       int32_t numberOfRows,
       int64_t sizeOfRow,
       int32_t numberOfIntersection,
+      std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst,
       bool useXorEncryption = true)
       : party_{party},
         communicationAgentFactory_{std::move(communicationAgentFactory)},
@@ -37,6 +39,7 @@ class UdpProcessApp {
         numberOfRows_{numberOfRows},
         sizeOfRow_{sizeOfRow},
         numberOfIntersection_{numberOfIntersection},
+        costEst_{costEst},
         useXorEncryption_{useXorEncryption} {}
 
   // return the extracted shares of intersected metadata from publiser and
@@ -63,6 +66,7 @@ class UdpProcessApp {
   int64_t numberOfRows_;
   int64_t sizeOfRow_;
   int64_t numberOfIntersection_;
+  std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst_;
   bool useXorEncryption_;
   common::SchedulerStatistics schedulerStatistics_;
 };

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
@@ -26,11 +26,11 @@ UdpProcessApp<schedulerId>::run() {
   auto& unionMap = std::get<0>(testData);
   auto& metaData = std::get<1>(testData);
   auto udpProcessGame = udpGameFactory_->create(std::move(scheduler));
-
+  costEst_->addCheckPoint("computation preparation");
   XLOGF(
       INFO, "Start to run Adapter with a unionMap of size {}", unionMap.size());
   auto indexes = udpProcessGame->playAdapter(unionMap);
-
+  costEst_->addCheckPoint("Adapter done");
   XLOGF(
       INFO,
       "Start to run DataProcessor with a metaData of size {} and intersection size of {}",
@@ -38,7 +38,7 @@ UdpProcessApp<schedulerId>::run() {
       indexes.size());
   auto shares = udpProcessGame->playDataProcessor(
       metaData, indexes, metaData.size(), sizeOfRow_);
-
+  costEst_->addCheckPoint("DataProcessor done");
   auto publisherShares = std::get<0>(shares);
   auto partnerShares = std::get<1>(shares);
 

--- a/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
@@ -48,6 +48,13 @@ int main(int argc, char** argv) {
   FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner
   // instead of 1 and 2
 
+  auto tlsInfo = common::getTlsInfoFromArgs(
+      false,
+      "cert_path",
+      "server_cert_path",
+      "private_key_path",
+      "passphrase_path");
+
   common::SchedulerStatistics schedulerStatistics;
 
   XLOG(INFO) << "Start UDP Processing...";
@@ -61,7 +68,8 @@ int main(int argc, char** argv) {
             FLAGS_row_number,
             FLAGS_row_size,
             FLAGS_intersection,
-            FLAGS_use_xor_encryption);
+            FLAGS_use_xor_encryption,
+            tlsInfo);
   } else if (FLAGS_party == common::PARTNER) {
     XLOG(INFO)
         << "Starting UDP Processing as Partner, will wait for Publisher...";
@@ -72,7 +80,8 @@ int main(int argc, char** argv) {
             FLAGS_row_number,
             FLAGS_row_size,
             FLAGS_intersection,
-            FLAGS_use_xor_encryption);
+            FLAGS_use_xor_encryption,
+            tlsInfo);
   } else {
     XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
   }

--- a/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/main.cpp
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <memory>
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
 
 #include "fbpcf/aws/AwsSdk.h"
-#include "fbpcs/performance_tools/CostEstimation.h"
 
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/Util.h"
@@ -21,13 +21,13 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  fbpcs::performance_tools::CostEstimation cost =
-      fbpcs::performance_tools::CostEstimation(
+  std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst =
+      std::make_shared<fbpcs::performance_tools::CostEstimation>(
           "data_processing_udp",
           FLAGS_log_cost_s3_bucket,
           FLAGS_log_cost_s3_region,
           "pcf2");
-  cost.start();
+  costEst->start();
 
   fbpcf::AwsSdk::aquire();
 
@@ -68,6 +68,7 @@ int main(int argc, char** argv) {
             FLAGS_row_number,
             FLAGS_row_size,
             FLAGS_intersection,
+            costEst,
             FLAGS_use_xor_encryption,
             tlsInfo);
   } else if (FLAGS_party == common::PARTNER) {
@@ -80,14 +81,15 @@ int main(int argc, char** argv) {
             FLAGS_row_number,
             FLAGS_row_size,
             FLAGS_intersection,
+            costEst,
             FLAGS_use_xor_encryption,
             tlsInfo);
   } else {
     XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
   }
 
-  cost.end();
-  XLOG(INFO, cost.getEstimatedCostString());
+  costEst->end();
+  XLOG(INFO, costEst->getEstimatedCostString());
 
   XLOGF(
       INFO,
@@ -109,14 +111,14 @@ int main(int argc, char** argv) {
     folly::dynamic extra_info = schedulerStatistics.details;
 
     folly::dynamic costDict =
-        cost.getEstimatedCostDynamic(run_name, party, extra_info);
+        costEst->getEstimatedCostDynamic(run_name, party, extra_info);
 
     auto objectName = run_name_specified
         ? run_name
         : folly::to<std::string>(
               FLAGS_run_name, '_', costDict["timestamp"].asString());
 
-    XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
+    XLOGF(INFO, "{}", costEst->writeToS3(party, objectName, costDict));
   }
 
   return 0;

--- a/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/test/UdpProcessAppTest.cpp
@@ -16,6 +16,7 @@
 #include "fbpcf/test/TestHelper.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
+#include "fbpcs/performance_tools/CostEstimation.h"
 
 namespace unified_data_process {
 template <int schedulerId>
@@ -25,6 +26,7 @@ runUdpProcessApp(
     int32_t rowNumber,
     int32_t rowSize,
     int32_t intersectionSize,
+    std::shared_ptr<fbpcs::performance_tools::CostEstimation> costEst,
     std::shared_ptr<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory>
         communicationAgentFactory,
@@ -37,7 +39,8 @@ runUdpProcessApp(
       std::move(udpGameFactory),
       rowNumber,
       rowSize,
-      intersectionSize);
+      intersectionSize,
+      costEst);
   return app.run();
 }
 
@@ -107,12 +110,20 @@ TEST(UdpProcessApp, testUdpProcessApp) {
   auto metricCollector1 =
       std::make_shared<fbpcf::util::MetricCollector>("attribution_test_1");
 
+  auto costEst0 = std::make_shared<fbpcs::performance_tools::CostEstimation>(
+      "data_processing_udp", "test_bucket", "test_s3_region", "pcf2");
+  costEst0->start();
+  auto costEst1 = std::make_shared<fbpcs::performance_tools::CostEstimation>(
+      "data_processing_udp", "test_bucket", "test_s3_region", "pcf2");
+  costEst1->start();
+
   auto future0 = std::async(
       runUdpProcessApp<0>,
       0,
       rowNumber,
       rowSize,
       intersectionSize,
+      costEst0,
       std::move(agentFactories[0]),
       std::move(metricCollector0),
       std::move(udpGameFactory0));
@@ -122,6 +133,7 @@ TEST(UdpProcessApp, testUdpProcessApp) {
       rowNumber,
       rowSize,
       intersectionSize,
+      costEst1,
       std::move(agentFactories[1]),
       std::move(metricCollector1),
       std::move(udpGameFactory1));


### PR DESCRIPTION
Summary:
In this diff, we add `addCheckpoints()` in `performance_tools/CostEstimation` to better measure the performance of separate UDP components inside one emp game.

- Add `checkPointMetrics_` and `checkPointName_` to contain metrics (runtime, rxBytes, txBytes, cost) and name for each checkpoint. The metrics of each checkpoint will be written into the json file. The result for each checkpoint represent the metrics happened from the previous checkpoint to the current one.

- Apply  `addCheckpoints()` in UDP binary, which requires to pass the instance of `CostEstimation` as a shared pointer into the emp App.

Reviewed By: robotal

Differential Revision: D40052701

