### PR TITLE
Fix FBPCF Version pinning

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -46,7 +46,7 @@ FORCE_EXTERNAL=false
 USE_GCP=false
 PLATFORM=""
 FBPCF_VERSION="latest"
-while getopts "u,f,g,t:,p,v:" o; do
+while getopts "u,f,g,t:,p:,v:" o; do
   case $o in
     (u) OS_VARIANT="ubuntu"
         OS_RELEASE=${UBUNTU_RELEASE}


### PR DESCRIPTION
Summary: There was a bug in the platform capture that was causing FBPCF to always be latest

Reviewed By: wenhaizhu

Differential Revision: D40567128

