### PR TITLE
expose server_uris from thrift service

### DIFF
--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -111,6 +111,7 @@ class MPCService:
         num_workers: int,
         server_ips: Optional[List[str]] = None,
         game_args: Optional[List[Dict[str, Any]]] = None,
+        server_uris: Optional[List[str]] = None,
     ) -> MPCInstance:
         self.logger.info(f"Creating MPC instance: {instance_id}")
 
@@ -123,7 +124,7 @@ class MPCService:
             [],
             MPCInstanceStatus.CREATED,
             game_args,
-            [],
+            server_uris,
         )
 
         self.instance_repository.create(instance)

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -108,6 +108,7 @@ from fbpcs.utils.optional import unwrap_or_default
 T = TypeVar("T")
 
 PCSERVICE_ENTITY_NAME = "pcservice"
+DEFAULT_SERVER_DOMAIN = "study123.pci.facebook.com"
 
 
 class PrivateComputationService:
@@ -372,7 +373,7 @@ class PrivateComputationService:
         # dynamically composed server domain for publisher side
         # when tls feature is enabled.
         # return f"publisher.study{instance_id}.pci.facebook.com"
-        return "study123.pci.facebook.com"
+        return DEFAULT_SERVER_DOMAIN
 
     def _get_number_of_mpc_containers(
         self,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -938,6 +938,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 mpc_party=mpc_party,
                 num_workers=num_containers,
                 game_args=game_args,
+                server_uris=None,
             ),
             mock_mpc_svc.create_instance.call_args,
         )


### PR DESCRIPTION
Summary: Similar to D41091769, We need to expose this field from thrift service to be propagated to graph, such that it can be accessed by partners. It will be used by partners to set up their routing for the tls connection.

Reviewed By: joe1234wu

Differential Revision: D41049694

