### PR TITLE
Update Get PCE config to use cloud provider

### DIFF
--- a/fbpcs/private_computation/entity/cloud_provider.py
+++ b/fbpcs/private_computation/entity/cloud_provider.py
@@ -8,7 +8,20 @@
 
 from enum import Enum
 
+from measurement.private_measurement.pcp.pce.pce_service.pce_service_thrift_base.types import (
+    CloudProvider as CloudProviderThriftType,
+)
+
 
 class CloudProvider(Enum):
     AWS = 1
     GCP = 2
+
+    @staticmethod
+    def from_thrift(
+        provider_type: CloudProviderThriftType,
+    ) -> "CloudProvider":
+        return {
+            CloudProviderThriftType.AWS: CloudProvider.AWS,
+            CloudProviderThriftType.GCP: CloudProvider.GCP,
+        }[provider_type]


### PR DESCRIPTION
Summary: In this diff I am adding cloud provider to get PCE config. By defualt get_pce_config uses AWS. I am adding support for GCP.

Reviewed By: zhuang-93

Differential Revision: D40732554

