### PR TITLE
mpc_game entity/repository migrate from fbpcp to fbpcs

### DIFF
--- a/fbpcs/bolt/test/test_oss_bolt_pcs.py
+++ b/fbpcs/bolt/test/test_oss_bolt_pcs.py
@@ -69,7 +69,9 @@ class TestBoltPCSClient(unittest.IsolatedAsyncioTestCase):
         private_computation_instance_repo_patcher = patch(
             "fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository"
         )
-        mpc_game_svc_patcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        mpc_game_svc_patcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = container_svc_patcher.start()
         storage_svc = storage_svc_patcher.start()
         mpc_instance_repository = mpc_instance_repo_patcher.start()

--- a/fbpcs/infra/mr_pid/partner/config_mrpid.yml
+++ b/fbpcs/infra/mr_pid/partner/config_mrpid.yml
@@ -73,7 +73,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation/entity/pc_infra_config_data.py
+++ b/fbpcs/private_computation/entity/pc_infra_config_data.py
@@ -37,7 +37,7 @@ class PrivateComputationInfraConfigInfo(Enum):
     )
 
     MPC_GAME_SERVICE = PrivateComputationInfraConfigData(
-        "fbpcp.service.mpc_game.MPCGameService",
+        "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService",
         set(),
     )
 

--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -11,9 +11,16 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, TypedDict
 
-from fbpcp.entity.mpc_game_config import MPCGameArgument, MPCGameConfig
-from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+
+from fbpcs.private_computation.service.mpc.entity.mpc_game_config import (
+    MPCGameArgument,
+    MPCGameConfig,
+)
+
+from fbpcs.private_computation.service.mpc.repository.mpc_game_repository import (
+    MPCGameRepository,
+)
 
 
 class GameNames(Enum):

--- a/fbpcs/private_computation/service/mpc/entity/mpc_game_config.py
+++ b/fbpcs/private_computation/service/mpc/entity/mpc_game_config.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class MPCGameArgument:
+    name: str
+    required: bool
+
+
+@dataclass
+class MPCGameConfig:
+    game_name: str
+    onedocker_package_name: str
+    arguments: List[MPCGameArgument]

--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -17,9 +17,9 @@ from fbpcp.entity.mpc_instance import MPCInstance, MPCInstanceStatus, MPCParty
 from fbpcp.error.pcp import PcpError
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.util.typing import checked_cast
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 
 DEFAULT_BINARY_VERSION = "latest"
 

--- a/fbpcs/private_computation/service/mpc/mpc_game.py
+++ b/fbpcs/private_computation/service/mpc/mpc_game.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from fbpcp.entity.mpc_game_config import MPCGameConfig
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpcp.repository.mpc_game_repository import MPCGameRepository
+from fbpcp.util.arg_builder import build_cmd_args
+
+LIFT_GAME_NAME = "lift"
+LIFT_AGGREGATOR_GAME_NAME = "aggregator"
+
+
+class MPCGameService:
+    def __init__(self, mpc_game_repository: MPCGameRepository) -> None:
+        self.logger: logging.Logger = logging.getLogger(__name__)
+        self.mpc_game_repository: MPCGameRepository = mpc_game_repository
+
+    # returns package_name and cmd which includes only arguments (no executable)
+    def build_onedocker_args(
+        self,
+        game_name: str,
+        mpc_party: MPCParty,
+        server_ip: Optional[str] = None,
+        port: Optional[int] = None,
+        **kwargs: object,
+    ) -> Tuple[str, str]:
+        mpc_game_config = self.mpc_game_repository.get_game(game_name)
+        return (
+            mpc_game_config.onedocker_package_name,
+            self._build_cmd(
+                mpc_game_config=mpc_game_config,
+                mpc_party=mpc_party,
+                server_ip=server_ip,
+                port=port,
+                **kwargs,
+            ),
+        )
+
+    # returns cmd which includes only arguments (no executable)
+    def _build_cmd(
+        self,
+        mpc_game_config: MPCGameConfig,
+        mpc_party: MPCParty,
+        server_ip: Optional[str] = None,
+        port: Optional[int] = None,
+        **kwargs: object,
+    ) -> str:
+        args = self._prepare_args(
+            mpc_game_config=mpc_game_config,
+            mpc_party=mpc_party,
+            server_ip=server_ip,
+            port=port,
+            **kwargs,
+        )
+        return build_cmd_args(**args)
+
+    def _prepare_args(
+        self,
+        mpc_game_config: MPCGameConfig,
+        mpc_party: MPCParty,
+        server_ip: Optional[str] = None,
+        port: Optional[int] = None,
+        **kwargs: object,
+    ) -> Dict[str, Any]:
+        all_arguments: Dict[str, Any] = {}
+
+        # push MPC required arguments to dict all_arguments
+        all_arguments["party"] = 1 if mpc_party == MPCParty.SERVER else 2
+
+        if mpc_party == MPCParty.CLIENT:
+            if server_ip is None:
+                raise ValueError("Client must provide a server ip address.")
+            all_arguments["server_ip"] = server_ip
+        if port is not None:
+            all_arguments["port"] = port
+
+        # push game specific arguments to dict all_arguments
+        for argument in mpc_game_config.arguments:
+            key = argument.name
+            value = kwargs.get(key)
+            if value is None and argument.required:
+                # Have to make game_name a special case for PL-Worker
+                if key == "game_name":
+                    all_arguments[key] = mpc_game_config.game_name
+                else:
+                    raise ValueError(f"Missing required argument {key}!")
+            if value is not None:
+                all_arguments[key] = value
+
+        return all_arguments

--- a/fbpcs/private_computation/service/mpc/mpc_game.py
+++ b/fbpcs/private_computation/service/mpc/mpc_game.py
@@ -9,10 +9,13 @@
 import logging
 from typing import Any, Dict, Optional, Tuple
 
-from fbpcp.entity.mpc_game_config import MPCGameConfig
 from fbpcp.entity.mpc_instance import MPCParty
-from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.util.arg_builder import build_cmd_args
+
+from fbpcs.private_computation.service.mpc.entity.mpc_game_config import MPCGameConfig
+from fbpcs.private_computation.service.mpc.repository.mpc_game_repository import (
+    MPCGameRepository,
+)
 
 LIFT_GAME_NAME = "lift"
 LIFT_AGGREGATOR_GAME_NAME = "aggregator"

--- a/fbpcs/private_computation/service/mpc/repository/mpc_game_repository.py
+++ b/fbpcs/private_computation/service/mpc/repository/mpc_game_repository.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import abc
+
+from fbpcs.private_computation.service.mpc.entity.mpc_game_config import MPCGameConfig
+
+
+class MPCGameRepository(abc.ABC):
+    @abc.abstractmethod
+    def get_game(self, name: str) -> MPCGameConfig:
+        pass

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -215,6 +215,19 @@ def get_pc_status_from_stage_state(
     return status
 
 
+# pyre-ignore return typing
+def deprecated_msg(msg: str):
+    warning_color = "\033[93m"  # orange/yellow ascii escape sequence
+    end = "\033[0m"  # end ascii escape sequence
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        f"{warning_color}{msg}{end}",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)
+
+
 # decorators are a serious pain to add typing for, so I'm not going to bother...
 # pyre-ignore return typing
 def deprecated(reason: str):
@@ -224,22 +237,10 @@ def deprecated(reason: str):
 
     # pyre-ignore return typing
     def wrap(func):
-        warning_color = "\033[93m"  # orange/yellow ascii escape sequence
-        end = "\033[0m"  # end ascii escape sequence
-        explanation: str = (
-            f"{warning_color}{func.__name__} is deprecated! explanation: {reason}{end}"
-        )
-
         @functools.wraps(func)
         # pyre-ignore typing on args, kwargs, and return
         def wrapped(*args, **kwargs):
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn(
-                explanation,
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            warnings.simplefilter("default", DeprecationWarning)
+            deprecated_msg(msg=f"{func.__name__} is deprecated! explanation: {reason}")
             return func(*args, **kwargs)
 
         return wrapped

--- a/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_config.yml
+++ b/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_config.yml
@@ -40,7 +40,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_override_config.yml
+++ b/fbpcs/private_computation/test/entity/test_resources/configs/expected_mini_override_config.yml
@@ -35,7 +35,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation/test/repository/test_private_computation_game.py
+++ b/fbpcs/private_computation/test/repository/test_private_computation_game.py
@@ -10,11 +10,12 @@ import unittest
 from typing import List
 from unittest.mock import patch
 
-from fbpcp.entity.mpc_game_config import MPCGameArgument
 from fbpcs.private_computation.repository.private_computation_game import (
     OneDockerArgument,
     PrivateComputationGameRepository,
 )
+
+from fbpcs.private_computation.service.mpc.entity.mpc_game_config import MPCGameArgument
 
 
 class TestPrivateComputationGameRepository(unittest.TestCase):

--- a/fbpcs/private_computation/test/service/mpc/test_mpc.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc.py
@@ -40,7 +40,9 @@ class TestMPCService(IsolatedAsyncioTestCase):
     def setUp(self):
         cspatcher = patch("fbpcp.service.container.ContainerService")
         irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
-        gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        gspatcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = cspatcher.start()
         instance_repository = irpatcher.start()
         mpc_game_svc = gspatcher.start()

--- a/fbpcs/private_computation/test/service/mpc/test_mpc_game.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc_game.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import List
+from unittest.mock import MagicMock, Mock
+
+from fbpcp.entity.mpc_game_config import MPCGameArgument, MPCGameConfig
+from fbpcp.entity.mpc_instance import MPCParty
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
+
+
+INPUT_DIRECTORY = "input_directory"
+OUTPUT_DIRECTORY = "output_directory"
+INPUT_PATH_1 = "input_path_1"
+INPUT_PATH_2 = "input_path_2"
+OUTPUT_PATH_1 = "out_path_1"
+OUTPUT_PATH_2 = "out_path_2"
+CONCURRENCY = 2
+GAME_NAME = "test_game"
+ONEDOCKER_PACKAGE_NAME = "onedocker_package/package_name"
+
+GAME_CONFIG = {
+    GAME_NAME: {
+        "onedocker_package_name": ONEDOCKER_PACKAGE_NAME,
+        "arguments": [
+            {"name": "input_filenames", "required": True},
+            {"name": "input_directory", "required": True},
+            {"name": "output_filenames", "required": True},
+            {"name": "output_directory", "required": True},
+            {"name": "concurrency", "required": True},
+        ],
+    }
+}
+
+
+class TestMPCGameService(unittest.TestCase):
+    def setUp(self):
+        game_repository = Mock()
+        self.mpc_game_svc = MPCGameService(game_repository)
+        arguments: List[MPCGameArgument] = [
+            MPCGameArgument(name=argument["name"], required=argument["required"])
+            for argument in GAME_CONFIG[GAME_NAME]["arguments"]
+        ]
+        self.mpc_game_config = MPCGameConfig(
+            game_name=GAME_NAME,
+            onedocker_package_name=GAME_CONFIG[GAME_NAME]["onedocker_package_name"],
+            arguments=arguments,
+        )
+        self.mpc_game_svc.mpc_game_repository.get_game = MagicMock(
+            return_value=self.mpc_game_config
+        )
+
+    def test_prepare_args(self):
+        self.assertEqual(
+            self.mpc_game_svc._prepare_args(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.CLIENT,
+                server_ip="192.0.2.0",
+                port=12345,
+                input_filenames=INPUT_PATH_1,
+                input_directory=INPUT_DIRECTORY,
+                output_filenames=OUTPUT_PATH_1,
+                output_directory=OUTPUT_DIRECTORY,
+                concurrency=CONCURRENCY,
+            ),
+            {
+                "party": 2,
+                "server_ip": "192.0.2.0",
+                "port": 12345,
+                "input_filenames": INPUT_PATH_1,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_1,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+        )
+
+    def test_prepare_args_with_optional_arg(self):
+        self.assertEqual(
+            self.mpc_game_svc._prepare_args(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.SERVER,
+                input_filenames=INPUT_PATH_1,
+                input_directory=INPUT_DIRECTORY,
+                output_filenames=OUTPUT_PATH_1,
+                output_directory=OUTPUT_DIRECTORY,
+                concurrency=CONCURRENCY,
+            ),
+            {
+                "party": 1,
+                "input_filenames": INPUT_PATH_1,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_1,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+        )
+
+    def test_prepare_args_with_missing_arg(self):
+        with self.assertRaisesRegex(
+            ValueError, "Missing required argument input_filenames!"
+        ):
+            self.mpc_game_svc._prepare_args(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.SERVER,
+                output_file=OUTPUT_PATH_1,
+            )
+
+    def test_build_cmd(self):
+        self.assertEqual(
+            self.mpc_game_svc._build_cmd(
+                mpc_game_config=self.mpc_game_config,
+                mpc_party=MPCParty.CLIENT,
+                server_ip="192.0.2.0",
+                port=12345,
+                input_filenames=INPUT_PATH_1,
+                input_directory=INPUT_DIRECTORY,
+                output_filenames=OUTPUT_PATH_1,
+                output_directory=OUTPUT_DIRECTORY,
+                concurrency=CONCURRENCY,
+            ),
+            f"--party=2 --server_ip=192.0.2.0 --port=12345 --input_filenames={INPUT_PATH_1} "
+            f"--input_directory={INPUT_DIRECTORY} --output_filenames={OUTPUT_PATH_1} "
+            f"--output_directory={OUTPUT_DIRECTORY} --concurrency={CONCURRENCY}",
+        )
+
+    def test_build_onedocker_args(self):
+        game_args = [
+            {
+                "input_filenames": INPUT_PATH_1,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_1,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+            {
+                "input_filenames": INPUT_PATH_2,
+                "input_directory": INPUT_DIRECTORY,
+                "output_filenames": OUTPUT_PATH_2,
+                "output_directory": OUTPUT_DIRECTORY,
+                "concurrency": CONCURRENCY,
+            },
+        ]
+
+        expected_arguments = [
+            (
+                ONEDOCKER_PACKAGE_NAME,
+                f"--party=1 --input_filenames={INPUT_PATH_1} --input_directory={INPUT_DIRECTORY} "
+                f"--output_filenames={OUTPUT_PATH_1} --output_directory={OUTPUT_DIRECTORY} "
+                f"--concurrency={CONCURRENCY}",
+            ),
+            (
+                ONEDOCKER_PACKAGE_NAME,
+                f"--party=1 --input_filenames={INPUT_PATH_2} --input_directory={INPUT_DIRECTORY} "
+                f"--output_filenames={OUTPUT_PATH_2} --output_directory={OUTPUT_DIRECTORY} "
+                f"--concurrency={CONCURRENCY}",
+            ),
+        ]
+
+        for i in range(len(game_args)):
+            expected_argument = expected_arguments[i]
+            game_arg = game_args[i]
+            self.assertEqual(
+                self.mpc_game_svc.build_onedocker_args(
+                    game_name="game",
+                    mpc_party=MPCParty.SERVER,
+                    **game_arg,
+                ),
+                expected_argument,
+            )

--- a/fbpcs/private_computation/test/service/mpc/test_mpc_game.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc_game.py
@@ -8,8 +8,12 @@ import unittest
 from typing import List
 from unittest.mock import MagicMock, Mock
 
-from fbpcp.entity.mpc_game_config import MPCGameArgument, MPCGameConfig
 from fbpcp.entity.mpc_instance import MPCParty
+
+from fbpcs.private_computation.service.mpc.entity.mpc_game_config import (
+    MPCGameArgument,
+    MPCGameConfig,
+)
 from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 
 

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -137,7 +137,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         private_computation_instance_repo_patcher = patch(
             "fbpcs.private_computation.repository.private_computation_instance_local.LocalPrivateComputationInstanceRepository"
         )
-        mpc_game_svc_patcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        mpc_game_svc_patcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = container_svc_patcher.start()
         storage_svc = storage_svc_patcher.start()
         mpc_instance_repository = mpc_instance_repo_patcher.start()

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -152,7 +152,9 @@ class TestUtils(IsolatedAsyncioTestCase):
     def _create_mpc_svc(self) -> MPCService:
         cspatcher = patch("fbpcp.service.container.ContainerService")
         irpatcher = patch("fbpcp.repository.mpc_instance.MPCInstanceRepository")
-        gspatcher = patch("fbpcp.service.mpc_game.MPCGameService")
+        gspatcher = patch(
+            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+        )
         container_svc = cspatcher.start()
         instance_repository = irpatcher.start()
         mpc_game_svc = gspatcher.start()

--- a/fbpcs/private_computation_cli/config.yml
+++ b/fbpcs/private_computation_cli/config.yml
@@ -56,7 +56,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -13,7 +13,6 @@ from fbpcp.entity.mpc_instance import MPCInstance
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.service.metric_service import MetricService
@@ -43,6 +42,7 @@ from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
 from fbpcs.private_computation.service.mpc.mpc import MPCService
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional, Type
 
 from fbpcp.entity.mpc_instance import MPCInstance
-from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
 from fbpcp.service.onedocker import OneDockerService
@@ -43,6 +42,9 @@ from fbpcs.private_computation.repository.private_computation_instance import (
 )
 from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
+from fbpcs.private_computation.service.mpc.repository.mpc_game_repository import (
+    MPCGameRepository,
+)
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -10,7 +10,6 @@ from unittest.mock import ANY, call, MagicMock, patch
 from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
-from fbpcp.service.mpc_game import MPCGameService
 from fbpcp.service.storage import StorageService
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 
@@ -22,6 +21,7 @@ from fbpcs.private_computation.entity.private_computation_instance import (
 from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
+from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_service_wrapper.py
@@ -7,7 +7,6 @@
 from unittest import TestCase
 from unittest.mock import ANY, call, MagicMock, patch
 
-from fbpcp.repository.mpc_game_repository import MPCGameRepository
 from fbpcp.repository.mpc_instance import MPCInstanceRepository
 from fbpcp.service.container import ContainerService
 from fbpcp.service.storage import StorageService
@@ -22,6 +21,10 @@ from fbpcs.private_computation.repository.private_computation_instance import (
     PrivateComputationInstanceRepository,
 )
 from fbpcs.private_computation.service.mpc.mpc_game import MPCGameService
+
+from fbpcs.private_computation.service.mpc.repository.mpc_game_repository import (
+    MPCGameRepository,
+)
 from fbpcs.private_computation.service.private_computation import (
     PrivateComputationService,
 )

--- a/fbpcs/tests/github/config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/config_one_command_runner_test.yml
@@ -43,7 +43,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/tests/github/fbpcs_e2e_aws.yml
+++ b/fbpcs/tests/github/fbpcs_e2e_aws.yml
@@ -46,7 +46,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/tests/github/rc_config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/rc_config_one_command_runner_test.yml
@@ -34,7 +34,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcp.service.mpc_game.MPCGameService
+      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Type, TypeVar
 from fbpcp.util.reflect import (  # @manual=//measurement/private_measurement/pcp:pcp"
     get_class as fbpcp_get_class,
 )
+from fbpcs.private_computation.service.utils import deprecated_msg
 from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/private_measurement/pcp:pcp"
     ConfigYamlClassNotFoundError,
     ConfigYamlModuleImportError,
@@ -18,6 +19,13 @@ from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/privat
     ConfigYamlWrongClassConfiguredError,
     ConfigYamlWrongConstructorError,
 )
+
+
+# Backward compatible for partners still using the old config settins
+DEPRECATED_CLASSES = {
+    "fbpcp.service.mpc_game.MPCGameService": "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
+}
+
 
 T = TypeVar("T")
 
@@ -38,6 +46,12 @@ def get_class(class_path: str, target_class: Type[T]) -> Type[T]:
         A class object of type target_class
     """
     try:
+        if class_path in DEPRECATED_CLASSES:
+            deprecated_msg(
+                f"'{class_path}' is deprecated, please replace with '{DEPRECATED_CLASSES[class_path]}' instead."
+            )
+            class_path = DEPRECATED_CLASSES[class_path]
+
         cls = fbpcp_get_class(class_path)
         assert issubclass(cls, target_class)
     except ImportError:


### PR DESCRIPTION
Summary:
## Why
In next couple weeks, I'm going to migrate mpc service from fbpcp to fbpcs.
This is the first guard to avoid any further changes in fbpcp's mpc realted files
detailed plan: https://docs.google.com/document/d/1qR1XVVCA2By95tldl2Ey9m__GKX3raodGAZ5yK9SCEw/edit?usp=sharing

## What
- hg copy `mpc_game_config.py` from fbpcp to fbpcs
- hg copy `mpc_game_repository.py` as as well
- change import to fbpcs

Differential Revision: D41201899

