### PR TITLE
Update tests to run on GitHub Runners

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,10 +39,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Print Tracker Hash
-        run: echo ${{ github.event.inputs.tracker_hash }}
+        run: echo ${{ inputs.tracker_hash }}
 
       - name: Remove unused images
         run: |
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build onedocker image in rc
         run: |
-          ./build-docker.sh onedocker -t ${{github.event.inputs.new_tag}} -f -p linux/amd64 -v ${{ env.FBPCF_VERSION }} -i ${{ env.PID_VERSION }}
+          ./build-docker.sh onedocker -t ${{ inputs.new_tag }} -f -p linux/amd64 -v ${{ env.FBPCF_VERSION }} -i ${{ env.PID_VERSION }}
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1
@@ -61,12 +61,12 @@ jobs:
 
       - name: Tag docker image
         run: |
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{github.event.inputs.new_tag}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{github.event.inputs.new_tag}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{github.event.inputs.new_tag}}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ inputs.new_tag }} ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ inputs.new_tag }} ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ inputs.new_tag }}
           # temporarily tagging with rc because the task definition
           # (fbpcs-github-cicd:4 https://us-west-2.console.aws.amazon.com/ecs/home?region=us-west-2#/taskDefinitions/fbpcs-github-cicd/4)
           # points at :rc instead of latest-build
-          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{github.event.inputs.new_tag}} ${{ env.RC_REGISTRY_IMAGE_NAME }}:rc
+          docker tag ${{ env.LOCAL_IMAGE_NAME }}:${{ inputs.new_tag }} ${{ env.RC_REGISTRY_IMAGE_NAME }}:rc
 
       - name: Push image to rc registry
         run: |
@@ -74,15 +74,31 @@ jobs:
 
   e2e_test:
     name: Run End to End Tests
-    runs-on: [self-hosted, fbpcs-e2e-test-runner]
+    runs-on: ubuntu-latest
     needs: build_image
     permissions:
+      id-token: write
       contents: read
       packages: write
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: Print Tracker Hash
-        run: echo ${{ github.event.inputs.tracker_hash }}
+        run: echo ${{ inputs.tracker_hash }}
+
+      - name: Get AWS Session name
+        id: aws_session_name
+        run: |
+          echo session_name=$(echo publish-onedocker-tests-${{ inputs.new_tag }} | tr " " "-") >> $GITHUB_OUTPUT
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_TEST_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+          role-duration-seconds: 5400
+          role-session-name: ${{ steps.aws_session_name.outputs.session_name }}
 
       - name: Clean Up Docker Images
         run: |
@@ -90,14 +106,14 @@ jobs:
 
       - name: Pull coordinator image
         run: |
-          docker pull ${{ env.COORDINATOR_IMAGE }}:${{ github.event.inputs.new_tag }}
+          docker pull ${{ env.COORDINATOR_IMAGE }}:${{ inputs.new_tag }}
 
       ### Private Lift and Attribution E2E tests
       - name: End to end testing
         timeout-minutes: 90
         run: |
-          docker run --rm -v "instances":"/instances" -v "$(realpath fbpcs_e2e_aws.yml):/home/pcs/pl_coordinator_env/fbpcs_e2e_aws.yml" -v "$(realpath bolt_config.yml):/home/pcs/pl_coordinator_env/bolt_config.yml" ${{ env.COORDINATOR_IMAGE }}:${{ github.event.inputs.new_tag }} python3.8 -m fbpcs.private_computation_cli.private_computation_cli bolt_e2e --bolt_config="bolt_config.yml"
-        working-directory: ./fbpcs/tests/github/
+          docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_DEFAULT_REGION --rm -v "instances":"/instances" -v "$(realpath fbpcs_e2e_aws.yml):/home/pcs/pl_coordinator_env/fbpcs_e2e_aws.yml" -v "$(realpath bolt_config.yml):/home/pcs/pl_coordinator_env/bolt_config.yml" ${{ env.COORDINATOR_IMAGE }}:${{ inputs.new_tag }} python3.8 -m fbpcs.private_computation_cli.private_computation_cli bolt_e2e --bolt_config="bolt_config.yml"
+        working-directory: fbpcs/tests/github/
 
       - name: Pull image from rc registry
         run: |
@@ -110,7 +126,7 @@ jobs:
       - name: Tag image
         run: |
           docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
-          docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:${{github.event.inputs.new_tag}}
+          docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:${{ inputs.new_tag }}
           docker tag ${{ env.RC_REGISTRY_IMAGE_NAME }}:${{ github.sha }} ${{ env.PROD_REGISTRY_IMAGE_NAME }}:${{ steps.vars.outputs.ref }}
 
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -89,16 +89,30 @@ jobs:
   ### Private Lift E2E tests
   pl_test:
     name: Private Lift E2E Tests
-    runs-on: [self-hosted, fbpcs-e2e-test-runner]
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
+      id-token: write
       contents: read
-      packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Print Tracker Hash
-        run: echo ${{ inputs.tracker_hash}}
+        run: echo ${{ inputs.tracker_hash }}
+
+      - name: Get AWS Session name
+        id: aws_session_name
+        run: |
+          echo session_name=$(echo ${{ inputs.test_name }}-${{ inputs.build_id }} | tr " " "-") >> $GITHUB_OUTPUT
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_TEST_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+          role-duration-seconds: 5400
+          role-session-name: ${{ steps.aws_session_name.outputs.session_name }}
 
       - name: One command runner
         id: runner
@@ -110,7 +124,11 @@ jobs:
           --input_paths=${{ inputs.input_path }} \
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
           -- \
-          --version=${{ inputs.tag }} > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
+          --version=${{ inputs.tag }} \
+          --docker_env=AWS_ACCESS_KEY_ID \
+          --docker_env=AWS_SECRET_ACCESS_KEY \
+          --docker_env=AWS_SESSION_TOKEN \
+          --docker_env=AWS_DEFAULT_REGION > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
 
       - name: Print runner console output
         continue-on-error: true
@@ -134,11 +152,16 @@ jobs:
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
           --expected_result_path=${{ inputs.expected_result_path }} \
           -- \
-          --version=${{ inputs.tag }}
+          --version=${{ inputs.tag }} \
+          --docker_env=AWS_ACCESS_KEY_ID \
+          --docker_env=AWS_SECRET_ACCESS_KEY \
+          --docker_env=AWS_SESSION_TOKEN \
+          --docker_env=AWS_DEFAULT_REGION
 
       - name: Validate runner logs
         # First command extracts the pc-cli log lines starting with "... ! Command line: ..." into a file.
         run: |
           sed -n '/^.* ! Command line: .*/,$p' < ${{env.CONSOLE_OUTPUT_FILE}} > ${{env.CONSOLE_OUTPUT_FILE}}.extracted
-          docker run --rm -v "${{env.CONSOLE_OUTPUT_FILE}}.extracted:${{env.CONSOLE_OUTPUT_FILE}}" ${{env.FBPCS_CONTAINER_REPO_URL}}/${{env.FBPCS_IMAGE_NAME}}:${{inputs.tag}} \
+          docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_DEFAULT_REGION --rm \
+          -v "${{env.CONSOLE_OUTPUT_FILE}}.extracted:${{env.CONSOLE_OUTPUT_FILE}}" ${{env.FBPCS_CONTAINER_REPO_URL}}/${{env.FBPCS_IMAGE_NAME}}:${{inputs.tag}} \
           python -m fbpcs.infra.logging_service.log_analyzer.log_analyzer ${{env.CONSOLE_OUTPUT_FILE}} --validate_one_runner_logs

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -82,16 +82,30 @@ jobs:
 
   pa_test:
     name: Private Attribution E2E Tests
-    runs-on: [self-hosted, fbpcs-e2e-test-runner]
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
+      id-token: write
       contents: read
-      packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Print Tracker Hash
         run: echo ${{ inputs.tracker_hash}}
+
+      - name: Get AWS Session name
+        id: aws_session_name
+        run: |
+          echo session_name=$(echo ${{ inputs.test_name }}-${{ inputs.build_id }} | tr " " "-") >> $GITHUB_OUTPUT
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_TEST_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+          role-duration-seconds: 5400
+          role-session-name: ${{ steps.aws_session_name.outputs.session_name }}
 
       - name: One Command runner
         run: |
@@ -106,7 +120,12 @@ jobs:
           --timestamp="1646870400" \
           --k_anonymity_threshold=0 \
           -- \
-          --version=${{ inputs.tag }}
+          --version=${{ inputs.tag }} \
+          --docker_env=AWS_ACCESS_KEY_ID \
+          --docker_env=AWS_SECRET_ACCESS_KEY \
+          --docker_env=AWS_SESSION_TOKEN \
+          --docker_env=AWS_DEFAULT_REGION
+
       - name: Validate Results
         # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
         # the fbpcs_instances directory is where instances are written to (feature of run_fbpcs.sh)
@@ -118,4 +137,8 @@ jobs:
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
           --expected_result_path=${{ inputs.expected_result_path }} \
           -- \
-          --version=${{ inputs.tag }}
+          --version=${{ inputs.tag }} \
+          --docker_env=AWS_ACCESS_KEY_ID \
+          --docker_env=AWS_SECRET_ACCESS_KEY \
+          --docker_env=AWS_SESSION_TOKEN \
+          --docker_env=AWS_DEFAULT_REGION

--- a/.github/workflows/rc_one_command_runner_test.yml
+++ b/.github/workflows/rc_one_command_runner_test.yml
@@ -7,11 +7,11 @@ on:
       study_id:
         description: Lift study id
         required: true
-        default: 322561936733136
+        default: "322561936733136"
       objective_id:
         description: Lift objective id
         required: true
-        default: 465652472226695
+        default: "465652472226695"
       input_path:
         description: S3 path to synthetic data
         required: true
@@ -42,16 +42,30 @@ jobs:
   ### Private Lift E2E tests
   pl_test:
     name: Private Lift RC E2E Tests
-    runs-on: [self-hosted, fbpcs-e2e-test-runner]
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
+      id-token: write
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Print Tracker Hash
         run: echo ${{ github.event.inputs.tracker_hash}}
+
+      - name: Get AWS Session name
+        id: aws_session_name
+        run: |
+          echo session_name=$(echo PL-RC-E2E-Tests-${{ inputs.build_id }} | tr " " "-") >> $GITHUB_OUTPUT
+
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_TEST_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+          role-duration-seconds: 5400
+          role-session-name: ${{ steps.aws_session_name.outputs.session_name }}
 
       - name: One command runner
         run: |
@@ -61,7 +75,11 @@ jobs:
           --input_paths=${{ github.event.inputs.input_path }} \
           --config=./fbpcs/tests/github/rc_config_one_command_runner_test.yml \
           -- \
-          --version=${{ github.event.inputs.tag }}
+          --version=${{ github.event.inputs.tag }} \
+          --docker_env=AWS_ACCESS_KEY_ID \
+          --docker_env=AWS_SECRET_ACCESS_KEY \
+          --docker_env=AWS_SESSION_TOKEN \
+          --docker_env=AWS_DEFAULT_REGION
 
       - name: Validate Results
         # instances are named after ent ids, so we are going to look for filenames that consist of only numbers and then run validation on them
@@ -74,4 +92,8 @@ jobs:
           --config=./fbpcs/tests/github/config_one_command_runner_test.yml \
           --expected_result_path=${{ github.event.inputs.expected_result_path }} \
           -- \
-          --version=${{ github.event.inputs.tag }}
+          --version=${{ github.event.inputs.tag }} \
+          --docker_env=AWS_ACCESS_KEY_ID \
+          --docker_env=AWS_SECRET_ACCESS_KEY \
+          --docker_env=AWS_SESSION_TOKEN \
+          --docker_env=AWS_DEFAULT_REGION

--- a/fbpcs/scripts/run_fbpcs.sh
+++ b/fbpcs/scripts/run_fbpcs.sh
@@ -29,7 +29,7 @@ function usage() {
 https://<s3_conversion_data_file_path_for_objective_2> \
 --log_path=/fbpcs_instances/output.txt"
 
-  example2="$example1 -- --version=latest [--image_version=latest]"
+  example2="$example1 -- --version=latest [--image_version=latest] [--docker_env=ENVIRONMENT_VAR]"
 
   echo "Usage :  $0 [PC-CLI options] -- [$0 options]
     PC-CLI Options:
@@ -37,12 +37,20 @@ https://<s3_conversion_data_file_path_for_objective_2> \
 
     $0 Options:
       --version=<version>   specify the release version of lift/attribution is used
+      --image_version=<image_version> specify the $FBPCS_IMAGE_NAME image version
+      --docker_env=<environment_variable_name> specify an existing environment variable that should be passed to the $FBPCS_IMAGE_NAME image
 
     Examples:
       $example1
 
       $example2
     "
+}
+
+function env_validation_failure() {
+  echo "The envrionment variable $1 is not valid."
+  usage
+  exit 1
 }
 
 function main() {
@@ -87,6 +95,7 @@ function parse_args() {
   fi
 
   docker_cmd=(python3.8 -m fbpcs.private_computation_cli.private_computation_cli)
+  environment_vars=(-e FBPCS_GRAPH_API_TOKEN)
 
   # PC-CLI arguments
   for arg in "$@"; do
@@ -129,6 +138,15 @@ function parse_args() {
         image_version="${arg#*=}"
         echo "Overriding docker version tag with $image_version"
         ;;
+      --docker_env=*)
+        env_var_name=${arg#*=}
+        if [[ "$env_var_name" =~ ^([a-zA-Z0-9_]+)$ ]]; then
+          echo "Adding environment variable $env_var_name"
+        else
+          env_validation_failure "$env_var_name"
+        fi
+        environment_vars+=(-e "$env_var_name")
+        ;;
       *)
         echo >&2 "$arg is not a valid argument"
         usage
@@ -151,7 +169,7 @@ function run_fbpcs() {
     aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$FBPCS_CONTAINER_REPO_URL"
   fi
   docker pull "$docker_image"
-  docker run -e FBPCS_GRAPH_API_TOKEN --rm \
+  docker run "${environment_vars[@]}" --rm \
     -v "$real_config_path":"$DOCKER_CONFIG_PATH" \
     -v "$REAL_INSTANCE_REPO":"$DOCKER_INSTANCE_REPO" \
     -v "$REAL_CREDENTIALS_PATH":"$DOCKER_CREDENTIALS_PATH" \


### PR DESCRIPTION
Summary:
## Background
As a way to reduce our cloud cost, increase scalability, reduce complexity and improve our cloud security, I have started to move our self-hosted runners to use GitHub hosted runners. The first and easiest to migrate is the end-to-end test runners since they mainly just start a ECS task.

One of the problems we have with running our E2E test throughout the day is that we have a limited number of test runners and it could delay our regular release testing by blocking all the runners for an hour+ at a time.

## This diff
This diff updates the E2E test runners to use GitHub hosted Ubuntu runners.

Differential Revision: D41364330

