### PR TITLE
implement conversion from ID_SPINE to unionMap

### DIFF
--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGame.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorGame.h
@@ -40,11 +40,14 @@ class MetadataCompactorGame : public IMetadataCompactorGame<schedulerId>,
         unified_data_process::data_processor::getDataProcessorFactoryWithAesCtr<
             schedulerId>(party_, partnerParty, agentFactory_)
             ->create();
+    auto prg = std::make_unique<fbpcf::engine::util::AesPrgFactory>()->create(
+        fbpcf::engine::util::getRandomM128iFromSystemNoise());
 
     return std::make_unique<CompactionBasedInputProcessor<schedulerId>>(
         party_,
         std::move(adapter),
         std::move(dataProcessor),
+        std::move(prg),
         inputData,
         numConversionPerUser);
   }

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <stdexcept>
+#include "fbpcf/engine/util/IPrg.h"
 #include "fbpcs/data_processing/unified_data_process/adapter/IAdapter.h"
 #include "fbpcs/data_processing/unified_data_process/data_processor/IDataProcessor.h"
 #include "fbpcs/emp_games/common/Constants.h"
@@ -33,11 +34,13 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
       std::unique_ptr<
           unified_data_process::data_processor::IDataProcessor<schedulerId>>
           dataProcessor,
+      std::unique_ptr<fbpcf::engine::util::IPrg> prg,
       InputData inputData,
       int32_t numConversionsPerUser)
       : myRole_{myRole},
         adapter_{std::move(adapter)},
         dataProcessor_{std::move(dataProcessor)},
+        prg_{std::move(prg)},
         inputData_{inputData},
         numConversionsPerUser_{numConversionsPerUser} {
     if (inputData.getNumRows() == 0) {
@@ -122,7 +125,7 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
   std::unique_ptr<
       unified_data_process::data_processor::IDataProcessor<schedulerId>>
       dataProcessor_;
-
+  std::unique_ptr<fbpcf::engine::util::IPrg> prg_;
   InputData inputData_;
   int32_t numConversionsPerUser_;
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include "fbpcf/mpc_std_lib/util/secureRandomPermutation.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/IInputProcessor.h"
 
@@ -17,10 +18,15 @@ namespace private_lift {
 template <int schedulerId>
 std::vector<int32_t>
 CompactionBasedInputProcessor<schedulerId>::shuffleAndGetUnionMap() {
-  // dummy implementation. Assume each PID is a match
-  std::vector<int32_t> unionMap(inputData_.getNumRows());
+  int32_t unionSize = inputData_.getNumRows();
+  const std::vector<uint32_t> randomPermutation =
+      fbpcf::mpc_std_lib::util::secureRandomPermutation(unionSize, *prg_);
+  std::vector<int32_t> unionMap(unionSize);
+  const std::vector<bool>& dummyRows = inputData_.getDummyRows();
+  int32_t nonDummyRows = 0;
   for (int32_t i = 0; i < unionMap.size(); i++) {
-    unionMap[i] = i;
+    unionMap[randomPermutation[i]] =
+        dummyRows[randomPermutation[i]] ? -1 : nonDummyRows++;
   }
   return unionMap;
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h
@@ -119,6 +119,10 @@ class InputData {
     return numRows_;
   }
 
+  const std::vector<bool>& getDummyRows() const {
+    return isDummyRow_;
+  }
+
  private:
   // Set the features header (only matters for partner, not publisher)
   void setFeaturesHeader(const std::vector<std::string>& header);
@@ -132,7 +136,7 @@ class InputData {
    * timestampArrays = an array to which input data from str append
    * offset = add offset to each value from str before append
    */
-  void setTimestamps(
+  bool setTimestamps(
       std::string& str,
       std::vector<std::vector<uint32_t>>& timestampArrays);
 
@@ -172,6 +176,7 @@ class InputData {
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;
   std::vector<std::vector<int64_t>> purchaseValueSquaredArrays_;
+  std::vector<bool> isDummyRow_;
 
   int64_t totalValue_ = 0;
   int64_t totalValueSquared_ = 0;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/InputDataTest.cpp
@@ -171,4 +171,55 @@ TEST_F(InputDataTest, TestGetBitmaskFor) {
   EXPECT_EQ(bitmask2, inputData.bitmaskFor(2));
 }
 
+TEST_F(InputDataTest, TestGetDummyRowsPublisher) {
+  InputData inputData0{
+      aliceInputFilename_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows0 = {
+      false, false, true,  true,  true,  false, false, false, false, false,
+      true,  true,  false, false, false, false, false, false, false, false};
+  auto resDummyRows0 = inputData0.getDummyRows();
+  EXPECT_EQ(expectDummyRows0, resDummyRows0);
+
+  InputData inputData1{
+      aliceInputFilename2_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows1 = {
+      false, false, true,  true,  true,  false, false, false, false, false,
+      true,  true,  false, false, false, false, false, false, false, false};
+  auto resDummyRows1 = inputData1.getDummyRows();
+  EXPECT_EQ(expectDummyRows1, resDummyRows1);
+}
+
+TEST_F(InputDataTest, TestGetDummyRowsPartner) {
+  InputData inputData0{
+      bobInputFilename_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows0 = {
+      true, false, true, true, false, true,  true, true, true, true,
+      true, true,  true, true, false, false, true, true, true, true};
+  auto resDummyRows0 = inputData0.getDummyRows();
+  EXPECT_EQ(expectDummyRows0, resDummyRows0);
+
+  InputData inputData1{
+      bobInputFilename2_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows1 = {
+      true, false, true, true, false, true,  true, true, true, true,
+      true, true,  true, true, false, false, true, true, true, true};
+  auto resDummyRows1 = inputData1.getDummyRows();
+  EXPECT_EQ(expectDummyRows1, resDummyRows1);
+}
 } // namespace private_lift


### PR DESCRIPTION
Summary:
This diff implemented `shuffleAndGetUnionMap()` in `CompactionBasedInputProcessor`.

In `shuffleAndGetUnionMap()`, we randomly shuffle the indexes of ID_SPINE. In the unionMap, `i-th` row will have a `-1` if its a dummy row. Otherwise, we place a shuffled index there.

For more details about the logic about generating the unionMap, please refer to the summary in D40687410 (https://github.com/facebookresearch/fbpcs/commit/35a252989833d02d2e423f9d35ca43365ac20f72)

Reviewed By: robotal

Differential Revision: D40749984

