### PR TITLE
Consume cpu & memory in PCSContainerInstance

### DIFF
--- a/fbpcs/common/entity/pcs_container_instance.py
+++ b/fbpcs/common/entity/pcs_container_instance.py
@@ -17,6 +17,8 @@ from fbpcp.entity.container_instance import ContainerInstance
 @dataclass
 class PCSContainerInstance(ContainerInstance):
     log_url: Optional[str] = None
+    cpu: Optional[int] = None
+    memory: Optional[int] = None
 
     @classmethod
     def from_container_instance(
@@ -27,4 +29,6 @@ class PCSContainerInstance(ContainerInstance):
             ip_address=container_instance.ip_address,
             status=container_instance.status,
             log_url=log_url,
+            cpu=container_instance.cpu,
+            memory=container_instance.memory,
         )


### PR DESCRIPTION
Summary:
- Before the cpu & memory were None when using PCS to start containers (context: T137045537)
{F790502495}
- Consume them in PCSContainerInstance to solve this issue

Differential Revision: D41047556

