### PR TITLE
move get env var to RunBinaryBaseService as util. Consolidate APIs

### DIFF
--- a/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/service/id_spine_combiner_stage_service.py
@@ -22,10 +22,7 @@ from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.data_processing.service.id_spine_combiner import IdSpineCombinerService
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import PrivateComputationGameType
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.pid_mr_config import Protocol
@@ -47,7 +44,10 @@ from fbpcs.private_computation.service.private_computation_service_data import (
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
-from fbpcs.private_computation.service.utils import get_pc_status_from_stage_state
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+)
 
 
 class IdSpineCombinerStageService(PrivateComputationStageService):
@@ -261,10 +261,7 @@ class IdSpineCombinerStageService(PrivateComputationStageService):
             run_id=private_computation_instance.infra_config.run_id,
             log_cost_bucket=private_computation_instance.infra_config.log_cost_bucket,
         )
-        env_vars = {}
-        if binary_config.repository_path:
-            env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
-
+        env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
         container_type = None
         if (
             private_computation_instance.infra_config.num_pid_containers == 1

--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -20,20 +20,13 @@ from fbpcp.util.typing import checked_cast
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
     PrivateComputationRole,
 )
 
-from fbpcs.private_computation.service.constants import (
-    CA_CERTIFICATE_ENV_VAR,
-    CA_CERTIFICATE_PATH_ENV_VAR,
-    DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
-    SERVER_CERTIFICATE_ENV_VAR,
-    SERVER_CERTIFICATE_PATH_ENV_VAR,
-)
+from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.mpc.entity.mpc_instance import (
     MPCInstance,
     MPCInstanceStatus,
@@ -46,6 +39,7 @@ from fbpcs.private_computation.service.mpc.repository.mpc_instance import (
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
+from fbpcs.private_computation.service.utils import generate_env_vars_dict
 
 DEFAULT_BINARY_VERSION = "latest"
 
@@ -451,17 +445,13 @@ async def create_and_start_mpc_instance(
             server_uris=server_uris,
         )
 
-    env_vars = {}
-    if repository_path:
-        env_vars[ONEDOCKER_REPOSITORY_PATH] = repository_path
-    server_cert = server_certificate_provider.get_certificate()
-    ca_cert = ca_certificate_provider.get_certificate()
-    if server_cert and server_certificate_path:
-        env_vars[SERVER_CERTIFICATE_ENV_VAR] = server_cert
-        env_vars[SERVER_CERTIFICATE_PATH_ENV_VAR] = server_certificate_path
-    if ca_cert and ca_certificate_path:
-        env_vars[CA_CERTIFICATE_ENV_VAR] = ca_cert
-        env_vars[CA_CERTIFICATE_PATH_ENV_VAR] = ca_certificate_path
+    env_vars = generate_env_vars_dict(
+        repository_path=repository_path,
+        server_certificate_provider=server_certificate_provider,
+        server_certificate_path=server_certificate_path,
+        ca_certificate_provider=ca_certificate_provider,
+        ca_certificate_path=ca_certificate_path,
+    )
 
     return await mpc_svc.start_instance_async(
         instance_id=instance_id,

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -16,10 +16,7 @@ from fbpcs.common.service.trace_logging_service import (
     TraceLoggingService,
 )
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -36,7 +33,10 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
-from fbpcs.private_computation.service.utils import get_pc_status_from_stage_state
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+)
 
 # 20 minutes
 PRE_VALIDATION_CHECKS_TIMEOUT: int = 1200
@@ -116,10 +116,7 @@ class PCPreValidationStageService(PrivateComputationStageService):
             pc_instance.product_config.common.input_path_start_ts,
             pc_instance.product_config.common.input_path_end_ts,
         )
-        env_vars = {}
-        if binary_config.repository_path:
-            env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
-
+        env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -18,10 +18,7 @@ from fbpcs.data_processing.service.pid_prepare_binary_service import (
     PIDPrepareBinaryService,
 )
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 
 from fbpcs.private_computation.entity.private_computation_instance import (
@@ -35,6 +32,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
     get_pc_status_from_stage_state,
     stop_stage_service,
 )
@@ -139,13 +137,10 @@ class PIDPrepareStageService(PrivateComputationStageService):
         # start containers
         logging.info(f"{pc_role} spinning up containers")
 
-        env_vars = {}
-        if onedocker_binary_config.repository_path:
-            env_vars[
-                ONEDOCKER_REPOSITORY_PATH
-            ] = onedocker_binary_config.repository_path
-
         pid_prepare_binary_service = PIDPrepareBinaryService()
+        env_vars = generate_env_vars_dict(
+            repository_path=onedocker_binary_config.repository_path
+        )
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -17,10 +17,7 @@ from fbpcs.data_processing.service.pid_run_protocol_binary_service import (
     PIDRunProtocolBinaryService,
 )
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.pid.entity.pid_instance import PIDProtocol
 
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
@@ -39,6 +36,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
     get_pc_status_from_stage_state,
     stop_stage_service,
 )
@@ -152,14 +150,10 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
             pid_protocol, pc_role
         )
         onedocker_binary_config = self._onedocker_binary_config_map[binary_name]
-        env_vars = {
-            "RUST_LOG": "info",
-        }
-        if onedocker_binary_config.repository_path:
-            env_vars[
-                ONEDOCKER_REPOSITORY_PATH
-            ] = onedocker_binary_config.repository_path
-
+        env_vars = generate_env_vars_dict(
+            repository_path=onedocker_binary_config.repository_path,
+            RUST_LOG="info",
+        )
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )

--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -14,10 +14,7 @@ from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.data_processing.service.sharding_service import ShardingService, ShardType
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -28,6 +25,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
     get_pc_status_from_stage_state,
     stop_stage_service,
 )
@@ -126,12 +124,9 @@ class PIDShardStageService(PrivateComputationStageService):
         )
         # start containers
         logging.info(f"{pc_role} spinning up containers")
-        env_vars = {}
-        if onedocker_binary_config.repository_path:
-            env_vars[
-                ONEDOCKER_REPOSITORY_PATH
-            ] = onedocker_binary_config.repository_path
-
+        env_vars = generate_env_vars_dict(
+            repository_path=onedocker_binary_config.repository_path
+        )
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -11,7 +11,6 @@ import logging
 from typing import Any, Dict, List
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus
-from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.service.pc_pre_validation_stage_service import (
     PRE_VALIDATION_CHECKS_TIMEOUT,
@@ -23,6 +22,7 @@ from fbpcs.private_computation.service.private_computation import (
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
+from fbpcs.private_computation.service.utils import generate_env_vars_dict
 from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     build_private_computation_service,
 )
@@ -39,9 +39,7 @@ class PreValidateService:
         onedocker_svc = pc_service.onedocker_svc
         binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
         binary_config = pc_service.onedocker_binary_config_map[binary_name]
-        env_vars = {}
-        if binary_config.repository_path:
-            env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
+        env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
 
         cmd_args = [
             get_cmd_args(

--- a/fbpcs/private_computation/service/shard_stage_service.py
+++ b/fbpcs/private_computation/service/shard_stage_service.py
@@ -17,12 +17,8 @@ from fbpcp.service.onedocker import OneDockerService
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.data_processing.service.sharding_service import ShardingService, ShardType
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
-from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -32,7 +28,10 @@ from fbpcs.private_computation.service.pid_utils import get_sharded_filepath
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
-from fbpcs.private_computation.service.utils import get_pc_status_from_stage_state
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+)
 
 
 class ShardStageService(PrivateComputationStageService):
@@ -178,10 +177,7 @@ class ShardStageService(PrivateComputationStageService):
             args_list.append(args_per_shard)
 
         binary_name = sharder.get_binary_name(ShardType.ROUND_ROBIN)
-        env_vars = {}
-        if binary_config.repository_path:
-            env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
-
+        env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
         return await sharder.start_containers(
             cmd_args_list=args_list,
             onedocker_svc=onedocker_svc,

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -11,10 +11,7 @@ from unittest.mock import MagicMock, patch
 from fbpcp.entity.container_instance import ContainerInstance
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
@@ -40,6 +37,7 @@ from fbpcs.private_computation.service.pc_pre_validation_stage_service import (
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
+from fbpcs.private_computation.service.utils import generate_env_vars_dict
 
 
 class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
@@ -131,7 +129,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             pc_instance, NullCertificateProvider(), NullCertificateProvider(), "", ""
         )
 
-        env_vars = {ONEDOCKER_REPOSITORY_PATH: "test_path/"}
+        env_vars = generate_env_vars_dict(repository_path="test_path/")
         mock_run_binary_base_service_start_containers.assert_called_with(
             cmd_args_list=[expected_cmd_args],
             onedocker_svc=mock_onedocker_svc,

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -35,6 +35,7 @@ from fbpcs.private_computation.service.constants import (
 from fbpcs.private_computation.service.pid_prepare_stage_service import (
     PIDPrepareStageService,
 )
+from fbpcs.private_computation.service.utils import generate_env_vars_dict
 
 
 class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
@@ -102,12 +103,9 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 server_certificate_path="",
                 ca_certificate_path="",
             )
-            env_vars = {}
-            if self.onedocker_binary_config.repository_path:
-                env_vars[
-                    "ONEDOCKER_REPOSITORY_PATH"
-                ] = self.onedocker_binary_config.repository_path
-
+            env_vars = generate_env_vars_dict(
+                repository_path=self.onedocker_binary_config.repository_path
+            )
             args_ls_expect = self.get_args_expected(
                 pc_role,
                 test_num_containers,

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -17,10 +17,7 @@ from fbpcs.data_processing.service.pid_run_protocol_binary_service import (
     PIDRunProtocolBinaryService,
 )
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
-from fbpcs.onedocker_binary_config import (
-    ONEDOCKER_REPOSITORY_PATH,
-    OneDockerBinaryConfig,
-)
+from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import (
     InfraConfig,
     PrivateComputationGameType,
@@ -46,6 +43,7 @@ from fbpcs.private_computation.service.pid_utils import (
     pid_should_use_row_numbers,
     PIDProtocol,
 )
+from fbpcs.private_computation.service.utils import generate_env_vars_dict
 
 
 class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
@@ -118,12 +116,10 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 pid_protocol, pc_role
             )
             binary_config = self.onedocker_binary_config_map[binary_name]
-            env_vars = {
-                "RUST_LOG": "info",
-            }
-            if binary_config.repository_path:
-                env_vars[ONEDOCKER_REPOSITORY_PATH] = binary_config.repository_path
-
+            env_vars = generate_env_vars_dict(
+                repository_path=binary_config.repository_path,
+                RUST_LOG="info",
+            )
             args_str_expect = self.get_args_expect(
                 pc_role,
                 pid_protocol,

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -32,6 +32,7 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.service.pid_shard_stage_service import (
     PIDShardStageService,
 )
+from fbpcs.private_computation.service.utils import generate_env_vars_dict
 
 
 class TestPIDShardStageService(IsolatedAsyncioTestCase):
@@ -86,12 +87,9 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 server_certificate_path="",
                 ca_certificate_path="",
             )
-            env_vars = {}
-            if self.onedocker_binary_config.repository_path:
-                env_vars[
-                    "ONEDOCKER_REPOSITORY_PATH"
-                ] = self.onedocker_binary_config.repository_path
-
+            env_vars = generate_env_vars_dict(
+                repository_path=self.onedocker_binary_config.repository_path
+            )
             args_ls_expect = self.get_args_expect(
                 pc_role, test_num_containers, has_hmac_key
             )


### PR DESCRIPTION
Summary:
## Why
Part of MPC service migration, having consolidate get_env_var method as util for cross stage services use
## What
- added `get_env_var` as util in `RunBinaryBaseService`
- refactor all usage of get_env_var across stage services

detailed plan: https://docs.google.com/document/d/1qR1XVVCA2By95tldl2Ey9m__GKX3raodGAZ5yK9SCEw/edit?usp=sharing

Differential Revision: D41454855

