### PR TITLE
fix get_log_urls index error

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -757,6 +757,10 @@ class PrivateComputationService:
             raise ValueError(
                 "instance_or_id must be either a str or PrivateComputationInstance"
             )
+
+        if not private_computation_instance.infra_config.instances:
+            return {}
+
         # Get the last pid or mpc instance
         last_instance = private_computation_instance.infra_config.instances[-1]
 


### PR DESCRIPTION
Summary:
## What

- If pc_instance.instances is empty, return an empty dict instead of raising an index error

## Why

- Since the dawn of time, this error has been included in the tupperware logs whenever the failure reporter reports a failure in CREATED or PC_PRE_VALIDATATION, and it's been causing some confusion
- https://fb.m.workplace.com/groups/331044242148818/permalink/618736543379585

Reviewed By: ztlbells

Differential Revision: D41450865

