### PR TITLE
should invoke stage API

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -88,6 +88,17 @@ class BoltClient(ABC, Generic[T]):
         return status in [
             previous_stage.completed_status if previous_stage else None,
             stage.started_status,
+            stage.initialized_status,
+            stage.failed_status,
+        ]
+
+    async def should_invoke_stage(
+        self, instance_id: str, stage: PrivateComputationBaseStageFlow
+    ) -> bool:
+        previous_stage = stage.previous_stage
+        status = (await self.update_instance(instance_id)).pc_instance_status
+        return status in [
+            previous_stage.completed_status if previous_stage else None,
             stage.failed_status,
         ]
 


### PR DESCRIPTION
Summary:
## What

- Add `should_invoke_stage` API
- previously: `should_invoke_stage` logic says "by default, I should run this stage unless it doesn't match a few statuses"
- After: `should_invoke_stage` logic says "by default, I should not run this stage unless it matches a few statuses"

## Why

- There is duplicate publisher + partner logic in the bolt runner that can be consolidated / maintained in the BoltClient API
- The "run by default" logic is way too trigger happy. For example, it runs when the status is processing request (S303172) or if the wrong stage is being executed (S301876).

Reviewed By: zhangpuhan

Differential Revision: D40153052

