### PR TITLE
implement PCInstance cert providers

### DIFF
--- a/fbpcs/infra/certificate/pc_instance_ca_certificate_provider.py
+++ b/fbpcs/infra/certificate/pc_instance_ca_certificate_provider.py
@@ -9,7 +9,6 @@
 from typing import Optional
 
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.infra.certificate.sample_tls_certificates import SAMPLE_CA_CERTIFICATE
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
 )
@@ -25,6 +24,4 @@ class PCInstanceCaCertificateProvider(CertificateProvider):
         self.pc_instance = pc_instance
 
     def get_certificate(self) -> Optional[str]:
-        # TODO: implement this by retrieving ca certificate
-        # from pc instance repo.
-        return SAMPLE_CA_CERTIFICATE
+        return self.pc_instance.infra_config.ca_certificate

--- a/fbpcs/infra/certificate/pc_instance_server_certificate.py
+++ b/fbpcs/infra/certificate/pc_instance_server_certificate.py
@@ -28,10 +28,4 @@ class PCInstanceServerCertificateProvider(CertificateProvider):
         """
         Get certificate value from pc instance repo.
         """
-        # TODO: implement this by retrieving server certificate
-        # from pc instance repo.
-
-        # This is a intermediate stage for us to do testing and
-        # there is no security risk of returning a sample
-        # static certificate
-        return SAMPLE_SERVER_CERTIFICATE
+        return self.pc_instance.infra_config.server_certificate

--- a/fbpcs/infra/certificate/tests/test_certificate_providers.py
+++ b/fbpcs/infra/certificate/tests/test_certificate_providers.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from fbpcs.infra.certificate.pc_instance_ca_certificate_provider import (
+    PCInstanceCaCertificateProvider,
+)
+from fbpcs.infra.certificate.pc_instance_server_certificate import (
+    PCInstanceServerCertificateProvider,
+)
+from fbpcs.private_computation.entity.infra_config import (
+    InfraConfig,
+    PrivateComputationGameType,
+)
+
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
+
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationInstance,
+    PrivateComputationInstanceStatus,
+    PrivateComputationRole,
+)
+
+from fbpcs.private_computation.entity.product_config import (
+    CommonProductConfig,
+    LiftConfig,
+    ProductConfig,
+)
+
+
+class TestCertificateProviders(unittest.TestCase):
+    def setUp(self) -> None:
+        self.instance_id = "test_instance_123"
+        self.test_server_cert_content = "test_server_certificate"
+        self.test_ca_cert_content = "test_ca_certificate"
+        self.pc_instance = self._create_pc_instance()
+
+    def test_pc_instance_server_certificate_provider(self) -> None:
+        # Arrange
+        cert_provider = PCInstanceServerCertificateProvider(self.pc_instance)
+        # Act
+        actual_cert_content = cert_provider.get_certificate()
+        # Assert
+        self.assertEqual(self.test_server_cert_content, actual_cert_content)
+
+    def test_pc_instance_ca_certificate_provider(self) -> None:
+        # Arrange
+        cert_provider = PCInstanceCaCertificateProvider(self.pc_instance)
+        # Act
+        actual_cert_content = cert_provider.get_certificate()
+        # Assert
+        self.assertEqual(self.test_ca_cert_content, actual_cert_content)
+
+    def _create_pc_instance(self) -> PrivateComputationInstance:
+        infra_config: InfraConfig = InfraConfig(
+            instance_id=self.instance_id,
+            role=PrivateComputationRole.PARTNER,
+            status=PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+            status_update_ts=1600000000,
+            instances=[],
+            game_type=PrivateComputationGameType.LIFT,
+            num_pid_containers=2,
+            num_mpc_containers=2,
+            num_files_per_mpc_container=4,
+            status_updates=[],
+            run_id="681ba82c-16d9-11ed-861d-0242ac120002",
+            pcs_features={PCSFeature.PCF_TLS},
+            server_certificate=self.test_server_cert_content,
+            ca_certificate=self.test_ca_cert_content,
+        )
+        common: CommonProductConfig = CommonProductConfig(
+            input_path="456",
+            output_dir="789",
+        )
+        product_config: ProductConfig = LiftConfig(
+            common=common,
+        )
+        return PrivateComputationInstance(
+            infra_config=infra_config,
+            product_config=product_config,
+        )

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -171,6 +171,9 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     # TODO: concurrency should be immutable eventually
     mpc_compute_concurrency: int = 1
 
+    server_certificate: Optional[str] = immutable_field(default=None)
+    ca_certificate: Optional[str] = immutable_field(default=None)
+
     @property
     def stage_flow(self) -> Type["PrivateComputationBaseStageFlow"]:
         # this inner-function import allow us to call PrivateComputationBaseStageFlow.cls_name_to_cls

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -42,6 +42,10 @@ from fbpcs.infra.certificate.pc_instance_server_certificate import (
     PCInstanceServerCertificateProvider,
 )
 from fbpcs.infra.certificate.sample_tls_certificates import SAMPLE_CA_CERTIFICATE
+from fbpcs.infra.certificate.sample_tls_certificates import (
+    SAMPLE_CA_CERTIFICATE,
+    SAMPLE_SERVER_CERTIFICATE,
+)
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
@@ -217,7 +221,18 @@ class PrivateComputationService:
             self.metric_svc.bump_entity_key(
                 PCSERVICE_ENTITY_NAME, f"pcs_feature_{feature.lower()}_enabled"
             )
-
+        # TODO: T136500624 Replace SAMPLE_SERVER_CERTIFICATE with dynamically generated certificates.
+        # The certificates returned below do not provide any security and
+        # are being used for intermediate testing purposes only.
+        server_certificate = (
+            SAMPLE_SERVER_CERTIFICATE
+            if PCSFeature.PCF_TLS in pcs_feature_enums
+            and role is PrivateComputationRole.PUBLISHER
+            else None
+        )
+        ca_certificate = (
+            SAMPLE_CA_CERTIFICATE if PCSFeature.PCF_TLS in pcs_feature_enums else None
+        )
         infra_config: InfraConfig = InfraConfig(
             instance_id=instance_id,
             role=role,
@@ -244,6 +259,8 @@ class PrivateComputationService:
             status_updates=[],
             run_id=run_id,
             log_cost_bucket=log_cost_bucket,
+            server_certificate=server_certificate,
+            ca_certificate=ca_certificate,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():


### PR DESCRIPTION
Summary: With D40816068 which stores the cert content in infra config upon PC instance creation, we can do the changes in this diff, so that when run_stage_async is called, we will be getting the cert content from certificate providers.

Reviewed By: danbunnell

Differential Revision: D40820122

