### PR TITLE
Move pl_utils and unit tests to their own targets

### DIFF
--- a/fbpcs/utils/abstract_file_ctx.py
+++ b/fbpcs/utils/abstract_file_ctx.py
@@ -10,8 +10,13 @@ import contextlib
 import os
 import pathlib
 
-from fbpcp.service.storage_s3 import S3StorageService
-from fbpcs.utils.buffered_s3_file_handler import BufferedS3Reader, BufferedS3Writer
+from fbpcp.service.storage_s3 import (  # @manual=//measurement/private_measurement/pcp:pcp"
+    S3StorageService,
+)
+from fbpcs.utils.buffered_s3_file_handler import (  # @manual=//measurement/private_measurement/pcp:pcp"
+    BufferedS3Reader,
+    BufferedS3Writer,
+)
 
 
 S3_PATH_DRIVE = "https:"

--- a/fbpcs/utils/buffered_s3_file_handler.py
+++ b/fbpcs/utils/buffered_s3_file_handler.py
@@ -12,7 +12,9 @@ import tempfile
 from types import TracebackType
 from typing import Optional, Type
 
-from fbpcp.service.storage_s3 import S3StorageService
+from fbpcp.service.storage_s3 import (  # @manual=//measurement/private_measurement/pcp:pcp"
+    S3StorageService,
+)
 
 
 class BufferedS3Reader(contextlib.AbstractContextManager):

--- a/fbpcs/utils/config_yaml/config_yaml_dict.py
+++ b/fbpcs/utils/config_yaml/config_yaml_dict.py
@@ -7,8 +7,8 @@
 from pathlib import Path
 from typing import Any, Dict
 
-from fbpcp.util import yaml
-from fbpcs.utils.config_yaml.exceptions import (
+from fbpcp.util import yaml  # @manual=//measurement/private_measurement/pcp:pcp"
+from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/private_measurement/pcp:pcp"
     ConfigYamlFieldNotFoundError,
     ConfigYamlFileParsingError,
     ConfigYamlValidationError,

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -8,8 +8,10 @@
 
 from typing import Any, Dict, Type, TypeVar
 
-from fbpcp.util.reflect import get_class as fbpcp_get_class
-from fbpcs.utils.config_yaml.exceptions import (
+from fbpcp.util.reflect import (  # @manual=//measurement/private_measurement/pcp:pcp"
+    get_class as fbpcp_get_class,
+)
+from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/private_measurement/pcp:pcp"
     ConfigYamlClassNotFoundError,
     ConfigYamlModuleImportError,
     ConfigYamlValidationError,


### PR DESCRIPTION
Summary: We are gradually desolving the huge target file under `fbpcs/` folder by moving buck tartgets to their own folders.

Differential Revision: D40486863

