### PR TITLE
Create MR-PID minimal running policy

### DIFF
--- a/fbpcs/infra/pid/aws_terraform_template/partner/minimal_running_policy.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/partner/minimal_running_policy.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_policy" "mrpid_partner_minimal_running_policy" {
+  name = "mrpid-partner-minimal-running-policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "states:DescribeExecution",
+        "states:StartExecution"
+      ],
+      "Resource": "${aws_sfn_state_machine.mrpid_partner_sfn.arn}"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
Summary: Create MR-PID minimal running policy, so if advertiser runs not with admin user, then need to attach this policy.

Reviewed By: Pradeepnitw

Differential Revision: D40818227

