### PR TITLE
mpc_game.py migrate from fbpcp to fbpcs

### DIFF
--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -69,7 +69,9 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
         private_computation_instance_repo_patcher = patch(
             "fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository"
         )
-        mpc_game_svc_patcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        mpc_game_svc_patcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = container_svc_patcher.start()
         storage_svc = storage_svc_patcher.start()
         mpc_instance_repository = mpc_instance_repo_patcher.start()

--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -12,8 +12,6 @@ from unittest.mock import patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 
-from fbpcp.service.mpc import MPCService
-
 from fbpcp.service.onedocker import OneDockerService
 from fbpcs.bolt.bolt_client import BoltState
 
@@ -50,6 +48,8 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.service.errors import (
     PrivateComputationServiceValidationError,
 )
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation import (
     NUM_NEW_SHARDS_PER_FILE,
     PrivateComputationService,

--- a/fbpcs/infra/mr_pid/partner/config_mrpid.yml
+++ b/fbpcs/infra/mr_pid/partner/config_mrpid.yml
@@ -73,7 +73,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation/entity/pc_infra_config_data.py
+++ b/fbpcs/private_computation/entity/pc_infra_config_data.py
@@ -37,7 +37,7 @@ class PrivateComputationInfraConfigInfo(Enum):
     )
 
     MPC_GAME_SERVICE = PrivateComputationInfraConfigData(
-        "fbpcp.service.mpc_game.MPCGameService",
+        "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService",
         set(),
     )
 

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -9,7 +9,6 @@
 
 from typing import DefaultDict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -27,6 +26,8 @@ from fbpcs.private_computation.entity.product_config import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -10,7 +10,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -28,6 +27,8 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.pcf2_lift_stage_service import (
     PCF2LiftStageService,
 )

--- a/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_aggregation_stage_service.py
@@ -10,7 +10,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -27,6 +26,8 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )

--- a/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/decoupled_attribution_stage_service.py
@@ -10,7 +10,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -26,6 +25,8 @@ from fbpcs.private_computation.entity.product_config import (
     AttributionRule,
 )
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )

--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -17,9 +17,9 @@ from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.error.pcp import PcpError
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.util.typing import checked_cast
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 
 DEFAULT_BINARY_VERSION = "latest"
 

--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from fbpcp.entity.certificate_request import CertificateRequest
+
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcp.error.pcp import PcpError
+from fbpcp.repository.mpc_instance import MPCInstanceRepository
+from fbpcp.service.container import ContainerService
+from fbpcp.service.mpc_game import MPCGameService
+from fbpcp.service.onedocker import OneDockerService
+from fbpcp.util.typing import checked_cast
+
+DEFAULT_BINARY_VERSION = "latest"
+
+
+class MPCService:
+    """MPCService is responsible for distributing a larger MPC game to multiple
+    MPC workers
+    """
+
+    def __init__(
+        self,
+        container_svc: ContainerService,
+        instance_repository: MPCInstanceRepository,
+        task_definition: str,
+        mpc_game_svc: MPCGameService,
+    ) -> None:
+        """Constructor of MPCService
+        Keyword arguments:
+        container_svc -- service to spawn container instances
+        instance_repository -- repository to CRUD MPCInstance
+        task_definition -- containers task definition
+        mpc_game_svc -- service to generate package name and game arguments.
+        """
+        if container_svc is None or instance_repository is None or mpc_game_svc is None:
+            raise ValueError(
+                f"Dependency is missing. container_svc={container_svc}, mpc_game_svc={mpc_game_svc}, "
+                f"instance_repository={instance_repository}"
+            )
+
+        self.container_svc = container_svc
+        self.instance_repository = instance_repository
+        self.task_definition = task_definition
+        self.mpc_game_svc: MPCGameService = mpc_game_svc
+        self.logger: logging.Logger = logging.getLogger(__name__)
+
+        self.onedocker_svc = OneDockerService(self.container_svc, self.task_definition)
+
+    """
+    The game_args should be consistent with the game_config, which should be
+    defined in caller's game repository.
+
+    For example,
+    If the game config looks like this:
+
+    game_config = {
+    "game": {
+        "onedocker_package_name": "package_name",
+        "arguments": [
+            {"name": "input_filenames", "required": True},
+            {"name": "input_directory", "required": True},
+            {"name": "output_filenames", "required": True},
+            {"name": "output_directory", "required": True},
+            {"name": "concurrency", "required": True},
+        ],
+    },
+
+    The game args should look like this:
+    [
+        # 1st container
+        {
+            "input_filenames": input_path_1,
+            "input_directory": input_directory,
+            "output_filenames": output_path_1,
+            "output_directory": output_directory,
+            "concurrency": cocurrency,
+        },
+        # 2nd container
+        {
+            "input_filenames": input_path_2,
+            "input_directory": input_directory,
+            "output_filenames": output_path_2,
+            "output_directory": output_directory,
+            "concurrency": cocurrency,
+        },
+    ]
+    """
+
+    def create_instance(
+        self,
+        instance_id: str,
+        game_name: str,
+        mpc_party: MPCParty,
+        num_workers: int,
+        server_ips: Optional[List[str]] = None,
+        game_args: Optional[List[Dict[str, Any]]] = None,
+    ) -> MPCInstance:
+        self.logger.info(f"Creating MPC instance: {instance_id}")
+
+        instance = MPCInstance(
+            instance_id,
+            game_name,
+            mpc_party,
+            num_workers,
+            server_ips,
+            [],
+            MPCInstanceStatus.CREATED,
+            game_args,
+            [],
+        )
+
+        self.instance_repository.create(instance)
+        return instance
+
+    def start_instance(
+        self,
+        instance_id: str,
+        output_files: Optional[List[str]] = None,
+        server_ips: Optional[List[str]] = None,
+        timeout: Optional[int] = None,
+        version: str = DEFAULT_BINARY_VERSION,
+        env_vars: Optional[Dict[str, str]] = None,
+        certificate_request: Optional[CertificateRequest] = None,
+        wait_for_containers_to_start_up: bool = True,
+    ) -> MPCInstance:
+        return asyncio.run(
+            self.start_instance_async(
+                instance_id,
+                output_files,
+                server_ips,
+                timeout,
+                version,
+                env_vars,
+                certificate_request,
+                wait_for_containers_to_start_up,
+            )
+        )
+
+    async def start_instance_async(
+        self,
+        instance_id: str,
+        output_files: Optional[List[str]] = None,
+        server_ips: Optional[List[str]] = None,
+        timeout: Optional[int] = None,
+        version: str = DEFAULT_BINARY_VERSION,
+        env_vars: Optional[Dict[str, str]] = None,
+        certificate_request: Optional[CertificateRequest] = None,
+        wait_for_containers_to_start_up: bool = True,
+    ) -> MPCInstance:
+        """To run a distributed MPC game
+        Keyword arguments:
+        instance_id -- unique id to identify the MPC instance
+        """
+        instance = self.instance_repository.read(instance_id)
+        self.logger.info(f"Starting MPC instance: {instance_id}")
+
+        if instance.mpc_party is MPCParty.CLIENT and not server_ips:
+            raise ValueError("Missing server_ips")
+
+        existing_containers = instance.containers
+
+        containers_to_start = self.get_containers_to_start(
+            instance.num_workers, existing_containers
+        )
+
+        if containers_to_start:
+            # spin up containers
+            self.logger.info(f"Spinning up {len(containers_to_start)} containers")
+            self.logger.info(f"Containers to start: {containers_to_start}")
+            game_args = instance.game_args
+            new_pending_containers = await self._spin_up_containers_onedocker(
+                instance.game_name,
+                instance.mpc_party,
+                len(containers_to_start),
+                game_args=[game_args[i] for i in containers_to_start]
+                if game_args
+                else game_args,
+                ip_addresses=[server_ips[i] for i in containers_to_start]
+                if server_ips
+                else server_ips,
+                timeout=timeout,
+                version=version,
+                env_vars=env_vars,
+                certificate_request=certificate_request,
+                wait_for_containers_to_start_up=wait_for_containers_to_start_up,
+            )
+            instance.containers = self.get_pending_containers(
+                new_pending_containers, containers_to_start, existing_containers
+            )
+        else:
+            self.logger.info(
+                "No containers are in a failed state - skipping container start-up"
+            )
+
+        if len(instance.containers) != instance.num_workers:
+            self.logger.warning(
+                f"Instance {instance_id} has {len(instance.containers)} containers spun up, but expecting {instance.num_workers} containers!"
+            )
+
+        if wait_for_containers_to_start_up:
+            if instance.mpc_party is MPCParty.SERVER:
+                ip_addresses = [
+                    checked_cast(str, instance.ip_address)
+                    for instance in instance.containers
+                ]
+                instance.server_ips = ip_addresses
+
+            instance.status = MPCInstanceStatus.STARTED
+        else:
+            instance.status = MPCInstanceStatus.CREATED
+
+        self.instance_repository.update(instance)
+
+        return instance
+
+    def stop_instance(self, instance_id: str) -> MPCInstance:
+        instance = self.instance_repository.read(instance_id)
+        container_ids = [instance.instance_id for instance in instance.containers]
+        if container_ids:
+            errors = self.onedocker_svc.stop_containers(container_ids)
+            error_msg = list(filter(lambda _: _[1], zip(container_ids, errors)))
+
+            if error_msg:
+                self.logger.error(
+                    f"We encountered errors when stopping containers: {error_msg}"
+                )
+
+        instance.status = MPCInstanceStatus.CANCELED
+        self.instance_repository.update(instance)
+        self.logger.info(f"MPC instance {instance_id} has been successfully canceled.")
+
+        return instance
+
+    def get_instance(self, instance_id: str) -> MPCInstance:
+        self.logger.info(f"Getting MPC instance: {instance_id}")
+        return self.instance_repository.read(instance_id)
+
+    def update_instance(self, instance_id: str) -> MPCInstance:
+        instance = self.instance_repository.read(instance_id)
+
+        self.logger.info(f"Updating MPC instance: {instance_id}")
+
+        if instance.status in [
+            MPCInstanceStatus.COMPLETED,
+            MPCInstanceStatus.FAILED,
+            MPCInstanceStatus.CANCELED,
+        ]:
+            return instance
+
+        # skip if no containers registered under instance yet
+        if instance.containers:
+            instance.containers = self._update_container_instances(instance.containers)
+
+            if len(instance.containers) != instance.num_workers:
+                raise PcpError(
+                    f"Instance {instance_id} has {len(instance.containers)} containers after update, but expecting {instance.num_workers} containers!"
+                )
+
+            instance.status = self._get_instance_status(instance)
+            if (
+                instance.status is MPCInstanceStatus.STARTED
+                and instance.mpc_party is MPCParty.SERVER
+            ):
+                ip_addresses = [
+                    checked_cast(str, c.ip_address) for c in instance.containers
+                ]
+                instance.server_ips = ip_addresses
+
+            self.instance_repository.update(instance)
+
+        return instance
+
+    async def _spin_up_containers_onedocker(
+        self,
+        game_name: str,
+        mpc_party: MPCParty,
+        num_containers: int,
+        game_args: Optional[List[Dict[str, Any]]] = None,
+        ip_addresses: Optional[List[str]] = None,
+        timeout: Optional[int] = None,
+        version: str = DEFAULT_BINARY_VERSION,
+        env_vars: Optional[Dict[str, str]] = None,
+        certificate_request: Optional[CertificateRequest] = None,
+        wait_for_containers_to_start_up: bool = True,
+    ) -> List[ContainerInstance]:
+        if game_args is not None and len(game_args) != num_containers:
+            raise ValueError(
+                "The number of containers is not consistent with the number of game argument dictionary."
+            )
+        if ip_addresses is not None and len(ip_addresses) != num_containers:
+            raise ValueError(
+                "The number of containers is not consistent with number of ip addresses."
+            )
+        cmd_tuple_list = []
+        for i in range(num_containers):
+            game_arg = game_args[i] if game_args is not None else {}
+            server_ip = ip_addresses[i] if ip_addresses is not None else None
+            cmd_tuple_list.append(
+                self.mpc_game_svc.build_onedocker_args(
+                    game_name=game_name,
+                    mpc_party=mpc_party,
+                    server_ip=server_ip,
+                    **game_arg,
+                )
+            )
+        cmd_args_list = [cmd_args for (package_name, cmd_args) in cmd_tuple_list]
+
+        containers = self.onedocker_svc.start_containers(
+            task_definition=self.task_definition,
+            package_name=cmd_tuple_list[0][0],
+            version=version,
+            cmd_args_list=cmd_args_list,
+            timeout=timeout,
+            env_vars=env_vars,
+            certificate_request=certificate_request,
+        )
+        if not wait_for_containers_to_start_up:
+            return containers
+
+        self.logger.info(
+            f"Waiting for {len(containers)} container(s) to become started"
+        )
+
+        return await self.onedocker_svc.wait_for_pending_containers(
+            [container.instance_id for container in containers]
+        )
+
+    def _update_container_instances(
+        self, containers: List[ContainerInstance]
+    ) -> List[ContainerInstance]:
+        ids = [container.instance_id for container in containers]
+        return list(
+            filter(
+                None,
+                map(
+                    self._get_updated_container,
+                    # TODO APIs of OneDocker service should be called here
+                    self.container_svc.get_instances(ids),
+                    containers,
+                ),
+            )
+        )
+
+    def _get_updated_container(
+        self,
+        queried_instance: Optional[ContainerInstance],
+        existing_instance: ContainerInstance,
+    ) -> Optional[ContainerInstance]:
+        # 1. If ECS returns an instance, return the instance to callers
+        # 2. If ECS could not find an instance and the status of existing instance is not stopped, return None to callers
+        # 3. If ECS cound not find an instance and the status of existing instance is stopped, return the existing instance to callers.
+        if queried_instance:
+            return queried_instance
+        elif existing_instance.status not in [
+            ContainerInstanceStatus.COMPLETED,
+            ContainerInstanceStatus.FAILED,
+        ]:
+            self.logger.error(
+                f"The unstopped container instance {existing_instance.instance_id} is missing from Cloud. None is returned to callers."
+            )
+            return queried_instance
+        else:
+            self.logger.info(
+                f"The stopped container instance {existing_instance.instance_id} is missing from Cloud. The existing container instance is returned."
+            )
+            return existing_instance
+
+    def _get_instance_status(self, instance: MPCInstance) -> MPCInstanceStatus:
+        if instance.status is MPCInstanceStatus.CANCELED:
+            return instance.status
+        status = MPCInstanceStatus.COMPLETED
+
+        for container in instance.containers:
+            if container.status == ContainerInstanceStatus.FAILED:
+                return MPCInstanceStatus.FAILED
+            if container.status == ContainerInstanceStatus.UNKNOWN:
+                return MPCInstanceStatus.UNKNOWN
+            if container.status == ContainerInstanceStatus.STARTED:
+                status = MPCInstanceStatus.STARTED
+
+        return status
+
+    @classmethod
+    def get_containers_to_start(
+        cls,
+        num_containers: int,
+        existing_containers: Optional[List[ContainerInstance]] = None,
+    ) -> List[int]:
+        if not existing_containers:
+            # if there are no existing containers, we need to spin containers up for
+            # every command
+            return list(range(num_containers))
+
+        if num_containers != len(existing_containers):
+            raise ValueError(
+                "Cannot retry stage - list of existing containers is not consistent with number of requested containers"
+            )
+
+        # only start containers that previously failed
+        return [
+            i
+            for i, container in enumerate(existing_containers)
+            if container.status is ContainerInstanceStatus.FAILED
+        ]
+
+    @classmethod
+    def get_pending_containers(
+        cls,
+        new_pending_containers: List[ContainerInstance],
+        containers_to_start: List[int],
+        existing_containers: Optional[List[ContainerInstance]] = None,
+    ) -> List[ContainerInstance]:
+        if not existing_containers:
+            return new_pending_containers
+
+        pending_containers = existing_containers.copy()
+        for i, new_pending_container in zip(
+            containers_to_start, new_pending_containers
+        ):
+            # replace existing container with the new pending container
+            pending_containers[i] = new_pending_container
+
+        return pending_containers

--- a/fbpcs/private_computation/service/mpc/mpc_game.py
+++ b/fbpcs/private_computation/service/mpc/mpc_game.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from fbpcp.entity.mpc_game_config import MPCGameConfig
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpcp.repository.mpc_game_repository import MPCGameRepository
+from fbpcp.util.arg_builder import build_cmd_args
+
+LIFT_GAME_NAME = "lift"
+LIFT_AGGREGATOR_GAME_NAME = "aggregator"
+
+
+class MPCGameService:
+    def __init__(self, mpc_game_repository: MPCGameRepository) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
+        self.mpc_game_repository: MPCGameRepository = mpc_game_repository
+
+    # returns package_name and cmd which includes only arguments (no executable)
+    def build_onedocker_args(
+        self,
+        game_name: str,
+        mpc_party: MPCParty,
+        server_ip: Optional[str] = None,
+        port: Optional[int] = None,
+        **kwargs: object,
+    ) -> Tuple[str, str]:
+        mpc_game_config = self.mpc_game_repository.get_game(game_name)
+        return (
+            mpc_game_config.onedocker_package_name,
+            self._build_cmd(
+                mpc_game_config=mpc_game_config,
+                mpc_party=mpc_party,
+                server_ip=server_ip,
+                port=port,
+                **kwargs,
+            ),
+        )
+
+    # returns cmd which includes only arguments (no executable)
+    def _build_cmd(
+        self,
+        mpc_game_config: MPCGameConfig,
+        mpc_party: MPCParty,
+        server_ip: Optional[str] = None,
+        port: Optional[int] = None,
+        **kwargs: object,
+    ) -> str:
+        args = self._prepare_args(
+            mpc_game_config=mpc_game_config,
+            mpc_party=mpc_party,
+            server_ip=server_ip,
+            port=port,
+            **kwargs,
+        )
+        return build_cmd_args(**args)
+
+    def _prepare_args(
+        self,
+        mpc_game_config: MPCGameConfig,
+        mpc_party: MPCParty,
+        server_ip: Optional[str] = None,
+        port: Optional[int] = None,
+        **kwargs: object,
+    ) -> Dict[str, Any]:
+        all_arguments: Dict[str, Any] = {}
+
+        # push MPC required arguments to dict all_arguments
+        all_arguments["party"] = 1 if mpc_party == MPCParty.SERVER else 2
+
+        if mpc_party == MPCParty.CLIENT:
+            if server_ip is None:
+                raise ValueError("Client must provide a server ip address.")
+            all_arguments["server_ip"] = server_ip
+        if port is not None:
+            all_arguments["port"] = port
+
+        # push game specific arguments to dict all_arguments
+        for argument in mpc_game_config.arguments:
+            key = argument.name
+            value = kwargs.get(key)
+            if value is None and argument.required:
+                # Have to make game_name a special case for PL-Worker
+                if key == "game_name":
+                    all_arguments[key] = mpc_game_config.game_name
+                else:
+                    raise ValueError(f"Missing required argument {key}!")
+            if value is not None:
+                all_arguments[key] = value
+
+        return all_arguments

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -10,7 +10,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -30,6 +29,8 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -10,7 +10,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -29,6 +28,8 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )

--- a/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
@@ -9,7 +9,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -29,6 +28,7 @@ from fbpcs.private_computation.service.constants import (
     DEFAULT_PADDING_SIZE,
 )
 
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -10,7 +10,6 @@
 import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -33,6 +32,8 @@ from fbpcs.private_computation.service.constants import (
     DEFAULT_LOG_COST_TO_S3,
     DEFAULT_PADDING_SIZE,
 )
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,
 )

--- a/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_shard_combiner_stage_service.py
@@ -10,7 +10,6 @@ import logging
 
 from typing import DefaultDict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -29,6 +28,8 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -15,7 +15,6 @@ from typing import Any, DefaultDict, Dict, List, Optional, Set, Type, TypeVar, U
 from fbpcp.entity.container_instance import ContainerInstanceStatus
 from fbpcp.entity.mpc_instance import MPCInstance
 from fbpcp.error.pcp import ThrottlingError
-from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
@@ -88,6 +87,7 @@ from fbpcs.private_computation.service.errors import (
     PrivateComputationServiceInvalidStageError,
     PrivateComputationServiceValidationError,
 )
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.pid_utils import (
     get_max_id_column_cnt,
     get_pid_protocol_from_num_shards,

--- a/fbpcs/private_computation/service/private_computation_stage_service.py
+++ b/fbpcs/private_computation/service/private_computation_stage_service.py
@@ -10,7 +10,6 @@ import abc
 from dataclasses import dataclass
 from typing import DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.service.metric_service import MetricService
@@ -23,6 +22,8 @@ from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
 )
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.service.workflow import WorkflowService
 
 

--- a/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
@@ -9,7 +9,6 @@
 
 from typing import DefaultDict, List, Optional
 
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -21,6 +20,8 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -13,10 +13,10 @@ from typing import Dict, List, Optional
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import ThrottlingError
-from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.service.retry_handler import RetryHandler
 from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 DEFAULT_WAIT_FOR_CONTAINER_POLL = 5
 

--- a/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
+++ b/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
@@ -8,8 +8,6 @@ import logging
 import math
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from fbpcp.service.mpc import MPCService
-
 from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
@@ -22,6 +20,8 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 )
 from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
 from fbpcs.private_computation.service.private_computation_service_data import (
     PrivateComputationServiceData,

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -215,6 +215,19 @@ def get_pc_status_from_stage_state(
     return status
 
 
+# pyre-ignore return typing
+def deprecated_msg(msg: str):
+    warning_color = "\033[93m"  # orange/yellow ascii escape sequence
+    end = "\033[0m"  # end ascii escape sequence
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        f"{warning_color}{msg}{end}",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)
+
+
 # decorators are a serious pain to add typing for, so I'm not going to bother...
 # pyre-ignore return typing
 def deprecated(reason: str):
@@ -224,22 +237,10 @@ def deprecated(reason: str):
 
     # pyre-ignore return typing
     def wrap(func):
-        warning_color = "\033[93m"  # orange/yellow ascii escape sequence
-        end = "\033[0m"  # end ascii escape sequence
-        explanation: str = (
-            f"{warning_color}{func.__name__} is deprecated! explanation: {reason}{end}"
-        )
-
         @functools.wraps(func)
         # pyre-ignore typing on args, kwargs, and return
         def wrapped(*args, **kwargs):
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn(
-                explanation,
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            warnings.simplefilter("default", DeprecationWarning)
+            deprecated_msg(msg=f"{func.__name__} is deprecated! explanation: {reason}")
             return func(*args, **kwargs)
 
         return wrapped

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Optional
 
 from fbpcp.entity.certificate_request import CertificateRequest
 from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
-from fbpcp.service.mpc import MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
@@ -35,6 +34,7 @@ from fbpcs.private_computation.service.constants import (
     SERVER_CERTIFICATE_ENV_VAR,
     SERVER_CERTIFICATE_PATH_ENV_VAR,
 )
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
 
 

--- a/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_config.yml
+++ b/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_config.yml
@@ -40,7 +40,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_override_config.yml
+++ b/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_override_config.yml
@@ -35,7 +35,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation/test/service/mpc/test_mpc.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc.py
@@ -40,7 +40,9 @@ class TestMPCService(IsolatedAsyncioTestCase):
     def setUp(self):
         cspatcher = patch("fbpcp.service.container.ContainerService")
         irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
-        gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        gspatcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = cspatcher.start()
         instance_repository = irpatcher.start()
         mpc_game_svc = gspatcher.start()

--- a/fbpcs/private_computation/test/service/mpc/test_mpc.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
+from fbpcs.private_computation.service.mpc.mpc import MPCService
+
+
+TEST_INSTANCE_ID = "123"
+TEST_GAME_NAME = "lift"
+TEST_MPC_ROLE = MPCParty.SERVER
+TEST_NUM_WORKERS = 1
+TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
+TEST_INPUT_ARGS = "test_input_file"
+TEST_OUTPUT_ARGS = "test_output_file"
+TEST_CONCURRENCY_ARGS = 1
+TEST_INPUT_DIRECTORY = "TEST_INPUT_DIRECTORY/"
+TEST_OUTPUT_DIRECTORY = "TEST_OUTPUT_DIRECTORY/"
+TEST_TASK_DEFINITION = "test_task_definition"
+INPUT_DIRECTORY = "input_directory"
+OUTPUT_DIRECTORY = "output_directory"
+GAME_ARGS = [
+    {
+        "input_filenames": TEST_INPUT_ARGS,
+        "input_directory": TEST_INPUT_DIRECTORY,
+        "output_filenames": TEST_OUTPUT_ARGS,
+        "output_directory": TEST_OUTPUT_DIRECTORY,
+        "concurrency": TEST_CONCURRENCY_ARGS,
+    }
+]
+
+
+class TestMPCService(IsolatedAsyncioTestCase):
+    def setUp(self):
+        cspatcher = patch("fbpcp.service.container.ContainerService")
+        irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
+        gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        container_svc = cspatcher.start()
+        instance_repository = irpatcher.start()
+        mpc_game_svc = gspatcher.start()
+        for patcher in (cspatcher, irpatcher, gspatcher):
+            self.addCleanup(patcher.stop)
+        self.mpc_service = MPCService(
+            container_svc,
+            instance_repository,
+            "test_task_definition",
+            mpc_game_svc,
+        )
+
+    @staticmethod
+    def _get_sample_mpcinstance():
+        return MPCInstance(
+            TEST_INSTANCE_ID,
+            TEST_GAME_NAME,
+            TEST_MPC_ROLE,
+            TEST_NUM_WORKERS,
+            TEST_SERVER_IPS,
+            [],
+            MPCInstanceStatus.CREATED,
+            GAME_ARGS,
+            [],
+        )
+
+    @staticmethod
+    def _get_sample_mpcinstance_with_game_args():
+        return MPCInstance(
+            TEST_INSTANCE_ID,
+            TEST_GAME_NAME,
+            TEST_MPC_ROLE,
+            TEST_NUM_WORKERS,
+            TEST_SERVER_IPS,
+            [],
+            MPCInstanceStatus.CREATED,
+            GAME_ARGS,
+            [],
+        )
+
+    @staticmethod
+    def _get_sample_mpcinstance_client():
+        return MPCInstance(
+            TEST_INSTANCE_ID,
+            TEST_GAME_NAME,
+            MPCParty.CLIENT,
+            TEST_NUM_WORKERS,
+            TEST_SERVER_IPS,
+            [],
+            MPCInstanceStatus.CREATED,
+            GAME_ARGS,
+            [],
+        )
+
+    async def test_spin_up_containers_onedocker_inconsistent_arguments(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "The number of containers is not consistent with the number of game argument dictionary.",
+        ):
+            await self.mpc_service._spin_up_containers_onedocker(
+                game_name=TEST_GAME_NAME,
+                mpc_party=MPCParty.SERVER,
+                num_containers=TEST_NUM_WORKERS,
+                game_args=[],
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "The number of containers is not consistent with number of ip addresses.",
+        ):
+            await self.mpc_service._spin_up_containers_onedocker(
+                game_name=TEST_GAME_NAME,
+                mpc_party=MPCParty.CLIENT,
+                num_containers=TEST_NUM_WORKERS,
+                ip_addresses=TEST_SERVER_IPS,
+            )
+
+    def test_create_instance_with_game_args(self):
+        self.mpc_service.create_instance(
+            instance_id=TEST_INSTANCE_ID,
+            game_name=TEST_GAME_NAME,
+            mpc_party=TEST_MPC_ROLE,
+            num_workers=TEST_NUM_WORKERS,
+            server_ips=TEST_SERVER_IPS,
+            game_args=GAME_ARGS,
+        )
+        self.mpc_service.instance_repository.create.assert_called()
+        self.assertEqual(
+            self._get_sample_mpcinstance_with_game_args(),
+            self.mpc_service.instance_repository.create.call_args[0][0],
+        )
+
+    def test_create_instance(self):
+        self.mpc_service.create_instance(
+            instance_id=TEST_INSTANCE_ID,
+            game_name=TEST_GAME_NAME,
+            mpc_party=TEST_MPC_ROLE,
+            num_workers=TEST_NUM_WORKERS,
+            server_ips=TEST_SERVER_IPS,
+            game_args=GAME_ARGS,
+        )
+        # check that instance with correct instance_id was created
+        self.mpc_service.instance_repository.create.assert_called()
+        self.assertEqual(
+            self._get_sample_mpcinstance(),
+            self.mpc_service.instance_repository.create.call_args[0][0],
+        )
+
+    def _read_side_effect_start(self, instance_id: str):
+        """mock MPCInstanceRepository.read for test_start"""
+        if instance_id == TEST_INSTANCE_ID:
+            return self._get_sample_mpcinstance()
+        else:
+            raise RuntimeError(f"{instance_id} does not exist")
+
+    def test_start_instance(self):
+        self.mpc_service.instance_repository.read = MagicMock(
+            side_effect=self._read_side_effect_start
+        )
+        created_instances = [
+            ContainerInstance(
+                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68",  # noqa
+                "10.0.1.130",
+                ContainerInstanceStatus.STARTED,
+            )
+        ]
+        self.mpc_service.onedocker_svc.start_containers = MagicMock(
+            return_value=created_instances
+        )
+        self.mpc_service.onedocker_svc.wait_for_pending_containers = AsyncMock(
+            return_value=created_instances
+        )
+        built_onedocker_args = ("private_lift/lift", "test one docker arguments")
+        self.mpc_service.mpc_game_svc.build_onedocker_args = MagicMock(
+            return_value=built_onedocker_args
+        )
+        # check that update is called with correct status
+        self.mpc_service.start_instance(TEST_INSTANCE_ID)
+        self.mpc_service.instance_repository.update.assert_called()
+        latest_update = self.mpc_service.instance_repository.update.call_args_list[-1]
+        updated_status = latest_update[0][0].status
+        self.assertEqual(updated_status, MPCInstanceStatus.STARTED)
+
+    def test_start_instance_missing_ips(self):
+        self.mpc_service.instance_repository.read = MagicMock(
+            return_value=self._get_sample_mpcinstance_client()
+        )
+        # Exception because role is client but server ips are not given
+        with self.assertRaises(ValueError):
+            self.mpc_service.start_instance(TEST_INSTANCE_ID)
+
+    def test_start_instance_skip_start_up(self):
+        # prep
+        self.mpc_service.instance_repository.read = MagicMock(
+            side_effect=self._read_side_effect_start
+        )
+        created_instances = [
+            ContainerInstance(
+                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68",  # noqa
+                None,
+                ContainerInstanceStatus.UNKNOWN,
+            )
+        ]
+        self.mpc_service.onedocker_svc.start_containers = MagicMock(
+            return_value=created_instances
+        )
+        self.mpc_service.onedocker_svc.wait_for_pending_containers = AsyncMock()
+        built_onedocker_args = ("private_lift/lift", "test one docker arguments")
+        self.mpc_service.mpc_game_svc.build_onedocker_args = MagicMock(
+            return_value=built_onedocker_args
+        )
+        # check that update is called with correct status
+        self.mpc_service.start_instance(
+            instance_id=TEST_INSTANCE_ID, wait_for_containers_to_start_up=False
+        )
+        # asserts
+        self.mpc_service.onedocker_svc.wait_for_pending_containers.assert_not_called()
+        self.mpc_service.instance_repository.update.assert_called()
+        latest_update = self.mpc_service.instance_repository.update.call_args_list[-1]
+        updated_status = latest_update[0][0].status
+        self.assertEqual(updated_status, MPCInstanceStatus.CREATED)
+
+    def _read_side_effect_update(self, instance_id):
+        """
+        mock MPCInstanceRepository.read for test_update,
+        with instance.containers is not None
+        """
+        if instance_id == TEST_INSTANCE_ID:
+            mpc_instance = self._get_sample_mpcinstance()
+        else:
+            raise RuntimeError(f"{instance_id} does not exist")
+
+        mpc_instance.status = MPCInstanceStatus.STARTED
+        mpc_instance.containers = [
+            ContainerInstance(
+                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68",  # noqa
+                "10.0.1.130",
+                ContainerInstanceStatus.STARTED,
+            )
+        ]
+        return mpc_instance
+
+    def test_update_instance(self):
+        self.mpc_service.instance_repository.read = MagicMock(
+            side_effect=self._read_side_effect_update
+        )
+        container_instances = [
+            ContainerInstance(
+                "arn:aws:ecs:us-west-1:592513842793:task/cd34aed2-321f-49d1-8641-c54baff8b77b",  # noqa
+                "10.0.1.130",
+                ContainerInstanceStatus.STARTED,
+            )
+        ]
+        self.mpc_service.container_svc.get_instances = MagicMock(
+            return_value=container_instances
+        )
+        self.mpc_service.update_instance(TEST_INSTANCE_ID)
+        self.mpc_service.instance_repository.update.assert_called()
+
+    def test_update_instance_from_unknown(self):
+        # prep
+        mpc_instance = self._get_sample_mpcinstance()
+        mpc_instance.containers = [
+            ContainerInstance(
+                "arn:aws:ecs:us-west-1:592513842793:task/cd34aed2-321f-49d1-8641-c54baff8b77b",  # noqa
+                None,
+                ContainerInstanceStatus.UNKNOWN,
+            )
+        ]
+        self.mpc_service.instance_repository.read = MagicMock(return_value=mpc_instance)
+        updated_container_instances = [
+            ContainerInstance(
+                "arn:aws:ecs:us-west-1:592513842793:task/cd34aed2-321f-49d1-8641-c54baff8b77b",  # noqa
+                "10.0.1.130",
+                ContainerInstanceStatus.STARTED,
+            )
+        ]
+        self.mpc_service.container_svc.get_instances = MagicMock(
+            return_value=updated_container_instances
+        )
+        # act
+        self.mpc_service.update_instance(TEST_INSTANCE_ID)
+        # asserts
+        self.mpc_service.instance_repository.update.assert_called()
+        latest_update = self.mpc_service.instance_repository.update.call_args_list[-1]
+        updated_instance = latest_update[0][0]
+        self.assertEqual(updated_instance.status, MPCInstanceStatus.STARTED)
+        self.assertEqual(updated_instance.server_ips, ["10.0.1.130"])
+
+    def test_stop_instance(self):
+        self.mpc_service.instance_repository.read = MagicMock(
+            side_effect=self._read_side_effect_update
+        )
+        self.mpc_service.onedocker_svc.stop_containers = MagicMock(return_value=[None])
+        mpc_instance = self.mpc_service.stop_instance(TEST_INSTANCE_ID)
+        self.mpc_service.onedocker_svc.stop_containers.assert_called_with(
+            [
+                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68"
+            ]
+        )
+        expected_mpc_instance = self._read_side_effect_update(TEST_INSTANCE_ID)
+        expected_mpc_instance.status = MPCInstanceStatus.CANCELED
+        self.assertEqual(expected_mpc_instance, mpc_instance)
+        self.mpc_service.instance_repository.update.assert_called_with(
+            expected_mpc_instance
+        )
+
+    def test_get_updated_instance(self):
+        # Arrange
+        queried_container = ContainerInstance(
+            TEST_INSTANCE_ID,  # noqa
+            TEST_SERVER_IPS[0],
+            ContainerInstanceStatus.COMPLETED,
+        )
+        existing_container_started = ContainerInstance(
+            TEST_INSTANCE_ID,
+            TEST_SERVER_IPS[0],
+            ContainerInstanceStatus.STARTED,
+        )
+        existing_container_completed = ContainerInstance(
+            TEST_INSTANCE_ID,
+            TEST_SERVER_IPS[0],
+            ContainerInstanceStatus.COMPLETED,
+        )
+
+        # Act and Assert
+        self.assertEqual(
+            queried_container,
+            self.mpc_service._get_updated_container(
+                queried_container, existing_container_started
+            ),
+        )
+        self.assertIsNone(
+            self.mpc_service._get_updated_container(None, existing_container_started)
+        )
+        self.assertEqual(
+            existing_container_completed,
+            self.mpc_service._get_updated_container(None, existing_container_completed),
+        )
+
+    def test_get_containers_to_start_no_existing_containers(self) -> None:
+        for num_containers in range(2):
+            with self.subTest(num_containers=num_containers):
+                containers_to_start = self.mpc_service.get_containers_to_start(
+                    num_containers
+                )
+                self.assertEqual(containers_to_start, list(range(num_containers)))
+
+    def test_get_containers_to_start_existing_containers(self) -> None:
+        for existing_statuses in (
+            (ContainerInstanceStatus.FAILED,),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.FAILED,
+            ),
+            (
+                ContainerInstanceStatus.FAILED,
+                ContainerInstanceStatus.COMPLETED,
+            ),
+            (
+                ContainerInstanceStatus.STARTED,
+                ContainerInstanceStatus.FAILED,
+            ),
+        ):
+            # expect to start only the failed containers
+            expected_result = [
+                i
+                for i, status in enumerate(existing_statuses)
+                if status is ContainerInstanceStatus.FAILED
+            ]
+            with self.subTest(
+                existing_statuses=existing_statuses, expected_result=expected_result
+            ):
+                containers_to_start = self.mpc_service.get_containers_to_start(
+                    len(existing_statuses),
+                    [
+                        ContainerInstance("id", "ip", status)
+                        for status in existing_statuses
+                    ],
+                )
+                self.assertEqual(containers_to_start, expected_result)
+
+    def test_get_containers_to_start_invalid_args(self) -> None:
+        # expect failure because num of command arguments != number existing containers
+        with self.assertRaises(ValueError):
+            self.mpc_service.get_containers_to_start(
+                2,
+                [
+                    ContainerInstance("id", "ip", ContainerInstanceStatus.FAILED),
+                ],
+            )
+
+    def test_get_pending_containers(self) -> None:
+        for existing_statuses, containers_to_start in (
+            # no existing containers case
+            ((), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.FAILED), [0, 1]),
+            ((ContainerInstanceStatus.FAILED, ContainerInstanceStatus.STARTED), [0]),
+            ((ContainerInstanceStatus.STARTED, ContainerInstanceStatus.FAILED), [1]),
+        ):
+            existing_containers = [
+                ContainerInstance(str(i), "ip", status)
+                for i, status in enumerate(existing_statuses)
+            ]
+            new_pending_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in containers_to_start
+            ]
+            expected_containers = [
+                ContainerInstance(str(i), "ip", ContainerInstanceStatus.STARTED)
+                for i in range(2)
+            ]
+
+            with self.subTest(
+                new_pending_containers=new_pending_containers,
+                containers_to_start=containers_to_start,
+                existing_containers=existing_containers,
+            ):
+                pending_containers = self.mpc_service.get_pending_containers(
+                    new_pending_containers, containers_to_start, existing_containers
+                )
+                self.assertEqual(pending_containers, expected_containers)

--- a/fbpcs/private_computation/test/service/mpc/test_mpc_game.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc_game.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import List
+from unittest.mock import MagicMock, Mock
+
+from fbpcp.entity.mpc_game_config import MPCGameArgument, MPCGameConfig
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
+
+
+INPUT_DIRECTORY = "input_directory"
+OUTPUT_DIRECTORY = "output_directory"
+INPUT_PATH_1 = "input_path_1"
+INPUT_PATH_2 = "input_path_2"
+OUTPUT_PATH_1 = "out_path_1"
+OUTPUT_PATH_2 = "out_path_2"
+CONCURRENCY = 2
+GAME_NAME = "test_game"
+ONEDOCKER_PACKAGE_NAME = "onedocker_package/package_name"
+
+GAME_CONFIG = {
+    GAME_NAME: {
+        "onedocker_package_name": ONEDOCKER_PACKAGE_NAME,
+        "arguments": [
+            {"name": "input_filenames", "required": True},
+            {"name": "input_directory", "required": True},
+            {"name": "output_filenames", "required": True},
+            {"name": "output_directory", "required": True},
+            {"name": "concurrency", "required": True},
+        ],
+    }
+}
+
+
+class TestMPCGameService(unittest.TestCase):
+    def setUp(self):
+        game_repository = Mock()
+        self.mpc_game_svc = MPCGameService(game_repository)
+        arguments: List[MPCGameArgument] = [
+            MPCGameArgument(name=argument["name"], required=argument["required"])
+            for argument in GAME_CONFIG[GAME_NAME]["arguments"]
+        ]
+        self.mpc_game_config = MPCGameConfig(
+            game_name=GAME_NAME,
+            onedocker_package_name=GAME_CONFIG[GAME_NAME]["onedocker_package_name"],
+            arguments=arguments,
+        )
+        self.mpc_game_svc.mpc_game_repository.get_game = MagicMock(
+            return_value=self.mpc_game_config
+        )
+
+    def test_prepare_args(self):
+        self.assertEqual(
+            self.mpc_game_svc._prepare_args(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.CLIENT,
+                server_ip="192.0.2.0",
+                port=12345,
+                input_filenames=INPUT_PATH_1,
+                input_directory=INPUT_DIRECTORY,
+                output_filenames=OUTPUT_PATH_1,
+                output_directory=OUTPUT_DIRECTORY,
+                concurrency=CONCURRENCY,
+            ),
+            {
+                "party": 2,
+                "server_ip": "192.0.2.0",
+                "port": 12345,
+                "input_filenames": INPUT_PATH_1,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_1,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+        )
+
+    def test_prepare_args_with_optional_arg(self):
+        self.assertEqual(
+            self.mpc_game_svc._prepare_args(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.SERVER,
+                input_filenames=INPUT_PATH_1,
+                input_directory=INPUT_DIRECTORY,
+                output_filenames=OUTPUT_PATH_1,
+                output_directory=OUTPUT_DIRECTORY,
+                concurrency=CONCURRENCY,
+            ),
+            {
+                "party": 1,
+                "input_filenames": INPUT_PATH_1,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_1,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+        )
+
+    def test_prepare_args_with_missing_arg(self):
+        with self.assertRaisesRegex(
+            ValueError, "Missing required argument input_filenames!"
+        ):
+            self.mpc_game_svc._prepare_args(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.SERVER,
+                output_file=OUTPUT_PATH_1,
+            )
+
+    def test_build_cmd(self):
+        self.assertEqual(
+            self.mpc_game_svc._build_cmd(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.CLIENT,
+                server_ip="192.0.2.0",
+                port=12345,
+                input_filenames=INPUT_PATH_1,
+                input_directory=INPUT_DIRECTORY,
+                output_filenames=OUTPUT_PATH_1,
+                output_directory=OUTPUT_DIRECTORY,
+                concurrency=CONCURRENCY,
+            ),
+            f"--party=2 --server_ip=192.0.2.0 --port=12345 --input_filenames={INPUT_PATH_1} "
+            f"--input_directory={INPUT_DIRECTORY} --output_filenames={OUTPUT_PATH_1} "
+            f"--output_directory={OUTPUT_DIRECTORY} --concurrency={CONCURRENCY}",
+        )
+
+    def test_build_onedocker_args(self):
+        game_args = [
+            {
+                "input_filenames": INPUT_PATH_1,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_1,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+            {
+                "input_filenames": INPUT_PATH_2,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_2,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+        ]
+
+        expected_arguments = [
+            (
+                ONEDOCKER_PACKAGE_NAME,
+                f"--party=1 --input_filenames={INPUT_PATH_1} --input_directory={INPUT_DIRECTORY} "
+                f"--output_filenames={OUTPUT_PATH_1} --output_directory={OUTPUT_DIRECTORY} "
+                f"--concurrency={CONCURRENCY}",
+            ),
+            (
+                ONEDOCKER_PACKAGE_NAME,
+                f"--party=1 --input_filenames={INPUT_PATH_2} --input_directory={INPUT_DIRECTORY} "
+                f"--output_filenames={OUTPUT_PATH_2} --output_directory={OUTPUT_DIRECTORY} "
+                f"--concurrency={CONCURRENCY}",
+            ),
+        ]
+
+        for i in range(len(game_args)):
+            expected_argument = expected_arguments[i]
+            game_arg = game_args[i]
+            self.assertEqual(
+                self.mpc_game_svc.build_onedocker_args(
+                    game_name="game",
+                    mpc_party=MPCParty.SERVER,
+                    **game_arg,
+                ),
+                expected_argument,
+            )

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -36,7 +36,7 @@ from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
 
 
 class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -12,7 +12,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.mpc_instance import MPCParty
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -36,10 +35,11 @@ from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
 )
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 
 class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc: MPCService) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_aggregation_stage_service.py
@@ -38,7 +38,7 @@ from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_f
 
 
 class TestAggregationStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_decoupled_attribution_stage_service.py
@@ -37,7 +37,7 @@ from fbpcs.private_computation.service.decoupled_attribution_stage_service impor
 
 
 class TestAttributionStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -38,7 +38,7 @@ from fbpcs.private_computation.stage_flows.private_computation_decoupled_stage_f
 
 
 class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -36,7 +36,7 @@ from fbpcs.private_computation.service.pcf2_attribution_stage_service import (
 
 
 class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -11,7 +11,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.mpc_instance import MPCParty
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 
@@ -33,6 +32,7 @@ from fbpcs.private_computation.entity.product_config import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 from fbpcs.private_computation.service.pcf2_lift_metadata_compaction_stage_service import (
     PCF2LiftMetadataCompactionStageService,
@@ -40,7 +40,7 @@ from fbpcs.private_computation.service.pcf2_lift_metadata_compaction_stage_servi
 
 
 class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc: MPCService) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -11,7 +11,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.mpc_instance import MPCParty
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -31,6 +30,7 @@ from fbpcs.private_computation.entity.product_config import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 from fbpcs.private_computation.service.pcf2_lift_stage_service import (
     PCF2LiftStageService,
@@ -38,7 +38,7 @@ from fbpcs.private_computation.service.pcf2_lift_stage_service import (
 
 
 class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc: MPCService) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_shard_combiner_stage_service.py
@@ -36,7 +36,7 @@ from fbpcs.private_computation.service.pcf2_shard_combiner_stage_service import 
 
 
 class TestShardCombinerStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, call, MagicMock, Mock, patch
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 
 from fbpcp.error.pcp import ThrottlingError
-from fbpcp.service.mpc import MPCInstanceStatus, MPCParty, MPCService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.common.entity.stage_state_instance import (
@@ -64,6 +63,11 @@ from fbpcs.private_computation.service.constants import (
 from fbpcs.private_computation.service.errors import (
     PrivateComputationServiceInvalidStageError,
     PrivateComputationServiceValidationError,
+)
+from fbpcs.private_computation.service.mpc.mpc import (
+    MPCInstanceStatus,
+    MPCParty,
+    MPCService,
 )
 from fbpcs.private_computation.service.pcf2_attribution_stage_service import (
     PCF2AttributionStageService,
@@ -880,7 +884,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             with self.subTest(stage=stage):
                 _run_sub_test(stage)
 
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     async def test_create_and_start_mpc_instance(self, mock_mpc_svc) -> None:
         mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())
         mock_mpc_svc.create_instance = MagicMock()

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -137,7 +137,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         private_computation_instance_repo_patcher = patch(
             "fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository"
         )
-        mpc_game_svc_patcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        mpc_game_svc_patcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = container_svc_patcher.start()
         storage_svc = storage_svc_patcher.start()
         mpc_instance_repository = mpc_instance_repo_patcher.start()

--- a/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
@@ -35,7 +35,7 @@ from fbpcs.private_computation.service.private_id_dfca_aggregate_stage_service i
 
 
 class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())

--- a/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
@@ -12,7 +12,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.mpc_instance import MPCParty
-from fbpcp.service.mpc import MPCService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 
@@ -33,6 +32,7 @@ from fbpcs.private_computation.entity.product_config import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 from fbpcs.private_computation.service.secure_random_sharder_stage_service import (
     SecureRandomShardStageService,
@@ -40,7 +40,7 @@ from fbpcs.private_computation.service.secure_random_sharder_stage_service impor
 
 
 class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcp.service.mpc.MPCService")
+    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
     def setUp(self, mock_mpc_svc: MPCService) -> None:
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -9,8 +9,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
 from fbpcp.entity.mpc_instance import MPCParty
-
-from fbpcp.service.mpc import MPCService
 from fbpcs.infra.certificate.basic_ca_certificate_provider import (
     BasicCaCertificateProvider,
 )
@@ -46,6 +44,8 @@ from fbpcs.private_computation.service.constants import (
     SERVER_CERTIFICATE_ENV_VAR,
     SERVER_CERTIFICATE_PATH_ENV_VAR,
 )
+
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.utils import create_and_start_mpc_instance
 
 ca_cert_content = "ca certificate"

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -152,7 +152,9 @@ class TestUtils(IsolatedAsyncioTestCase):
     def _create_mpc_svc(self) -> MPCService:
         cspatcher = patch("fbpcp.service.container.ContainerService")
         irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
-        gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        gspatcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = cspatcher.start()
         instance_repository = irpatcher.start()
         mpc_game_svc = gspatcher.start()

--- a/fbpcs/private_computation_cli/config.yml
+++ b/fbpcs/private_computation_cli/config.yml
@@ -56,7 +56,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -13,7 +13,6 @@ from fbpcp.entity.mpc_instance import MPCInstance
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc import MPCService
 from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
@@ -43,6 +42,7 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -13,7 +13,6 @@ from fbpcp.entity.mpc_instance import MPCInstance
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.service.metric_service import MetricService
@@ -43,6 +42,7 @@ from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
 from fbpcs.private_computation.service.mpc.mpc import MPCService
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -10,7 +10,6 @@ from unittest.mock import ANY, call, MagicMock, patch
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.storage import StorageService
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 
@@ -22,6 +21,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/tests/github/config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/config_one_command_runner_test.yml
@@ -43,7 +43,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/tests/github/fbpcs_e2e_aws.yml
+++ b/fbpcs/tests/github/fbpcs_e2e_aws.yml
@@ -46,7 +46,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/tests/github/rc_config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/rc_config_one_command_runner_test.yml
@@ -34,7 +34,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Type, TypeVar
 from fbpcp.util.reflect import (  # @manual=//measurement/private_measurement/pcp:pcp"
     get_class as fbpcp_get_class,
 )
+from fbpcs.private_computation.service.utils import deprecated_msg
 from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/private_measurement/pcp:pcp"
     ConfigYamlClassNotFoundError,
     ConfigYamlModuleImportError,
@@ -18,6 +19,13 @@ from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/privat
     ConfigYamlWrongClassConfiguredError,
     ConfigYamlWrongConstructorError,
 )
+
+
+# Backward compatible for partners still using the old config settins
+DEPRECATED_CLASSES = {
+    "fbpcp.service.mpc_game.MPCGameService": "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+}
+
 
 T = TypeVar("T")
 
@@ -38,6 +46,12 @@ def get_class(class_path: str, target_class: Type[T]) -> Type[T]:
         A class object of type target_class
     """
     try:
+        if class_path in DEPRECATED_CLASSES:
+            deprecated_msg(
+                f"'{class_path}' is deprecated, please replace with '{DEPRECATED_CLASSES[class_path]}' instead."
+            )
+            class_path = DEPRECATED_CLASSES[class_path]
+
         cls = fbpcp_get_class(class_path)
         assert issubclass(cls, target_class)
     except ImportError:


### PR DESCRIPTION
Summary:
## Why
In next couple weeks, I'm going to migrate mpc service from fbpcp to fbpcs.
This is the first guard to avoid any further changes in fbpcp's mpc realted files
detailed plan: https://docs.google.com/document/d/1qR1XVVCA2By95tldl2Ey9m__GKX3raodGAZ5yK9SCEw/edit?usp=sharing

## What
- copy `mpc_game.py` from fbpcp to fbpcs
- copy `test_mpc_game.py` as as well

## Plan
- migrate mpc)game service from fbpcp to fbpcs (this diff)
- migrate mpc instance from fbpcp to fbpcs

## Impact after this diff
- decoupled mpc_game service class from fbpcp

Differential Revision: D41142149

