### PR TITLE
Adding new PCS feature for Co-Retry.

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Generic, List, Optional, Type, TypeVar
 
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
@@ -63,6 +64,10 @@ class BoltClient(ABC, Generic[T]):
 
     @abstractmethod
     async def update_instance(self, instance_id: str) -> BoltState:
+        pass
+
+    @abstractmethod
+    async def has_feature(self, instance_id: str, feature: PCSFeature) -> bool:
         pass
 
     @abstractmethod

--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -295,6 +295,10 @@ class BoltRunner(Generic[T, U]):
                                 instance_id=partner_id
                             ),
                         )
+                        await self.publisher_client.cancel_current_stage(
+                            instance_id=publisher_id
+                        )
+
                     except Exception as e:
                         logger.error(
                             f"Unable to cancel current stage {stage.name}. Error: type: {type(e)}, message: {e}."

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -23,6 +23,7 @@ from fbpcs.private_computation.entity.infra_config import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.pce_config import PCEConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
 
 from fbpcs.private_computation.entity.product_config import (
@@ -188,6 +189,11 @@ class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
         )
         return state
 
+    async def has_feature(self, instance_id: str, feature: PCSFeature) -> bool:
+
+        pc_instance = self.pcs.get_instance(instance_id)
+        return pc_instance.has_feature(feature)
+
     async def validate_results(
         self, instance_id: str, expected_result_path: Optional[str] = None
     ) -> bool:
@@ -219,10 +225,9 @@ class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
                 )
                 return True
 
-    # canceling stages is not properly supported
-    # async def cancel_current_stage(self, instance_id: str) -> None:
-    #     loop = asyncio.get_running_loop()
-    #     await loop.run_in_executor(None, self.pcs.cancel_current_stage, instance_id)
+    async def cancel_current_stage(self, instance_id: str) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self.pcs.cancel_current_stage, instance_id)
 
     async def get_or_create_instance(
         self, instance_args: BoltPCSCreateInstanceArgs

--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -30,6 +30,7 @@ from fbpcs.private_computation.entity.infra_config import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
 )
@@ -143,11 +144,34 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
             concurrency=self.test_concurrency,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             hmac_key=self.test_hmac_key,
+            pcs_features=[PCSFeature.PCS_DUMMY.value],
         )
 
     async def test_create_instance(self) -> None:
         return_id = await self.bolt_pcs_client.create_instance(self.bolt_instance_args)
         self.assertEqual(return_id, self.test_instance_id)
+
+    @mock.patch(
+        "fbpcs.private_computation.service.private_computation.PrivateComputationService.get_instance"
+    )
+    async def test_has_feature(self, mock_get_instance) -> None:
+        # mock pc update_instance to return a pc instance with specific test status and instances
+        mock_get_instance.return_value = self._get_test_instance()
+        instance_id = await self.bolt_pcs_client.create_instance(
+            self.bolt_instance_args
+        )
+        for pcs_feature, expected_result in [
+            (PCSFeature.PCS_DUMMY, True),
+            (PCSFeature.PRIVATE_LIFT_PCF2_RELEASE, False),
+        ]:
+            with self.subTest(
+                pcs_feature=pcs_feature,
+                expected_result=expected_result,
+            ):
+                is_feature_enabled = await self.bolt_pcs_client.has_feature(
+                    instance_id, pcs_feature
+                )
+                self.assertEqual(is_feature_enabled, expected_result)
 
     @mock.patch(
         "fbpcs.private_computation.service.private_computation.PrivateComputationService.update_instance"
@@ -268,3 +292,48 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
                     self.bolt_instance_args
                 )
                 self.assertEqual(expected_result, actual_result)
+
+    def _get_test_instance(self) -> PrivateComputationInstance:
+        stage_state_instance = StageStateInstance(
+            instance_id="stage_state_instance",
+            stage_name="test_stage",
+            status=StageStateInstanceStatus.COMPLETED,
+            containers=[
+                ContainerInstance(
+                    instance_id="test_container_instance",
+                    ip_address="10.0.10.242",
+                    status=ContainerInstanceStatus.COMPLETED,
+                )
+            ],
+        )
+        infra_config: InfraConfig = InfraConfig(
+            instance_id=self.test_instance_id,
+            role=self.test_role,
+            status=PrivateComputationInstanceStatus.CREATED,
+            status_update_ts=0,
+            instances=[stage_state_instance],
+            game_type=self.test_game_type,
+            num_pid_containers=self.test_num_containers,
+            num_mpc_containers=self.test_num_containers,
+            num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
+            status_updates=[],
+            pcs_features={PCSFeature.PCS_DUMMY},
+        )
+        common: CommonProductConfig = CommonProductConfig(
+            input_path=self.test_input_path,
+            output_dir=self.test_output_path,
+        )
+        product_config: ProductConfig
+        if self.test_game_type is PrivateComputationGameType.ATTRIBUTION:
+            product_config = AttributionConfig(
+                common=common,
+                attribution_rule=AttributionRule.LAST_CLICK_1D,
+                aggregation_type=AggregationType.MEASUREMENT,
+            )
+        elif self.test_game_type is PrivateComputationGameType.LIFT:
+            product_config = LiftConfig(common=common)
+        test_instance = PrivateComputationInstance(
+            infra_config=infra_config,
+            product_config=product_config,
+        )
+        return test_instance

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
 import json
 import logging
 import os
@@ -18,6 +19,7 @@ from fbpcs.pl_coordinator.exceptions import (
     GraphAPIGenericException,
     GraphAPITokenNotFound,
 )
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -196,6 +198,14 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
         else:
             self.logger.info("instance_id is empty, fetching a valid one")
             return False
+
+    async def has_feature(self, instance_id: str, feature: PCSFeature) -> bool:
+        response = json.loads((await self.get_instance(instance_id)).text)
+        feature_list = response.get("feature_list")
+        if feature_list:
+            if feature.value in feature_list:
+                return True
+        return False
 
     async def get_instance(self, instance_id: str) -> requests.Response:
         r = requests.get(f"{self.graphapi_url}/{instance_id}", self.params)

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -14,6 +14,7 @@ class PCSFeature(Enum):
 
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
+    PC_COORDINATED_RETRY = "private_computation_coordinated_retry"
     PRIVATE_LIFT_UNIFIED_DATA_PROCESS = "private_lift_unified_data_process"
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"


### PR DESCRIPTION
Summary:
We need to add gatekeeping to - cancel publisher stage in bolt_runner.
While creating the publisher instance, bolt_runner gets a list of feature list back and saves it to the instance.
In this diff, adding a new PCS feature corresponding to the gatekeeper
- https://www.internalfb.com/intern/gatekeeper/projects/private_computation_coordinated_retry/

Reviewed By: jrodal98

Differential Revision: D40549659

