### PR TITLE
Close VPC retry peering modal automatically after a connection is successful & some other bug fixes

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
@@ -92,7 +92,9 @@ public class Validator {
     if (currentVPCsInThisRegion >= quota.getValue()) {
       return new ValidatorResult(
           false,
-          "VPC limit is at peek in this region, please choose another region or delete some unused VPC to continue deploy");
+          String.format(
+              "VPC limit is at peek in region %s . Contact your Meta representatives for more information if needed",
+              deploymentParams.region));
     }
 
     return new ValidatorResult(true, "VPC limit validation successful");


### PR DESCRIPTION
Summary:
Fixes:

1. Close VPC retry peering modal automatically after a connection is successful
2. Close a particular formContext, and add a TODO as formContext seems to not get cleared
3. Adds an error section once deploy start, as some error comes from deploy stage.
4. Added a header content to review and deploy page

UX alignment of error view in review and deploy state:
https://www.internalfb.com/intern/px/p/2jW0h/

Differential Revision: D41054723

