### PR TITLE
skeleton of the certificate provider

### DIFF
--- a/fbpcs/infra/certificate/basic_ca_certificate_provider.py
+++ b/fbpcs/infra/certificate/basic_ca_certificate_provider.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcs.infra.certificate.certificate_provider import CertificateProvider
+
+
+class BasicCaCertificateProvider(CertificateProvider):
+    """
+    A certificate provider which simply returns certificate
+    based on the argument upon initialization.
+    """
+
+    def __init__(self, ca_certificate: str) -> None:
+        self.ca_certificate = ca_certificate
+
+    def get_certificate(self) -> str:
+        return self.ca_certificate

--- a/fbpcs/infra/certificate/certificate_provider.py
+++ b/fbpcs/infra/certificate/certificate_provider.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class CertificateProvider(ABC):
+    @abstractmethod
+    def get_certificate(self) -> Optional[str]:
+        pass

--- a/fbpcs/infra/certificate/null_certificate_provider.py
+++ b/fbpcs/infra/certificate/null_certificate_provider.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcs.infra.certificate.certificate_provider import CertificateProvider
+
+
+class NullCertificateProvider(CertificateProvider):
+    """
+    A null pattern for the abstract class CertificateProvider
+    """
+
+    def get_certificate(self) -> None:
+        return None

--- a/fbpcs/infra/certificate/pc_instance_ca_certificate_provider.py
+++ b/fbpcs/infra/certificate/pc_instance_ca_certificate_provider.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcs.infra.certificate.certificate_provider import CertificateProvider
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+)
+
+
+class PCInstanceCaCertificateProvider(CertificateProvider):
+    """
+    A certificate provider which returns ca certificate value
+    from PC instance repo.
+    """
+    def __init__(self, pc_instance: PrivateComputationInstance) -> None:
+        self.pc_instance = pc_instance
+
+    def get_certificate(self) -> str:
+        # TODO: implement this by retrieving ca certificate
+        # from pc instance repo.
+        raise NotImplementedError

--- a/fbpcs/infra/certificate/pc_instance_server_certificate.py
+++ b/fbpcs/infra/certificate/pc_instance_server_certificate.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from fbpcs.infra.certificate.certificate_provider import CertificateProvider
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+)
+
+
+class PCInstanceServerCertificateProvider(CertificateProvider):
+    """
+    A certificate provider which returns server certificate value
+    from PC instance repo.
+    """
+
+    def __init__(self, pc_instance: PrivateComputationInstance) -> None:
+        self.pc_instance = pc_instance
+
+    def get_certificate(self) -> str:
+        """
+        Get certificate value from pc instance repo.
+        """
+        # TODO: implement this by retrieving server certificate
+        # from pc instance repo.
+        raise NotImplementedError


### PR DESCRIPTION
Summary:
This is the first of a stack of diffs on getting and passing the certificates from the stage services to onedocker container.

This diff:
Provide a unified interface to retrieve TLS certificates for different parties. In stage services, we will be calling get_tls_certificates on the specific provider class. For publisher, we expect to get root_cert, server_cert, and private key from PCInstanceRepo; for partner, we expect to get root_cert from the parameters that got passed in during initialization.

Upcoming diffs:
call get_tls_certificates in stage services and pass it down to the onedocker container.

Reviewed By: danbunnell

Differential Revision: D40369181

