### PR TITLE
Allow storage permissions for Service Account

### DIFF
--- a/fbpcs/infra/pce/gcp_terraform_template/common/pce/wi.tf
+++ b/fbpcs/infra/pce/gcp_terraform_template/common/pce/wi.tf
@@ -4,6 +4,12 @@ locals {
   k8s_sa = kubernetes_service_account.k8s_sa.metadata[0].name
 }
 
+resource "google_project_iam_member" "project" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.gke_sa.email}"
+}
+
 resource "google_service_account" "gke_sa" {
   account_id   = local.gke_sa
   display_name = local.gke_sa


### PR DESCRIPTION
Summary:
While reading and writing from GCS during PL run I am facing the following error -
```
Caller does not have storage.objects.get access to the Google Cloud Storage object
```
In this diff I am adding changes to support google service account to have the storage permissions.
They were previously removed as part of - https://www.internalfb.com/diff/D36520578 (https://github.com/facebookresearch/fbpcs/commit/41c6b993aa5a4ef9d2136086c80103c32c47c34b)?transaction_fbid=814787466245808

Reviewed By: zhuang-93

Differential Revision:
D41479842

LaMa Project: L416713

