### PR TITLE
Show errors returned by the path generator

### DIFF
--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/glue_ETL.py
@@ -13,6 +13,8 @@ import sys
 from datetime import datetime
 from ipaddress import ip_address, IPv4Address, IPv6Address
 
+from urllib.parse import unquote_plus
+
 from awsglue.context import GlueContext
 from awsglue.dynamicframe import DynamicFrame
 from awsglue.transforms import DropNullFields, Map
@@ -46,7 +48,10 @@ args = getResolvedOptions(sys.argv, ["JOB_NAME", "s3_read_path", "s3_write_path"
 
 # Parameters
 
-s3_options = {"paths": ["s3://" + args["s3_read_path"]]}
+# Unquote the read path in case it has any escaped characters in it
+s3_read_path = unquote_plus(args["s3_read_path"], encoding="utf-8")
+
+s3_options = {"paths": ["s3://" + s3_read_path]}
 s3_write_path = "s3://" + args["s3_write_path"]
 
 #########################################


### PR DESCRIPTION
Summary:
And also fix the semi-automated job to handle URL encoded filepaths, so that
these events get processed instead of silently failing to load the input file.

Differential Revision: D40783446

