### PR TITLE
vpc automation, imrpoved streaming logs to not show vpc related log when vpc peering is automated

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -27,6 +27,7 @@ public class DeploymentParams {
   public String awsAccessKeyId;
   public String awsSecretAccessKey;
   public String awsSessionToken;
+  public String publisherPCEId;
   private final Logger logger = LoggerFactory.getLogger(DeploymentParams.class);
 
   enum LogLevel {
@@ -177,6 +178,8 @@ public class DeploymentParams {
             .append(", Data Storage: ")
             .append(dataStorage)
             .append(", Tag: ")
+            .append(", publisherPCEId: ")
+            .append(publisherPCEId)
             .append(tag)
             .append(", Enable Semi-Automated Data Ingestion: ")
             .append(String.valueOf(enableSemiAutomatedDataIngestion));

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -10,6 +10,7 @@ package com.facebook.business.cloudbridge.pl.server;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.*;
 import java.util.*;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +122,9 @@ public class DeploymentRunner extends Thread {
     environmentVariables = new HashMap<String, String>();
     environmentVariables.put("AWS_ACCESS_KEY_ID", deployment.awsAccessKeyId);
     environmentVariables.put("AWS_SECRET_ACCESS_KEY", deployment.awsSecretAccessKey);
+    environmentVariables.put(
+        "SHOULD_SKIP_VPC_PEERING_VALIDATION",
+        StringUtils.isEmpty(deployment.publisherPCEId) ? "1" : "0");
     if (!deployment.awsSessionToken.isEmpty()) {
       environmentVariables.put("AWS_SESSION_TOKEN", deployment.awsSessionToken);
     }

--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -123,10 +123,14 @@ validateDeploymentResources () {
     then
         echo "PCE validator found some issue..please analyze further to debug the issue"
         log_streaming_data "validator might have found some issue..please analyze the logs further to debug the issue"
+    elif [ "$SHOULD_SKIP_VPC_PEERING_VALIDATION" -ne 0 ]
+        then
+        log_streaming_data "PCE validation successful"
     else
         log_streaming_data "PCE validation successful"
         log_streaming_data "Action: Please contact META representative to accept the VPC peering request using META's AWS account"
     fi
+
     echo "##### validating through PCE validator end"
 }
 


### PR DESCRIPTION
Summary:
New deployment UI with vpc automation has 2 usecase:

1. Automated VPC peering.
2. Fallback.

In case of #2, we used to show a streaming log of "contact meta representative." which should not be shown now if user choose automated way.

This diff:

1. send vpc peerign requirement info to pl-service via environment variable.
2. during pce validator we check the environment variable to determine which log to show.

Differential Revision: D40612602

