### PR TITLE
Fix 'workflow_call' input types.

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -8,37 +8,40 @@ on:
         description: Lift study id
         required: true
         default: 32102205110410
+        type: number
       objective_id:
         description: Lift objective id
         required: true
         default: 23502204952992
+        type: number
       input_path:
         description: S3 path to synthetic data
         required: true
         default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
+        type: string
       expected_result_path:
         description: S3 path to expected results from synthetic run
         required: true
         default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json
+        type: string
       tag:
         description: Version tag to use
         required: true
         default: rc
+        type: string
       build_id:
         description: The build id
         required: false
         default: null
+        type: string
       test_name:
         description: The name of the type of tests that are being run
         default: 'PL E2E Tests'
-        type: 'choice'
-        options:
-          - PL E2E Tests
-          - Multi-key PL E2E Tests
+        type: string
       tracker_hash:
         description: '[Internal usage] Used for tracking workflow job status within Meta infra'
         required: false
-        type: str
+        type: string
 
   workflow_dispatch:
     inputs:
@@ -76,7 +79,7 @@ on:
       tracker_hash:
         description: '[Internal usage] Used for tracking workflow job status within Meta infra'
         required: false
-        type: str
+        type: string
 
 env:
   FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -8,33 +8,35 @@ on:
         description: Attribution Dataset id
         required: true
         default: 1127612294482487
+        type: number
       input_path:
         description: S3 path to synthetic attribution data
         required: true
         default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/partner_e2e_input.csv
+        type: string
       expected_result_path:
         description: S3 path to expected results from synthetic run
         required: true
         default: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result_last_click.json
+        type: string
       build_id:
         description: The build id
         required: false
         default: null
+        type: string
       test_name:
         description: The name of the type of tests that are being run
         default: 'PA E2E Tests'
-        type: 'choice'
-        options:
-          - PA E2E Tests
-          - Multi-key PA E2E Tests
+        type: string
       tag:
         description: Version tag to use
         required: true
         default: rc
+        type: string
       tracker_hash:
         description: '[Internal usage] Used for tracking workflow job status within Meta infra'
         required: false
-        type: str
+        type: string
 
   workflow_dispatch:
     inputs:
@@ -68,7 +70,7 @@ on:
       tracker_hash:
         description: '[Internal usage] Used for tracking workflow job status within Meta infra'
         required: false
-        type: str
+        type: string
 
 env:
   FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs


### PR DESCRIPTION
Summary:
## Background
When using the 'workflow_call' event, the type parameter is required.

## This diff
This diff adds the type parameter to the workflow call inputs.

Differential Revision: D40838271

