### PR TITLE
Fix Scheduled E2E tests

### DIFF
--- a/.github/workflows/e2e_test_cron.yml
+++ b/.github/workflows/e2e_test_cron.yml
@@ -16,7 +16,7 @@ jobs:
     name: Select the PL Objective ID
     runs-on: ubuntu-latest
     outputs:
-      pl_objective_id: ${{ steps.select_pl_objective.outputs.objective_id }}
+      pl_objective_id: ${{ steps.select_pl_objective_id.outputs.objective_id }}
     steps:
       - name: Select PL Objective ID
         id: select_pl_objective_id
@@ -31,7 +31,7 @@ jobs:
     name: Select the Multi-Key PL Objective ID
     runs-on: ubuntu-latest
     outputs:
-      pl_objective_id: ${{ steps.select_pl_objective.outputs.objective_id }}
+      pl_objective_id: ${{ steps.select_pl_objective_id.outputs.objective_id }}
     steps:
       - name: Select MK PL Objective ID
         id: select_pl_objective_id

--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -98,19 +98,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Print Tracker Hash
-        run: echo ${{ github.event.inputs.tracker_hash}}
+        run: echo ${{ inputs.tracker_hash}}
 
       - name: One command runner
         id: runner
         continue-on-error: true
         run: |
           ./fbpcs/scripts/run_fbpcs.sh run_study \
-          ${{ github.event.inputs.study_id }} \
-          --objective_ids=${{ github.event.inputs.objective_id }} \
-          --input_paths=${{ github.event.inputs.input_path }} \
+          ${{ inputs.study_id }} \
+          --objective_ids=${{ inputs.objective_id }} \
+          --input_paths=${{ inputs.input_path }} \
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
           -- \
-          --version=${{ github.event.inputs.tag }} > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
+          --version=${{ inputs.tag }} > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
 
       - name: Print runner console output
         continue-on-error: true
@@ -132,13 +132,13 @@ jobs:
           validate \
           "/{}" \
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
-          --expected_result_path=${{ github.event.inputs.expected_result_path }} \
+          --expected_result_path=${{ inputs.expected_result_path }} \
           -- \
-          --version=${{ github.event.inputs.tag }}
+          --version=${{ inputs.tag }}
 
       - name: Validate runner logs
         # First command extracts the pc-cli log lines starting with "... ! Command line: ..." into a file.
         run: |
           sed -n '/^.* ! Command line: .*/,$p' < ${{env.CONSOLE_OUTPUT_FILE}} > ${{env.CONSOLE_OUTPUT_FILE}}.extracted
-          docker run --rm -v "${{env.CONSOLE_OUTPUT_FILE}}.extracted:${{env.CONSOLE_OUTPUT_FILE}}" ${{env.FBPCS_CONTAINER_REPO_URL}}/${{env.FBPCS_IMAGE_NAME}}:${{github.event.inputs.tag}} \
+          docker run --rm -v "${{env.CONSOLE_OUTPUT_FILE}}.extracted:${{env.CONSOLE_OUTPUT_FILE}}" ${{env.FBPCS_CONTAINER_REPO_URL}}/${{env.FBPCS_IMAGE_NAME}}:${{inputs.tag}} \
           python -m fbpcs.infra.logging_service.log_analyzer.log_analyzer ${{env.CONSOLE_OUTPUT_FILE}} --validate_one_runner_logs

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -91,14 +91,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Print Tracker Hash
-        run: echo ${{ github.event.inputs.tracker_hash}}
+        run: echo ${{ inputs.tracker_hash}}
 
       - name: One Command runner
         run: |
           ./fbpcs/scripts/run_fbpcs.sh run_attribution \
-          --dataset_id=${{ github.event.inputs.dataset_id}} \
+          --dataset_id=${{ inputs.dataset_id }} \
           --attribution_rule="last_click_1d" \
-          --input_path=${{ github.event.inputs.input_path}} \
+          --input_path=${{ inputs.input_path }} \
           --aggregation_type="measurement" \
           --concurrency=4 \
           --num_files_per_mpc_container=4 \
@@ -106,7 +106,7 @@ jobs:
           --timestamp="1646870400" \
           --k_anonymity_threshold=0 \
           -- \
-          --version=${{ github.event.inputs.tag }}
+          --version=${{ inputs.tag }}
       - name: Validate Results
         # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
         # the fbpcs_instances directory is where instances are written to (feature of run_fbpcs.sh)
@@ -116,6 +116,6 @@ jobs:
           validate \
           "/{}" \
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
-          --expected_result_path=${{ github.event.inputs.expected_result_path }} \
+          --expected_result_path=${{ inputs.expected_result_path }} \
           -- \
-          --version=${{ github.event.inputs.tag }}
+          --version=${{ inputs.tag }}


### PR DESCRIPTION
Summary:
## Background
Right now, the scheduled E2E test are failing because the input parameters that are required are not being passed to the actual test script. You can see the inputs being pased to the job:
https://pxl.cl/2jxc0
But when we try to run the `run_fbpcs.sh` script, none of the values are present:
https://pxl.cl/2jxcj

This is because the `workflow_call` syntax doesn't support the `github.event.inputs` context because the [`github.event` context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) comes from the webhook payload and the [webhook payload for the `workload_call` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call) matches the payload of the caller. This means that the values that we pass in don't exist in the `github.event` context.

## This diff
Both the `workflow_call` and `workflow_dispatch` events support the [`inputs` context](https://docs.github.com/en/actions/learn-github-actions/contexts#inputs-context) so this diff updates the PA and PL E2E tests to use that context to get the input values.

Differential Revision: D40939341

