### PR TITLE
EP enable running PL with graph API

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -239,7 +239,6 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
             token = os.getenv(FBPCS_GRAPH_API_TOKEN)
             if not token:
                 no_token_exception = GraphAPITokenNotFound.make_error()
-                self.logger.exception(no_token_exception)
                 raise no_token_exception from None
             self.logger.info(
                 f"successfully read graph api token from {FBPCS_GRAPH_API_TOKEN} env var"


### PR DESCRIPTION
Summary:
## What

- Add call to `run_study` when the a PLGraphAPIExperiment is specified

## Why

- So that we can run PL graph API experiments

## What is this diff stack

- I am introducing the ability to configure and execute PL and PA graph API experiments on the experimentation platform
- See [high level doc](https://docs.google.com/document/d/1BK8qBvl7z-gZ6WzdFyPBWSKO1tp8wUMxmOPFoTkEgyo/edit)
- See [doc on configurability changes](https://docs.google.com/document/d/1pAdho-D_iXzpuh6Y5pOrP6FLfpkIxYilztNJp5GP9xI/edit#heading=h.iduazwf5vrr9)

Reviewed By: nguytc, yanglu-fb

Differential Revision: D40453810

