### PR TITLE
Add log_cost_bucket changes to ID combiner.

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.cpp
@@ -30,7 +30,7 @@ DEFINE_bool(
     false,
     "Log cost info into cloud which will be used for dashboard");
 DEFINE_int32(max_id_column_cnt, 1, "Maximum number of id columns to use as id");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.cpp
@@ -34,3 +34,4 @@ DEFINE_string(
     run_id,
     "",
     "A run_id used to identify all the logs in a PL/PA run.");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");

--- a/fbpcs/data_processing/service/id_spine_combiner.py
+++ b/fbpcs/data_processing/service/id_spine_combiner.py
@@ -38,6 +38,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
         run_name: Optional[str] = None,
         log_cost: Optional[bool] = False,
         run_id: Optional[str] = None,
+        log_cost_bucket: Optional[str] = None,
     ) -> List[str]:
         # TODO: Combiner could be made async so we don't have to spawn our
         # own ThreadPoolExecutor here and instead use async primitives
@@ -59,6 +60,7 @@ class IdSpineCombinerService(RunBinaryBaseService):
                 log_cost=log_cost,
                 run_id=run_id,
                 protocol_type=protocol_type,
+                log_cost_s3_bucket=log_cost_bucket,
             )
             cmd_args_list.append(cmd_args)
         return cmd_args_list

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/AggregationOptions.cpp
@@ -60,7 +60,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -52,7 +52,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/compactor/main.cpp
+++ b/fbpcs/emp_games/compactor/main.cpp
@@ -52,7 +52,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/dotproduct/DotproductOptions.cpp
+++ b/fbpcs/emp_games/dotproduct/DotproductOptions.cpp
@@ -39,7 +39,7 @@ DEFINE_bool(
     add_dp_noise,
     true,
     "If true, dp noise will not be added to the output.");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactionOptions.cpp
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactionOptions.cpp
@@ -68,7 +68,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -91,7 +91,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationOptions.cpp
@@ -64,7 +64,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionOptions.cpp
@@ -60,7 +60,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
@@ -57,7 +57,7 @@ DEFINE_bool(
     log_cost,
     false,
     "Log cost info into cloud which will be used for dashboard");
-DEFINE_string(log_cost_s3_bucket, "cost-estimation-logs", "s3 bucket name");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
 DEFINE_string(
     log_cost_s3_region,
     ".s3.us-west-2.amazonaws.com/",

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -155,6 +155,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     )
     pce_config: Optional[PCEConfig] = None
     run_id: Optional[str] = immutable_field(default=None)
+    log_cost_bucket: Optional[str] = immutable_field(default=None)
 
     # stored as a string because the enum was refusing to serialize to json, no matter what I tried.
     # TODO(T103299005): [BE] Figure out how to serialize StageFlow objects to json instead of using their class name

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -147,6 +147,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
                 else pc_instance.product_config.k_anonymity_threshold,
                 "run_name": run_name,
                 "log_cost": self._log_cost_to_s3,
+                "log_cost_s3_bucket": pc_instance.infra_config.log_cost_bucket,
                 "run_id": pc_instance.infra_config.run_id,
             },
         ]

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -236,6 +236,7 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
             multi_conversion_limit=multi_conversion_limit,
             log_cost=log_cost,
             run_id=private_computation_instance.infra_config.run_id,
+            log_cost_bucket=private_computation_instance.infra_config.log_cost_bucket,
         )
         env_vars = {}
         if binary_config.repository_path:

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -182,6 +182,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
             "max_num_conversions": private_computation_instance.product_config.common.padding_size,
             "log_cost": self._log_cost_to_s3,
+            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
             "use_new_output_format": False,
             "run_id": private_computation_instance.infra_config.run_id,
         }

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -189,6 +189,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             "use_xor_encryption": True,
             "use_postfix": True,
             "run_id": private_computation_instance.infra_config.run_id,
+            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
         }
         if private_computation_instance.feature_flags is not None:
             common_game_args[

--- a/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
@@ -192,6 +192,7 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
                 "num_conversions_per_user": pc_instance.product_config.common.padding_size,
                 "run_name": f"{run_name_base}_{shard}" if self._log_cost_to_s3 else "",
                 "log_cost": self._log_cost_to_s3,
+                "log_cost_s3_bucket": pc_instance.infra_config.log_cost_bucket,
                 # TODO T133330151 Add run_id support to PL UDP binary
                 # "run_id": private_computation_instance.infra_config.run_id,
                 **tls_args,

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -187,6 +187,7 @@ class PCF2LiftStageService(PrivateComputationStageService):
             "run_name": run_name,
             "log_cost": self._log_cost_to_s3,
             "run_id": private_computation_instance.infra_config.run_id,
+            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
         }
         if private_computation_instance.feature_flags is not None:
             common_compute_game_args[

--- a/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
@@ -138,6 +138,7 @@ class ShardCombinerStageService(PrivateComputationStageService):
             else pc_instance.product_config.k_anonymity_threshold,
             "run_name": run_name,
             "log_cost": self._log_cost_to_s3,
+            "log_cost_s3_bucket": pc_instance.infra_config.log_cost_bucket,
         }
         compute_args.update(tls_args)
         # Create and start MPC instance

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -177,6 +177,7 @@ class PrivateComputationService:
         pid_configs: Optional[Dict[str, Any]] = None,
         pcs_features: Optional[List[str]] = None,
         run_id: Optional[str] = None,
+        log_cost_bucket: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
         self.metric_svc.bump_entity_key(PCSERVICE_ENTITY_NAME, "create_instance")
@@ -229,6 +230,7 @@ class PrivateComputationService:
             mpc_compute_concurrency=concurrency or DEFAULT_CONCURRENCY,
             status_updates=[],
             run_id=run_id,
+            log_cost_bucket=log_cost_bucket,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -89,6 +89,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
                 "log_cost": True,
                 "run_id": self.run_id,
                 "pc_feature_flags": private_computation_instance.feature_flags,
+                "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
             }
         ]
 
@@ -119,6 +120,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             status_updates=[],
             run_id=self.run_id,
             pcs_features={PCSFeature.PCS_DUMMY},
+            log_cost_bucket="test_log_cost_bucket",
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -52,8 +52,13 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
 
     async def test_id_spine_combiner(self) -> None:
 
-        for test_run_id in (None, "2621fda2-0eca-11ed-861d-0242ac120002"):
-            with self.subTest(test_run_id=test_run_id):
+        for test_run_id, test_log_cost_bucket in (
+            (None, "test-log-bucket"),
+            ("2621fda2-0eca-11ed-861d-0242ac120002", "test-log-bucket"),
+        ):
+            with self.subTest(
+                test_run_id=test_run_id, test_log_cost_bucket=test_log_cost_bucket
+            ):
                 private_computation_instance = self.create_sample_instance(test_run_id)
 
                 with patch.object(
@@ -66,6 +71,9 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
                     )
                     mock_combine.assert_called()
                     self.assertEqual(pc_instance.infra_config.run_id, test_run_id)
+                    self.assertEqual(
+                        pc_instance.infra_config.log_cost_bucket, test_log_cost_bucket
+                    )
 
     def create_sample_instance(
         self, test_run_id: Optional[str] = None
@@ -82,6 +90,7 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
             run_id=test_run_id,
+            log_cost_bucket="test-log-bucket",
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -105,6 +105,7 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             "ca_cert_path": "",
             "server_cert_path": "",
             "private_key_path": "",
+            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
         }
         test_game_args = [
             {
@@ -138,6 +139,7 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
             run_id=self.run_id,
+            log_cost_bucket="test_log_cost_bucket",
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -98,6 +98,7 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             "ca_cert_path": "",
             "server_cert_path": "",
             "private_key_path": "",
+            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
         }
         test_game_args = [
             {
@@ -128,6 +129,7 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
             run_id=self.run_id,
+            log_cost_bucket="test_log_cost_bucket",
         )
 
         common: CommonProductConfig = CommonProductConfig(

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -99,6 +99,7 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
                 "server_cert_path": "",
                 "private_key_path": "",
                 "pc_feature_flags": "private_lift_unified_data_process",
+                "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
             }
             for i in range(2)
         ]
@@ -124,6 +125,7 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
             pcs_features={PCSFeature.PRIVATE_LIFT_UNIFIED_DATA_PROCESS},
+            log_cost_bucket="test_log_cost_bucket",
         )
 
         common: CommonProductConfig = CommonProductConfig(

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -100,6 +100,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             "ca_cert_path": "",
             "server_cert_path": "",
             "private_key_path": "",
+            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
         }
         test_game_args = [
             {
@@ -130,6 +131,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
             run_id=self.run_id,
+            log_cost_bucket="test_log_cost_bucket",
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
@@ -89,6 +89,7 @@ class TestShardCombinerStageService(IsolatedAsyncioTestCase):
                 "ca_cert_path": "",
                 "server_cert_path": "",
                 "private_key_path": "",
+                "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
             }
         ]
 
@@ -117,6 +118,7 @@ class TestShardCombinerStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=2,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             status_updates=[],
+            log_cost_bucket="test_log_cost_bucket",
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -186,6 +186,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         self.test_output_dir = "out_dir"
         self.test_game_type = PrivateComputationGameType.LIFT
         self.test_concurrency = 1
+        self.log_cost_bucket = "test_log_bucket"
         self.test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
 
     @mock.patch("time.time", new=mock.MagicMock(return_value=1))
@@ -1144,6 +1145,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             mpc_compute_concurrency=self.test_concurrency,
             status_updates=[],
+            log_cost_bucket=self.log_cost_bucket,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.test_input_path,


### PR DESCRIPTION
Summary:
Current cost estimation is broken for RC, canary and prod runs. Thus in this diff stack adding functionality to log cost estimation to correct buckets as per the tier.
In this diff, adding the changes to attribution id combiner stage.

Differential Revision: D40616271

