### PR TITLE
Pass cert paths from stage svc to container

### DIFF
--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -66,12 +66,18 @@ class AggregateShardsStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation aggregate metrics stage
 
         Args:
-            pc_instance: the private computation instance to run aggregate metrics with
+            pc_instance: the private computation instance to run aggregate metrics with.
+            server_certificate_providder: A provider class to get TLS server certificate.
+            ca_certificate_provider: A provider class to get TLS CA certificate.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:
@@ -181,6 +187,8 @@ class AggregateShardsStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,

--- a/fbpcs/private_computation/service/argument_helper.py
+++ b/fbpcs/private_computation/service/argument_helper.py
@@ -8,17 +8,23 @@
 
 from typing import Any, Dict
 
-from fbpcs.private_computation.service.constants import (
-    CA_CERT_PATH,
-    PRIVATE_KEY_PATH,
-    SERVER_CERT_PATH,
-)
+from fbpcs.private_computation.service.constants import PRIVATE_KEY_PATH
+
+TLS_ARG_KEY_CA_CERT_PATH = "ca_cert_path"
+TLS_ARG_KEY_SERVER_CERT_PATH = "server_cert_path"
+TLS_ARG_KEY_PRIVATE_CERT_PATH = "private_key_path"
 
 
-def get_tls_arguments(has_tls_feature: bool) -> Dict[str, Any]:
+def get_tls_arguments(
+    has_tls_feature: bool,
+    server_certificate_path: str,
+    ca_certificate_path: str,
+) -> Dict[str, Any]:
     return {
         "use_tls": has_tls_feature,
-        "ca_cert_path": CA_CERT_PATH if has_tls_feature else "",
-        "server_cert_path": SERVER_CERT_PATH if has_tls_feature else "",
-        "private_key_path": PRIVATE_KEY_PATH if has_tls_feature else "",
+        TLS_ARG_KEY_CA_CERT_PATH: ca_certificate_path if has_tls_feature else "",
+        TLS_ARG_KEY_SERVER_CERT_PATH: server_certificate_path
+        if has_tls_feature
+        else "",
+        TLS_ARG_KEY_PRIVATE_CERT_PATH: PRIVATE_KEY_PATH if has_tls_feature else "",
     }

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -77,6 +77,8 @@ class ComputeMetricsStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation compute metrics stage
@@ -103,6 +105,8 @@ class ComputeMetricsStageService(PrivateComputationStageService):
                 pc_instance=pc_instance,
                 server_certificate_provider=server_certificate_provider,
                 ca_certificate_provider=ca_certificate_provider,
+                server_certificate_path=server_certificate_path,
+                ca_certificate_path=ca_certificate_path,
                 server_ips=server_ips,
             )
 
@@ -142,6 +146,8 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -69,6 +69,8 @@ class AggregationStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the decoupled private aggregation stage
@@ -115,6 +117,8 @@ class AggregationStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -68,6 +68,8 @@ class AttributionStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the decoupled private attribution stage
@@ -113,6 +115,8 @@ class AttributionStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,

--- a/fbpcs/private_computation/service/dummy_stage_service.py
+++ b/fbpcs/private_computation/service/dummy_stage_service.py
@@ -34,6 +34,8 @@ class DummyStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """

--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -81,12 +81,18 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation prepare data stage - spine combiner stage
 
         Args:
             pc_instance: the private computation instance to run prepare data with
+            server_certificate_provider: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: ignored
 
         Returns:

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -76,6 +76,8 @@ class PCPreValidationStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -72,12 +72,18 @@ class PCF2AggregationStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the pcf2.0 based private aggregation stage
 
         Args:
             pc_instance: the private computation instance to run aggregation stage
+            server_certificate_providder: A provider class to get TLS server certificate.
+            ca_certificate_provider: A provider class to get TLS CA certificate.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:
@@ -87,6 +93,8 @@ class PCF2AggregationStageService(PrivateComputationStageService):
         # Prepare arguments for attribution game
         game_args = self._get_compute_metrics_game_args(
             pc_instance,
+            server_certificate_path,
+            ca_certificate_path,
         )
 
         # We do this check here because depends on how game_args is generated, len(game_args) could be different,
@@ -120,6 +128,8 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
@@ -139,6 +149,8 @@ class PCF2AggregationStageService(PrivateComputationStageService):
     def _get_compute_metrics_game_args(
         self,
         private_computation_instance: PrivateComputationInstance,
+        server_certificate_path: str,
+        ca_certificate_path: str,
     ) -> List[Dict[str, Any]]:
         """Gets the game args passed to game binaries by onedocker
 
@@ -147,6 +159,8 @@ class PCF2AggregationStageService(PrivateComputationStageService):
 
         Args:
             pc_instance: the private computation instance to generate game args for
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
 
         Returns:
             MPC game args to be used by onedocker
@@ -192,7 +206,9 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             "run_id": private_computation_instance.infra_config.run_id,
         }
         tls_args = get_tls_arguments(
-            private_computation_instance.has_feature(PCSFeature.PCF_TLS)
+            private_computation_instance.has_feature(PCSFeature.PCF_TLS),
+            server_certificate_path,
+            ca_certificate_path,
         )
         if private_computation_instance.feature_flags is not None:
             common_game_args[

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -71,12 +71,18 @@ class PCF2AttributionStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the pcf2.0 based private attribution stage
 
         Args:
-            pc_instance: the private computation instance to run attribution stage
+            pc_instance: the private computation instance to run attribution stage.
+            server_certificate_providder: A provider class to get TLS server certificate.
+            ca_certificate_provider: A provider class to get TLS CA certificate.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:
@@ -86,6 +92,8 @@ class PCF2AttributionStageService(PrivateComputationStageService):
         # Prepare arguments
         game_args = self._get_compute_metrics_game_args(
             pc_instance,
+            server_certificate_path,
+            ca_certificate_path,
         )
 
         # We do this check here because depends on how game_args is generated, len(game_args) could be different,
@@ -116,6 +124,8 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
@@ -149,6 +159,8 @@ class PCF2AttributionStageService(PrivateComputationStageService):
     def _get_compute_metrics_game_args(
         self,
         private_computation_instance: PrivateComputationInstance,
+        server_certificate_path: str,
+        ca_certificate_path: str,
     ) -> List[Dict[str, Any]]:
         """Gets the game args passed to game binaries by onedocker
 
@@ -156,7 +168,9 @@ class PCF2AttributionStageService(PrivateComputationStageService):
         arguments required by the game binary being ran. This function prepares that dictionary.
 
         Args:
-            pc_instance: the private computation instance to generate game args for
+            pc_instance: the private computation instance to generate game args for.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
 
         Returns:
             MPC game args to be used by onedocker
@@ -201,7 +215,9 @@ class PCF2AttributionStageService(PrivateComputationStageService):
                 "pc_feature_flags"
             ] = private_computation_instance.feature_flags
         tls_args = get_tls_arguments(
-            private_computation_instance.has_feature(PCSFeature.PCF_TLS)
+            private_computation_instance.has_feature(PCSFeature.PCF_TLS),
+            server_certificate_path,
+            ca_certificate_path,
         )
         game_args = [
             {

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -79,12 +79,18 @@ class PCF2LiftStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation PCF2.0 Lift stage
 
         Args:
-            pc_instance: the private computation instance to run lift with
+            pc_instance: the private computation instance to run lift with.
+            server_certificate_providder: A provider class to get TLS server certificate.
+            ca_certificate_provider: A provider class to get TLS CA certificate.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:
@@ -94,6 +100,8 @@ class PCF2LiftStageService(PrivateComputationStageService):
         # Prepare arguments for lift game
         game_args = self._get_compute_metrics_game_args(
             pc_instance,
+            server_certificate_path,
+            ca_certificate_path,
         )
 
         # We do this check here because depends on how game_args is generated, len(game_args) could be different,
@@ -125,6 +133,8 @@ class PCF2LiftStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,
@@ -160,6 +170,8 @@ class PCF2LiftStageService(PrivateComputationStageService):
     def _get_compute_metrics_game_args(
         self,
         private_computation_instance: PrivateComputationInstance,
+        server_certificate_path: str,
+        ca_certificate_path: str,
     ) -> List[Dict[str, Any]]:
         """Gets the game args passed to game binaries by onedocker
 
@@ -167,7 +179,9 @@ class PCF2LiftStageService(PrivateComputationStageService):
         arguments required by the game binary being ran. This function prepares that dictionary.
 
         Args:
-            pc_instance: the private computation instance to generate game args for
+            pc_instance: the private computation instance to generate game args for.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
 
         Returns:
             MPC game args to be used by onedocker
@@ -201,7 +215,9 @@ class PCF2LiftStageService(PrivateComputationStageService):
                 "pc_feature_flags"
             ] = private_computation_instance.feature_flags
         tls_args = get_tls_arguments(
-            private_computation_instance.has_feature(PCSFeature.PCF_TLS)
+            private_computation_instance.has_feature(PCSFeature.PCF_TLS),
+            server_certificate_path,
+            ca_certificate_path,
         )
 
         common_compute_game_args.update(tls_args)

--- a/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
@@ -68,12 +68,18 @@ class ShardCombinerStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation combine aggregate metrics stage
 
         Args:
-            pc_instance: the private computation instance to run aggregate metrics with
+            pc_instance: the private computation instance to run aggregate metrics with.
+            server_certificate_providder: A provider class to get TLS server certificate.
+            ca_certificate_provider: A provider class to get TLS CA certificate.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:
@@ -130,7 +136,11 @@ class ShardCombinerStageService(PrivateComputationStageService):
         else:
             run_name = ""
 
-        tls_args = get_tls_arguments(pc_instance.has_feature(PCSFeature.PCF_TLS))
+        tls_args = get_tls_arguments(
+            pc_instance.has_feature(PCSFeature.PCF_TLS),
+            server_certificate_path,
+            ca_certificate_path,
+        )
         compute_args = {
             "input_base_path": input_stage_path,
             "metrics_format_type": metrics_format_type,
@@ -171,6 +181,8 @@ class ShardCombinerStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,

--- a/fbpcs/private_computation/service/pid_mr_stage_service.py
+++ b/fbpcs/private_computation/service/pid_mr_stage_service.py
@@ -45,12 +45,18 @@ class PIDMRStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """This function run mr workflow service
 
         Args:
             pc_instance: the private computation instance to run mr match
+            server_certificate_providder: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -68,11 +68,17 @@ class PIDPrepareStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the PID prepare stage
         Args:
             pc_instance: the private computation instance to start pid prepare stage service
+            server_certificate_providder: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: No need in this stage.
         Returns:
             An updated version of pc_instance

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -69,12 +69,18 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the PID run protocol stage
 
         Args:
             pc_instance: the private computation instance to start pid run protocol stage service
+            server_certificate_providder: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: only used by partner to get server hostnames
         Returns:
             An updated version of pc_instance

--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -61,11 +61,17 @@ class PIDShardStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the PID shard stage service
         Args:
             pc_instance: the private computation instance to start pid shard stage service
+            server_certificate_providder: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: No need in this stage.
         Returns:
             An updated version of pc_instance

--- a/fbpcs/private_computation/service/post_processing_stage_service.py
+++ b/fbpcs/private_computation/service/post_processing_stage_service.py
@@ -57,6 +57,8 @@ class PostProcessingStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation post processing handlers stage
@@ -66,6 +68,10 @@ class PostProcessingStageService(PrivateComputationStageService):
 
         Args:
             pc_instance: the private computation instance to run post processing handlers with
+            server_certificate_providder: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -62,12 +62,14 @@ from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
 from fbpcs.private_computation.service.constants import (
+    CA_CERT_PATH,
     DEFAULT_CONCURRENCY,
     DEFAULT_HMAC_KEY,
     DEFAULT_K_ANONYMITY_THRESHOLD_PA,
     DEFAULT_K_ANONYMITY_THRESHOLD_PL,
     DEFAULT_PADDING_SIZE,
     NUM_NEW_SHARDS_PER_FILE,
+    SERVER_CERT_PATH,
 )
 from fbpcs.private_computation.service.errors import (
     PrivateComputationServiceInvalidStageError,
@@ -587,13 +589,16 @@ class PrivateComputationService:
             checkpoint_name=checkpoint_name,
             status=CheckpointStatus.STARTED,
         )
-
+        # TODO: T136265785 refactor the tls input validation logic into a TLS config class
+        enable_tls = pc_instance.has_feature(PCSFeature.PCF_TLS)
         try:
             stage_svc = stage_svc or stage.get_stage_service(self.stage_service_args)
             pc_instance = await stage_svc.run_async(
                 pc_instance,
                 server_certificate_provider,
                 ca_certificate_provider,
+                SERVER_CERT_PATH if enable_tls else "",
+                CA_CERT_PATH if enable_tls else "",
                 server_ips,
             )
         except Exception as e:

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -57,6 +57,8 @@ class PrivateComputationStageService(abc.ABC):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         # TODO(T102471612): remove server_ips from run_async, move to subclass constructor instead
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:

--- a/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
@@ -58,12 +58,18 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation aggregate metrics stage
 
         Args:
-            pc_instance: the private computation instance to run aggregate metrics with
+            pc_instance: the private computation instance to run aggregate metrics with.
+            server_certificate_providder: A provider class to get TLS server certificate.
+            ca_certificate_provider: A provider class to get TLS CA certificate.
+            server_certificate_path: The path to write server certificate on a container.
+            ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
 
         Returns:
@@ -115,6 +121,8 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
             game_args=game_args,
             container_timeout=self._container_timeout,

--- a/fbpcs/private_computation/service/shard_stage_service.py
+++ b/fbpcs/private_computation/service/shard_stage_service.py
@@ -57,12 +57,18 @@ class ShardStageService(PrivateComputationStageService):
         pc_instance: PrivateComputationInstance,
         server_certificate_provider: CertificateProvider,
         ca_certificate_provider: CertificateProvider,
+        server_certificate_path: str,
+        ca_certificate_path: str,
         server_ips: Optional[List[str]] = None,
     ) -> PrivateComputationInstance:
         """Runs the private computation prepare data stage - shard stage
 
         Args:
             pc_instance: the private computation instance to run prepare data with
+            server_certificate_providder: ignored
+            ca_certificate_provider: ignored
+            server_certificate_path: ignored
+            ca_certificate_path: ignored
             server_ips: ignored
 
         Returns:

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -30,8 +30,10 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation.service.constants import (
     CA_CERTIFICATE_ENV_VAR,
+    CA_CERTIFICATE_PATH_ENV_VAR,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     SERVER_CERTIFICATE_ENV_VAR,
+    SERVER_CERTIFICATE_PATH_ENV_VAR,
 )
 from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
 
@@ -45,6 +47,8 @@ async def create_and_start_mpc_instance(
     binary_version: str,
     server_certificate_provider: CertificateProvider,
     ca_certificate_provider: CertificateProvider,
+    server_certificate_path: str,
+    ca_certificate_path: str,
     server_ips: Optional[List[str]] = None,
     game_args: Optional[List[Dict[str, Any]]] = None,
     container_timeout: Optional[int] = None,
@@ -87,11 +91,12 @@ async def create_and_start_mpc_instance(
         env_vars[ONEDOCKER_REPOSITORY_PATH] = repository_path
     server_cert = server_certificate_provider.get_certificate()
     ca_cert = ca_certificate_provider.get_certificate()
-    if server_cert:
+    if server_cert and server_certificate_path:
         env_vars[SERVER_CERTIFICATE_ENV_VAR] = server_cert
-    if ca_cert:
+        env_vars[SERVER_CERTIFICATE_PATH_ENV_VAR] = server_certificate_path
+    if ca_cert and ca_certificate_path:
         env_vars[CA_CERTIFICATE_ENV_VAR] = ca_cert
-    # TODO: get certificate paths and add them to env_vars
+        env_vars[CA_CERTIFICATE_PATH_ENV_VAR] = ca_certificate_path
 
     return await mpc_svc.start_instance_async(
         instance_id=instance_id,

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -74,6 +74,8 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
         test_game_args = [

--- a/fbpcs/private_computation/test/service/test_argument_helpers.py
+++ b/fbpcs/private_computation/test/service/test_argument_helpers.py
@@ -16,7 +16,7 @@ from fbpcs.private_computation.service.constants import (
 
 class TestArgumentHelpers(TestCase):
     def test_get_tls_arguments_no_feature(self):
-        tls_arguments = get_tls_arguments(False)
+        tls_arguments = get_tls_arguments(False, "some path", "some path")
 
         self.assertFalse(tls_arguments["use_tls"])
         self.assertEqual(tls_arguments["ca_cert_path"], "")
@@ -24,7 +24,7 @@ class TestArgumentHelpers(TestCase):
         self.assertEqual(tls_arguments["private_key_path"], "")
 
     def test_get_tls_arguments_with_feature(self):
-        tls_arguments = get_tls_arguments(True)
+        tls_arguments = get_tls_arguments(True, SERVER_CERT_PATH, CA_CERT_PATH)
 
         self.assertTrue(tls_arguments["use_tls"])
         self.assertEqual(tls_arguments["ca_cert_path"], CA_CERT_PATH)

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -93,6 +93,8 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                     private_computation_instance,
                     NullCertificateProvider(),
                     NullCertificateProvider(),
+                    "",
+                    "",
                     test_server_ips,
                 )
 

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -74,6 +74,8 @@ class TestAggregationStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
 

--- a/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
@@ -73,6 +73,8 @@ class TestAttributionStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
 

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -72,6 +72,8 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
                         private_computation_instance,
                         NullCertificateProvider(),
                         NullCertificateProvider(),
+                        "",
+                        "",
                     )
                     mock_combine.assert_called()
                     self.assertEqual(pc_instance.infra_config.run_id, test_run_id)

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -128,7 +128,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         )
 
         await stage_service.run_async(
-            pc_instance, NullCertificateProvider(), NullCertificateProvider()
+            pc_instance, NullCertificateProvider(), NullCertificateProvider(), "", ""
         )
 
         env_vars = {ONEDOCKER_REPOSITORY_PATH: "test_path/"}
@@ -170,7 +170,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         )
 
         await stage_service.run_async(
-            pc_instance, NullCertificateProvider(), NullCertificateProvider()
+            pc_instance, NullCertificateProvider(), NullCertificateProvider(), "", ""
         )
         status = stage_service.get_status(pc_instance)
 
@@ -198,7 +198,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         )
 
         await stage_service.run_async(
-            pc_instance, NullCertificateProvider(), NullCertificateProvider()
+            pc_instance, NullCertificateProvider(), NullCertificateProvider(), "", ""
         )
         status = stage_service.get_status(pc_instance)
 
@@ -248,7 +248,11 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
 
         with self.assertRaisesRegex(RuntimeError, exception_message):
             await stage_service.run_async(
-                pc_instance, NullCertificateProvider(), NullCertificateProvider()
+                pc_instance,
+                NullCertificateProvider(),
+                NullCertificateProvider(),
+                "",
+                "",
             )
 
     @patch(

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fbpcp.entity.mpc_instance import MPCParty
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
-
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
@@ -78,6 +77,8 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
 
@@ -124,9 +125,8 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
                 "file_start_index": private_computation_instance.infra_config.num_files_per_mpc_container,
             },
         ]
-
         actual_value = self.stage_svc._get_compute_metrics_game_args(
-            private_computation_instance
+            private_computation_instance, "", ""
         )
         self.assertEqual(
             test_game_args,

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -73,6 +73,8 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
 
@@ -116,10 +118,11 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
                 "file_start_index": private_computation_instance.infra_config.num_files_per_mpc_container,
             },
         ]
-
         self.assertEqual(
             test_game_args,
-            self.stage_svc._get_compute_metrics_game_args(private_computation_instance),
+            self.stage_svc._get_compute_metrics_game_args(
+                private_computation_instance, "", ""
+            ),
         )
 
     def _create_pc_instance(self) -> PrivateComputationInstance:

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -78,6 +78,8 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
 
@@ -110,11 +112,10 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             }
             for i in range(2)
         ]
-
         self.assertEqual(
             test_game_args,
             self.stage_svc._get_lift_metadata_compaction_game_args(
-                private_computation_instance
+                private_computation_instance, "", ""
             ),
         )
 

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -76,6 +76,8 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
 
@@ -121,7 +123,11 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             test_game_args,
-            self.stage_svc._get_compute_metrics_game_args(private_computation_instance),
+            self.stage_svc._get_compute_metrics_game_args(
+                private_computation_instance,
+                "",
+                "",
+            ),
         )
 
     def _create_pc_instance(self) -> PrivateComputationInstance:

--- a/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
@@ -73,6 +73,8 @@ class TestShardCombinerStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
         test_game_args = [

--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -93,7 +93,11 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
                     service,
                 )
                 await stage_svc.run_async(
-                    pc_instance, NullCertificateProvider(), NullCertificateProvider()
+                    pc_instance,
+                    NullCertificateProvider(),
+                    NullCertificateProvider(),
+                    "",
+                    "",
                 )
 
                 self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -99,6 +99,8 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 pc_instance=pc_instance,
                 server_certificate_provider=NullCertificateProvider(),
                 ca_certificate_provider=NullCertificateProvider(),
+                server_certificate_path="",
+                ca_certificate_path="",
             )
             env_vars = {}
             if self.onedocker_binary_config.repository_path:

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -109,6 +109,8 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 pc_instance=pc_instance,
                 server_certificate_provider=NullCertificateProvider(),
                 ca_certificate_provider=NullCertificateProvider(),
+                server_certificate_path="",
+                ca_certificate_path="",
                 server_ips=self.server_ips,
             )
 

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -83,6 +83,8 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 pc_instance=pc_instance,
                 server_certificate_provider=NullCertificateProvider(),
                 ca_certificate_provider=NullCertificateProvider(),
+                server_certificate_path="",
+                ca_certificate_path="",
             )
             env_vars = {}
             if self.onedocker_binary_config.repository_path:

--- a/fbpcs/private_computation/test/service/test_post_processing_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_post_processing_stage_service.py
@@ -67,6 +67,8 @@ class TestPostProcessingStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
         )
 
         post_processing_instance = private_computation_instance.infra_config.instances[
@@ -115,6 +117,8 @@ class TestPostProcessingStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
         )
 
         post_processing_instance = private_computation_instance.infra_config.instances[
@@ -163,6 +167,8 @@ class TestPostProcessingStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
         )
 
         post_processing_instance = private_computation_instance.infra_config.instances[

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -830,6 +830,8 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             binary_version=binary_version,
             server_certificate_provider=NullCertificateProvider(),
             ca_certificate_provider=NullCertificateProvider(),
+            server_certificate_path="",
+            ca_certificate_path="",
             container_timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
             server_ips=server_ips,
             game_args=game_args,

--- a/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
@@ -73,6 +73,8 @@ class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
             private_computation_instance,
             NullCertificateProvider(),
             NullCertificateProvider(),
+            "",
+            "",
             test_server_ips,
         )
         test_game_args = [

--- a/fbpcs/private_computation/test/service/test_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_shard_stage_service.py
@@ -59,6 +59,8 @@ class TestShardStageService(IsolatedAsyncioTestCase):
                 private_computation_instance,
                 NullCertificateProvider(),
                 NullCertificateProvider(),
+                "",
+                "",
             )
             mock_shard.assert_called()
 

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from fbpcp.entity.mpc_instance import MPCParty
+
+from fbpcp.service.mpc import MPCService
+from fbpcs.infra.certificate.basic_ca_certificate_provider import (
+    BasicCaCertificateProvider,
+)
+from fbpcs.infra.certificate.pc_instance_server_certificate import (
+    PCInstanceServerCertificateProvider,
+)
+
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    PrivateComputationGameType,
+)
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+    PrivateComputationRole,
+)
+from fbpcs.private_computation.entity.product_config import (
+    CommonProductConfig,
+    LiftConfig,
+    ProductConfig,
+)
+from fbpcs.private_computation.service.argument_helper import (
+    TLS_ARG_KEY_CA_CERT_PATH,
+    TLS_ARG_KEY_SERVER_CERT_PATH,
+)
+
+from fbpcs.private_computation.service.constants import (
+    CA_CERT_PATH,
+    CA_CERTIFICATE_ENV_VAR,
+    CA_CERTIFICATE_PATH_ENV_VAR,
+    SERVER_CERT_PATH,
+    SERVER_CERTIFICATE_ENV_VAR,
+    SERVER_CERTIFICATE_PATH_ENV_VAR,
+)
+from fbpcs.private_computation.service.utils import create_and_start_mpc_instance
+
+ca_cert_content = "ca certificate"
+server_cert_content = "server certificate"
+
+
+class TestUtils(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.instance_id = "test_instance_123"
+        self.pc_instance = self._create_pc_instance()
+        # TODO: replace this with checked in certificates
+
+        self.ca_certificate_provider = BasicCaCertificateProvider(ca_cert_content)
+        self.server_certificate_provider = PCInstanceServerCertificateProvider(
+            self.pc_instance
+        )
+        self.test_binary_version = "latest"
+        self.mpc_svc = self._create_mpc_svc()
+
+    @patch.object(MPCService, "start_instance_async")
+    @patch.object(
+        BasicCaCertificateProvider, "get_certificate", return_value=ca_cert_content
+    )
+    @patch.object(
+        PCInstanceServerCertificateProvider,
+        "get_certificate",
+        return_value=server_cert_content,
+    )
+    @patch.object(MPCService, "get_instance")
+    async def test_create_and_start_mpc_instance_env_vars_setup(
+        self,
+        getInstanceMock,
+        serverCertProviderMock,
+        caCertProviderMock,
+        startInstanceAsyncMock,
+    ) -> None:
+        # Arrange
+        expected_env_vars = {
+            SERVER_CERTIFICATE_ENV_VAR: server_cert_content,
+            SERVER_CERTIFICATE_PATH_ENV_VAR: SERVER_CERT_PATH,
+            CA_CERTIFICATE_ENV_VAR: ca_cert_content,
+            CA_CERTIFICATE_PATH_ENV_VAR: CA_CERT_PATH,
+        }
+        game_args = [
+            {
+                TLS_ARG_KEY_CA_CERT_PATH: CA_CERT_PATH,
+                TLS_ARG_KEY_SERVER_CERT_PATH: SERVER_CERT_PATH,
+            }
+        ]
+        # Act
+        await create_and_start_mpc_instance(
+            self.mpc_svc,
+            self.instance_id,
+            "private_lift",
+            MPCParty.SERVER,
+            num_containers=1,
+            binary_version=self.test_binary_version,
+            server_certificate_path=SERVER_CERT_PATH,
+            ca_certificate_path=CA_CERT_PATH,
+            game_args=game_args,
+            server_certificate_provider=self.server_certificate_provider,
+            ca_certificate_provider=self.ca_certificate_provider,
+        )
+
+        # Assert
+        getInstanceMock.assert_called_once_with(self.instance_id)
+        startInstanceAsyncMock.assert_awaited_once_with(
+            instance_id=self.instance_id,
+            server_ips=None,
+            timeout=43200,
+            version=self.test_binary_version,
+            env_vars=expected_env_vars,
+            certificate_request=None,
+            wait_for_containers_to_start_up=True,
+        )
+
+    def _create_pc_instance(self) -> PrivateComputationInstance:
+        infra_config: InfraConfig = InfraConfig(
+            instance_id=self.instance_id,
+            role=PrivateComputationRole.PARTNER,
+            status=PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+            status_update_ts=1600000000,
+            instances=[],
+            game_type=PrivateComputationGameType.LIFT,
+            num_pid_containers=2,
+            num_mpc_containers=2,
+            num_files_per_mpc_container=4,
+            status_updates=[],
+            run_id="681ba82c-16d9-11ed-861d-0242ac120002",
+            pcs_features={PCSFeature.PCF_TLS},
+        )
+        common: CommonProductConfig = CommonProductConfig(
+            input_path="456",
+            output_dir="789",
+        )
+        product_config: ProductConfig = LiftConfig(
+            common=common,
+        )
+        return PrivateComputationInstance(
+            infra_config=infra_config,
+            product_config=product_config,
+        )
+
+    def _create_mpc_svc(self) -> MPCService:
+        cspatcher = patch("fbpcp.service.container.ContainerService")
+        irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
+        gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        container_svc = cspatcher.start()
+        instance_repository = irpatcher.start()
+        mpc_game_svc = gspatcher.start()
+        for patcher in (cspatcher, irpatcher, gspatcher):
+            self.addCleanup(patcher.stop)
+        return MPCService(
+            container_svc,
+            instance_repository,
+            "test_task_definition",
+            mpc_game_svc,
+        )


### PR DESCRIPTION
Summary:
This diff:
* adds two optional arguments in stage service `run_async` to pass the certificateproviders from upstream callers.
* get the certificate from providers and pass them as env vars to onedocker containers.

Next diffs:
* implement the same approach for other stage services
* add certificate paths to env_var and pass it to onedocker containers

Differential Revision: D40625412

