### PR TITLE
Adding resource based auth minimum permissions for the logging infra

### DIFF
--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy.json
@@ -118,6 +118,13 @@
                 "ecr:GetRepositoryPolicy"
             ],
             "Resource": "*"
+        },
+        {
+            "Action": [
+                "logs:*"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
Summary:
**What**
Adding permission in the IAM policy to allow user to access cloudwatch logs.

**Why**
In the current IAM policy cloudwatch logs not accessible.

Differential Revision: D40907295

