### PR TITLE
Correct AWS prices and rounding errors in binary Cost Estimation

### DIFF
--- a/fbpcs/performance_tools/CostEstimation.cpp
+++ b/fbpcs/performance_tools/CostEstimation.cpp
@@ -121,13 +121,14 @@ void CostEstimation::calculateCostCheckPoints() {
 
 void CostEstimation::calculateCost() {
   // CPU cost
-  double cpu_cost = vCPUS * (PER_CPU_HOUR_COST / 60) * (runningTimeInSec_ / 60);
+  double cpu_cost =
+      vCPUS * (PER_CPU_HOUR_COST / 60) * ((double)runningTimeInSec_ / 60);
   // Memory cost
   double memory_cost =
-      MEMORY_SIZE * (PER_GB_HOUR_COST / 60) * (runningTimeInSec_ / 60);
+      MEMORY_SIZE * (PER_GB_HOUR_COST / 60) * ((double)runningTimeInSec_ / 60);
   // Network cost
   double network_cost =
-      (((networkRXBytes_ + networkTXBytes_) / 1024) / 1024 / 1024) *
+      (((double)(networkRXBytes_ + networkTXBytes_) / 1024) / 1024 / 1024) *
       NETWORK_PER_GB_COST;
   // ECR cost
   double binarySizeInGB = 0.2; // The PA binary file is about ~200MB

--- a/fbpcs/performance_tools/CostEstimation.h
+++ b/fbpcs/performance_tools/CostEstimation.h
@@ -16,9 +16,9 @@ namespace fbpcs::performance_tools {
 const int64_t MEMORY_SIZE = 30;
 const int64_t vCPUS = 4;
 const double PER_CPU_HOUR_COST =
-    0.04656; // Source: https://aws.amazon.com/fargate/pricing/
+    0.04048; // Source: https://aws.amazon.com/fargate/pricing/
 const double PER_GB_HOUR_COST =
-    0.00511; // Source: https://aws.amazon.com/fargate/pricing/
+    0.004445; // Source: https://aws.amazon.com/fargate/pricing/
 const double NETWORK_PER_GB_COST = 0.01;
 const double ECR_PER_GB_COST =
     0.01; // Source: https://aws.amazon.com/ecr/pricing/


### PR DESCRIPTION
Summary:
This diff mainly corrected two things to make the cost estimation in binary be consistant with that in AWS insights.
1. Previously, `costEstimation` used the AWS prices of CPU and memory in US west (north california), which ought to be US west (oregon).
2. Removed the rounding when dividing integers variable `runningTimeInSec_`, `networkRXBytes_`, and `networkTXBytes_`. It now aligns with the AWS insight that rounding does not occur when calculating costs.

AWS insights: https://www.internalfb.com/code/fbsource/[6de2cdf460b7]/fbcode/identity/private_aggregation/mpc_aem/experimentation_platform/insights/aws_tracker.py

Reviewed By: adshastri

Differential Revision: D39907025

