### PR TITLE
Pin to the specific FBPCP version

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -3,7 +3,7 @@ botocore==1.21.65
 cython==0.29.30 # required by thriftpy2 setup
 dataclasses-json==0.5.2 # fbpcp requires this version, so we must as well
 docopt>=0.6.2
-fbpcp>=0.3.0 # depending on: boto3, botocore
+fbpcp==0.3.4 # depending on: boto3, botocore
 marshmallow==3.5.1
 networkx>=2.6.3
 requests>=2.26.0


### PR DESCRIPTION
Summary:
## Background
To reduce the risk of a new FBPCP version being released that breaks our build, I am pinning the version to the current version that is used.

Reviewed By: marksliva

Differential Revision: D41097945

