### PR TITLE
adding timer contextmanager in metric service

### DIFF
--- a/fbpcs/common/service/metric_service.py
+++ b/fbpcs/common/service/metric_service.py
@@ -18,3 +18,7 @@ class MetricService(abc.ABC):
     @abc.abstractmethod
     def bump_entity_key(self, entity: str, key: str, value: int = 1) -> None:
         pass
+
+    @abc.abstractmethod
+    def bump_entity_key_avg(self, entity: str, key: str, value: int = 1) -> None:
+        pass

--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -22,4 +22,10 @@ class SimpleMetricService(MetricService):
         self.logger.info(json.dumps(result))
 
     def bump_entity_key_avg(self, entity: str, key: str, value: int) -> None:
-        pass
+        result = {
+            "operation": "bump_entity_key_avg",
+            "entity": f"{self.category}.{entity}",
+            "key": key,
+            "value": value,
+        }
+        self.logger.info(json.dumps(result))

--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -20,3 +20,6 @@ class SimpleMetricService(MetricService):
             "value": value,
         }
         self.logger.info(json.dumps(result))
+
+    def bump_entity_key_avg(self, entity: str, key: str, value: int) -> None:
+        pass

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -69,3 +69,25 @@ class TestSimpleMetricService(TestCase):
 
         # Assert
         self.logger.info.assert_called_once_with(expected_dump)
+
+    @mock.patch(
+        "time.perf_counter_ns",
+        new=mock.MagicMock(side_effect=[28000000000000, 29000000000000]),
+    )
+    def test_timer(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key_avg",
+                "entity": "default.entity",
+                "key": "prefix.time_ms",
+                "value": 1000000,
+            }
+        )
+
+        # Act
+        with self.svc.timer("entity", "prefix"):
+            pass
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -52,3 +52,20 @@ class TestSimpleMetricService(TestCase):
 
         # Assert
         self.logger.info.assert_called_once_with(expected_dump)
+
+    def test_bump_entity_key_avg_custom_value(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key_avg",
+                "entity": "default.entity",
+                "key": "key",
+                "value": 123,
+            }
+        )
+
+        # Act
+        self.svc.bump_entity_key_avg("entity", "key", 123)
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -314,6 +314,24 @@ class PrivateComputationInstance(InstanceBase):
                 f"Updating status of {self.infra_config.instance_id} from {old_status} to {self.infra_config.status} at time {self.infra_config.status_update_ts}"
             )
 
+    def get_status_elapsed_time(
+        self,
+        start_status: PrivateComputationInstanceStatus,
+        end_status: PrivateComputationInstanceStatus,
+    ) -> int:
+        start_update_ts = end_update_ts = 0
+        # reversed traverse from the last stage status
+        for status_update in reversed(self.infra_config.status_updates):
+            if start_status is status_update.status:
+                start_update_ts = status_update.status_update_ts
+            if end_status is status_update.status:
+                end_update_ts = status_update.status_update_ts
+
+        if start_update_ts and end_update_ts:
+            return end_update_ts - start_update_ts
+
+        return -1
+
     @property
     def server_ips(self) -> List[str]:
         server_ips_list = []

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -400,6 +400,18 @@ class PrivateComputationService:
             new_status = stage_svc.get_status(private_computation_instance)
             private_computation_instance.update_status(new_status, self.logger)
             self.instance_repository.update(private_computation_instance)
+            if private_computation_instance.stage_flow.is_completed_status(new_status):
+                stage_elapsed_time = (
+                    private_computation_instance.get_status_elapsed_time(
+                        start_status=stage.initialized_status, end_status=new_status
+                    )
+                )
+                self.metric_svc.bump_entity_key_avg(
+                    PCSERVICE_ENTITY_NAME,
+                    f"{stage.name}.time_ms",
+                    stage_elapsed_time * 1000,
+                )
+
         except ThrottlingError as e:
             self.logger.warning(
                 f"Got ThrottlingError when updating instance. Skipping update! Error: {e}"

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -500,11 +500,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         )
 
         before_end_time = time.time()
+        before_update_time = private_computation_instance.infra_config.status_update_ts
         private_computation_instance.update_status(
             private_computation_instance.stage_flow.get_last_stage().completed_status,
             logging.getLogger(),
         )
         after_end_time = time.time()
+        after_update_time = private_computation_instance.infra_config.status_update_ts
         # We have this somewhat complicated assert because `time.time` will be called
         # multiple times inside the `update_status` statement and don't want any
         # *really* specific testing like "end_ts = time.time() + 2" since that would
@@ -522,6 +524,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             expected_elapsed_time,
             private_computation_instance.elapsed_time,
+        )
+        self.assertEqual(
+            private_computation_instance.get_status_elapsed_time(
+                start_status=PrivateComputationInstanceStatus.COMPUTATION_COMPLETED,
+                end_status=private_computation_instance.stage_flow.get_last_stage().completed_status,
+            ),
+            after_update_time - before_update_time,
         )
 
     def test_update_instance_throttling_error(self) -> None:


### PR DESCRIPTION
Summary:
## Why
Having timer contextmanager help to easy time the calls to have metrics
## What
as title

Differential Revision: D41008482

