### PR TITLE
Add Private ID DFCA GameType

### DIFF
--- a/fbpcs/bolt/constants.py
+++ b/fbpcs/bolt/constants.py
@@ -6,21 +6,34 @@
 
 # pyre-strict
 
-from typing import List
+from typing import Dict, List, Type
+
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+)
 from fbpcs.private_computation.stage_flows.private_computation_pcf2_stage_flow import (
     PrivateComputationPCF2StageFlow,
+)
+from fbpcs.private_computation.stage_flows.private_computation_private_id_dfca_stage_flow import (
+    PrivateComputationPrivateIdDfcaStageFlow,
 )
 from fbpcs.private_computation.stage_flows.private_computation_stage_flow import (
     PrivateComputationStageFlow,
 )
 
 DEFAULT_POLL_INTERVAL_SEC = 5
-DEFAULT_ATTRIBUTION_STAGE_FLOW = PrivateComputationPCF2StageFlow
-DEFAULT_LIFT_STAGE_FLOW = PrivateComputationStageFlow
+DEFAULT_STAGE_FLOW: Dict[
+    PrivateComputationGameType, Type[PrivateComputationBaseStageFlow]
+] = {
+    PrivateComputationGameType.ATTRIBUTION: PrivateComputationPCF2StageFlow,
+    PrivateComputationGameType.LIFT: PrivateComputationStageFlow,
+    PrivateComputationGameType.PRIVATE_ID_DFCA: PrivateComputationPrivateIdDfcaStageFlow,
+}
 DEFAULT_MAX_PARALLEL_RUNS = 10
 DEFAULT_NUM_TRIES = 4
 TIMEOUT_SEC = 1200

--- a/fbpcs/bolt/oss_bolt_pcs.py
+++ b/fbpcs/bolt/oss_bolt_pcs.py
@@ -16,7 +16,7 @@ from dataclasses_json import config, DataClassJsonMixin
 
 from fbpcs.bolt.bolt_client import BoltClient, BoltState
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
-from fbpcs.bolt.constants import DEFAULT_ATTRIBUTION_STAGE_FLOW, DEFAULT_LIFT_STAGE_FLOW
+from fbpcs.bolt.constants import DEFAULT_STAGE_FLOW
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
 from fbpcs.private_computation.entity.infra_config import (
     PrivateComputationGameType,
@@ -89,11 +89,7 @@ class BoltPCSCreateInstanceArgs(BoltCreateInstanceArgs, DataClassJsonMixin):
 
     def __post_init__(self) -> None:
         if self.stage_flow_cls is PrivateComputationBaseStageFlow:
-            self.stage_flow_cls = (
-                DEFAULT_ATTRIBUTION_STAGE_FLOW
-                if self.game_type is PrivateComputationGameType.ATTRIBUTION
-                else DEFAULT_LIFT_STAGE_FLOW
-            )
+            self.stage_flow_cls = DEFAULT_STAGE_FLOW[self.game_type]
         if not self.output_dir:
             self.output_dir = self.input_path[: self.input_path.rfind("/")]
 

--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -44,6 +44,7 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
     CommonProductConfig,
     LiftConfig,
+    PrivateIdDfcaConfig,
     ProductConfig,
 )
 from fbpcs.private_computation.service.errors import (
@@ -289,6 +290,8 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
             )
         elif self.test_game_type is PrivateComputationGameType.LIFT:
             product_config = LiftConfig(common=common)
+        elif self.test_game_type is PrivateComputationGameType.PRIVATE_ID_DFCA:
+            product_config = PrivateIdDfcaConfig(common=common)
         test_instance = PrivateComputationInstance(
             infra_config=infra_config,
             product_config=product_config,

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -37,7 +37,6 @@ from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import FBPCS_BUNDLE_ID
 from marshmallow import fields
 from marshmallow_enum import EnumField
 
@@ -192,4 +191,5 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
         super().__post_init__()
         # note: The reason can't make it fbpcs_bundle_id = immutable_field(default=os.getenv(FBPCS_BUNDLE_ID)),
         # is because that will happend in static varible when module been loaded, moved it to __post_init__ for better init control
-        self.fbpcs_bundle_id = os.getenv(FBPCS_BUNDLE_ID)
+        # TODO: T135712075 Use constant from fbpcs.private_computation.service.constants, fix circular import
+        self.fbpcs_bundle_id = os.getenv("FBPCS_BUNDLE_ID")

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -48,6 +48,7 @@ from fbpcs.private_computation.entity.private_computation_status import (
 from fbpcs.private_computation.entity.product_config import (
     AttributionConfig,
     LiftConfig,
+    PrivateIdDfcaConfig,
     ProductConfig,
 )
 
@@ -123,6 +124,8 @@ class PrivateComputationInstance(InstanceBase):
             return AttributionConfig.schema()
         elif json_object["infra_config"]["game_type"] == "LIFT":
             return LiftConfig.schema()
+        elif json_object["infra_config"]["game_type"] == "PRIVATE_ID_DFCA":
+            return PrivateIdDfcaConfig.schema()
         raise RuntimeError(f"Invalid product config: {json_object}")
 
     @classmethod

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -6,7 +6,11 @@
 
 # pyre-strict
 
+import typing
+
 from fbpcs.pid.entity.pid_instance import PIDProtocol
+
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 
 """
 43200 s = 12 hrs
@@ -32,8 +36,11 @@ DEFAULT_PID_PROTOCOL: PIDProtocol = PIDProtocol.UNION_PID
 DEFAULT_HMAC_KEY: str = ""
 DEFAULT_CONCURRENCY = 4
 ATTRIBUTION_TEST_CONCURRENCY = 1
-LIFT_DEFAULT_PADDING_SIZE = 25
-ATTRIBUTION_DEFAULT_PADDING_SIZE = 4
+DEFAULT_PADDING_SIZE: typing.Dict[PrivateComputationGameType, typing.Optional[int]] = {
+    PrivateComputationGameType.LIFT: 25,
+    PrivateComputationGameType.ATTRIBUTION: 4,
+    PrivateComputationGameType.PRIVATE_ID_DFCA: None,
+}
 DEFAULT_LOG_COST_TO_S3 = True
 DEFAULT_SORT_STRATEGY = "sort"
 DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT = 6

--- a/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
@@ -13,6 +13,7 @@ from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
@@ -24,7 +25,7 @@ from fbpcs.private_computation.repository.private_computation_game import GameNa
 from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import (
     DEFAULT_LOG_COST_TO_S3,
-    LIFT_DEFAULT_PADDING_SIZE,
+    DEFAULT_PADDING_SIZE,
 )
 
 from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
@@ -57,7 +58,9 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
         self,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
-        padding_size: int = LIFT_DEFAULT_PADDING_SIZE,
+        padding_size: Optional[int] = DEFAULT_PADDING_SIZE[
+            PrivateComputationGameType.LIFT
+        ],
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
     ) -> None:

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -30,7 +30,7 @@ from fbpcs.private_computation.repository.private_computation_game import GameNa
 from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import (
     DEFAULT_LOG_COST_TO_S3,
-    LIFT_DEFAULT_PADDING_SIZE,
+    DEFAULT_PADDING_SIZE,
 )
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
@@ -59,7 +59,9 @@ class PCF2LiftStageService(PrivateComputationStageService):
         self,
         onedocker_binary_config_map: DefaultDict[str, OneDockerBinaryConfig],
         mpc_service: MPCService,
-        padding_size: int = LIFT_DEFAULT_PADDING_SIZE,
+        padding_size: Optional[int] = DEFAULT_PADDING_SIZE[
+            PrivateComputationGameType.LIFT
+        ],
         log_cost_to_s3: bool = DEFAULT_LOG_COST_TO_S3,
         container_timeout: Optional[int] = None,
     ) -> None:

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -52,6 +52,7 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
     CommonProductConfig,
     LiftConfig,
+    PrivateIdDfcaConfig,
     ProductConfig,
     ResultVisibility,
 )
@@ -59,12 +60,11 @@ from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
 from fbpcs.private_computation.service.constants import (
-    ATTRIBUTION_DEFAULT_PADDING_SIZE,
     DEFAULT_CONCURRENCY,
     DEFAULT_HMAC_KEY,
     DEFAULT_K_ANONYMITY_THRESHOLD_PA,
     DEFAULT_K_ANONYMITY_THRESHOLD_PL,
-    LIFT_DEFAULT_PADDING_SIZE,
+    DEFAULT_PADDING_SIZE,
     NUM_NEW_SHARDS_PER_FILE,
 )
 from fbpcs.private_computation.service.errors import (
@@ -245,9 +245,7 @@ class PrivateComputationService:
             hmac_key=unwrap_or_default(optional=hmac_key, default=DEFAULT_HMAC_KEY),
             padding_size=unwrap_or_default(
                 optional=padding_size,
-                default=LIFT_DEFAULT_PADDING_SIZE
-                if game_type is PrivateComputationGameType.LIFT
-                else ATTRIBUTION_DEFAULT_PADDING_SIZE,
+                default=DEFAULT_PADDING_SIZE[game_type],
             ),
             result_visibility=result_visibility or ResultVisibility.PUBLIC,
             pid_use_row_numbers=pid_should_use_row_numbers(
@@ -280,6 +278,10 @@ class PrivateComputationService:
                     else DEFAULT_K_ANONYMITY_THRESHOLD_PL,
                 ),
                 breakdown_key=breakdown_key,
+            )
+        elif game_type is PrivateComputationGameType.PRIVATE_ID_DFCA:
+            product_config = PrivateIdDfcaConfig(
+                common=common,
             )
         instance = PrivateComputationInstance(
             infra_config=infra_config,

--- a/fbpcs/private_computation/service/private_computation_service_data.py
+++ b/fbpcs/private_computation/service/private_computation_service_data.py
@@ -125,6 +125,12 @@ class PrivateComputationServiceData:
         service=None,
     )
 
+    PRIVATE_ID_DFCA_COMBINER_STAGE_DATA: StageData = StageData(
+        binary_name=OneDockerBinaryNames.PRIVATE_ID_DFCA_SPINE_COMBINER.value,
+        game_name=None,
+        service=IdSpineCombinerService(),
+    )
+
     @classmethod
     def get(
         cls, game_type: PrivateComputationGameType
@@ -138,6 +144,11 @@ class PrivateComputationServiceData:
             return cls(
                 combiner_stage=PrivateComputationServiceData.ATTRIBUTION_COMBINER_STAGE_DATA,
                 compute_stage=PrivateComputationServiceData.DECOUPLED_ATTRIBUTION_STAGE_DATA,
+            )
+        elif game_type is PrivateComputationGameType.PRIVATE_ID_DFCA:
+            return cls(
+                combiner_stage=PrivateComputationServiceData.PRIVATE_ID_DFCA_COMBINER_STAGE_DATA,
+                compute_stage=StageData(""),
             )
         else:
             raise ValueError("Unknown game type")

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -218,7 +218,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 None,
                 schema.And(
                     schema.Use(str.upper),
-                    lambda s: s in ("LIFT", "ATTRIBUTION"),
+                    lambda s: s in ("LIFT", "ATTRIBUTION", "PRIVATE_ID_DFCA"),
                     schema.Use(PrivateComputationGameType),
                 ),
             ),


### PR DESCRIPTION
Summary:
# Context
**Internal:** [Private ID DFCA one-pager](https://docs.google.com/document/d/1mwImSRCljqU66uXWJS7jL-dQOrYAR4aBZ3bpJ8quiJw) Advertisers want to be able to target their customers on our platform in a privacy-safe manner. We utilise Private ID with the existing DFCA solution to provide this.

We're adding a new game type `PRIVATE_ID_DFCA` whose inputs for both parties are csvs with the columns `user_pii, user_id_{party}`, and the output is a csv of `publisher_user_id, partner_user_id` which can then be fed to our existing DFCA APIs.
After running the existing PID stages, we need to run two new binaries to get the output in its final form:
- private_id_dfca_spine_combiner
- private_id_dfca_aggregator

# This Diff
Adds the `PRIVATE_ID_DFCA` GameType and edits the game-aware logic where needed. These code locations were found with a mix of `fbgs` + figuring out where the E2E test was failing, so I might have missed some.

# This Stack
- Add spine combiner binary
- Add aggregation binary
- Add aggregation stage
- Add Stageflow
- **Add game type**

Reviewed By: jrodal98

Differential Revision: D39846614

