### PR TITLE
add server_domain and server_key_ref to infra config

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -173,6 +173,8 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
 
     server_certificate: Optional[str] = immutable_field(default=None)
     ca_certificate: Optional[str] = immutable_field(default=None)
+    server_key_ref: Optional[str] = immutable_field(default=None)
+    server_domain: Optional[str] = immutable_field(default=None)
 
     @property
     def stage_flow(self) -> Type["PrivateComputationBaseStageFlow"]:

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -284,6 +284,8 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     int(yesterday_timestamp),
                     args.product_config.common.post_processing_data.dataset_timestamp,
                 )
+                self.assertEqual(args.infra_config.server_domain, None)
+                self.assertEqual(args.infra_config.server_key_ref, None)
                 if pcs_features is not None:
                     if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value in pcs_features:
                         self.assertTrue(


### PR DESCRIPTION
Summary:
Storing these fields upon PCInstance creation --
1. server_domain will be used later to compose server hostname for each container instance
2. server_key_ref will be used later to retrieve server private key from aws secret manager

Differential Revision: D40902357

