### PR TITLE
Logging Infra: produce the logs archive including container_id:instance_id mapping

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs.py
@@ -127,13 +127,13 @@ class AwsContainerLogs(AwsCloud):
             # store logs in local
             self.utils.create_folder(folder_location=local_folder_location)
 
-            if enable_data_pipeline_logs:
-                # upload computation run container logs
-                self._upload_computation_run_container_logs(
-                    container_arn_list=container_arn_list,
-                    local_log_folder_location=local_folder_location,
-                )
+            # upload computation run container logs
+            self._upload_computation_run_container_logs(
+                container_arn_list=container_arn_list,
+                local_log_folder_location=local_folder_location,
+            )
 
+            if enable_data_pipeline_logs:
                 # upload kinesis firehose error and config logs
                 self._upload_kinesis_logs(
                     local_log_folder_location=local_folder_location
@@ -186,6 +186,9 @@ class AwsContainerLogs(AwsCloud):
         """
         Uploads computation run stage container logs from AWS cloudwatch to S3
         """
+        self.log.info(
+            f"Downloading worker container logs. Containers: {len(container_arn_list)}"
+        )
         # Call threading function to download logs locally and upload to S3
         computaion_run_container_log_folder = self.utils.string_formatter(
             StringFormatter.FILE_LOCATION,
@@ -642,6 +645,6 @@ class AwsContainerLogs(AwsCloud):
         """
         Copy logs from temp dir for local debugging
         """
-        self.log.info(f"Copying compressed logs to {destination}")
+        self.log.info(f"Copying compressed logs from {source} to {destination}")
         self.utils.copy_file(source=source, destination=destination)
         self.log.info(f"Copied compressed logs to {destination}")

--- a/fbpcs/infra/logging_service/download_logs/download_logs_cli.py
+++ b/fbpcs/infra/logging_service/download_logs/download_logs_cli.py
@@ -27,18 +27,26 @@ Options:
 import logging
 import re
 import sys
+import tempfile
 import time
 from os.path import abspath
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import schema
 from docopt import docopt
 from fbpcs.infra.logging_service.download_logs.download_logs import AwsContainerLogs
+from fbpcs.infra.logging_service.download_logs.utils.utils import Utils
 from fbpcs.infra.logging_service.log_analyzer.log_analyzer import LogDigest
 
 
 class DownloadLogsCli:
+    # When a file in the logs archive has name beginning with '.', the file will be handled specially during logs upload.
+    # E.g. container info file contains mapping of container ID (i.e. ARN) to run flow instance ID.
+    CONTAINER_INFO_FILENAME = ".container_info.csv"
+    CONTAINER_INFO_CSV_HEADER = "#container_id,instance_id"
+    TEMP_DIR_PREFIX = "download_"
+
     def __init__(
         self,
     ) -> None:
@@ -47,6 +55,7 @@ class DownloadLogsCli:
         self.container_ids: List[str] = []
         self.aws_region = ""
         self.aws_container_logs: Optional[AwsContainerLogs] = None
+        self.utils = Utils()
 
     def run(self, argv: Optional[List[str]] = None) -> None:
         s = schema.Schema(
@@ -94,14 +103,26 @@ class DownloadLogsCli:
         self.s3_bucket = self._get_s3_bucket_name(arguments["<s3_bucket>"])
         self.logger.info(f"Will upload log archive to S3 bucket: {self.s3_bucket}")
 
-        self.container_ids = self._extract_container_ids(
+        # Each tuple is (container ID, run flow instance ID)
+        container_infos = self._extract_container_infos(
             cli_log_file, arguments["--input_ids"] or False
         )
-        self.logger.info(f"Found container ID's count: {len(self.container_ids)}")
-        if log_level == logging.DEBUG:
-            ids_lines = "\n".join(self.container_ids)
-            self.logger.debug(f"Found container ID's:\n{ids_lines}")
+        self.logger.info(f"Found container count: {len(container_infos)}")
+        info_csv_lines = [self.CONTAINER_INFO_CSV_HEADER]
+        info_csv_lines.extend(
+            [
+                f"{container_id},{instance_id}"
+                for container_id, instance_id in container_infos
+            ]
+        )
 
+        if log_level == logging.DEBUG:
+            combined_info_lines = "\n".join(info_csv_lines)
+            self.logger.debug(f"Found container info:\n{combined_info_lines}")
+
+        self.container_ids = [
+            container_id for container_id, instance_id in container_infos
+        ]
         self.aws_region = self._get_aws_region(self.container_ids)
         self.logger.info(f"Found aws_region: {self.aws_region}")
 
@@ -110,24 +131,31 @@ class DownloadLogsCli:
             aws_region=self.aws_region,
             deployment_tag=deployment_tag,
         )
-        include_local_files = [abspath(cli_log_file)]
-        # pyre-ignore[16]: `Optional` has no attribute `upload_logs_to_s3_from_cloudwatch`.
-        self.aws_container_logs.upload_logs_to_s3_from_cloudwatch(
-            self.s3_bucket,
-            self.container_ids,
-            include_local_files=include_local_files,
-            enable_data_pipeline_logs=get_data_pipeline_logs,
-            enable_deployment_logs=get_deployment_logs,
-        )
+
+        with tempfile.TemporaryDirectory(prefix=self.TEMP_DIR_PREFIX) as tempdir:
+            info_csv_file_path = self._export_container_info(
+                str(tempdir), info_csv_lines
+            )
+            include_local_files = [abspath(cli_log_file), info_csv_file_path]
+            # pyre-ignore[16]: `Optional` has no attribute `upload_logs_to_s3_from_cloudwatch`.
+            self.aws_container_logs.upload_logs_to_s3_from_cloudwatch(
+                self.s3_bucket,
+                self.container_ids,
+                include_local_files=include_local_files,
+                enable_data_pipeline_logs=get_data_pipeline_logs,
+                enable_deployment_logs=get_deployment_logs,
+            )
         self.logger.info("After uploading log archive")
 
     def _get_s3_bucket_name(
         self,
         s3_bucket: str,
     ) -> str:
-        # Input string can be any of the following:
-        # https://bucket-name.s3.us-west-2.amazonaws.com/photos/puppy.jpg
-        # bucket-name
+        """
+        Input string can be any of the following:
+        https://bucket-name.s3.us-west-2.amazonaws.com/photos/puppy.jpg
+        bucket-name
+        """
         if match := re.compile(r"^https://([^\.]+)\.s3\.").match(s3_bucket):
             return match.group(1)
         return s3_bucket
@@ -150,17 +178,23 @@ class DownloadLogsCli:
             raise ValueError(error_message)
         return list(regions)[0]
 
-    def _extract_container_ids(
+    def _extract_container_infos(
         self,
         cli_log_file: Path,
         is_input_ids: bool,
-    ) -> List[str]:
+    ) -> List[Tuple[str, str]]:
+        """
+        Extract the mapping container_id:instance_id for all worker containers.
+        Output:
+        Each tuple is (container ID (i.e. ARN), run flow instance ID).
+        """
+
         container_ids = []
         if is_input_ids:
             # Input file has container ID's, with one ID per line.
             with open(cli_log_file) as infile:
                 container_ids = [line.rstrip() for line in infile if len(line) > 0]
-            return container_ids
+            return [(id, "") for id in container_ids]
 
         # Input file has the logs from execution of private computation cli script.
         digest = LogDigest(cli_log_file, self.logger)
@@ -170,8 +204,25 @@ class DownloadLogsCli:
         )
         for instance_flow in run_study.instances.values():
             for flow_stage in instance_flow.stages:
-                container_ids.extend([c.container_id for c in flow_stage.containers])
+                container_ids.extend(
+                    [
+                        (c.container_id, instance_flow.instance_id)
+                        for c in flow_stage.containers
+                    ]
+                )
         return container_ids
+
+    def _export_container_info(self, tempdir: str, info_csv_lines: List[str]) -> str:
+        tempfile_path = f"{tempdir}/{self.CONTAINER_INFO_FILENAME}"
+        self.logger.info(
+            f"Exporting container infos, line count={len(info_csv_lines)}, to temp file '{tempfile_path}'"
+        )
+        self.utils.create_file(
+            file_location=tempfile_path,
+            content=info_csv_lines,
+        )
+        self.logger.info("Exported container infos to file.")
+        return tempfile_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
**What**
Added the container_id:instance_id mapping as a CSV file .container_info.csv in the logs archive.

**Why**
The run flow instance ID will be added to every log lines from any worker containers. Such ID does not apply to log lines from coordinator or data infra pipleline.

Reviewed By: ankushksingh

Differential Revision: D40610982

