### PR TITLE
Adding getTlsInfoFromArgs API in fbpcf & marking the one in fbpcs as depreciated

### DIFF
--- a/fbpcs/emp_games/common/Util.h
+++ b/fbpcs/emp_games/common/Util.h
@@ -236,13 +236,14 @@ inline folly::dynamic getCostExtraInfo(
         ("mpc_traffic_details", schedulerStatistics.details);
 }
 
-inline fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo
-getTlsInfoFromArgs(
-    bool useTls,
-    std::string ca_cert_path,
-    std::string server_cert_path,
-    std::string private_key_path,
-    std::string passphrase_path) {
+[[deprecated("Use the one in fbpcf/ instead.")]] inline fbpcf::engine::
+    communication::SocketPartyCommunicationAgent::TlsInfo
+    getTlsInfoFromArgs(
+        bool useTls,
+        std::string ca_cert_path,
+        std::string server_cert_path,
+        std::string private_key_path,
+        std::string passphrase_path) {
   const char* home_dir = std::getenv("HOME");
   if (home_dir == nullptr) {
     home_dir = "";


### PR DESCRIPTION
Summary:
As title.
This function will be used in multiple binaries (as opposite to only emp games). It makes more sense to add it in fbpcf folder.

Reviewed By: adshastri

Differential Revision: D40878071

