### PR TITLE
Fix B&R for UDP stage (currently it is not being uploaded to one docker)

### DIFF
--- a/promote_scripts/promote_binaries.sh
+++ b/promote_scripts/promote_binaries.sh
@@ -22,7 +22,6 @@ binary_names=(
     'private_lift/lift'
     'private_lift/pcf2_lift'
     'private_lift/pcf2_lift_metadata_compaction'
-    'private_lift/aggregator'
     'private_attribution/decoupled_attribution'
     'private_attribution/decoupled_aggregation'
     'private_attribution/pcf2_attribution'

--- a/upload-binaries-to-s3.sh
+++ b/upload-binaries-to-s3.sh
@@ -32,7 +32,7 @@ shift
 one_docker_repo="one-docker-repository-prod"
 lift_package="s3://$one_docker_repo/private_lift/lift/${TAG}/lift"
 pcf2_lift_package="s3://$one_docker_repo/private_lift/pcf2_lift/${TAG}/pcf2_lift"
-pcf2_lift_metadata_compaction_package="s3://$one_docker_repo/private_lift/pcf2_lift_metadata_compaction${TAG}/pcf2_lift_metadata_compaction"
+pcf2_lift_metadata_compaction_package="s3://$one_docker_repo/private_lift/pcf2_lift_metadata_compaction/${TAG}/pcf2_lift_metadata_compaction"
 attribution_repo="s3://$one_docker_repo/private_attribution"
 decoupled_attribution="$attribution_repo/decoupled_attribution/${TAG}/decoupled_attribution"
 decoupled_aggregation="$attribution_repo/decoupled_aggregation/${TAG}/decoupled_aggregation"


### PR DESCRIPTION
Summary:
I just tried running the UDP flow E2E with `--version = dev` binaries and got the following error: https://fburl.com/vt8j0vif

```
ERROR:onedocker.script.runner.onedocker_runner:An error was raised while preparing private_lift/pcf2_lift_metadata_compaction:dev from https://one-docker-repository-prod.s3.us-west-2.amazonaws.com/, error: An error occurred (404) when calling the HeadObject operation: Not Found
```

Prior to this we had only been building custom binaries which has worked.

Upon investigating the B&R logs I noticed that the promote binaries script wasn't actually doing anything with this binary. See https://github.com/facebookresearch/fbpcs/actions/runs/3473781131/jobs/5806200035

It just says

```
start copy binary path s3://one-docker-repository-prod/private_lift/pcf2_lift_metadata_compaction from 1095 to dev
start copy binary path s3://one-docker-repository-prod/private_lift/aggregator from 1095 to dev
start copy binary path s3://one-docker-repository-prod/private_attribution/decoupled_attribution from 1095 to dev
Completed 8.0 MiB/128.0 MiB (9.2 MiB/s) with 1 file(s) remaining
```

The first two files don't exist and it just silently continues.

I looked at the extract and upload binaries script for `emp_games` and noticed the following (https://github.com/facebookresearch/fbpcs/actions/runs/3473738888/jobs/5806108450)

```
upload: ./pcf2_lift_metadata_compaction to s3://one-docker-repository-prod/private_lift/pcf2_lift_metadata_compaction1095/pcf2_lift_metadata_compaction
Completed 256.0 KiB/128.0 MiB (282.6 KiB/s) with 1 file(s) remaining
Completed 512.0 KiB/128.0 MiB (516.7 KiB/s) with 1 file(s) remaining
Completed 768.0 KiB/128.0 MiB (774.3 KiB/s) with 1 file(s) remaining
Completed 1.0 MiB/128.0 MiB (953.5 KiB/s) with 1 file(s) remaining
Completed 1.2 MiB/128.0 MiB (1.2 MiB/s) with 1 file(s) remaining
Completed 1.5 MiB/128.0 MiB (1.4 MiB/s) with 1 file(s) remaining
```

Looks like the one docker s3 repo has been polluted with a bunch of private_lift/pcf2_lift_metadata_compactionXXXX folders and wasn't noticed. This change should fix that. I don't have SSO admin on the account containing this repo, but ideally we should clean this up.

Differential Revision:
D41321660

LaMa Project: L416713

