### PR TITLE
adding bump_num_times_called_and_error_count contextmanager in metric service

### DIFF
--- a/fbpcs/common/service/metric_service.py
+++ b/fbpcs/common/service/metric_service.py
@@ -18,3 +18,7 @@ class MetricService(abc.ABC):
     @abc.abstractmethod
     def bump_entity_key(self, entity: str, key: str, value: int = 1) -> None:
         pass
+
+    @abc.abstractmethod
+    def bump_entity_key_avg(self, entity: str, key: str, value: int = 1) -> None:
+        pass

--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -22,4 +22,10 @@ class SimpleMetricService(MetricService):
         self.logger.info(json.dumps(result))
 
     def bump_entity_key_avg(self, entity: str, key: str, value: int) -> None:
-        pass
+        result = {
+            "operation": "bump_entity_key_avg",
+            "entity": f"{self.category}.{entity}",
+            "key": key,
+            "value": value,
+        }
+        self.logger.info(json.dumps(result))

--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -20,3 +20,6 @@ class SimpleMetricService(MetricService):
             "value": value,
         }
         self.logger.info(json.dumps(result))
+
+    def bump_entity_key_avg(self, entity: str, key: str, value: int) -> None:
+        pass

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -69,3 +69,25 @@ class TestSimpleMetricService(TestCase):
 
         # Assert
         self.logger.info.assert_called_once_with(expected_dump)
+
+    @mock.patch(
+        "time.perf_counter_ns",
+        new=mock.MagicMock(side_effect=[28000000000000, 29000000000000]),
+    )
+    def test_timer(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key_avg",
+                "entity": "default.entity",
+                "key": "prefix.time_ms",
+                "value": 1000000,
+            }
+        )
+
+        # Act
+        with self.svc.timer("entity", "prefix"):
+            pass
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -52,3 +52,20 @@ class TestSimpleMetricService(TestCase):
 
         # Assert
         self.logger.info.assert_called_once_with(expected_dump)
+
+    def test_bump_entity_key_avg_custom_value(self) -> None:
+        # Arrange
+        expected_dump = json.dumps(
+            {
+                "operation": "bump_entity_key_avg",
+                "entity": "default.entity",
+                "key": "key",
+                "value": 123,
+            }
+        )
+
+        # Act
+        self.svc.bump_entity_key_avg("entity", "key", 123)
+
+        # Assert
+        self.logger.info.assert_called_once_with(expected_dump)

--- a/fbpcs/private_computation/entity/private_computation_instance.py
+++ b/fbpcs/private_computation/entity/private_computation_instance.py
@@ -314,6 +314,24 @@ class PrivateComputationInstance(InstanceBase):
                 f"Updating status of {self.infra_config.instance_id} from {old_status} to {self.infra_config.status} at time {self.infra_config.status_update_ts}"
             )
 
+    def get_status_elapsed_time(
+        self,
+        start_status: PrivateComputationInstanceStatus,
+        end_status: PrivateComputationInstanceStatus,
+    ) -> int:
+        start_update_ts = end_update_ts = 0
+        # reversed traverse from the last stage status
+        for status_update in reversed(self.infra_config.status_updates):
+            if start_status is status_update.status:
+                start_update_ts = status_update.status_update_ts
+            if end_status is status_update.status:
+                end_update_ts = status_update.status_update_ts
+
+        if start_update_ts and end_update_ts:
+            return end_update_ts - start_update_ts
+
+        return -1
+
     @property
     def server_ips(self) -> List[str]:
         server_ips_list = []

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -400,6 +400,18 @@ class PrivateComputationService:
             new_status = stage_svc.get_status(private_computation_instance)
             private_computation_instance.update_status(new_status, self.logger)
             self.instance_repository.update(private_computation_instance)
+            if private_computation_instance.stage_flow.is_completed_status(new_status):
+                stage_elapsed_time = (
+                    private_computation_instance.get_status_elapsed_time(
+                        start_status=stage.initialized_status, end_status=new_status
+                    )
+                )
+                self.metric_svc.bump_entity_key_avg(
+                    PCSERVICE_ENTITY_NAME,
+                    f"{stage.name}.time_ms",
+                    stage_elapsed_time * 1000,
+                )
+
         except ThrottlingError as e:
             self.logger.warning(
                 f"Got ThrottlingError when updating instance. Skipping update! Error: {e}"

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -36,6 +36,7 @@ from fbpcs.onedocker_service_config import OneDockerServiceConfig
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
     PrivateComputationGameType,
+    StatusUpdate,
     UnionedPCInstance,
 )
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
@@ -78,6 +79,7 @@ from fbpcs.private_computation.service.pid_shard_stage_service import (
 )
 
 from fbpcs.private_computation.service.private_computation import (
+    PCSERVICE_ENTITY_NAME,
     PrivateComputationService,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
@@ -399,6 +401,8 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
     @mock.patch("time.time", new=mock.MagicMock(side_effect=range(1, 100)))
     def test_update_instance(self) -> None:
+        mock_metric_svc = MagicMock()
+        self.private_computation_service.metric_svc = mock_metric_svc
         stage_state_instance = StageStateInstance(
             instance_id=self.test_private_computation_id,
             stage_name="test_stage",
@@ -452,9 +456,16 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             num_workers=2,
         )
 
+        initialized_time = int(time.time())
         private_computation_instance = self.create_sample_instance(
-            status=PrivateComputationInstanceStatus.COMPUTATION_STARTED,
+            status=PrivateComputationInstanceStatus.COMPUTATION_INITIALIZED,
             instances=[mpc_instance],
+            status_updates=[
+                StatusUpdate(
+                    status=PrivateComputationInstanceStatus.COMPUTATION_INITIALIZED,
+                    status_update_ts=initialized_time,
+                )
+            ],
         )
 
         updated_mpc_instance = mpc_instance
@@ -497,6 +508,15 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             time.time() - private_computation_instance.infra_config.creation_ts + 1,
             private_computation_instance.elapsed_time,
+        )
+        mock_metric_svc.bump_entity_key_avg.assert_called_with(
+            PCSERVICE_ENTITY_NAME,
+            f"{private_computation_instance.current_stage.name}.time_ms",
+            (
+                private_computation_instance.infra_config.status_update_ts
+                - initialized_time
+            )
+            * 1000,
         )
 
         before_end_time = time.time()
@@ -1256,6 +1276,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         role: PrivateComputationRole = PrivateComputationRole.PUBLISHER,
         instances: Optional[List[UnionedPCInstance]] = None,
         game_type: PrivateComputationGameType = PrivateComputationGameType.LIFT,
+        status_updates: Optional[List[StatusUpdate]] = None,
     ) -> PrivateComputationInstance:
         infra_config: InfraConfig = InfraConfig(
             instance_id=self.test_private_computation_id,
@@ -1268,7 +1289,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             num_mpc_containers=self.test_num_containers,
             num_files_per_mpc_container=NUM_NEW_SHARDS_PER_FILE,
             mpc_compute_concurrency=self.test_concurrency,
-            status_updates=[],
+            status_updates=status_updates or [],
             log_cost_bucket=self.log_cost_bucket,
             server_certificate=SAMPLE_SERVER_CERTIFICATE,
             ca_certificate=SAMPLE_CA_CERTIFICATE,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -500,11 +500,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         )
 
         before_end_time = time.time()
+        before_update_time = private_computation_instance.infra_config.status_update_ts
         private_computation_instance.update_status(
             private_computation_instance.stage_flow.get_last_stage().completed_status,
             logging.getLogger(),
         )
         after_end_time = time.time()
+        after_update_time = private_computation_instance.infra_config.status_update_ts
         # We have this somewhat complicated assert because `time.time` will be called
         # multiple times inside the `update_status` statement and don't want any
         # *really* specific testing like "end_ts = time.time() + 2" since that would
@@ -522,6 +524,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             expected_elapsed_time,
             private_computation_instance.elapsed_time,
+        )
+        self.assertEqual(
+            private_computation_instance.get_status_elapsed_time(
+                start_status=PrivateComputationInstanceStatus.COMPUTATION_COMPLETED,
+                end_status=private_computation_instance.stage_flow.get_last_stage().completed_status,
+            ),
+            after_update_time - before_update_time,
         )
 
     def test_update_instance_throttling_error(self) -> None:


### PR DESCRIPTION
Summary:
## Why
Having timer bump_num_times_called_and_error_count help to easy bump the calls to have metrics
## What
as title

Differential Revision: D41008555

