### PR TITLE
Minor fixes to UDP binary and PCS layer to enable concurrency

### DIFF
--- a/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h
+++ b/fbpcs/emp_games/lift/metadata_compaction/MetadataCompactorApp_impl.h
@@ -18,10 +18,12 @@ namespace private_lift {
 
 template <int schedulerId>
 void MetadataCompactorApp<schedulerId>::run() {
+  // first communication agent created
   auto scheduler = createScheduler();
 
   auto metricsCollector = communicationAgentFactory_->getMetricsCollector();
 
+  // second communication agent created
   auto metadataCompactorGame =
       compactorGameFactory_->create(std::move(scheduler), party_);
 

--- a/fbpcs/emp_games/lift/metadata_compaction/main.cpp
+++ b/fbpcs/emp_games/lift/metadata_compaction/main.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <signal.h>
 #include <sstream>
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
@@ -30,6 +31,8 @@ int main(int argc, char** argv) {
   cost.start();
 
   fbpcf::AwsSdk::aquire();
+
+  signal(SIGPIPE, SIG_IGN);
 
   // since DEFINE_INT16 is not supported, cast int32_t FLAGS_concurrency to
   // int16_t is necessary here

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -80,9 +80,15 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
     GameNames.PCF2_LIFT_METADATA_COMPACTION.value: {
         "onedocker_package_name": OneDockerBinaryNames.PCF2_LIFT_METADATA_COMPACTION.value,
         "arguments": [
-            OneDockerArgument(name="input_path", required=True),
-            OneDockerArgument(name="output_global_params_path", required=True),
-            OneDockerArgument(name="output_secret_shares_path", required=True),
+            OneDockerArgument(name="input_path", required=False),
+            OneDockerArgument(name="output_global_params_path", required=False),
+            OneDockerArgument(name="output_secret_shares_path", required=False),
+            OneDockerArgument(name="input_base_path", required=False),
+            OneDockerArgument(name="output_global_params_base_path", required=False),
+            OneDockerArgument(name="output_secret_shares_base_path", required=False),
+            OneDockerArgument(name="file_start_index", required=False),
+            OneDockerArgument(name="num_files", required=False),
+            OneDockerArgument(name="concurrency", required=True),
             OneDockerArgument(name="epoch", required=False),
             OneDockerArgument(name="num_conversions_per_user", required=False),
             OneDockerArgument(name="compute_publisher_breakdowns", required=False),


### PR DESCRIPTION
Summary:
Some minor additions required to successfully E2E test the UDP flow

1. Add signal handler for SIGPIPE. This is received somewhere in the AWS sdk on this line https://fburl.com/code/ovkh3gll, and is out of our control.
2. Add arguments for concurrent execution of UDP files

Differential Revision: D41035816

