### PR TITLE
added optional Role in PCEconfig, overide the default OSSAdmin role

### DIFF
--- a/fbpcs/private_computation/entity/pce_config.py
+++ b/fbpcs/private_computation/entity/pce_config.py
@@ -27,6 +27,7 @@ class PCEConfig:
     cloud_account_id: Optional[str] = None
     partner_id: Optional[str] = None
     pce_id: Optional[str] = None
+    role: Optional[str] = None
 
     def __str__(self) -> str:
         # pyre-ignore


### PR DESCRIPTION
Summary:
## Why
In the recent ACL cleanup, https://fb.workplace.com/groups/126488202795965/permalink/463689675742481/
`SSOAdming` will no longer and not be suggested to have in running service.
In OneDocker it's using `SSOAdmin` by default. https://fburl.com/code/fqn3jeei
Which supports the role as an argument to override it. This diff is to change config & publisher side PCE default config to appropriate role setup.

NOTE: SSOQuality is for fb-ads-crypto-dev only

{F785746853}

Added pass role and VPC peering to SSOQuality: D40697514

## What
- add Optional `role` in PCEConfig
- add `SSOQuality` role in config for accessing `fb-ads-crypto-dev` aws account

Differential Revision: D40697130

