### PR TITLE
Generate server_uris in create_and_start_mpc_instance

### DIFF
--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -111,6 +111,7 @@ class MPCService:
         num_workers: int,
         server_ips: Optional[List[str]] = None,
         game_args: Optional[List[Dict[str, Any]]] = None,
+        server_uris: Optional[List[str]] = None,
     ) -> MPCInstance:
         self.logger.info(f"Creating MPC instance: {instance_id}")
 
@@ -123,7 +124,7 @@ class MPCService:
             [],
             MPCInstanceStatus.CREATED,
             game_args,
-            [],
+            server_uris,
         )
 
         self.instance_repository.create(instance)

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -938,6 +938,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 mpc_party=mpc_party,
                 num_workers=num_containers,
                 game_args=game_args,
+                server_uris=None,
             ),
             mock_mpc_svc.create_instance.call_args,
         )


### PR DESCRIPTION
Summary: For each container, we want to assign a unique server_uri under the domain of server_domain in order to use the generated certificates to set up the TLS connection. This diff creates num_containers # of server_uris and pass them to the MPCInstance.

Reviewed By: joe1234wu

Differential Revision: D41045373

