### PR TITLE
Improve E2E test run naming to make it easier for people to know what run is happening.

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -1,4 +1,5 @@
 name: One command runner test
+run-name: ${{ inputs.test_name }} on ${{ inputs.tag }} for build ${{ inputs.build_id }}
 
 on:
   workflow_dispatch:
@@ -23,6 +24,17 @@ on:
         description: Version tag to use
         required: true
         default: rc
+      build_id:
+        description: The build id
+        required: false
+        default: null
+      test_name:
+        description: The name of the type of tests that are being run
+        default: 'PL E2E Tests'
+        type: 'choice'
+        options:
+          - PL E2E Tests
+          - Multi-key PL E2E Tests
       tracker_hash:
         description: '[Internal usage] Used for tracking workflow job status within Meta infra'
         required: false

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -1,4 +1,5 @@
 name: PA One command runner test
+run-name: ${{ inputs.test_name }} on ${{ inputs.tag }} for build ${{ inputs.build_id }}
 
 on:
   workflow_dispatch:
@@ -15,6 +16,17 @@ on:
         description: S3 path to expected results from synthetic run
         required: true
         default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result_last_click.json
+      build_id:
+        description: The build id
+        required: false
+        default: null
+      test_name:
+        description: The name of the type of tests that are being run
+        default: 'PA E2E Tests'
+        type: 'choice'
+        options:
+          - PA E2E Tests
+          - Multi-key PA E2E Tests
       tag:
         description: Version tag to use
         required: true


### PR DESCRIPTION
Summary:
## Background
Right now the Actions page on FBPCS can be a little unhelpful to know what is actually happening for a E2E test run. We use the same action yaml for both single key an multikey test runs and so the names just show up as the same.

https://pxl.cl/2hRK7

In the case of a failure, you would need to dig deeper to know which run actually failed.

## This Diff
This diff adds the 'run-name' parameter, which is a way for us to dynamically name the run so it is more obvious which run is happening.

Differential Revision: D40687002

