### PR TITLE
Adding GK check before cancelling stages.

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Generic, List, Optional, Type, TypeVar
 
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
@@ -63,6 +64,10 @@ class BoltClient(ABC, Generic[T]):
 
     @abstractmethod
     async def update_instance(self, instance_id: str) -> BoltState:
+        pass
+
+    @abstractmethod
+    async def has_feature(self, instance_id: str, feature: PCSFeature) -> bool:
         pass
 
     @abstractmethod

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -23,6 +23,7 @@ from fbpcs.private_computation.entity.infra_config import (
     PrivateComputationRole,
 )
 from fbpcs.private_computation.entity.pce_config import PCEConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.post_processing_data import PostProcessingData
 
 from fbpcs.private_computation.entity.product_config import (
@@ -188,6 +189,14 @@ class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
         )
         return state
 
+    async def has_feature(self, instance_id: str, feature: PCSFeature) -> bool:
+
+        loop = asyncio.get_running_loop()
+        pc_instance = await loop.run_in_executor(
+            None, self.pcs.get_instance, instance_id
+        )
+        return pc_instance.has_feature(feature)
+
     async def validate_results(
         self, instance_id: str, expected_result_path: Optional[str] = None
     ) -> bool:
@@ -219,10 +228,9 @@ class BoltPCSClient(BoltClient[BoltPCSCreateInstanceArgs]):
                 )
                 return True
 
-    # canceling stages is not properly supported
-    # async def cancel_current_stage(self, instance_id: str) -> None:
-    #     loop = asyncio.get_running_loop()
-    #     await loop.run_in_executor(None, self.pcs.cancel_current_stage, instance_id)
+    async def cancel_current_stage(self, instance_id: str) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self.pcs.cancel_current_stage, instance_id)
 
     async def get_or_create_instance(
         self, instance_args: BoltPCSCreateInstanceArgs

--- a/fbpcs/bolt/test/test_bolt_runner.py
+++ b/fbpcs/bolt/test/test_bolt_runner.py
@@ -290,7 +290,8 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
                     mock_partner_run_stage.assert_called_once()
 
     @mock.patch("fbpcs.bolt.bolt_runner.asyncio.sleep")
-    async def test_wait_stage_complete(self, mock_sleep) -> None:
+    @mock.patch("fbpcs.bolt.bolt_client.BoltClient.has_feature")
+    async def test_wait_stage_complete(self, mock_sleep, mock_has_feature) -> None:
         for (
             stage,
             publisher_statuses,
@@ -298,6 +299,7 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
             result,
         ) in self._get_wait_stage_complete_data():
             self.test_runner.partner_client.cancel_current_stage = mock.AsyncMock()
+            mock_has_feature.return_value = True
             with self.subTest(
                 stage=stage,
                 publisher_statuses=publisher_statuses,
@@ -325,6 +327,9 @@ class TestBoltRunner(unittest.IsolatedAsyncioTestCase):
                         # make sure it calls cancel_current_stage
                         self.test_runner.partner_client.cancel_current_stage.assert_called_once_with(
                             instance_id="test_part_id"
+                        )
+                        self.test_runner.publisher_client.cancel_current_stage.assert_called_once_with(
+                            instance_id="test_pub_id"
                         )
                     else:
                         self.test_runner.partner_client.cancel_current_stage.assert_not_called()

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
 import json
 import logging
 import os
@@ -18,6 +19,7 @@ from fbpcs.pl_coordinator.exceptions import (
     GraphAPIGenericException,
     GraphAPITokenNotFound,
 )
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -196,6 +198,14 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
         else:
             self.logger.info("instance_id is empty, fetching a valid one")
             return False
+
+    async def has_feature(self, instance_id: str, feature: PCSFeature) -> bool:
+        response = json.loads((await self.get_instance(instance_id)).text)
+        feature_list = response.get("feature_list")
+        if feature_list:
+            if feature.value in feature_list:
+                return True
+        return False
 
     async def get_instance(self, instance_id: str) -> requests.Response:
         r = requests.get(f"{self.graphapi_url}/{instance_id}", self.params)

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -19,6 +19,7 @@ from fbpcs.pl_coordinator.bolt_graphapi_client import (
     BoltPLGraphAPICreateInstanceArgs,
 )
 from fbpcs.pl_coordinator.exceptions import GraphAPITokenNotFound
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
@@ -180,6 +181,26 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             PrivateComputationInstanceStatus.COMPUTATION_STARTED,
         )
         self.assertEqual(state.server_ips, "1.1.1.1")
+
+    @patch(
+        "fbpcs.pl_coordinator.bolt_graphapi_client.BoltGraphAPIClient.get_instance",
+        new_callable=AsyncMock,
+    )
+    async def test_bolt_has_feature(self, mock_get_instance) -> None:
+        data = {"status": 200, "feature_list": [PCSFeature.PCS_DUMMY.value]}
+        mock_get_instance.return_value = self._get_graph_api_output(data)
+        for pcs_feature, expected_result in [
+            (PCSFeature.PCS_DUMMY, True),
+            (PCSFeature.PRIVATE_LIFT_PCF2_RELEASE, False),
+        ]:
+            with self.subTest(
+                pcs_feature=pcs_feature,
+                expected_result=expected_result,
+            ):
+                is_feature_enabled = await self.test_client.has_feature(
+                    "id,", pcs_feature
+                )
+                self.assertEqual(is_feature_enabled, expected_result)
 
     async def test_validate_results_without_path(self) -> None:
         valid = await self.test_client.validate_results("id")

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -14,6 +14,7 @@ class PCSFeature(Enum):
 
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
+    PC_COORDINATED_RETRY = "private_computation_coordinated_retry"
     PRIVATE_LIFT_UNIFIED_DATA_PROCESS = "private_lift_unified_data_process"
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"


### PR DESCRIPTION
Summary:
We need to add gatekeeping to - cancel publisher stage in bolt_runner.
While creating the publisher instance, bolt_runner gets a list of feature list back and saves it to the instance.
In this diff, doing two things
Adding GK check before cancelling the stages.

Reviewed By: jrodal98

Differential Revision: D40549969

