### PR TITLE
log bundle id

### DIFF
--- a/fbpcs/common/service/test/test_trace_logging_registry.py
+++ b/fbpcs/common/service/test/test_trace_logging_registry.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Dict
+from unittest import TestCase
+
+from fbpcs.common.service.trace_logging_registry import RegistryFactory
+
+
+class DummyRegistry(RegistryFactory[str]):
+
+    _REGISTRY: Dict[str, str] = {}
+
+    @classmethod
+    def _get_default_value(cls) -> str:
+        return "default value"
+
+
+class TestRegistryFactory(TestCase):
+    def test_registry(self) -> None:
+        expected_registry = {}
+        for key in [None, "key1", DummyRegistry._DEFAULT_KEY]:
+            for register_val in [None, "val1"]:
+                start_registry = expected_registry.copy()
+                if register_val and key:
+                    expected_value = register_val
+                else:
+                    expected_value = DummyRegistry._get_default_value()
+
+                expected_registry[key or DummyRegistry._DEFAULT_KEY] = expected_value
+                with self.subTest(
+                    key=key,
+                    register_val=register_val,
+                    expected_value=expected_value,
+                    start_registry=start_registry,
+                    expected_registry=expected_registry,
+                ):
+                    self.assertEqual(DummyRegistry._REGISTRY, start_registry)
+
+                    if register_val and key:
+                        DummyRegistry.register_object(key, register_val)
+
+                    actual_value = DummyRegistry.get(key)
+                    self.assertEqual(actual_value, expected_value)
+
+                    self.assertEqual(DummyRegistry._REGISTRY, expected_registry)

--- a/fbpcs/common/service/test/test_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_trace_logging_service.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+from unittest import TestCase
+
+from fbpcs.common.service.trace_logging_service import (
+    CheckpointStatus,
+    TraceLoggingService,
+)
+
+
+class DummyTraceLoggingService(TraceLoggingService):
+    def __init__(self, fail_to_log: bool = False) -> None:
+        self.events = []
+        self.fail_to_log = fail_to_log
+
+    # pyre-ignore
+    def _write_checkpoint_impl(
+        self,
+        **kwargs,
+    ) -> None:
+        if self.fail_to_log:
+            raise RuntimeError("Failing to log for test")
+        self.events.append(kwargs)
+
+    def _extract_caller_info(self) -> Dict[str, str]:
+        return {"caller_info": "caller_info"}
+
+    def _extract_error_info(self) -> Dict[str, str]:
+        return {"error_info": "error_info"}
+
+
+class TestTraceLoggingService(TestCase):
+    def test_write_checkpoint_simple(self) -> None:
+        for checkpoint_data in (None, {}, {"my_data": "my_data"}):
+            for status in CheckpointStatus:
+                with self.subTest(checkpoint_data=checkpoint_data, status=status):
+                    svc = DummyTraceLoggingService()
+                    payload = {
+                        "run_id": "run123",
+                        "instance_id": "instance456",
+                        "checkpoint_name": "foo",
+                        "status": CheckpointStatus.STARTED,
+                        "checkpoint_data": checkpoint_data,
+                    }
+                    # pyre-ignore
+                    svc.write_checkpoint(**payload.copy())
+
+                    checkpoint_data = checkpoint_data or {}
+                    checkpoint_data["caller_info"] = "caller_info"
+                    if status is CheckpointStatus.FAILED:
+                        checkpoint_data["error_info"] = "error_info"
+
+                    payload["checkpoint_data"] = checkpoint_data
+                    self.assertEqual(payload, svc.events[0])
+
+    def test_write_checkpoint_cm(self) -> None:
+        for checkpoint_data in (None, {}, {"my_data": "my_data"}):
+            for bad_function_payload in (False, True):
+                for fail_to_log in (False, True):
+                    with self.subTest(
+                        checkpoint_data=checkpoint_data,
+                        bad_funtion_payload=bad_function_payload,
+                        fail_to_log=fail_to_log,
+                    ):
+                        svc = DummyTraceLoggingService(fail_to_log=fail_to_log)
+                        payload = {
+                            "run_id": "run123",
+                            "instance_id": "instance456",
+                            "checkpoint_name": "foo",
+                            "checkpoint_data": checkpoint_data.copy()
+                            if checkpoint_data
+                            else None,
+                        }
+
+                        try:
+                            with svc.write_checkpoint_cm(
+                                # pyre-ignore
+                                **payload
+                            ) as cm:
+                                cm["before_failure"] = "before_failure"
+                                assert bad_function_payload is False
+                                cm["after_failure"] = "after_failure"
+                        except AssertionError:
+                            self.assertTrue(bad_function_payload)
+                            expected_payload2 = {
+                                **payload,
+                                "status": CheckpointStatus.FAILED,
+                                "checkpoint_data": {
+                                    **(checkpoint_data or {}),
+                                    "before_failure": "before_failure",
+                                    "error_info": "error_info",
+                                },
+                            }
+                        else:
+                            expected_payload2 = {
+                                **payload,
+                                "status": CheckpointStatus.COMPLETED,
+                                "checkpoint_data": {
+                                    **(checkpoint_data or {}),
+                                    "before_failure": "before_failure",
+                                    "after_failure": "after_failure",
+                                },
+                            }
+                        finally:
+                            if fail_to_log:
+                                self.assertEqual(len(svc.events), 0)
+                            else:
+                                self.assertEqual(len(svc.events), 2)
+                                started_payload = {
+                                    **payload,
+                                    "status": CheckpointStatus.STARTED,
+                                    "checkpoint_data": checkpoint_data or {},
+                                }
+                                self.assertEqual(started_payload, svc.events[0])
+
+                                actual_payload = svc.events[1]
+                                del actual_payload["checkpoint_data"]["runtime_ms"]
+                                self.assertEqual(actual_payload, expected_payload2)

--- a/fbpcs/common/service/test/test_write_checkpoint.py
+++ b/fbpcs/common/service/test/test_write_checkpoint.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+import inspect
+import itertools
+from contextlib import nullcontext
+from typing import Any, Callable, ContextManager, Dict, List
+from unittest import IsolatedAsyncioTestCase
+
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+from fbpcs.common.service.trace_logging_registry import InstanceIdtoRunIdRegistry
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
+
+from fbpcs.common.service.write_checkpoint import write_checkpoint
+
+
+class dummy_checkpoint(write_checkpoint):
+    _DEFAULT_REGISTRY_KEY = "dummy_checkpoint_key"
+    _PARAMS_CONTAINING_INSTANCE_ID: List[str] = [
+        "instance_id",
+    ]
+    _DEFAULT_COMPONENT_NAME = "DefaultDummyComponent"
+
+    def _get_trace_logger_cm(
+        self,
+        func: Callable,  # pyre-ignore
+        *args: Any,
+        **kwargs: Dict[str, Any],
+    ) -> ContextManager[Dict[str, str]]:
+        return nullcontext(self.checkpoint_data)
+
+
+class DummyException(Exception):
+    pass
+
+
+def add(instance_id: str, x: int, y: int = 2) -> int:
+    return x + y
+
+
+def raise_exception(instance_id: str) -> None:
+    raise DummyException
+
+
+class DummyTraceLoggingService(SimpleTraceLoggingService):
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+
+
+class DummyClass:
+    TRACE_LOGGING_SVC = DummyTraceLoggingService("class_default")
+    _OBJ_TRACE_LOGGING_SVC = DummyTraceLoggingService("obj_default")
+
+    def __init__(self) -> None:
+        self.trace_logging_svc: TraceLoggingService = self._OBJ_TRACE_LOGGING_SVC
+
+    def add(self, instance_id: str, x: int, y: int) -> int:
+        return x + y
+
+    @classmethod
+    def subtract(cls, x: int, y: int) -> int:
+        return x - y
+
+    async def async_add(self, instance_id: str, x: int, y: int) -> int:
+        return x + y
+
+
+class TestWriteCheckpoint(IsolatedAsyncioTestCase):
+    async def test_basic_usage(self) -> None:
+        # test that the decorator doesn't affect results
+        with self.subTest("static func"):
+            res = dummy_checkpoint()(add)("instance_id", 1, 2)
+            self.assertEqual(res, 3)
+
+        with self.subTest("method"):
+            obj = DummyClass()
+            res = dummy_checkpoint()(obj.add)("instance_id", 1, 2)
+            self.assertEqual(res, 3)
+
+        with self.subTest("class method"):
+            res = dummy_checkpoint()(DummyClass.subtract)(1, 2)
+            self.assertEqual(res, -1)
+
+        with self.subTest("raise exception"):
+            with self.assertRaises(DummyException):
+                res = dummy_checkpoint()(raise_exception)("instance_id")
+
+        with self.subTest("async add"):
+            obj = DummyClass()
+            res = await dummy_checkpoint()(obj.async_add)("instance_id", 1, 2)
+            self.assertEqual(res, 3)
+
+    async def test_dump_return_val(self) -> None:
+        for dump_return_val in (True, False):
+            with self.subTest(dump_return_value=dump_return_val):
+                checkpoint_dec = dummy_checkpoint(dump_return_val=dump_return_val)
+                res = checkpoint_dec(add)("instance", 1)
+                self.assertEqual(res, 3)
+                if dump_return_val:
+                    self.assertEqual(
+                        checkpoint_dec.checkpoint_data["return_value"], str(res)
+                    )
+                else:
+                    self.assertNotIn("return_value", checkpoint_dec.checkpoint_data)
+
+    def test_get_checkpoint_data(self) -> None:
+        for (
+            my_checkpoint_data,
+            component_name,
+            dump_params,
+            include,
+        ) in itertools.product(
+            ({}, {"my_data": "my_data"}),
+            ((None, "test component")),
+            ((True, False)),
+            ((None, ["x"])),
+        ):
+            with self.subTest(
+                my_checkpoint_data=my_checkpoint_data,
+                component_name=component_name,
+                dump_params=dump_params,
+                include=include,
+            ):
+                kwargs = {"instance_id": "instance", "x": 1, "y": 2}
+                function_args = inspect.signature(add).bind(**kwargs).arguments
+                checkpoint_data = dummy_checkpoint(
+                    checkpoint_data=my_checkpoint_data,
+                    component=component_name,
+                    dump_params=dump_params,
+                    include=include,
+                )._get_checkpoint_data(function_args)
+                if dump_params:
+                    for k, v in kwargs.items():
+                        if include and k not in include:
+                            self.assertNotIn(k, checkpoint_data)
+                        else:
+                            self.assertEqual(checkpoint_data[k], str(v))
+                else:
+                    for k in kwargs:
+                        self.assertNotIn(k, checkpoint_data)
+
+                for k, v in my_checkpoint_data.items():
+                    self.assertEqual(checkpoint_data[k], str(v))
+
+                expected_component_name = (
+                    component_name or dummy_checkpoint._DEFAULT_COMPONENT_NAME
+                )
+
+                self.assertEqual(checkpoint_data["component"], expected_component_name)
+
+    def test_get_instance_id(self) -> None:
+        for instance_id_param in (None, "instance_id"):
+            with self.subTest(instance_id_param=instance_id_param):
+                kwargs = {"instance_id": "instance", "x": 1, "y": 2}
+                function_args = inspect.signature(add).bind(**kwargs).arguments
+                instance_id = dummy_checkpoint(
+                    instance_id_param=instance_id_param
+                )._get_instance_id(function_args)
+
+                self.assertEqual(kwargs["instance_id"], instance_id)
+
+    def test_get_trace_logging_service(self) -> None:
+        with self.subTest("default"):
+            kwargs = {"instance_id": "instance", "x": 1, "y": 2}
+            function_args = inspect.signature(add).bind(**kwargs).arguments
+            trace_logging_svc = dummy_checkpoint()._get_trace_logging_svc(function_args)
+            isinstance(trace_logging_svc, TraceLoggingService)
+
+        with self.subTest("new default"):
+            kwargs = {"instance_id": "instance", "x": 1, "y": 2}
+            function_args = inspect.signature(add).bind(**kwargs).arguments
+            checkpoint = dummy_checkpoint()
+            new_svc = DummyTraceLoggingService("new service")
+            dummy_checkpoint.register_trace_logger(new_svc)
+            trace_logging_svc = checkpoint._get_trace_logging_svc(function_args)
+            self.assertEqual(new_svc, trace_logging_svc)
+
+        with self.subTest("custom registry key"):
+            kwargs = {"instance_id": "instance", "x": 1, "y": 2}
+            function_args = inspect.signature(add).bind(**kwargs).arguments
+            checkpoint = dummy_checkpoint(logging_svc_registry_key="test key")
+            new_svc = DummyTraceLoggingService("new service")
+            dummy_checkpoint.register_trace_logger(new_svc, key="test key")
+            trace_logging_svc = checkpoint._get_trace_logging_svc(function_args)
+            self.assertEqual(new_svc, trace_logging_svc)
+
+        with self.subTest("class method, stored on class"):
+            kwargs = {"x": 1, "y": 2}
+            function_args = (
+                inspect.signature(DummyClass.subtract).bind(**kwargs).arguments
+            )
+            function_args["cls"] = DummyClass
+
+            trace_logging_svc = dummy_checkpoint()._get_trace_logging_svc(function_args)
+            self.assertEqual(trace_logging_svc, DummyClass.TRACE_LOGGING_SVC)
+
+        with self.subTest("method, stored on obj"):
+            kwargs = {"instance_id": "instance", "x": 1, "y": 2}
+            obj = DummyClass()
+            function_args = inspect.signature(obj.add).bind(**kwargs).arguments
+            function_args["self"] = obj
+            trace_logging_svc = dummy_checkpoint()._get_trace_logging_svc(function_args)
+            self.assertEqual(trace_logging_svc, obj.trace_logging_svc)
+
+    def test_instance_id_to_run_id(self) -> None:
+        instance_id = "instance id"
+        default_run_id = "12345"
+        run_id_registry_key = "test key"
+        InstanceIdtoRunIdRegistry.register_object(run_id_registry_key, default_run_id)
+
+        with self.subTest("default run id, default registry key"):
+            checkpoint = dummy_checkpoint()
+            self.assertNotEqual(
+                default_run_id, checkpoint._instance_id_to_run_id(instance_id)
+            )
+
+        with self.subTest("default run id, custom registry key"):
+            checkpoint = dummy_checkpoint(run_id_registry_key=run_id_registry_key)
+            self.assertEqual(
+                default_run_id, checkpoint._instance_id_to_run_id(instance_id)
+            )
+
+        with self.subTest("matched instance id"):
+            run_id = "hello"
+            checkpoint = dummy_checkpoint()
+            checkpoint.register_run_id(run_id, key=instance_id)
+            self.assertEqual(run_id, checkpoint._instance_id_to_run_id(instance_id))

--- a/fbpcs/common/service/trace_logging_registry.py
+++ b/fbpcs/common/service/trace_logging_registry.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from abc import ABC, abstractmethod
+from typing import Dict, Generic, Optional, TypeVar
+from uuid import uuid4
+
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
+
+R = TypeVar("R")
+
+
+class RegistryFactory(ABC, Generic[R]):
+    _DEFAULT_KEY: str = "RegistryFactoryDefaultKey"
+
+    @classmethod
+    def register_object(cls, key: str, value: R) -> None:
+        cls._REGISTRY[key] = value
+
+    @classmethod
+    def get(cls, key: Optional[str] = None) -> R:
+        # get the value associated with the key or the default (if the default is set)
+        key = key or cls._DEFAULT_KEY
+        val = cls._REGISTRY.get(key or cls._DEFAULT_KEY)
+        if val:
+            return val
+
+        # get or register the default
+        val = cls._REGISTRY.get(cls._DEFAULT_KEY)
+        if not val:
+            val = cls._get_default_value()
+            cls.register_object(cls._DEFAULT_KEY, val)
+
+        # set the key equal to the default
+        cls.register_object(key, val)
+        return val
+
+    @classmethod
+    def is_default_value(cls, val: R) -> bool:
+        return val == cls.get()
+
+    @classmethod
+    @abstractmethod
+    def _get_default_value(cls) -> R:
+        raise NotImplementedError
+
+    @classmethod
+    @property
+    @abstractmethod
+    def _REGISTRY(cls) -> Dict[str, R]:
+        raise NotImplementedError
+
+
+class InstanceIdtoRunIdRegistry(RegistryFactory[str]):
+    _REGISTRY: Dict[str, str] = {}
+
+    @classmethod
+    def _get_default_value(cls) -> str:
+        return f"{uuid4()}-fbpcs-default"
+
+
+class TraceLoggingRegistry(RegistryFactory[TraceLoggingService]):
+    """This class will be used to get and store globally available trace loggers"""
+
+    _REGISTRY: Dict[str, TraceLoggingService] = {}
+
+    @classmethod
+    def _get_default_value(cls) -> TraceLoggingService:
+        return SimpleTraceLoggingService()

--- a/fbpcs/common/service/trace_logging_service.py
+++ b/fbpcs/common/service/trace_logging_service.py
@@ -10,6 +10,7 @@ import abc
 import functools
 import inspect
 import logging
+import os
 import sys
 import time
 import traceback
@@ -48,6 +49,8 @@ class TraceLoggingService(abc.ABC):
                 checkpoint_data.update(self._extract_caller_info())
             if status is CheckpointStatus.FAILED:
                 checkpoint_data.update(self._extract_error_info())
+            if bundle_id := os.getenv("FBPCS_BUNDLE_ID"):
+                checkpoint_data["FBPCS_BUNDLE_ID"] = bundle_id
 
             self._write_checkpoint_impl(
                 run_id=run_id,

--- a/fbpcs/common/service/write_checkpoint.py
+++ b/fbpcs/common/service/write_checkpoint.py
@@ -1,0 +1,190 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import functools
+import inspect
+from contextlib import nullcontext, suppress
+from typing import Any, Callable, ContextManager, Dict, List, Optional
+
+from fbpcs.common.service.trace_logging_registry import (
+    InstanceIdtoRunIdRegistry,
+    TraceLoggingRegistry,
+)
+
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
+
+
+class write_checkpoint:
+    _DEFAULT_REGISTRY_KEY = "checkpoint_key"
+    _PARAMS_CONTAINING_INSTANCE_ID: List[str] = []
+    _DEFAULT_COMPONENT_NAME = ""
+
+    def __init__(
+        self,
+        *,
+        instance_id_param: Optional[str] = None,
+        dump_params: bool = False,
+        dump_return_val: bool = False,
+        # if include is not specified, only explicitly included kwarg values
+        # will be dumped
+        include: Optional[List[str]] = None,
+        checkpoint_name: Optional[str] = None,
+        checkpoint_data: Optional[Dict[str, str]] = None,
+        component: Optional[str] = None,
+        logging_svc_registry_key: Optional[str] = None,
+        run_id_registry_key: Optional[str] = None,
+    ) -> None:
+        self.instance_id_param = instance_id_param
+        self.dump_params = dump_params
+        self.dump_return_val = dump_return_val
+        self.include = include
+        self.checkpoint_name = checkpoint_name
+        self.checkpoint_data: Dict[str, str] = checkpoint_data or {}
+        if component:
+            self.checkpoint_data["component"] = component
+
+        self._logging_svc_registry_key: str = (
+            logging_svc_registry_key or self._DEFAULT_REGISTRY_KEY
+        )
+        self._run_id_registry_key: str = (
+            run_id_registry_key or self._DEFAULT_REGISTRY_KEY
+        )
+
+    def __call__(self, func: Callable) -> Callable:  # pyre-ignore
+        @functools.wraps(func)
+        async def wrapper_async(*args: Any, **kwargs: Any) -> Any:  # pyre-ignore
+            with self._get_trace_logger_cm(func, *args, **kwargs) as checkpoint_data:
+                res = await func(*args, **kwargs)
+                if self.dump_return_val:
+                    checkpoint_data["return_value"] = str(res)
+                return res
+
+        @functools.wraps(func)
+        def wrapper_sync(*args: Any, **kwargs: Any) -> Any:  # pyre-ignore
+            with self._get_trace_logger_cm(func, *args, **kwargs) as checkpoint_data:
+                res = func(*args, **kwargs)
+                if self.dump_return_val:
+                    checkpoint_data["return_value"] = str(res)
+                return res
+
+        if asyncio.iscoroutinefunction(func):
+            return wrapper_async
+        else:
+            return wrapper_sync
+
+    def _get_trace_logger_cm(
+        self,
+        func: Callable,  # pyre-ignore
+        *args: Any,
+        **kwargs: Dict[str, Any],
+    ) -> ContextManager[Dict[str, str]]:
+        ctx = nullcontext({})
+        with suppress(Exception):
+            function_args = inspect.signature(func).bind(*args, **kwargs).arguments
+            instance_id = self._get_instance_id(function_args)
+            run_id = self._instance_id_to_run_id(instance_id)
+            trace_logging_svc = self._get_trace_logging_svc(function_args)
+            checkpoint_data = self._get_checkpoint_data(function_args)
+            checkpoint_name = self._get_checkpoint_name(func)
+            ctx = trace_logging_svc.write_checkpoint_cm(
+                run_id=run_id,
+                instance_id=instance_id,
+                checkpoint_name=checkpoint_name,
+                checkpoint_data=checkpoint_data,
+            )
+        return ctx
+
+    def _get_checkpoint_name(self, func: Callable) -> str:  # pyre-ignore
+        return self.checkpoint_name or func.__name__.upper()
+
+    def _get_component(self, function_args: Dict[str, Any]) -> str:
+        if kls_arg := function_args.get("cls"):
+            return kls_arg.__name__
+        elif self_arg := function_args.get("self"):
+            return self_arg.__class__.__name__
+        else:
+            return self._DEFAULT_COMPONENT_NAME
+
+    def _get_trace_logging_svc(
+        self, function_args: Dict[str, Any]
+    ) -> TraceLoggingService:
+        if kls_arg := function_args.get("cls"):
+            trace_logging_svc = getattr(kls_arg, "TRACE_LOGGING_SVC", None) or getattr(
+                kls_arg, "TRACE_LOGGING_SERVICE", None
+            )
+        elif self_arg := function_args.get("self"):
+            trace_logging_svc = getattr(self_arg, "trace_logging_svc", None) or getattr(
+                self_arg, "trace_logging_service", None
+            )
+        else:
+            trace_logging_svc = None
+
+        if not isinstance(trace_logging_svc, TraceLoggingService):
+            trace_logging_svc = None
+
+        return trace_logging_svc or self._get_default_trace_logger()
+
+    def _get_checkpoint_data(self, kwargs: Dict[str, Any]) -> Dict[str, str]:
+        checkpoint_data = self.checkpoint_data.copy()
+        checkpoint_data["component"] = checkpoint_data.get(
+            "component", self._get_component(kwargs)
+        )
+
+        if not self.dump_params:
+            return checkpoint_data
+
+        include = self.include or [
+            key for key in kwargs.keys() if key not in ("cls", "self")
+        ]
+        checkpoint_data.update({param: str(kwargs.get(param)) for param in include})
+        return checkpoint_data
+
+    def _get_instance_id(self, kwargs: Dict[str, Any]) -> str:
+        if id_param := self.instance_id_param:
+            if instance_id := self._param_to_instance_id(id_param, kwargs):
+                return instance_id
+        else:
+            for id_param in self._PARAMS_CONTAINING_INSTANCE_ID:
+                if instance_id := self._param_to_instance_id(id_param, kwargs):
+                    return instance_id
+        return ""  # no instance id found
+
+    @classmethod
+    def _param_to_instance_id(
+        cls, instance_id_param: str, kwargs: Dict[str, Any]
+    ) -> Optional[str]:
+        instance_id_obj = kwargs.get(instance_id_param)
+        if isinstance(instance_id_obj, str):
+            return instance_id_obj
+        else:
+            return None
+
+    @classmethod
+    def register_trace_logger(
+        cls, trace_logging_service: TraceLoggingService, *, key: Optional[str] = None
+    ) -> None:
+        key = key or cls._DEFAULT_REGISTRY_KEY
+        TraceLoggingRegistry.register_object(key, trace_logging_service)
+
+    @classmethod
+    def register_run_id(
+        cls, run_id: Optional[str], *, key: Optional[str] = None
+    ) -> str:
+        run_id = run_id or InstanceIdtoRunIdRegistry.get()
+        key = key or cls._DEFAULT_REGISTRY_KEY
+        InstanceIdtoRunIdRegistry.register_object(key, run_id)
+        return run_id
+
+    def _get_default_trace_logger(self) -> TraceLoggingService:
+        return TraceLoggingRegistry.get(self._logging_svc_registry_key)
+
+    def _instance_id_to_run_id(self, instance_id: str) -> Optional[str]:
+        run_id = InstanceIdtoRunIdRegistry.get(instance_id)
+        if InstanceIdtoRunIdRegistry.is_default_value(run_id):
+            run_id = InstanceIdtoRunIdRegistry.get(self._run_id_registry_key)
+        return run_id


### PR DESCRIPTION
Summary:
## What

- trace log bundle ID if it's stored in the environment

## Why

- No more wondering, "gee, was this advertiser running the right bundle?"

## What is this stack

Add a decorator that can magically trace log with instance id and run id to the correct trace logger - no need to pass trace logging services all around the place:

```
write_checkpoint()
def my_func(...):
   ...

write_checkpoint(dump_params=True, dump_return_val=True)
def my_func(...):
   ...

# and much more ;)
```

I built the API so that it can be used in PCS as well, but I only added checkpointing in Bolt, since that is a mega gap right now.

{F802371475}

Reviewed By: joe1234wu

Differential Revision:
D41440520

LaMa Project: L416713

