### PR TITLE
Add TLS certificate generation interfaces

### DIFF
--- a/fbpcs/infra/certificate/service.py
+++ b/fbpcs/infra/certificate/service.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from abc import ABC, abstractmethod
+
+
+class X509Certificate(ABC):
+    """A class which represents a X.509 Certificate"""
+
+    @abstractmethod
+    def public_bytes(self) -> bytes:
+        """Returns the certificate as PEM-encoded bytes"""
+        pass

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, DefaultDict, Dict, List, Optional, Set, Type, TypeVar, Union
+from typing import Any, DefaultDict, Dict, List, Optional, Type, TypeVar, Union
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus
 from fbpcp.error.pcp import ThrottlingError
@@ -39,10 +39,7 @@ from fbpcs.infra.certificate.pc_instance_ca_certificate_provider import (
 from fbpcs.infra.certificate.pc_instance_server_certificate import (
     PCInstanceServerCertificateProvider,
 )
-from fbpcs.infra.certificate.sample_tls_certificates import (
-    SAMPLE_CA_CERTIFICATE,
-    SAMPLE_SERVER_CERTIFICATE,
-)
+from fbpcs.infra.certificate.sample_tls_certificates import SAMPLE_CA_CERTIFICATE
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.post_processing_handler.post_processing_handler import PostProcessingHandler
 from fbpcs.private_computation.entity.breakdown_key import BreakdownKey
@@ -108,7 +105,6 @@ from fbpcs.utils.optional import unwrap_or_default
 T = TypeVar("T")
 
 PCSERVICE_ENTITY_NAME = "pcservice"
-DEFAULT_SERVER_DOMAIN = "study123.pci.facebook.com"
 
 
 class PrivateComputationService:
@@ -199,6 +195,9 @@ class PrivateComputationService:
         log_cost_bucket: Optional[str] = None,
         input_path_start_ts: Optional[str] = None,
         input_path_end_ts: Optional[str] = None,
+        server_certificate: Optional[str] = None,
+        ca_certificate: Optional[str] = None,
+        server_domain: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
         self.metric_svc.bump_entity_key(PCSERVICE_ENTITY_NAME, "create_instance")
@@ -225,19 +224,6 @@ class PrivateComputationService:
             self.metric_svc.bump_entity_key(
                 PCSERVICE_ENTITY_NAME, f"pcs_feature_{feature.lower()}_enabled"
             )
-        # TODO: T136500624 Replace SAMPLE_SERVER_CERTIFICATE with dynamically generated certificates.
-        # The certificates returned below do not provide any security and
-        # are being used for intermediate testing purposes only.
-        server_certificate = (
-            SAMPLE_SERVER_CERTIFICATE
-            if PCSFeature.PCF_TLS in pcs_feature_enums
-            and role is PrivateComputationRole.PUBLISHER
-            else None
-        )
-        ca_certificate = (
-            SAMPLE_CA_CERTIFICATE if PCSFeature.PCF_TLS in pcs_feature_enums else None
-        )
-        server_domain = self._get_server_domain(instance_id, role, pcs_feature_enums)
 
         infra_config: InfraConfig = InfraConfig(
             instance_id=instance_id,
@@ -361,23 +347,6 @@ class PrivateComputationService:
             entity=PCSERVICE_ENTITY_NAME, prefix="instance_repo_update"
         ):
             self.instance_repository.update(instance=instance)
-
-    def _get_server_domain(
-        self,
-        instance_id: str,
-        role: PrivateComputationRole,
-        pcs_feature_enums: Set[PCSFeature],
-    ) -> Optional[str]:
-        if (
-            role is not PrivateComputationRole.PUBLISHER
-            or PCSFeature.PCF_TLS not in pcs_feature_enums
-        ):
-            return None
-        # TODO: T136704156 Replace the static server domain value with a
-        # dynamically composed server domain for publisher side
-        # when tls feature is enabled.
-        # return f"publisher.study{instance_id}.pci.facebook.com"
-        return DEFAULT_SERVER_DOMAIN
 
     def _get_number_of_mpc_containers(
         self,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -24,10 +24,6 @@ from fbpcs.common.entity.stage_state_instance import (
     StageStateInstanceStatus,
 )
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
-from fbpcs.infra.certificate.sample_tls_certificates import (
-    SAMPLE_CA_CERTIFICATE,
-    SAMPLE_SERVER_CERTIFICATE,
-)
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.onedocker_service_config import OneDockerServiceConfig
@@ -200,18 +196,35 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
     @mock.patch("time.time", new=mock.MagicMock(return_value=1))
     def test_create_instance(self) -> None:
-        for test_game_type, expected_k_anon, pcs_features, test_role in (
+        expected_server_certificate = "test server certificate"
+        expected_ca_certificate = "test ca certificate"
+        expected_server_domain = "example.com"
+        for (
+            test_game_type,
+            expected_k_anon,
+            pcs_features,
+            test_role,
+            server_certificate,
+            ca_certificate,
+            server_domain,
+        ) in (
             (
                 PrivateComputationGameType.LIFT,
                 DEFAULT_K_ANONYMITY_THRESHOLD_PL,
                 [PCSFeature.PCS_DUMMY.value, PCSFeature.UNKNOWN.value],
                 PrivateComputationRole.PUBLISHER,
+                None,
+                None,
+                None,
             ),
             (
                 PrivateComputationGameType.ATTRIBUTION,
                 DEFAULT_K_ANONYMITY_THRESHOLD_PA,
                 None,
                 PrivateComputationRole.PUBLISHER,
+                None,
+                None,
+                None,
             ),
             # test PCSFeature.PRIVATE_ATTRIBUTION_MR_PID for attribution with publisher
             (
@@ -222,6 +235,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value,
                 ],
                 PrivateComputationRole.PUBLISHER,
+                None,
+                None,
+                None,
             ),
             # test PCSFeature.PRIVATE_ATTRIBUTION_MR_PID for lift with publisher
             (
@@ -232,6 +248,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value,
                 ],
                 PrivateComputationRole.PUBLISHER,
+                None,
+                None,
+                None,
             ),
             # test PCSFeature.PCF_TLS for lift with publisher
             (
@@ -242,6 +261,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     PCSFeature.PCF_TLS.value,
                 ],
                 PrivateComputationRole.PUBLISHER,
+                expected_server_certificate,
+                expected_ca_certificate,
+                expected_server_domain,
             ),
             # test PCSFeature.PCF_TLS for lift with partner
             (
@@ -252,6 +274,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     PCSFeature.PCF_TLS.value,
                 ],
                 PrivateComputationRole.PARTNER,
+                None,
+                expected_ca_certificate,
+                None,
             ),
         ):
             with self.subTest(
@@ -273,6 +298,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     attribution_rule=AttributionRule.LAST_CLICK_1D,
                     aggregation_type=AggregationType.MEASUREMENT,
                     pcs_features=pcs_features,
+                    server_certificate=server_certificate,
+                    ca_certificate=ca_certificate,
+                    server_domain=server_domain,
                 )
                 # check instance_repository.create is called with the correct arguments
                 # pyre-fixme[16]: Callable `create` has no attribute `assert_called`.
@@ -347,15 +375,15 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                 ):
                     self.assertEqual(
                         args.infra_config.server_certificate,
-                        SAMPLE_SERVER_CERTIFICATE,
+                        expected_server_certificate,
                     )
                     self.assertEqual(
                         args.infra_config.ca_certificate,
-                        SAMPLE_CA_CERTIFICATE,
+                        expected_ca_certificate,
                     )
                     self.assertEqual(
                         args.infra_config.server_domain,
-                        "study123.pci.facebook.com",
+                        expected_server_domain,
                     )
 
                 if (
@@ -369,7 +397,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     )
                     self.assertEqual(
                         args.infra_config.ca_certificate,
-                        SAMPLE_CA_CERTIFICATE,
+                        expected_ca_certificate,
                     )
                     self.assertEqual(
                         args.infra_config.server_domain,
@@ -1259,8 +1287,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             mpc_compute_concurrency=self.test_concurrency,
             status_updates=status_updates or [],
             log_cost_bucket=self.log_cost_bucket,
-            server_certificate=SAMPLE_SERVER_CERTIFICATE,
-            ca_certificate=SAMPLE_CA_CERTIFICATE,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.test_input_path,


### PR DESCRIPTION
Summary:
This change adds some interfaces which will be used in PCS to issue certificates for use during Private Lift.

The interface implementation will be done in a subsequent change.

Reviewed By: liliarizona

Differential Revision: D41269735

