### PR TITLE
Get and store certificates when creating PCInstance

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -171,6 +171,9 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     # TODO: concurrency should be immutable eventually
     mpc_compute_concurrency: int = 1
 
+    server_certificate: Optional[str] = immutable_field(default=None)
+    ca_certificate: Optional[str] = immutable_field(default=None)
+
     @property
     def stage_flow(self) -> Type["PrivateComputationBaseStageFlow"]:
         # this inner-function import allow us to call PrivateComputationBaseStageFlow.cls_name_to_cls

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -41,7 +41,10 @@ from fbpcs.infra.certificate.pc_instance_ca_certificate_provider import (
 from fbpcs.infra.certificate.pc_instance_server_certificate import (
     PCInstanceServerCertificateProvider,
 )
-from fbpcs.infra.certificate.sample_tls_certificates import SAMPLE_CA_CERTIFICATE
+from fbpcs.infra.certificate.sample_tls_certificates import (
+    SAMPLE_CA_CERTIFICATE,
+    SAMPLE_SERVER_CERTIFICATE,
+)
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
@@ -217,7 +220,18 @@ class PrivateComputationService:
             self.metric_svc.bump_entity_key(
                 PCSERVICE_ENTITY_NAME, f"pcs_feature_{feature.lower()}_enabled"
             )
-
+        # TODO: T136500624 Replace SAMPLE_SERVER_CERTIFICATE with dynamically generated certificates.
+        # The certificates returned below do not provide any security and
+        # are being used for intermediate testing purposes only.
+        server_certificate = (
+            SAMPLE_SERVER_CERTIFICATE
+            if PCSFeature.PCF_TLS in pcs_feature_enums
+            and role is PrivateComputationRole.PUBLISHER
+            else None
+        )
+        ca_certificate = (
+            SAMPLE_CA_CERTIFICATE if PCSFeature.PCF_TLS in pcs_feature_enums else None
+        )
         infra_config: InfraConfig = InfraConfig(
             instance_id=instance_id,
             role=role,
@@ -244,6 +258,8 @@ class PrivateComputationService:
             status_updates=[],
             run_id=run_id,
             log_cost_bucket=log_cost_bucket,
+            server_certificate=server_certificate,
+            ca_certificate=ca_certificate,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():


### PR DESCRIPTION
Summary:
When creating a PCInstance for a study, we will:
1. get the certificate content
2. store them in the PCInstance Infra config for later consumption

This diff achieves #1 by reading cert contents from static files, which is an intermediary solution to be replaced by calling a CertificateCreator to generate certificate dynamically.

From this [note](https://fb.workplace.com/groups/126488202795965/permalink/401184761992973/), it is safe to add optional fields (fields with default values) in InfraConfig.

Next diff:
1. Implement the `get_certificate` logic in PCInstance.*CertificateProviders to read it from the infra config
2. Get and store server_hostname when creating PCinstance.

Differential Revision: D40816068

