### PR TITLE
Use regex in restore script & add unit tests

### DIFF
--- a/fbpcs/infra/restore_run_state/restore_state.py
+++ b/fbpcs/infra/restore_run_state/restore_state.py
@@ -18,6 +18,7 @@ Options:
 
 import logging
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -98,23 +99,11 @@ class RestoreRunState:
         return parts[-1]
 
     def _split_path(self, s3_path: str) -> Optional[Tuple[str, str]]:
-        # TODO Use regex match  s3://(.*)/(.*)
-        if s3_path.startswith("s3://"):
-            s3_path = s3_path.replace("s3://", "")
-            parts = s3_path.split("/")
-            bucket = parts[0]
-            first = True
-            prefix = ""
-            for part in parts:
-                if first:
-                    first = False
-                    continue
-                if prefix != "":
-                    prefix += "/"
-                prefix += part
+        p = re.compile("s3://(.+?)/(.+)")
+        m = p.match(s3_path)
 
-            return bucket, prefix
-
+        if m is not None:
+            return m.group(1, 2)
         return None
 
     def _init_s3(self, region_name: str) -> None:

--- a/fbpcs/infra/restore_run_state/tests/test_restore_state.py
+++ b/fbpcs/infra/restore_run_state/tests/test_restore_state.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from unittest import mock, TestCase
+from unittest.mock import ANY
+
+from fbpcs.infra.restore_run_state.restore_state import RestoreRunState
+
+
+class TestRestoreState(TestCase):
+    def setUp(self) -> None:
+        self.restore_state = RestoreRunState()
+
+    def test_split_path(self) -> None:
+        with self.subTest("Valid path"):
+            self.assertEqual(
+                ("fb-pc-data-bucket-wnm6", "logging/logs_20220928T201923/last"),
+                self.restore_state._split_path(
+                    "s3://fb-pc-data-bucket-wnm6/logging/logs_20220928T201923/last"
+                ),
+            )
+        with self.subTest("Valid path 2"):
+            self.assertEqual(
+                ("fb-pc-data-bucket-wnm6", "last"),
+                self.restore_state._split_path("s3://fb-pc-data-bucket-wnm6/last"),
+            )
+        with self.subTest("Invalid path"):
+            self.assertIsNone(
+                self.restore_state._split_path("s3://fb-pc-data-bucket-wnm6"),
+            )
+        with self.subTest("Invalid path 2"):
+            self.assertIsNone(
+                self.restore_state._split_path(
+                    "fb-pc-data-bucket-wnm6/logging/logs_20220928T201923/last"
+                ),
+            )
+
+    def test_copy_files(self) -> None:
+        objects = [
+            mock.Mock(key="key1"),
+            mock.Mock(key="key2/"),
+        ]
+        self.restore_state.s3 = mock.MagicMock()
+        bucket = mock.MagicMock()
+        bucket.objects = mock.MagicMock()
+        bucket.objects.filter = mock.MagicMock(return_value=objects)
+        self.restore_state.s3.Bucket = mock.MagicMock(return_value=bucket)
+
+        self.restore_state._copy_files(
+            "s3://fb-pc-data-bucket-wnm6/logging/last", "/tmp"
+        )
+
+        bucket.download_file.assert_called_once_with("key1", ANY)


### PR DESCRIPTION
Summary:
Followups from earlier diff:
  Add UT for restore script
  Use regex

Reviewed By: ztlbells

Differential Revision: D41314279

