### PR TITLE
integrate BoltSummary into BoltRunner

### DIFF
--- a/fbpcs/bolt/bolt_summary.py
+++ b/fbpcs/bolt/bolt_summary.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class BoltJobSummary:
+    job_name: str
+    publisher_instance_id: str
+    partner_instance_id: str
+    is_success: bool
+
+
+@dataclass
+class BoltSummary:
+    job_summaries: List[BoltJobSummary]
+
+    def __bool__(self) -> bool:
+        return self.is_success
+
+    @property
+    def is_success(self) -> bool:
+        return self.num_failures == 0
+
+    @property
+    def is_failure(self) -> bool:
+        return not self.is_success
+
+    @property
+    def num_jobs(self) -> int:
+        return len(self.job_summaries)
+
+    @property
+    def num_successes(self) -> int:
+        return self.num_jobs - self.num_failures
+
+    @property
+    def num_failures(self) -> int:
+        return len(self.failed_job_summaries)
+
+    @property
+    def failed_job_summaries(self) -> List[BoltJobSummary]:
+        return [s for s in self.job_summaries if not s.is_success]
+
+    @property
+    def failed_job_names(self) -> List[str]:
+        return [s.job_name for s in self.failed_job_summaries]

--- a/fbpcs/bolt/test/test_bolt_summary.py
+++ b/fbpcs/bolt/test/test_bolt_summary.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from unittest import TestCase
+
+from fbpcs.bolt.bolt_summary import BoltJobSummary, BoltSummary
+
+
+class TestBoltSummary(TestCase):
+    def setUp(self) -> None:
+        self.only_failed = BoltSummary(
+            job_summaries=[
+                BoltJobSummary(
+                    job_name="failed_1",
+                    publisher_instance_id="publisher_failed_1",
+                    partner_instance_id="partner_failed_1",
+                    is_success=False,
+                ),
+                BoltJobSummary(
+                    job_name="failed_2",
+                    publisher_instance_id="publisher_failed_2",
+                    partner_instance_id="partner_failed_2",
+                    is_success=False,
+                ),
+            ]
+        )
+        self.only_success = BoltSummary(
+            job_summaries=[
+                BoltJobSummary(
+                    job_name="success_1",
+                    publisher_instance_id="publisher_success_1",
+                    partner_instance_id="partner_success_1",
+                    is_success=True,
+                ),
+                BoltJobSummary(
+                    job_name="success_2",
+                    publisher_instance_id="publisher_success_2",
+                    partner_instance_id="partner_success_2",
+                    is_success=True,
+                ),
+            ]
+        )
+        self.mixed_results = BoltSummary(
+            job_summaries=[
+                BoltJobSummary(
+                    job_name="success_1",
+                    publisher_instance_id="publisher_success_1",
+                    partner_instance_id="partner_success_1",
+                    is_success=True,
+                ),
+                BoltJobSummary(
+                    job_name="failed_2",
+                    publisher_instance_id="publisher_failed_2",
+                    partner_instance_id="partner_failed_2",
+                    is_success=False,
+                ),
+            ]
+        )
+
+    def test_dunder_bool(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertFalse(bool(self.only_failed))
+
+        with self.subTest("mixed_results"):
+            self.assertFalse(bool(self.mixed_results))
+
+        with self.subTest("only_success"):
+            self.assertTrue(bool(self.only_success))
+
+    def test_is_success(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertFalse(self.only_failed.is_success)
+
+        with self.subTest("mixed_results"):
+            self.assertFalse(self.mixed_results.is_success)
+
+        with self.subTest("only_success"):
+            self.assertTrue(self.only_success.is_success)
+
+    def test_is_failure(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertTrue(self.only_failed.is_failure)
+
+        with self.subTest("mixed_results"):
+            self.assertTrue(self.mixed_results.is_failure)
+
+        with self.subTest("only_success"):
+            self.assertFalse(self.only_success.is_failure)
+
+    def test_num_jobs(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertEqual(2, self.only_failed.num_jobs)
+
+        with self.subTest("mixed_results"):
+            self.assertEqual(2, self.mixed_results.num_jobs)
+
+        with self.subTest("only_success"):
+            self.assertEqual(2, self.only_success.num_jobs)
+
+    def test_num_successes(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertEqual(0, self.only_failed.num_successes)
+
+        with self.subTest("mixed_results"):
+            self.assertEqual(1, self.mixed_results.num_successes)
+
+        with self.subTest("only_success"):
+            self.assertEqual(2, self.only_success.num_successes)
+
+    def test_num_failures(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertEqual(2, self.only_failed.num_failures)
+
+        with self.subTest("mixed_results"):
+            self.assertEqual(1, self.mixed_results.num_failures)
+
+        with self.subTest("only_success"):
+            self.assertEqual(0, self.only_success.num_failures)
+
+    def test_failed_job_summaries(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertEqual(
+                self.only_failed.job_summaries, self.only_failed.failed_job_summaries
+            )
+
+        with self.subTest("mixed_results"):
+            self.assertEqual(
+                [self.mixed_results.job_summaries[1]],
+                self.mixed_results.failed_job_summaries,
+            )
+
+        with self.subTest("only_success"):
+            self.assertEqual([], self.only_success.failed_job_summaries)
+
+    def test_failed_job_names(self) -> None:
+        with self.subTest("only_failed"):
+            self.assertEqual(
+                [s.job_name for s in self.only_failed.job_summaries],
+                self.only_failed.failed_job_names,
+            )
+
+        with self.subTest("mixed_results"):
+            self.assertEqual(
+                [self.mixed_results.job_summaries[1].job_name],
+                self.mixed_results.failed_job_names,
+            )
+
+        with self.subTest("only_success"):
+            self.assertEqual([], self.only_success.failed_job_names)

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -476,12 +476,9 @@ def main(argv: Optional[List[str]] = None) -> None:
     elif arguments["bolt_e2e"]:
         bolt_config = ConfigYamlDict.from_file(arguments["--bolt_config"])
         bolt_runner, jobs = parse_bolt_config(config=bolt_config, logger=logger)
-        run_results = asyncio.run(bolt_runner.run_async(jobs))
-        if not all(run_results):
-            failed_job_names = [
-                job.job_name for job, result in zip(jobs, run_results) if not result
-            ]
-            raise RuntimeError(f"Jobs failed: {failed_job_names}")
+        bolt_summary = asyncio.run(bolt_runner.run_async(jobs))
+        if bolt_summary.is_failure:
+            raise RuntimeError(f"Jobs failed: {bolt_summary.failed_job_names}")
         else:
             print("Jobs succeeded")
     elif arguments["secret_scrubber"]:


### PR DESCRIPTION
Summary:
## What

- Integrate the `BoltSummary` introduced in `D40870335` into the BoltRunner
- Update callers of `BoltRunner` to use the new `BoltSummary`

## Why

- This will give the BoltRunner the ability to transfer much more information to the caller than just "success or fail"
- In this particular diff stack, I want to be able to get the instance ids of graph api experiments after the completion of the run to use for AWS cost measurement purposes. Since we don't know that information before runtime for graph API runs, the information is being swallowed by BoltRunner.
- This change is analogous to how, in thrift, the best practice is to return a struct in responses so that we have more flexibility in the future

Differential Revision: D40875093

