### PR TITLE
Update PCF2-PL components (UDP + Compute Stage) to support zero rows

### DIFF
--- a/fbpcs/emp_games/lift/common/GroupedLiftMetrics.cpp
+++ b/fbpcs/emp_games/lift/common/GroupedLiftMetrics.cpp
@@ -16,13 +16,6 @@
 
 namespace private_lift {
 
-GroupedLiftMetrics::GroupedLiftMetrics() {
-  // TODO: Uncomment the following lines once the Cohort and Publisher breakdown
-  // are implemented as MPC application.
-  //   cohortMetrics.resize(kNumDefaultCohorts);
-  //   publisherBreakdowns.resize(kNumPublisherBreakdown);
-}
-
 GroupedLiftMetrics::GroupedLiftMetrics(
     uint64_t numCohorts,
     uint64_t numPublisheBreakdown) {

--- a/fbpcs/emp_games/lift/common/GroupedLiftMetrics.h
+++ b/fbpcs/emp_games/lift/common/GroupedLiftMetrics.h
@@ -24,7 +24,7 @@ struct GroupedLiftMetrics {
   std::vector<LiftMetrics> cohortMetrics;
   std::vector<LiftMetrics> publisherBreakdowns;
 
-  GroupedLiftMetrics();
+  GroupedLiftMetrics() : metrics(), cohortMetrics(), publisherBreakdowns() {}
   GroupedLiftMetrics(uint64_t numCohorts, uint64_t numPublisheBreakdown);
 
   GroupedLiftMetrics(

--- a/fbpcs/emp_games/lift/common/LiftMetrics.h
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.h
@@ -34,7 +34,23 @@ struct LiftMetrics {
   std::vector<int64_t> testConvHistogram;
   std::vector<int64_t> controlConvHistogram;
 
-  LiftMetrics() {}
+  LiftMetrics()
+      : testConversions(0),
+        controlConversions(0),
+        testConverters(0),
+        controlConverters(0),
+        testValue(0),
+        controlValue(0),
+        testValueSquared(0),
+        controlValueSquared(0),
+        testNumConvSquared(0),
+        controlNumConvSquared(0),
+        testMatchCount(0),
+        controlMatchCount(0),
+        reachedConversions(0),
+        reachedValue(0),
+        testConvHistogram(),
+        controlConvHistogram() {}
 
   LiftMetrics(
       int64_t testConversions_,

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
@@ -47,7 +47,8 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
         inputData_{inputData},
         numConversionsPerUser_{numConversionsPerUser} {
     if (inputData.getNumRows() == 0) {
-      throw std::invalid_argument("Tried to process dataset with no rows");
+      liftGameProcessedData_ = {};
+      return;
     }
 
     liftGameProcessedData_.numRows = inputData.getNumRows();
@@ -61,6 +62,12 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
     auto unionMap = shuffleAndGetUnionMap();
 
     auto intersectionMap = getIntersectionMap(unionMap);
+
+    if (intersectionMap.size() == 0) {
+      liftGameProcessedData_ = {};
+      return;
+    }
+
     auto plaintextData = preparePlaintextData(unionMap);
 
     auto publisherPartnerJointMetadataShares =

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h
@@ -31,6 +31,12 @@ void LiftGameProcessedData<schedulerId>::writeToCSV(
   private_measurement::csv::writeCsv(
       globalParamsOutputPath, GLOBAL_PARAMS_HEADER, globalParams);
 
+  if (numRows == 0) {
+    private_measurement::csv::writeCsv(
+        secretSharesOutputPath, SECRET_SHARES_HEADER, {});
+    return;
+  }
+
   std::vector<std::vector<std::string>> secretShares(numRows);
 
   std::vector<uint64_t> opportunityTimestampsShares =

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/GenFakeData.cpp
@@ -182,6 +182,13 @@ void GenFakeData::genFakeInputFiles(
       // generate a random cohort id between 0 and numCohorts - 1
       int32_t randomCohortId =
           folly::Random::secureRand32(0, params.numCohorts_);
+
+      if (i == 0) {
+        // Artificially trick the synthetic data generator to assign at least
+        // one user to last cohort. In prod use case the partner should not have
+        // last cohort is empty, as that would imply numCohorts is 1 less value.
+        randomCohortId = params.numCohorts_ - 1;
+      }
       partnerLine += "," + std::to_string(randomCohortId);
     }
     partnerLine += '\n';


### PR DESCRIPTION
Summary: Followup to D40909773 (https://github.com/facebookresearch/fbpcs/commit/0a4bff61825c222ecaacd8195aee35de2e28f504) to fix non initialization of values. Not sure how these tests were passing before, we are getting some failures on other diffs.

Differential Revision: D41046302

