### PR TITLE
Fix missing PID configs on running attribution on Partner

### DIFF
--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -242,6 +242,7 @@ def run_attribution(
             num_files_per_mpc_container=num_files_per_mpc_container,
             k_anonymity_threshold=k_anonymity_threshold,
             pcs_features=pcs_features,
+            pid_configs=config["pid"],
             run_id=run_id,
         )
     )


### PR DESCRIPTION
Summary: Fix missing PID configs on running attribution on Partner

Reviewed By: Pradeepnitw

Differential Revision: D40613798

