### PR TITLE
Fix TARGETS files in //fbpcs/emp_games/lift

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/MainUtil.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <gflags/gflags.h>
 #include <future>
 #include <memory>
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/main.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <signal.h>
 #include <algorithm>

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h
@@ -20,7 +20,7 @@
 #include <fbpcs/emp_games/common/Csv.h>
 #include <fbpcs/emp_games/lift/common/GroupedLiftMetrics.h>
 #include <sys/types.h>
-#include "../../OutputMetricsData.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/OutputMetricsData.h"
 
 namespace private_lift {
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftFakeDataParamsTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftFakeDataParamsTest.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "common/LiftFakeDataParams.h"
+#include "fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftFakeDataParams.h"
 #include <gtest/gtest.h>
 
 namespace private_lift {


### PR DESCRIPTION
Summary:
I am trying to add a test in PCF2_LIFT which depends on some of the newly added UDP code, however this is a bit difficult because none of the core business logic is wrapped in a `cpp_library` TARGET. This effectively means the same files have to be included in multiple build targets for `cpp_binary` or `cpp_unittest` targets.

I started making `cpp_library` modules that could be used across multiple projects and ended up with the following refactor. It also moves the `GenFakeData` tests to their own targets.

Differential Revision: D40737249

