### PR TITLE
create global registry

### DIFF
--- a/fbpcs/common/service/test/test_trace_logging_registry.py
+++ b/fbpcs/common/service/test/test_trace_logging_registry.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from typing import Dict
+from unittest import TestCase
+
+from fbpcs.common.service.trace_logging_registry import RegistryFactory
+
+
+class DummyRegistry(RegistryFactory[str]):
+
+    _REGISTRY: Dict[str, str] = {}
+
+    @classmethod
+    def _get_default_value(cls) -> str:
+        return "default value"
+
+
+class TestRegistryFactory(TestCase):
+    def test_registry(self) -> None:
+        expected_registry = {}
+        for key in [None, "key1", DummyRegistry._DEFAULT_KEY]:
+            for register_val in [None, "val1"]:
+                start_registry = expected_registry.copy()
+                if register_val and key:
+                    expected_value = register_val
+                else:
+                    expected_value = DummyRegistry._get_default_value()
+
+                expected_registry[key or DummyRegistry._DEFAULT_KEY] = expected_value
+                with self.subTest(
+                    key=key,
+                    register_val=register_val,
+                    expected_value=expected_value,
+                    start_registry=start_registry,
+                    expected_registry=expected_registry,
+                ):
+                    self.assertEqual(DummyRegistry._REGISTRY, start_registry)
+
+                    if register_val and key:
+                        DummyRegistry.register_object(key, register_val)
+
+                    actual_value = DummyRegistry.get(key)
+                    self.assertEqual(actual_value, expected_value)
+
+                    self.assertEqual(DummyRegistry._REGISTRY, expected_registry)

--- a/fbpcs/common/service/test/test_trace_logging_service.py
+++ b/fbpcs/common/service/test/test_trace_logging_service.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+from unittest import TestCase
+
+from fbpcs.common.service.trace_logging_service import (
+    CheckpointStatus,
+    TraceLoggingService,
+)
+
+
+class DummyTraceLoggingService(TraceLoggingService):
+    def __init__(self, fail_to_log: bool = False) -> None:
+        self.events = []
+        self.fail_to_log = fail_to_log
+
+    # pyre-ignore
+    def _write_checkpoint_impl(
+        self,
+        **kwargs,
+    ) -> None:
+        if self.fail_to_log:
+            raise RuntimeError("Failing to log for test")
+        self.events.append(kwargs)
+
+    def _extract_caller_info(self) -> Dict[str, str]:
+        return {"caller_info": "caller_info"}
+
+    def _extract_error_info(self) -> Dict[str, str]:
+        return {"error_info": "error_info"}
+
+
+class TestTraceLoggingService(TestCase):
+    def test_write_checkpoint_simple(self) -> None:
+        for checkpoint_data in (None, {}, {"my_data": "my_data"}):
+            for status in CheckpointStatus:
+                with self.subTest(checkpoint_data=checkpoint_data, status=status):
+                    svc = DummyTraceLoggingService()
+                    payload = {
+                        "run_id": "run123",
+                        "instance_id": "instance456",
+                        "checkpoint_name": "foo",
+                        "status": CheckpointStatus.STARTED,
+                        "checkpoint_data": checkpoint_data,
+                    }
+                    # pyre-ignore
+                    svc.write_checkpoint(**payload.copy())
+
+                    checkpoint_data = checkpoint_data or {}
+                    checkpoint_data["caller_info"] = "caller_info"
+                    if status is CheckpointStatus.FAILED:
+                        checkpoint_data["error_info"] = "error_info"
+
+                    payload["checkpoint_data"] = checkpoint_data
+                    self.assertEqual(payload, svc.events[0])
+
+    def test_write_checkpoint_cm(self) -> None:
+        for checkpoint_data in (None, {}, {"my_data": "my_data"}):
+            for bad_function_payload in (False, True):
+                for fail_to_log in (False, True):
+                    with self.subTest(
+                        checkpoint_data=checkpoint_data,
+                        bad_funtion_payload=bad_function_payload,
+                        fail_to_log=fail_to_log,
+                    ):
+                        svc = DummyTraceLoggingService(fail_to_log=fail_to_log)
+                        payload = {
+                            "run_id": "run123",
+                            "instance_id": "instance456",
+                            "checkpoint_name": "foo",
+                            "checkpoint_data": checkpoint_data.copy()
+                            if checkpoint_data
+                            else None,
+                        }
+
+                        try:
+                            with svc.write_checkpoint_cm(
+                                # pyre-ignore
+                                **payload
+                            ) as cm:
+                                cm["before_failure"] = "before_failure"
+                                assert bad_function_payload is False
+                                cm["after_failure"] = "after_failure"
+                        except AssertionError:
+                            self.assertTrue(bad_function_payload)
+                            expected_payload2 = {
+                                **payload,
+                                "status": CheckpointStatus.FAILED,
+                                "checkpoint_data": {
+                                    **(checkpoint_data or {}),
+                                    "before_failure": "before_failure",
+                                    "error_info": "error_info",
+                                },
+                            }
+                        else:
+                            expected_payload2 = {
+                                **payload,
+                                "status": CheckpointStatus.COMPLETED,
+                                "checkpoint_data": {
+                                    **(checkpoint_data or {}),
+                                    "before_failure": "before_failure",
+                                    "after_failure": "after_failure",
+                                },
+                            }
+                        finally:
+                            if fail_to_log:
+                                self.assertEqual(len(svc.events), 0)
+                            else:
+                                self.assertEqual(len(svc.events), 2)
+                                started_payload = {
+                                    **payload,
+                                    "status": CheckpointStatus.STARTED,
+                                    "checkpoint_data": checkpoint_data or {},
+                                }
+                                self.assertEqual(started_payload, svc.events[0])
+
+                                actual_payload = svc.events[1]
+                                del actual_payload["checkpoint_data"]["runtime_ms"]
+                                self.assertEqual(actual_payload, expected_payload2)

--- a/fbpcs/common/service/trace_logging_registry.py
+++ b/fbpcs/common/service/trace_logging_registry.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from abc import ABC, abstractmethod
+from typing import Dict, Generic, Optional, TypeVar
+from uuid import uuid4
+
+from fbpcs.common.service.simple_trace_logging_service import SimpleTraceLoggingService
+
+from fbpcs.common.service.trace_logging_service import TraceLoggingService
+
+R = TypeVar("R")
+
+
+class RegistryFactory(ABC, Generic[R]):
+    _DEFAULT_KEY: str = "RegistryFactoryDefaultKey"
+
+    @classmethod
+    def register_object(cls, key: str, value: R) -> None:
+        cls._REGISTRY[key] = value
+
+    @classmethod
+    def get(cls, key: Optional[str] = None) -> R:
+        # get the value associated with the key or the default (if the default is set)
+        key = key or cls._DEFAULT_KEY
+        val = cls._REGISTRY.get(key or cls._DEFAULT_KEY)
+        if val:
+            return val
+
+        # get or register the default
+        val = cls._REGISTRY.get(cls._DEFAULT_KEY)
+        if not val:
+            val = cls._get_default_value()
+            cls.register_object(cls._DEFAULT_KEY, val)
+
+        # set the key equal to the default
+        cls.register_object(key, val)
+        return val
+
+    @classmethod
+    def is_default_value(cls, val: R) -> bool:
+        return val == cls.get()
+
+    @classmethod
+    @abstractmethod
+    def _get_default_value(cls) -> R:
+        raise NotImplementedError
+
+    @classmethod
+    @property
+    @abstractmethod
+    def _REGISTRY(cls) -> Dict[str, R]:
+        raise NotImplementedError
+
+
+class InstanceIdtoRunIdRegistry(RegistryFactory[str]):
+    _REGISTRY: Dict[str, str] = {}
+
+    @classmethod
+    def _get_default_value(cls) -> str:
+        return f"{uuid4()}-fbpcs-default"
+
+
+class TraceLoggingRegistry(RegistryFactory[TraceLoggingService]):
+    """This class will be used to get and store globally available trace loggers"""
+
+    _REGISTRY: Dict[str, TraceLoggingService] = {}
+
+    @classmethod
+    def _get_default_value(cls) -> TraceLoggingService:
+        return SimpleTraceLoggingService()


### PR DESCRIPTION
Summary:
## What

- Create global registry for storing global vars

## Why

- So that we can magically grab a trace logger or run id anywhere in PCS without needing to pass it around. Analogous to `logging.getLogger`

## What is this stack

Add a decorator that can magically trace log with instance id and run id to the correct trace logger - no need to pass trace logging services all around the place:

```
write_checkpoint()
def my_func(...):
   ...

write_checkpoint(dump_params=True, dump_return_val=True)
def my_func(...):
   ...

# and much more ;)
```

I built the API so that it can be used in PCS as well, but I only added checkpointing in Bolt, since that is a mega gap right now.

{F802371475}

Reviewed By: joe1234wu

Differential Revision:
D41440516

LaMa Project: L416713

