### PR TITLE
Add crypto key components for use in TLS

### DIFF
--- a/fbpcs/infra/certificate/keys.py
+++ b/fbpcs/infra/certificate/keys.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+
+class EllipticCurvePublicKey:
+    """An elliptic curve public key"""
+
+    def __init__(self, key: ec.EllipticCurvePublicKeyWithSerialization) -> None:
+        self._public_key = key
+
+    def verify(self, signature: bytes, data: bytes) -> None:
+        """Verifies one block of data was signed with the private key associated with this public key"""
+
+        hash_algorithm = hashes.SHA256()  # most common, secure hash for ECDSA
+        signature_algorithm = ec.ECDSA(hash_algorithm)  # only one currently supported
+
+        return self._public_key.verify(signature, data, signature_algorithm)
+
+    def public_bytes(self) -> bytes:
+        """Serializes the key to bytes of an unencrypted PEM in Subject Public Key Info format"""
+
+        encoding = Encoding.PEM  # most commonly supported
+        key_format = PublicFormat.SubjectPublicKeyInfo  # standard
+
+        return self._public_key.public_bytes(encoding, key_format)
+
+
+class EllipticCurvePrivateKey:
+    """An elliptic curve private key"""
+
+    def __init__(self, key: ec.EllipticCurvePrivateKeyWithSerialization) -> None:
+        self._key = key
+
+    def sign(self, data: bytes) -> bytes:
+        """Signs one block of data, which can be verified using the paired public key"""
+
+        hash_algorithm = hashes.SHA256()  # most common, secure hash for ECDSA
+        signature_algorithm = ec.ECDSA(hash_algorithm)  # only one currently supported
+
+        return self._key.sign(data, signature_algorithm)
+
+    def private_bytes(self) -> bytes:
+        """Serializes the key to bytes of an unencrypted PEM in PKCS8 format"""
+
+        encoding = Encoding.PEM  # most commonly supported
+        key_format = PrivateFormat.PKCS8  # modern, well-supported
+        encryption = NoEncryption()  # need raw bytes, may support encryption later
+
+        return self._key.private_bytes(encoding, key_format, encryption)
+
+    def public_key(self) -> EllipticCurvePublicKey:
+        return EllipticCurvePublicKey(self._key.public_key())
+
+
+class KeyFactory:
+    """A factory which produces cryptographic keys"""
+
+    @staticmethod
+    def create_ec_key() -> EllipticCurvePrivateKey:
+        curve = (
+            ec.SECP256R1
+        )  # only support NIST P-256 key for now, most commonly used ECC for certificates
+
+        return EllipticCurvePrivateKey(ec.generate_private_key(curve))

--- a/fbpcs/infra/certificate/tests/test_keys.py
+++ b/fbpcs/infra/certificate/tests/test_keys.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+)
+
+from fbpcs.infra.certificate.keys import EllipticCurvePrivateKey, KeyFactory
+
+
+class TestKeys(unittest.TestCase):
+    def test_key_factory_create_ec_key(self) -> None:
+        # Act
+        key = KeyFactory.create_ec_key()
+
+        # Assert
+        self.assertIsNotNone(key)
+        self.assertIsInstance(key, EllipticCurvePrivateKey)
+
+    def test_ec_private_key_serialization(self) -> None:
+        # Arrange
+        key = KeyFactory.create_ec_key()
+        expected_curve = ec.SECP256R1()
+        expected_key_length = 256
+
+        # Act
+        serialized_key = key.private_bytes()
+        deserialized_key = load_pem_private_key(serialized_key, password=None)
+
+        # Assert
+        self.assertIsInstance(
+            deserialized_key, ec.EllipticCurvePrivateKey
+        )  # implicitly verifies that key was serialized to unencrypted PEM
+
+        curve = deserialized_key.curve
+        self.assertEqual(curve.name, expected_curve.name)
+        self.assertEqual(curve.key_size, expected_curve.key_size)
+
+        self.assertEqual(deserialized_key.key_size, expected_key_length)
+
+    def test_ec_public_key_serialization(self) -> None:
+        # Arrange
+        key = KeyFactory.create_ec_key()
+        expected_curve = ec.SECP256R1()
+        expected_key_length = 256
+
+        # Act
+        serialized_key = key.public_key().public_bytes()
+        deserialized_key = load_pem_public_key(serialized_key)
+
+        # Assert
+        self.assertIsInstance(
+            deserialized_key, ec.EllipticCurvePublicKey
+        )  # implicitly verifies that key was serialized to PEM
+
+        curve = deserialized_key.curve
+        self.assertEqual(curve.name, expected_curve.name)
+        self.assertEqual(curve.key_size, expected_curve.key_size)
+
+        self.assertEqual(deserialized_key.key_size, expected_key_length)
+
+    def test_ec_key_signature_verification_failure(self) -> None:
+        # Arrange
+        key = KeyFactory.create_ec_key()
+        actual_data = "some test information".encode("utf-8")
+        non_matching_data = "invalid data".encode("utf-8")
+
+        # Act
+        signature = key.sign(actual_data)
+
+        # Assert
+        with self.assertRaises(InvalidSignature):
+            key.public_key().verify(signature, non_matching_data)
+
+    def test_ec_key_signature_verification_success(self) -> None:
+        # Arrange
+        key = KeyFactory.create_ec_key()
+        actual_data = "some test information".encode("utf-8")
+
+        # Act
+        signature = key.sign(actual_data)
+
+        # Assert
+        key.public_key().verify(signature, actual_data)  # valid if no error


### PR DESCRIPTION
Summary:
We are adding support for TLS in Private Lift. In a subsequent change, we will need to generate TLS certificates. To generate a certificate, cryptographic keys will be used for signing.

This change adds support for generating and using Elliptic-Curve Cryptography keys for digital signatures. This will later be used during certificate generation.

We will be using ECC keys because they can achieve high security with a short key length: 244-bit ECC is similar to 2048-bit RSA. ECC is faster for key generation and signing, but RSA is faster for signature verification.

The module was designed to abstract the underlying implementation of the cryptography, which relies on the widely used PYCA Cryptography library. It also hides most of the crypto choices from the consumer, to avoid misconfiguration.

Reviewed By: Kewen12

Differential Revision: D41269734

