### PR TITLE
Skip the PCE policy validation

### DIFF
--- a/fbpcs/infra/cloud_bridge/pceValidator.sh
+++ b/fbpcs/infra/cloud_bridge/pceValidator.sh
@@ -17,7 +17,7 @@ validate_pce () {
     local pce_id=$2
     log_pce_validator "validate_pce $region $pce_id"
     local pceValidatorOutput
-    pceValidatorOutput=$(python3 -m pce.validator --region="$region" --pce-id="$pce_id" 2>&1)
+    pceValidatorOutput=$(python3 -m pce.validator --region="$region" --pce-id="$pce_id" --skip-step=iam_roles 2>&1)
     local pceValidatorExitCode=$?
     log_pce_validator "$pceValidatorOutput"
     log_pce_validator "validator exitcode: $pceValidatorExitCode"


### PR DESCRIPTION
Summary:
In D40406015 (https://github.com/facebookresearch/fbpcs/commit/43e5094f9e9e40576ba6ac9556c2c03b4fc2698f) the PCE's s3 access was limited to the data bucket, however the
PCE Validator was never updated to validate this updated policy. Skip the
policy validation for now until it is updated to handle the new policy.

Differential Revision: D40925773

