### PR TITLE
override default registries

### DIFF
--- a/fbpcs/common/service/trace_logging_registry.py
+++ b/fbpcs/common/service/trace_logging_registry.py
@@ -24,6 +24,10 @@ class RegistryFactory(ABC, Generic[R]):
         cls._REGISTRY[key] = value
 
     @classmethod
+    def override_default(cls, value: R) -> None:
+        cls.register_object(cls._DEFAULT_KEY, value)
+
+    @classmethod
     def get(cls, key: Optional[str] = None) -> R:
         # get the value associated with the key or the default (if the default is set)
         key = key or cls._DEFAULT_KEY
@@ -35,7 +39,7 @@ class RegistryFactory(ABC, Generic[R]):
         val = cls._REGISTRY.get(cls._DEFAULT_KEY)
         if not val:
             val = cls._get_default_value()
-            cls.register_object(cls._DEFAULT_KEY, val)
+            cls.override_default(val)
 
         # set the key equal to the default
         cls.register_object(key, val)

--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -50,7 +50,8 @@ class TestPlStudyRunner(TestCase):
         mock_graph_api_client,
         mock_logger,
     ) -> None:
-        self.config = {}
+        # this is the start of a valid private computation config.yml file
+        self.config = {"private_computation": {"dependency": {}}}
         self.test_logger = logging.getLogger(__name__)
         self.client_mock = MagicMock()
         valid_start_date = datetime.datetime.now() - datetime.timedelta(hours=1)


### PR DESCRIPTION
Summary:
## What

- bolt_checkpoint set default registry value if given no key

## Why

Consider the following scenario:

1) Advertiser passes run id, meaning Bolt is NOT using a default run id
2) PCS code decorates a function with write_checkpoint that has no instance id arg (e.g. staticmethod)

This will result in the PCS code applying the default run id, NOT the same run id Bolt is using. With the updated implementation, Bolt will set the global default id if the advertiser passes a run id, ensuring a consistent run ID on the client side.

Bolt is in a good position to be the component setting the global defaults, as it is essentially the entry point to any private computation run.

## What is this stack

Add a decorator that can magically trace log with instance id and run id to the correct trace logger - no need to pass trace logging services all around the place:

```
bolt_checkpoint()
def my_func(...):
   ...

bolt_checkpoint(dump_params=True, dump_return_val=True)
def my_func(...):
   ...

# and much more ;)
```

I built the API so that it can be used in PCS as well, but I only added checkpointing in Bolt, since that is a mega gap right now.

{F802371475}

Reviewed By: joe1234wu

Differential Revision:
D41465180

LaMa Project: L416713

