### PR TITLE
Fix CalculatorApp to allow empty files.

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorGame.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorGame.h
@@ -32,6 +32,12 @@ class CalculatorGame : public fbpcf::frontend::MpcGame<schedulerId> {
         communicationAgentFactory_(communicationAgentFactory) {}
 
   std::string play(const CalculatorGameConfig& config) {
+    if (config.inputData.getNumRows() == 0) {
+      XLOG(INFO) << "skipped calculating as numRows==0.";
+      // skip game::run(), just output the default metrics.
+      return GroupedLiftMetrics().toJson();
+    }
+
     auto inputProcessor = InputProcessor<schedulerId>(
         party_, config.inputData, config.numConversionsPerUser);
     auto attributor = std::make_unique<Attributor<schedulerId>>(
@@ -54,6 +60,12 @@ class CalculatorGame : public fbpcf::frontend::MpcGame<schedulerId> {
         globalParamsInputPath, secretSharesInputPath);
     XLOG(INFO) << "Have " << inputProcessor.getLiftGameProcessedData().numRows
                << " values in inputData.";
+    if (inputProcessor.getLiftGameProcessedData().numRows == 0) {
+      XLOG(INFO) << "skipped calculating as numRows==0.";
+      // skip game::run(), just output the default metrics.
+      return GroupedLiftMetrics().toJson();
+    }
+
     auto attributor = std::make_unique<Attributor<schedulerId>>(
         party_,
         std::make_unique<SecretShareInputProcessor<schedulerId>>(

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <stdexcept>
 #include <string>
 
 #include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData.h"
@@ -134,7 +135,7 @@ LiftGameProcessedData<schedulerId>::readFromCSV(
           testReachShares));
 
   if (result.numRows == 0) {
-    XLOG(FATAL, "Lift Game shares file was empty");
+    return LiftGameProcessedData<schedulerId>{};
   }
 
   result.indexShares = transpose(indexShares);

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -511,6 +511,69 @@ TEST_P(CalculatorAppTestFixture, TestCorrectnessRandomInputAndCohort) {
   EXPECT_EQ(expectedResult, res);
 }
 
+void generateSyntheticData_ZeroRow(
+    const std::string& publisherPlaintextInputPath,
+    const std::string& partnerPlaintextInputPath,
+    int numConversionsPerUser,
+    bool generatePublisherBreakdowns,
+    bool useCohorts) {
+  // Generate test input files with random data
+  GenFakeData testDataGenerator;
+  LiftFakeDataParams params;
+  params.setNumRows(0)
+      .setOpportunityRate(0.5)
+      .setTestRate(0.5)
+      .setPurchaseRate(0.5)
+      .setIncrementalityRate(0.0)
+      .setNumConversions(numConversionsPerUser)
+      .setOmitValuesColumn(false)
+      .setEpoch(1546300800);
+
+  if (generatePublisherBreakdowns) {
+    params.setNumBreakdowns(2);
+  }
+
+  if (useCohorts) {
+    params.setNumCohorts(4);
+  }
+
+  testDataGenerator.genFakeInputFiles(
+      publisherPlaintextInputPath, partnerPlaintextInputPath, params);
+}
+
+TEST_P(CalculatorAppTestFixture, TestWithEmptyInput) {
+  // Run calculator app with test input
+  bool useTls = std::get<0>(GetParam());
+  bool useXorEncryption = std::get<1>(GetParam());
+  bool computePublisherBreakdowns = std::get<2>(GetParam());
+  bool readInputFromSecretShares = std::get<3>(GetParam());
+
+  // Generate test input files with random data
+  int numConversionsPerUser = 25;
+
+  generateSyntheticData_ZeroRow(
+      publisherPlaintextInputPath_,
+      partnerPlaintextInputPath_,
+      numConversionsPerUser,
+      computePublisherBreakdowns,
+      true);
+
+  GroupedLiftMetrics res = runTest(
+      publisherPlaintextInputPath_,
+      partnerPlaintextInputPath_,
+      "",
+      publisherOutputPath_,
+      partnerOutputPath_,
+      numConversionsPerUser,
+      computePublisherBreakdowns,
+      useTls,
+      useXorEncryption);
+
+  GroupedLiftMetrics expectedResult = {};
+
+  EXPECT_EQ(expectedResult, res);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CalculatorAppTest,
     CalculatorAppTestFixture,


### PR DESCRIPTION
Summary: Empty files ideally should not appear, but just in case, Compute stage should still handle it correctly instead of crashing.

Differential Revision: D40909773

