### PR TITLE
Temprorary rollback github config to unblock hotfix e2e test

### DIFF
--- a/fbpcs/tests/github/config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/config_one_command_runner_test.yml
@@ -43,7 +43,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
+      class: fbpcp.service.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository

--- a/fbpcs/tests/github/rc_config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/rc_config_one_command_runner_test.yml
@@ -34,7 +34,7 @@ pid:
 mpc:
   dependency:
     MPCGameService:
-      class: fbpcs.private_computation.service.mpc.mpc_game.MPCGameService
+      class: fbpcp.service.mpc_game.MPCGameService
       dependency:
         PrivateComputationGameRepository:
           class: fbpcs.private_computation.repository.private_computation_game.PrivateComputationGameRepository


### PR DESCRIPTION
Summary:
## Why
In previous diff stack, we migrated mpc from fbpcp repo to fbpcs.
But during the code freeze, and hotfix we had, hotfix was based on the previous commit which didn't include the migration changes.
It only fail as we're duing the code freeze and RC is releasing with hotfix which isn't include the previous change.
So this this is to revert config in github as it's in-sync config, this change won't break any internal testing as we had fallback logic to compatible both class path
> fallback logic https://fburl.com/code/38u3ojo2
## What
- revert config been used in github back to fbpcp for temprorary

Reviewed By: musebc

Differential Revision: D41311591

