### PR TITLE
Allow retrying failed Step Functions execution

### DIFF
--- a/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_mr_stage_service.py
@@ -84,7 +84,12 @@ class TestPIDMRStageService(IsolatedAsyncioTestCase):
                     product_config=product_config,
                 )
 
-                service = SfnWorkflowService("us-west-2", "access_key", "access_data")
+                service = SfnWorkflowService(
+                    "us-west-2",
+                    "access_key",
+                    "access_data",
+                    session_token="session_token",
+                )
                 service.start_workflow = MagicMock(return_value="execution_arn")
                 service.get_workflow_status = MagicMock(
                     return_value=WorkflowStatus.COMPLETED

--- a/fbpcs/service/test/test_workflow_sfn.py
+++ b/fbpcs/service/test/test_workflow_sfn.py
@@ -25,7 +25,9 @@ class TestSfnWorkflowService(unittest.TestCase):
 
     @patch("boto3.client")
     def test_start_workflow_with_conf(self, MockBoto3):
-        service = SfnWorkflowService("us-west-2", "access_key", "access_data")
+        service = SfnWorkflowService(
+            "us-west-2", "access_key", "access_data", session_token="session_token"
+        )
         service.client.start_execution = MagicMock(
             return_value={"executionArn": "execution_arn"}
         )


### PR DESCRIPTION
Summary: Allow retrying failed Step Functions execution by setting unique execution name

Reviewed By: Pradeepnitw, jiancao-yajc

Differential Revision: D40646937

