### PR TITLE
fix a bug when there's no checkpoint in costEstimation

### DIFF
--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -134,7 +134,9 @@ void CostEstimation::calculateCost() {
   double ecr_cost = binarySizeInGB * ECR_PER_GB_COST;
   // Total estimated cost
   estimatedCost_ = cpu_cost + memory_cost + network_cost + ecr_cost;
-  calculateCostCheckPoints();
+  if (checkPoints_ > 0) {
+    calculateCostCheckPoints();
+  }
 }
 
 std::unordered_map<std::string, long> CostEstimation::readNetworkSnapshot() {


### PR DESCRIPTION
Summary:
Previous Diff D40052701 (https://github.com/facebookresearch/fbpcs/commit/ef4c890a2e2296b731f10fbb43d4170be36cce1e) has a bug when there's no checking point.
https://www.internalfb.com/code/fbsource/[7b7bb142966d]/fbcode/fbpcs/performance_tools/CostEstimation.cpp?lines=91
This diff added a check when there's no checking

Reviewed By: robotal

Differential Revision: D40592253

