### PR TITLE
add graph api domain override

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -28,8 +28,10 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
 from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
 from fbpcs.utils.config_yaml.exceptions import ConfigYamlBaseException
 
-GRAPHPI_BASE_URL = "https://graph.facebook.com"
+GRAPHAPI_HTTPS = "https://"
+GRAPHAPI_DEFAULT_DOMAIN = "graph.facebook.com"
 GRAPHAPI_DEFAULT_VERSION = "v13.0"
+
 GRAPHAPI_INSTANCE_STATUSES: Dict[str, PrivateComputationInstanceStatus] = {
     **{status.value: status for status in PrivateComputationInstanceStatus},
     **{
@@ -71,18 +73,23 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
         config: Dict[str, Any],
         logger: Optional[logging.Logger] = None,
         graphapi_version: Optional[str] = None,
+        graphapi_domain: Optional[str] = None,
     ) -> None:
         """Bolt GraphAPI Client
 
         Args:
             - config: the graphapi section of the larger config dictionary: config["graphapi"]
             - logger: logger
+            - graphapi_version: version to use, e.g. "v13.0" or "v14.0"
+            - graphapi_domain: domain, e.g. "graph.facebook.com"
         """
+
         self.logger: logging.Logger = (
             logging.getLogger(__name__) if logger is None else logger
         )
         _graphapi_version = graphapi_version or GRAPHAPI_DEFAULT_VERSION
-        self.graphapi_url = f"{GRAPHPI_BASE_URL}/{_graphapi_version}"
+        _graphapi_domain = graphapi_domain or GRAPHAPI_DEFAULT_DOMAIN
+        self.graphapi_url = f"{GRAPHAPI_HTTPS}{_graphapi_domain}/{_graphapi_version}"
         self.logger.info(f"GraphAPI URL: {self.graphapi_url}")
         self.access_token = self._get_graph_api_token(config)
         self.params = {"access_token": self.access_token}

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -91,6 +91,7 @@ def run_study(
     run_id: Optional[str] = None,
     graphapi_version: Optional[str] = None,
     output_dir: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> None:
     asyncio.run(
         run_study_async(
@@ -107,6 +108,7 @@ def run_study(
             run_id,
             graphapi_version,
             output_dir,
+            graphapi_domain,
         )
     )
 
@@ -125,6 +127,7 @@ async def run_study_async(
     run_id: Optional[str] = None,
     graphapi_version: Optional[str] = None,
     output_dir: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> None:
     ## Step 1: Validation. Function arguments and study metadata must be valid for private lift run.
     _validate_input(objective_ids, input_paths)
@@ -134,6 +137,7 @@ async def run_study_async(
         config=config,
         logger=logger,
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
     try:
         study_data = _get_study_data(study_id, client)
@@ -264,7 +268,13 @@ async def run_study_async(
         )
         job_list.append(job)
 
-    await run_bolt(config, logger, job_list, graphapi_version=graphapi_version)
+    await run_bolt(
+        config,
+        logger,
+        job_list,
+        graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
+    )
 
     ## Step 4: Print out the initial and end states
     new_cell_obj_instances = _get_cell_obj_instance(
@@ -302,6 +312,7 @@ async def run_bolt(
         BoltJob[BoltPLGraphAPICreateInstanceArgs, BoltPCSCreateInstanceArgs]
     ],
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> None:
     """Run private lift with the BoltRunner in a dedicated function to ensure that
     the BoltRunner semaphore and runner.run_async share the same event loop.
@@ -323,6 +334,7 @@ async def run_bolt(
         config=config,
         logger=logger,
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
 
     # Create a GraphApiTraceLoggingService specific for this study_id
@@ -490,11 +502,13 @@ def get_runnable_objectives(
     config: Dict[str, Any],
     logger: logging.Logger,
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> List[str]:
     client: BoltGraphAPIClient[BoltPLGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
         config=config,
         logger=logger,
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
 
     study_data = _get_study_data(study_id, client)

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -10,13 +10,14 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import requests
-
 from fbpcs.bolt.constants import FBPCS_GRAPH_API_TOKEN
-
 from fbpcs.pl_coordinator.bolt_graphapi_client import (
     BoltGraphAPIClient,
     BoltPAGraphAPICreateInstanceArgs,
     BoltPLGraphAPICreateInstanceArgs,
+    GRAPHAPI_DEFAULT_DOMAIN,
+    GRAPHAPI_DEFAULT_VERSION,
+    GRAPHAPI_HTTPS,
 )
 from fbpcs.pl_coordinator.exceptions import GraphAPITokenNotFound
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
@@ -28,9 +29,7 @@ from fbpcs.private_computation.stage_flows.private_computation_stage_flow import
 )
 
 ACCESS_TOKEN = "access_token"
-GRAPHPI_BASE_URL = "https://graph.facebook.com"
-GRAPHAPI_DEFAULT_VERSION = "v13.0"
-URL = f"{GRAPHPI_BASE_URL}/{GRAPHAPI_DEFAULT_VERSION}"
+URL = f"{GRAPHAPI_HTTPS}{GRAPHAPI_DEFAULT_DOMAIN}/{GRAPHAPI_DEFAULT_VERSION}"
 
 
 class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
@@ -41,10 +40,24 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
         self.test_client = BoltGraphAPIClient(config, mock_logger)
         self.test_client._check_err = MagicMock()
 
+    def test_customize_graphapi_domain(self) -> None:
+        config = {"access_token": ACCESS_TOKEN}
+        domain = "graph.bookface.com"
+        test_client = BoltGraphAPIClient(
+            config, self.mock_logger, graphapi_domain=domain
+        )
+        self.assertEqual(
+            test_client.graphapi_url,
+            f"{GRAPHAPI_HTTPS}{domain}/{GRAPHAPI_DEFAULT_VERSION}",
+        )
+
     def test_customize_graphapi_version(self) -> None:
         config = {"access_token": ACCESS_TOKEN}
         test_client = BoltGraphAPIClient(config, self.mock_logger, "v15.0")
-        self.assertEqual(test_client.graphapi_url, f"{GRAPHPI_BASE_URL}/v15.0")
+        self.assertEqual(
+            test_client.graphapi_url,
+            f"{GRAPHAPI_HTTPS}{GRAPHAPI_DEFAULT_DOMAIN}/v15.0",
+        )
 
     def test_get_graph_api_token_from_env_empty_config(self) -> None:
         expected_token = "from_env"

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -165,13 +165,8 @@ async def run_attribution_async(
     attribution_rule_str = attribution_rule.name
     attribution_rule_val = attribution_rule.value
     instance_id = None
-    pacific_timezone = pytz.timezone("US/Pacific")
-    # Validate if input is datetime or timestamp
-    is_date_format = _iso_date_validator(timestamp)
-    if is_date_format:
-        dt = pacific_timezone.localize(datetime.strptime(timestamp, "%Y-%m-%d"))
-    else:
-        dt = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+
+    dt = timestamp_to_dt(timestamp)
 
     # Compute the argument after the timestamp has been input
     dt_arg = int(datetime.timestamp(dt))
@@ -400,6 +395,26 @@ def _check_version(
         raise IncorrectVersionError.make_error(
             instance["id"], expected_tier, config_tier
         )
+
+
+def _is_unix_ts(timestamp: str) -> bool:
+    try:
+        int(timestamp)
+        return True
+    except ValueError:
+        return False
+
+
+def timestamp_to_dt(timestamp: str) -> datetime:
+    pacific_timezone = pytz.timezone("US/Pacific")
+    # Validate if input is datetime or timestamp
+    is_date_format = _iso_date_validator(timestamp)
+    if is_date_format:
+        return pacific_timezone.localize(datetime.strptime(timestamp, "%Y-%m-%d"))
+    elif _is_unix_ts(timestamp):
+        return datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+    else:
+        return dateutil.parser.parse(timestamp)
 
 
 def _should_resume_instance(

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -100,6 +100,7 @@ def run_attribution(
     final_stage: Optional[PrivateComputationBaseStageFlow] = None,
     run_id: Optional[str] = None,
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> None:
     asyncio.run(
         run_attribution_async(
@@ -118,6 +119,7 @@ def run_attribution(
             final_stage=final_stage,
             run_id=run_id,
             graphapi_version=graphapi_version,
+            graphapi_domain=graphapi_domain,
         )
     )
 
@@ -138,6 +140,7 @@ async def run_attribution_async(
     final_stage: Optional[PrivateComputationBaseStageFlow] = None,
     run_id: Optional[str] = None,
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> None:
 
     ## Step 1: Validation. Function arguments and  for private attribution run.
@@ -146,6 +149,7 @@ async def run_attribution_async(
         config=config,
         logger=logger,
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
     try:
         datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
@@ -286,6 +290,7 @@ async def run_attribution_async(
         logger=logger,
         job_list=[job],
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
     logger.info(f"Finished running instance {instance_id}.")
     if not all(all_run_success):
@@ -299,6 +304,7 @@ async def run_bolt(
         BoltJob[BoltPAGraphAPICreateInstanceArgs, BoltPCSCreateInstanceArgs]
     ],
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> List[bool]:
     """Run private attribution with the BoltRunner in a dedicated function to ensure that
     the BoltRunner semaphore and runner.run_async share the same event loop.
@@ -317,7 +323,10 @@ async def run_bolt(
 
     # We create the publisher_client here so we can reuse the access_token in our trace logger svc
     publisher_client = BoltGraphAPIClient(
-        config=config, logger=logger, graphapi_version=graphapi_version
+        config=config,
+        logger=logger,
+        graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
 
     # Create a GraphApiTraceLoggingService specific for this study_id
@@ -455,11 +464,13 @@ def get_attribution_dataset_info(
     dataset_id: str,
     logger: logging.Logger,
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> str:
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
         config=config,
         logger=logger,
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
 
     return json.loads(
@@ -476,12 +487,14 @@ def get_runnable_timestamps(
     logger: logging.Logger,
     attribution_rule: AttributionRule,
     graphapi_version: Optional[str] = None,
+    graphapi_domain: Optional[str] = None,
 ) -> Iterable[str]:
 
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
         config=config,
         logger=logger,
         graphapi_version=graphapi_version,
+        graphapi_domain=graphapi_domain,
     )
 
     datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -17,14 +17,14 @@ Usage:
     pc-cli get_instance <instance_id> --config=<config_file> [options]
     pc-cli get_server_ips <instance_id> --config=<config_file> [options]
     pc-cli get_mpc <instance_id> --config=<config_file> [options]
-    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--output_dir=<output_dir> --tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --graphapi_version=<graphapi_version> --dry_run] [options]
+    pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--output_dir=<output_dir> --tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --graphapi_version=<graphapi_version> --graphapi_domain=<graphapi_domain> --dry_run] [options]
     pc-cli pre_validate [<study_id>] --config=<config_file> [--objective_ids=<objective_ids>] --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
     pc-cli print_current_status <instance_id> --config=<config_file> [options]
     pc-cli print_log_urls <instance_id> --config=<config_file> [options]
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
-    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [--run_id=<run_id> --graphapi_version=<graphapi_version>] [options]
+    pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [--run_id=<run_id> --graphapi_version=<graphapi_version> --graphapi_domain=<graphapi_domain>] [options]
     pc-cli pre_validate --config=<config_file> [--dataset_id=<dataset_id>] --input_path=<input_path> [--timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>] [options]
     pc-cli bolt_e2e --bolt_config=<bolt_config_file> [options]
     pc-cli secret_scrubber <secret_input_path> <scrubbed_output_path> [options]
@@ -262,6 +262,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             ),
             "--run_id": schema.Or(None, str),
             "--graphapi_version": schema.Or(None, str),
+            "--graphapi_domain": schema.Or(None, str),
             "--stage": schema.Or(None, str),
             "--verbose": bool,
             "--help": bool,
@@ -321,6 +322,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             config=config,
             logger=logger,
             graphapi_version=arguments["--graphapi_version"],
+            graphapi_domain=arguments["--graphapi_domain"],
         )
         token_validator = TokenValidator(client=graph_client)
         token_validator.validate_common_rules()
@@ -404,6 +406,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             result_visibility=arguments["--result_visibility"],
             run_id=arguments["--run_id"],
             graphapi_version=arguments["--graphapi_version"],
+            graphapi_domain=arguments["--graphapi_domain"],
             final_stage=PrivateComputationStageFlow.AGGREGATE,
             output_dir=arguments["--output_dir"],
         )
@@ -424,6 +427,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             final_stage=PrivateComputationPCF2StageFlow.AGGREGATE,
             run_id=arguments["--run_id"],
             graphapi_version=arguments["--graphapi_version"],
+            graphapi_domain=arguments["--graphapi_domain"],
         )
 
     elif arguments["cancel_current_stage"]:

--- a/fbpcs/private_computation_cli/tests/test_pc_attribution_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pc_attribution_runner.py
@@ -1,0 +1,148 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+from datetime import datetime, timezone
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from fbpcs.private_computation import pc_attribution_runner
+from fbpcs.private_computation.entity.product_config import AttributionRule
+
+
+class TestPcAttributionRunner(TestCase):
+    @patch(
+        "fbpcs.private_computation.pc_attribution_runner.BoltGraphAPIClient",
+        new=MagicMock(),
+    )
+    @patch(
+        "fbpcs.private_computation.pc_attribution_runner.datetime",
+    )
+    def test_get_runnable_timestamps(self, mock_datetime: MagicMock) -> None:
+        mock_datetime.now = MagicMock(
+            return_value=datetime(2022, 10, 27, 23, 27, 55, 204663, tzinfo=timezone.utc)
+        )
+
+        dataset_id = "123"
+        target_id = "456"
+
+        datasets_info = {
+            "datasets_information": [
+                {
+                    "key": "LAST_CLICK_1D",
+                    "value": [
+                        # in progress run, not a runnable timestamp
+                        {
+                            "timestamp": "2022-03-11T00:00:00+0000",
+                            "status": "PROCESSING_REQUEST",
+                            "hmac_key": "test",
+                            "num_rows": 1,
+                        },
+                        # expired instance, runnable timestamp
+                        {
+                            "timestamp": "2022-03-13T00:00:00+0000",
+                            "status": "PCF2_AGGREGATION_FAILED",
+                            "hmac_key": "test",
+                            "num_rows": 1,
+                        },
+                        # terminal state, runnable timestamp
+                        {
+                            "timestamp": "2022-05-10T07:00:00+0000",
+                            "status": "RESULT_READY",
+                            "hmac_key": "test",
+                            "num_rows": 4800,
+                        },
+                        # no existing instance, runnable timestamp
+                        {
+                            "timestamp": "2022-03-14T00:00:00+0000",
+                            "status": "Created",
+                            "hmac_key": "test",
+                            "num_rows": 1,
+                        },
+                    ],
+                },
+            ],
+            "target_id": target_id,
+            "id": dataset_id,
+        }
+
+        instance_data = {
+            "data": [
+                {
+                    # in progress run, not a runnable timestamp
+                    "id": "1",
+                    "status": "PROCESSING_REQUEST",
+                    "attribution_rule": "last_click_1d",
+                    "created_time": "2022-10-27T21:42:24+0000",
+                    "num_containers": 2,
+                    "num_shards": 2,
+                    "timestamp": "2022-03-11T00:00:00+0000",
+                    "tier": "private_measurement.private_computation_service_rc",
+                    "feature_list": [
+                        "num_mpc_container_mutation",
+                        "private_computation_coordinated_retry",
+                    ],
+                },
+                {
+                    # expired instance, runnable timestamp
+                    "id": "2",
+                    "status": "PCF2_AGGREGATION_FAILED",
+                    "attribution_rule": "last_click_1d",
+                    "server_ips": ["10.0.12.216"],
+                    "created_time": "2022-10-26T00:44:20+0000",
+                    "num_containers": 2,
+                    "num_shards": 2,
+                    "timestamp": "2022-03-13T00:00:00+0000",
+                    "tier": "private_measurement.private_computation_service_rc",
+                    "feature_list": [
+                        "num_mpc_container_mutation",
+                        "private_computation_coordinated_retry",
+                    ],
+                },
+                {
+                    # terminal state, runnable timestamp
+                    "id": "3",
+                    "status": "RESULT_READY",
+                    "attribution_rule": "last_click_1d",
+                    "server_ips": ["10.0.27.77"],
+                    "created_time": "2022-10-27T21:42:24+0000",
+                    "num_containers": 2,
+                    "num_shards": 2,
+                    "timestamp": "2022-05-10T07:00:00+0000",
+                    "tier": "private_measurement.private_computation_service_rc",
+                    "feature_list": [
+                        "num_mpc_container_mutation",
+                        "private_computation_coordinated_retry",
+                    ],
+                },
+            ],
+        }
+
+        pc_attribution_runner._get_attribution_dataset_info = MagicMock(
+            return_value=datasets_info
+        )
+        pc_attribution_runner._get_existing_pa_instances = MagicMock(
+            return_value=instance_data
+        )
+
+        expected_results = {
+            "2022-03-13T00:00:00+0000",
+            "2022-05-10T07:00:00+0000",
+            "2022-03-14T00:00:00+0000",
+        }
+
+        actual_results = pc_attribution_runner.get_runnable_timestamps(
+            config={},
+            dataset_id=dataset_id,
+            logger=logging.getLogger(__name__),
+            attribution_rule=AttributionRule.LAST_CLICK_1D,
+        )
+
+        self.assertEqual(expected_results, actual_results)


### PR DESCRIPTION
Summary:
## What

- Allow overriding of the graph API domain in the BoltGraphAPIClient

## Why

- Sometimes, we want to run an integration test with WWW changes
- To do that, you can change the domain you are targeting, e.g. prod, intern, devserver, od
- This diff makes it so that it requires no temporary code modifications to target a different host.

Reviewed By: ztlbells

Differential Revision: D40811972

