### PR TITLE
Trace log BoltClient

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generic, List, Optional, Type, TypeVar
 
+from fbpcs.bolt.bolt_checkpoint import bolt_checkpoint
+
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 
@@ -76,6 +78,7 @@ class BoltClient(ABC, Generic[T]):
     ) -> bool:
         pass
 
+    @bolt_checkpoint()
     async def cancel_current_stage(self, instance_id: str) -> None:
         pass
 
@@ -92,6 +95,7 @@ class BoltClient(ABC, Generic[T]):
             stage.failed_status,
         ]
 
+    @bolt_checkpoint(dump_params=True, dump_return_val=True)
     async def should_invoke_stage(
         self, instance_id: str, stage: PrivateComputationBaseStageFlow
     ) -> bool:
@@ -102,6 +106,7 @@ class BoltClient(ABC, Generic[T]):
             stage.failed_status,
         ]
 
+    @bolt_checkpoint(dump_params=True, dump_return_val=True)
     async def get_valid_stage(
         self, instance_id: str, stage_flow: Type[PrivateComputationBaseStageFlow]
     ) -> Optional[PrivateComputationBaseStageFlow]:
@@ -113,6 +118,9 @@ class BoltClient(ABC, Generic[T]):
                 return stage
         return None
 
+    @bolt_checkpoint(
+        dump_return_val=True,
+    )
     async def is_existing_instance(self, instance_args: T) -> bool:
         """Returns whether the instance with instance_args exists
 
@@ -133,6 +141,7 @@ class BoltClient(ABC, Generic[T]):
             self.logger.info(f"{instance_id} not found.")
             return False
 
+    @bolt_checkpoint()
     async def get_or_create_instance(self, instance_args: T) -> str:
         if await self.is_existing_instance(instance_args):
             self.logger.info(f"instance {instance_args.instance_id} exists - returning")
@@ -143,5 +152,6 @@ class BoltClient(ABC, Generic[T]):
             )
             return await self.create_instance(instance_args)
 
+    @bolt_checkpoint()
     async def log_failed_containers(self, instance_id: str) -> None:
         pass

--- a/fbpcs/common/service/trace_logging_registry.py
+++ b/fbpcs/common/service/trace_logging_registry.py
@@ -24,6 +24,10 @@ class RegistryFactory(ABC, Generic[R]):
         cls._REGISTRY[key] = value
 
     @classmethod
+    def override_default(cls, value: R) -> None:
+        cls.register_object(cls._DEFAULT_KEY, value)
+
+    @classmethod
     def get(cls, key: Optional[str] = None) -> R:
         # get the value associated with the key or the default (if the default is set)
         key = key or cls._DEFAULT_KEY
@@ -35,7 +39,7 @@ class RegistryFactory(ABC, Generic[R]):
         val = cls._REGISTRY.get(cls._DEFAULT_KEY)
         if not val:
             val = cls._get_default_value()
-            cls.register_object(cls._DEFAULT_KEY, val)
+            cls.override_default(val)
 
         # set the key equal to the default
         cls.register_object(key, val)

--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -50,7 +50,8 @@ class TestPlStudyRunner(TestCase):
         mock_graph_api_client,
         mock_logger,
     ) -> None:
-        self.config = {}
+        # this is the start of a valid private computation config.yml file
+        self.config = {"private_computation": {"dependency": {}}}
         self.test_logger = logging.getLogger(__name__)
         self.client_mock = MagicMock()
         valid_start_date = datetime.datetime.now() - datetime.timedelta(hours=1)


### PR DESCRIPTION
Summary:
## What

- see title

## Why

- trace logging is good

## What is this stack

Add a decorator that can magically trace log with instance id and run id to the correct trace logger - no need to pass trace logging services all around the place:

```
bolt_checkpoint()
def my_func(...):
   ...

bolt_checkpoint(dump_params=True, dump_return_val=True)
def my_func(...):
   ...

# and much more ;)
```

I built the API so that it can be used in PCS as well, but I only added checkpointing in Bolt, since that is a mega gap right now.

{F802371475}

Reviewed By: yanglu-fb

Differential Revision:
D41440528

LaMa Project: L416713

