### PR TITLE
Use larger fargate container for SNMK

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -19,6 +19,7 @@ class PCSFeature(Enum):
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"
     NUM_MPC_CONTAINER_MUTATION = "num_mpc_container_mutation"
+    PID_SNMK_LARGER_CONTAINER_TYPE = "pid_snmk_larger_container_type"
     PCF_TLS = "pcf_tls"
     UNKNOWN = "unknown"
 

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -46,6 +46,11 @@ DEFAULT_SORT_STRATEGY = "sort"
 DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT = 6
 FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"
 
+# RUN PID has separate timeout to accommodate for 20M rows capacity on SNMK
+# According to the capacity test, 20M 6keys on both side would take 3.5 hrs total.
+# We set default time out to 5 hrs as the buffer.
+DEFAULT_RUN_PID_TIMEOUT_IN_SEC = 18000
+
 CA_CERT_PATH = "tls/ca_cert.pem"
 SERVER_CERT_PATH = "tls/server_cert.pem"
 PRIVATE_KEY_PATH = "tls/private_key.pem"

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -11,6 +11,7 @@ import logging
 from typing import Dict, List, Optional
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import ThrottlingError
 from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
@@ -32,6 +33,7 @@ class RunBinaryBaseService:
         env_vars: Optional[Dict[str, str]] = None,
         wait_for_containers_to_start_up: bool = True,
         existing_containers: Optional[List[ContainerInstance]] = None,
+        container_type: Optional[ContainerType] = None,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
@@ -51,6 +53,7 @@ class RunBinaryBaseService:
                 cmd_args_list=[cmd_args_list[i] for i in containers_to_start],
                 timeout=timeout,
                 env_vars=env_vars,
+                container_type=container_type,
             )
 
             pending_containers = MPCService.get_pending_containers(

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_local_test_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.decoupled_aggregation_stage_service import (
     AggregationStageService,
 )
@@ -70,6 +71,7 @@ class PrivateComputationDecoupledLocalTestStageFlow(PrivateComputationBaseStageF
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.decoupled_aggregation_stage_service import (
     AggregationStageService,
 )
@@ -78,6 +79,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -10,6 +10,7 @@ from fbpcs.private_computation.entity.private_computation_status import (
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
@@ -64,6 +65,7 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
@@ -7,7 +7,10 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
+    DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
+)
 from fbpcs.private_computation.service.pcf2_lift_stage_service import (
     PCF2LiftStageService,
 )
@@ -73,6 +76,7 @@ class PrivateComputationPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_udp_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_udp_stage_flow.py
@@ -7,7 +7,10 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
+    DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
+)
 from fbpcs.private_computation.service.pcf2_lift_metadata_compaction_stage_service import (
     PCF2LiftMetadataCompactionStageService,
 )
@@ -76,6 +79,7 @@ class PrivateComputationPCF2LiftUDPStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_local_test_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
     PCF2AggregationStageService,
 )
@@ -70,6 +71,7 @@ class PrivateComputationPCF2LocalTestStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -7,6 +7,7 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
     PCF2AggregationStageService,
 )
@@ -77,6 +78,7 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pid_only_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pid_only_test_stage_flow.py
@@ -9,6 +9,7 @@ import logging
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
@@ -64,6 +65,7 @@ class PrivateComputationPIDOnlyTestStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -10,7 +10,10 @@ from fbpcs.private_computation.entity.private_computation_status import (
 from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
+    DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
+)
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
     PrivateComputationStageServiceArgs,
@@ -73,6 +76,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
         is_joint_stage=True,
         is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
     )
     ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -119,6 +119,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 cmd_args_list=args_ls_expect,
                 timeout=self.container_timeout,
                 env_vars=env_vars,
+                container_type=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -21,7 +21,6 @@ from fbpcs.onedocker_binary_config import (
     ONEDOCKER_REPOSITORY_PATH,
     OneDockerBinaryConfig,
 )
-
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
     PrivateComputationGameType,
@@ -136,6 +135,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 cmd_args_list=args_str_expect,
                 timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
                 env_vars=env_vars,
+                container_type=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -100,6 +100,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 cmd_args_list=args_ls_expect,
                 timeout=self.container_timeout,
                 env_vars=env_vars,
+                container_type=None,
             )
             # test the return value is as expected
             self.assertEqual(


### PR DESCRIPTION
Summary:
# Context
In this diff, we are adding logic to use larger fargate container for PID RUN PROTOCOL, PID PREPARE, and ID Combiner stages for SNMK. We are using [customizable container support](https://www.internalfb.com/intern/wiki/Private_Computation_Infra/Cloud_Infra/OneDocker_0/Customized_Container_Support_in_OneDocker/) built by Privacy Cloud.

It would be gated by [feature gating](https://www.internalfb.com/intern/wiki/Private_Computation_Infra/Private_Services_Infra/PCS_wikis/How_to_add_a_feature_gating_to_PCS/).

# Details
Below are the list of changes.
- changed PID RUN PROTOCOL stage's timeout to 5 hours (we observerd the issue with timeout during [capacity testing](https://docs.google.com/document/d/1wsUVZ7j_xdcO-PO_sOP2SEJQBQRbNf3D44l8itKIRoE/edit?usp=sharing))
- added feature gating pid_snmk_larger_container_type
- added container type field in RunBinaryBaseService
- added a logic to use larger fargate container for SNMK

Differential Revision: D40571152

