### PR TITLE
Pass server_uris in when creating MPCInstance (#459)

### DIFF
--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -111,6 +111,7 @@ class MPCService:
         num_workers: int,
         server_ips: Optional[List[str]] = None,
         game_args: Optional[List[Dict[str, Any]]] = None,
+        server_uris: Optional[List[str]] = None,
     ) -> MPCInstance:
         self.logger.info(f"Creating MPC instance: {instance_id}")
 
@@ -123,7 +124,7 @@ class MPCService:
             [],
             MPCInstanceStatus.CREATED,
             game_args,
-            [],
+            server_uris,
         )
 
         self.instance_repository.create(instance)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcp/pull/459

As title. server_uris will be passed into MPCInstance upon creation on the publisher side. We need to store server_uris in the MPCInstance to be propagated back to the partner side.

Differential Revision: D40997128

