### PR TITLE
Add the semi-automated job permission

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -371,6 +371,8 @@ deploy_aws_resources() {
             -var "app_data_input_bucket_arn=$data_bucket_arn" \
             -var "data_upload_key_path=$data_upload_key_path"
         echo "######################## Deploy Semi-automated Data Ingestion Terraform scripts completed ########################"
+        # Store the outputs into variables
+        semi_automated_glue_job_arn=$(terraform output semi_automated_glue_job_arn | tr -d '"')
     fi
 
     echo "########################Finished AWS Infrastructure Deployment########################"
@@ -413,7 +415,8 @@ deploy_aws_resources() {
         --table_name "$table_name" \
         --cluster_name "$aws_ecs_cluster_name" \
         --ecs_task_execution_role_name "$ecs_task_execution_role_name" \
-        --events_data_crawler_arn "$events_data_crawler_arn"
+        --events_data_crawler_arn "$events_data_crawler_arn" \
+        --semi_automated_glue_job_arn "$semi_automated_glue_job_arn"
     echo "######################## Finished deploy resources policy ########################"
     log_streaming_data "validating generated resoureces and policies..."
     # validate generated resources through PCE validator

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper_tool.py
@@ -50,6 +50,7 @@ class AwsDeploymentHelperTool:
                 ecs_task_execution_role_name=self.cli_args.ecs_task_execution_role_name,
                 data_ingestion_lambda_name=self.cli_args.data_ingestion_lambda_name,
                 events_data_crawler_arn=self.cli_args.events_data_crawler_arn,
+                semi_automated_glue_job_arn=self.cli_args.semi_automated_glue_job_arn,
             )
             self.aws_deployment_helper_obj.create_policy(
                 policy_name=self.cli_args.policy_name,

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_parser_builder.py
@@ -132,6 +132,13 @@ class AwsParserBuilder:
             help="The events_data Glue crawler ARN",
         )
 
+        iam_policy_command_group.add_argument(
+            "--semi_automated_glue_job_arn",
+            type=str,
+            required=False,
+            help="The semi-automated Glue job ARN",
+        )
+
         return self
 
     def with_attach_iam_policy_parser_arguments(

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/semi_automated_statement.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/semi_automated_statement.json
@@ -1,0 +1,14 @@
+{
+    "Effect": "Allow",
+    "Action": [
+        "glue:Get*",
+        "glue:BatchGet*",
+        "glue:List*",
+        "glue:QuerySchemaVersionMetadata",
+        "glue:CheckSchemaVersionValidity",
+        "glue:SearchTables"
+    ],
+    "Resource": [
+        "${SEMI_AUTOMATED_GLUE_JOB_ARN}"
+    ]
+}

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/policy_params.py
@@ -19,3 +19,4 @@ class PolicyParams:
     ecs_task_execution_role_name: str
     data_ingestion_lambda_name: str
     events_data_crawler_arn: str
+    semi_automated_glue_job_arn: str

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
@@ -64,8 +64,13 @@ class TestAwsDeploymentHelper(unittest.TestCase):
         test_policy_name = "TestIamPolicyName"
         test_policy_params = {"test-key-1": "test-val-1"}
         test_user_name = "test-user-name"
-        test_policy_json_data = {"test-key-2": "test-val-2"}
-        test_policy_json_data_string = '{"test-key-2": "test-val-2"}'
+        test_policy_json_data = {
+            "test-key-2": "test-val-2",
+            "Statement": [
+                {"Effect": "Allow", "Action": "logs:Describe*", "Resource": "*"}
+            ],
+        }
+        test_policy_json_data_string = '{"test-key-2": "test-val-2", "Statement": [{"Effect": "Allow", "Action": "logs:Describe*", "Resource": "*"}]}'
         self.aws_deployment_helper.read_json_file = MagicMock()
         self.aws_deployment_helper.read_json_file.return_value = test_policy_json_data
         self.aws_deployment_helper.iam.create_policy.return_value = {}
@@ -337,6 +342,7 @@ class TestAwsDeploymentHelper(unittest.TestCase):
         self.aws_deployment_helper.region = "test_region"
         test_policy = MagicMock()
         test_policy.cluster_name = "test_cluster_name"
+        test_policy.semi_automated_glue_job_arn = ""
 
         test_file = (
             pathlib.Path(__file__).parent

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper_tool.py
@@ -33,6 +33,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
         test_ecs_task_execution_role_name = "test-ecs-execution-role"
         test_data_ingestion_lambda_name = "test-di-lambda-name"
         test_events_data_crawler_arn = "test-events-data-crawler-arn"
+        test_semi_automated_glue_job_arn = "test-semi-automated-glue-job-arn"
 
         with self.subTest("add_iam_user_basic"):
             cli_args = self.setup_cli_args_mock()
@@ -70,6 +71,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
             cli_args.ecs_task_execution_role_name = test_ecs_task_execution_role_name
             cli_args.data_ingestion_lambda_name = test_data_ingestion_lambda_name
             cli_args.events_data_crawler_arn = test_events_data_crawler_arn
+            cli_args.semi_automated_glue_job_arn = test_semi_automated_glue_job_arn
             aws_deployment_helper_tool = AwsDeploymentHelperTool(cli_args)
 
             aws_deployment_helper_tool.create()
@@ -87,6 +89,7 @@ class TestAwsDeploymentHelperTool(unittest.TestCase):
                     ecs_task_execution_role_name=test_ecs_task_execution_role_name,
                     data_ingestion_lambda_name=test_data_ingestion_lambda_name,
                     events_data_crawler_arn=test_events_data_crawler_arn,
+                    semi_automated_glue_job_arn=test_semi_automated_glue_job_arn,
                 ),
             )
 

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/output.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/output.tf
@@ -1,0 +1,4 @@
+output "semi_automated_glue_job_arn" {
+  value       = aws_glue_job.glue_job.arn
+  description = "The semi-automated Glue job ARN"
+}


### PR DESCRIPTION
Summary:
In order to enable fetching the semi-automated Glue job state, add permissions
to access the provisioned Glue job.

Differential Revision: D40943770

