### PR TITLE
upgrade log level to warning for empty files

### DIFF
--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorApp.cpp
@@ -68,7 +68,7 @@ void ShardAggregatorApp::run() {
       putOutputData(result);
     }
   } else {
-    XLOG(INFO) << "inputData is empty().";
+    XLOG(WARN) << "inputData is empty().";
     putOutputData(nullptr);
   }
 };
@@ -97,7 +97,7 @@ std::vector<std::shared_ptr<AggMetrics>> ShardAggregatorApp::getInputData() {
             XLOG(INFO) << "Opening file at <" << inputPath << ">";
             auto contents = fbpcf::io::FileIOWrappers::readFile(inputPath);
             if (contents.empty()) {
-              XLOG(INFO) << "Empty file: <" << inputPath << ">";
+              XLOG(WARN) << "Empty file: <" << inputPath << ">";
               return nullptr;
             }
             return std::make_shared<AggMetrics>(

--- a/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
+++ b/fbpcs/emp_games/lift/calculator/CalculatorApp.cpp
@@ -38,7 +38,7 @@ void CalculatorApp::run() {
 
       putOutputData(output);
     } else {
-      XLOG(INFO) << "skipped calculating as numValues==0.";
+      XLOG(WARN) << "skipped calculating as numValues==0.";
       // skip game::run(), just output the default metrics.
       if (party_ == fbpcf::Party::Alice) {
         putOutputData(OutputMetrics<PUBLISHER>{

--- a/fbpcs/emp_games/lift/pcf2_calculator/CalculatorGame.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/CalculatorGame.h
@@ -33,7 +33,7 @@ class CalculatorGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   std::string play(const CalculatorGameConfig& config) {
     if (config.inputData.getNumRows() == 0) {
-      XLOG(INFO) << "skipped calculating as numRows==0.";
+      XLOG(WARN) << "skipped calculating as numRows==0.";
       // skip game::run(), just output the default metrics.
       return GroupedLiftMetrics().toJson();
     }
@@ -61,7 +61,7 @@ class CalculatorGame : public fbpcf::frontend::MpcGame<schedulerId> {
     XLOG(INFO) << "Have " << inputProcessor.getLiftGameProcessedData().numRows
                << " values in inputData.";
     if (inputProcessor.getLiftGameProcessedData().numRows == 0) {
-      XLOG(INFO) << "skipped calculating as numRows==0.";
+      XLOG(WARN) << "skipped calculating as numRows==0.";
       // skip game::run(), just output the default metrics.
       return GroupedLiftMetrics().toJson();
     }


### PR DESCRIPTION
Summary:
Empty files ideally should not appear, but just in case, Compute stage should still handle it correctly instead of crashing.

We upgrade the log level to warning  for both PCF1.0 and PCF2.0 for better tracking, monitoring and detection

Differential Revision: D41215323

