### PR TITLE
extend write checkpoint decorator

### DIFF
--- a/fbpcs/bolt/bolt_checkpoint.py
+++ b/fbpcs/bolt/bolt_checkpoint.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Dict, Optional
+
+from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs, BoltJob, BoltPlayerArgs
+from fbpcs.common.service.write_checkpoint import write_checkpoint
+
+
+class bolt_checkpoint(write_checkpoint):
+    _DEFAULT_REGISTRY_KEY = "bolt_checkpoint_key"
+    _PARAMS_CONTAINING_INSTANCE_ID = [
+        "instance_id",
+        "publisher_id",
+        "partner_id",
+        "job",
+        "instance_args",
+    ]
+    _DEFAULT_COMPONENT_NAME = "Bolt"
+
+    @classmethod
+    def _param_to_instance_id(
+        cls, instance_id_param: str, kwargs: Dict[str, Any]
+    ) -> Optional[str]:
+        instance_id_obj = kwargs.get(instance_id_param)
+        if not instance_id_obj:
+            return instance_id_obj
+        elif isinstance(instance_id_obj, str):
+            return instance_id_obj
+        elif isinstance(instance_id_obj, BoltCreateInstanceArgs):
+            return instance_id_obj.instance_id
+        elif isinstance(instance_id_obj, BoltPlayerArgs):
+            return instance_id_obj.create_instance_args.instance_id
+        elif isinstance(instance_id_obj, BoltJob):
+            return instance_id_obj.publisher_bolt_args.create_instance_args.instance_id
+        else:
+            return super()._param_to_instance_id(
+                instance_id_param=instance_id_param, kwargs=kwargs
+            )


### PR DESCRIPTION
Summary:
## What

- Extend the default write checkpoint decorator introduced in D41440518

## Why

- default registry key to avoid clashing with other users of the base decorator (e.g. possibly PCS in the future)
- default component (in case a staticmethod is being decorated)
- Map bolt primitives to instance ids

## What is this stack

Add a decorator that can magically trace log with instance id and run id to the correct trace logger - no need to pass trace logging services all around the place:

```
write_checkpoint()
def my_func(...):
   ...

write_checkpoint(dump_params=True, dump_return_val=True)
def my_func(...):
   ...

# and much more ;)
```

I built the API so that it can be used in PCS as well, but I only added checkpointing in Bolt, since that is a mega gap right now.

{F802371475}

Reviewed By: ztlbells

Differential Revision:
D41440525

LaMa Project: L416713

