### PR TITLE
Fix incorrectly labeled CMake option for EMP

### DIFF
--- a/docker/data_processing/Dockerfile.ubuntu
+++ b/docker/data_processing/Dockerfile.ubuntu
@@ -24,7 +24,7 @@ COPY fbpcs/data_processing/sharding/ ./fbpcs/data_processing/sharding
 COPY fbpcs/data_processing/load_testing_utils/ ./fbpcs/data_processing/load_testing_utils
 COPY fbpcs/data_processing/private_id_dfca_id_combiner/ ./fbpcs/data_processing/private_id_dfca_id_combiner
 
-RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON
+RUN cmake . -DTHREADING=ON -DUSE_RANDOM_DEVICE=ON
 RUN make && make install
 
 CMD ["/bin/sh"]

--- a/docker/emp_games/Dockerfile.ubuntu
+++ b/docker/emp_games/Dockerfile.ubuntu
@@ -24,7 +24,7 @@ COPY fbpcs/emp_games/private_id_dfca_aggregator/ ./fbpcs/emp_games/private_id_df
 COPY fbpcs/emp_games/lift/ ./fbpcs/emp_games/lift
 COPY fbpcs/emp_games/common/ ./fbpcs/emp_games/common
 
-RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON
+RUN cmake . -DTHREADING=ON -DUSE_RANDOM_DEVICE=ON
 RUN make && make install
 
 CMD ["/bin/sh"]

--- a/docker/tee_experiment/Dockerfile.ubuntu
+++ b/docker/tee_experiment/Dockerfile.ubuntu
@@ -18,7 +18,7 @@ COPY fbpcs/performance_tools/ ./fbpcs/performance_tools
 COPY fbpcs/emp_games/lift/ ./fbpcs/emp_games/lift
 COPY fbpcs/emp_games/common/ ./fbpcs/emp_games/common
 
-RUN cmake . -DTHREADING=ON -DEMP_USE_RANDOM_DEVICE=ON
+RUN cmake . -DTHREADING=ON -DUSE_RANDOM_DEVICE=ON
 RUN make && make install
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
Summary:
We've been adding this option to CMake called "EMP_USE_RANDOM_DEVICE" -- the intention is to *force* EMP to use `std::random_device` instead of `x86intrin.h` since the former is guaranteed to exist on all systems but the latter is CPU-dependent.

Unfortunately... we named it incorrectly. We shouldn't be using the `EMP_` prefix. By doing so, we were letting EMP decide whether to use `std::random_device` or `x86intrin.h` by checking if the build machine had access to `rdseed` internally.

What this means is that in some cases (like the ones described in the linked SEV task), we built on a machine with access to `rdseed`, but later when running in ECS, `rdseed` wasn't present. This gives the cryptic "Invalid Instruction" error because we're trying to execute a CPU instruction that doesn't exist on the machine where the computation is actually running.

Since there's no major difference to use between using `random_device` and `rdseed` and since we can't guarantee that we'll be given access to a machine with `rdseed` capabilities at runtime, we want to force EMP to always use `random_device`. This diff fixes that issue.

Differential Revision:
D41375296

LaMa Project: L416713

