### PR TITLE
check dummy rows when initializing InputData

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h
@@ -119,6 +119,10 @@ class InputData {
     return numRows_;
   }
 
+  const std::vector<bool>& getDummyRows() const {
+    return isDummyRow_;
+  }
+
  private:
   // Set the features header (only matters for partner, not publisher)
   void setFeaturesHeader(const std::vector<std::string>& header);
@@ -131,8 +135,9 @@ class InputData {
    * brackets
    * timestampArrays = an array to which input data from str append
    * offset = add offset to each value from str before append
+   * return true if all timestamps in str are all zeros, otherwise return false
    */
-  void setTimestamps(
+  bool setTimestamps(
       std::string& str,
       std::vector<std::vector<uint32_t>>& timestampArrays);
 
@@ -172,6 +177,7 @@ class InputData {
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
   std::vector<std::vector<int64_t>> purchaseValueArrays_;
   std::vector<std::vector<int64_t>> purchaseValueSquaredArrays_;
+  std::vector<bool> isDummyRow_;
 
   int64_t totalValue_ = 0;
   int64_t totalValueSquared_ = 0;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/InputDataTest.cpp
@@ -171,4 +171,55 @@ TEST_F(InputDataTest, TestGetBitmaskFor) {
   EXPECT_EQ(bitmask2, inputData.bitmaskFor(2));
 }
 
+TEST_F(InputDataTest, TestGetDummyRowsPublisher) {
+  InputData inputData0{
+      aliceInputFilename_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows0 = {
+      false, false, true,  true,  true,  false, false, false, false, false,
+      true,  true,  false, false, false, false, false, false, false, false};
+  auto resDummyRows0 = inputData0.getDummyRows();
+  EXPECT_EQ(expectDummyRows0, resDummyRows0);
+
+  InputData inputData1{
+      aliceInputFilename2_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows1 = {
+      false, false, true,  true,  true,  false, false, false, false, false,
+      true,  true,  false, false, false, false, false, false, false, false};
+  auto resDummyRows1 = inputData1.getDummyRows();
+  EXPECT_EQ(expectDummyRows1, resDummyRows1);
+}
+
+TEST_F(InputDataTest, TestGetDummyRowsPartner) {
+  InputData inputData0{
+      bobInputFilename_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows0 = {
+      true, false, true, true, false, true,  true, true, true, true,
+      true, true,  true, true, false, false, true, true, true, true};
+  auto resDummyRows0 = inputData0.getDummyRows();
+  EXPECT_EQ(expectDummyRows0, resDummyRows0);
+
+  InputData inputData1{
+      bobInputFilename2_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800, /* epoch */
+      4 /* num_conversions_per_user */};
+  std::vector<bool> expectDummyRows1 = {
+      true, false, true, true, false, true,  true, true, true, true,
+      true, true,  true, true, false, false, true, true, true, true};
+  auto resDummyRows1 = inputData1.getDummyRows();
+  EXPECT_EQ(expectDummyRows1, resDummyRows1);
+}
 } // namespace private_lift


### PR DESCRIPTION
Summary:
This diff made changes in initialization of `InputData` to identify dummy rows in `ID_spine`.

When reading `ID_spine` and converting it into `InputData`, we check if all timestamps in a row are all zeros. If so, we push a `true` into vector `isDummyRow_`. Otherwise, it's not dummy row and we push a `false`.

It is noted that a non-dummy row may have invalid timestamp. For example, a row may have a non-zero timestamp that is smaller than epic. We assume it is not a dummy row here.

Reviewed By: robotal

Differential Revision: D40709406

