### PR TITLE
Add PL and PA timestamp validation

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -7,7 +7,7 @@
 
 
 import re
-from typing import Dict, List, Pattern
+from typing import Dict, List, Pattern, Set
 
 from fbpcs.pc_pre_validation.binary_path import BinaryInfo
 
@@ -25,6 +25,7 @@ CONVERSION_TIMESTAMP_FIELD = "conversion_timestamp"
 CONVERSION_METADATA_FIELD = "conversion_metadata"
 VALUE_FIELD = "value"
 EVENT_TIMESTAMP_FIELD = "event_timestamp"
+TIMESTAMP = "timestamp"
 
 PA_FIELDS: List[str] = [
     CONVERSION_VALUE_FIELD,
@@ -53,6 +54,10 @@ ALL_FIELDS: List[str] = [
     CONVERSION_VALUE_FIELD,
     CONVERSION_TIMESTAMP_FIELD,
 ]
+RANGE_FIELDS: Set[str] = {
+    EVENT_TIMESTAMP_FIELD,
+    CONVERSION_TIMESTAMP_FIELD,
+}
 
 INTEGER_REGEX: Pattern[str] = re.compile(r"^[0-9]+$")
 TIMESTAMP_REGEX: Pattern[str] = re.compile(r"^[0-9]{10}$")


### PR DESCRIPTION
Summary:
The PL and PA timestamps are now available in the InputDataValidator so the
event_timestamps and conversion_timestamps are validated to be in the expected
range that was returned by the Graph API.

Differential Revision: D41510892

