### PR TITLE
adding explicit cause message on token validation rules

### DIFF
--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -164,10 +164,12 @@ class GraphAPITokenValidationError(
     OneCommandRunnerBaseException, GraphAPIGenericException
 ):
     @classmethod
-    def make_error(cls, rule: TokenValidationRule) -> "GraphAPITokenValidationError":
+    def make_error(
+        cls, rule: TokenValidationRule, cause: str = ""
+    ) -> "GraphAPITokenValidationError":
         return cls(
             msg="Graph API token didn't pass the validation.",
-            cause=f"Graph API token didn't pass. rule={rule}",
+            cause=f"Graph API token didn't pass. rule={rule} cause={cause}",
             remediation="Please check your Graph API token meet the requirements",
             exit_code=cls._determine_exit_code(rule),
         )


### PR DESCRIPTION
Summary:
## Why
In previous token validation released,
https://fb.workplace.com/groups/164332244998024/permalink/967972554633985/
We added several token common validation rules, had some feedback that validation could provide explicit cause why it's failing

## What
- this is the diff to add cause msg that allow advertiser can know which exact token validation failure

Differential Revision: D41165530

