### PR TITLE
support PA run id

### DIFF
--- a/fbpcs/bolt/bolt_client.py
+++ b/fbpcs/bolt/bolt_client.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generic, List, Optional, Type, TypeVar
 
+from fbpcs.bolt.bolt_checkpoint import bolt_checkpoint
+
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 
@@ -76,6 +78,7 @@ class BoltClient(ABC, Generic[T]):
     ) -> bool:
         pass
 
+    @bolt_checkpoint()
     async def cancel_current_stage(self, instance_id: str) -> None:
         pass
 
@@ -92,6 +95,7 @@ class BoltClient(ABC, Generic[T]):
             stage.failed_status,
         ]
 
+    @bolt_checkpoint(dump_params=True, dump_return_val=True)
     async def should_invoke_stage(
         self, instance_id: str, stage: PrivateComputationBaseStageFlow
     ) -> bool:
@@ -102,6 +106,7 @@ class BoltClient(ABC, Generic[T]):
             stage.failed_status,
         ]
 
+    @bolt_checkpoint(dump_params=True, dump_return_val=True)
     async def get_valid_stage(
         self, instance_id: str, stage_flow: Type[PrivateComputationBaseStageFlow]
     ) -> Optional[PrivateComputationBaseStageFlow]:
@@ -113,6 +118,9 @@ class BoltClient(ABC, Generic[T]):
                 return stage
         return None
 
+    @bolt_checkpoint(
+        dump_return_val=True,
+    )
     async def is_existing_instance(self, instance_args: T) -> bool:
         """Returns whether the instance with instance_args exists
 
@@ -133,6 +141,7 @@ class BoltClient(ABC, Generic[T]):
             self.logger.info(f"{instance_id} not found.")
             return False
 
+    @bolt_checkpoint()
     async def get_or_create_instance(self, instance_args: T) -> str:
         if await self.is_existing_instance(instance_args):
             self.logger.info(f"instance {instance_args.instance_id} exists - returning")
@@ -143,5 +152,6 @@ class BoltClient(ABC, Generic[T]):
             )
             return await self.create_instance(instance_args)
 
+    @bolt_checkpoint()
     async def log_failed_containers(self, instance_id: str) -> None:
         pass

--- a/fbpcs/common/service/trace_logging_registry.py
+++ b/fbpcs/common/service/trace_logging_registry.py
@@ -24,6 +24,10 @@ class RegistryFactory(ABC, Generic[R]):
         cls._REGISTRY[key] = value
 
     @classmethod
+    def override_default(cls, value: R) -> None:
+        cls.register_object(cls._DEFAULT_KEY, value)
+
+    @classmethod
     def get(cls, key: Optional[str] = None) -> R:
         # get the value associated with the key or the default (if the default is set)
         key = key or cls._DEFAULT_KEY
@@ -35,7 +39,7 @@ class RegistryFactory(ABC, Generic[R]):
         val = cls._REGISTRY.get(cls._DEFAULT_KEY)
         if not val:
             val = cls._get_default_value()
-            cls.register_object(cls._DEFAULT_KEY, val)
+            cls.override_default(val)
 
         # set the key equal to the default
         cls.register_object(key, val)

--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -59,6 +59,7 @@ class BoltPAGraphAPICreateInstanceArgs(BoltCreateInstanceArgs):
     dataset_id: str
     timestamp: str
     attribution_rule: str
+    run_id: Optional[str]
 
 
 BoltGraphAPICreateInstanceArgs = TypeVar(
@@ -113,6 +114,8 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
         elif isinstance(instance_args, BoltPAGraphAPICreateInstanceArgs):
             params["attribution_rule"] = instance_args.attribution_rule
             params["timestamp"] = instance_args.timestamp
+            if instance_args.run_id is not None:
+                params["run_id"] = instance_args.run_id
             r = requests.post(
                 f"{self.graphapi_url}/{instance_args.dataset_id}/instance",
                 params=params,

--- a/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/tests/test_bolt_graphapi_client.py
@@ -144,6 +144,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
             dataset_id="dataset_id",
             timestamp="0",
             attribution_rule="attribution_rule",
+            run_id="test-run-id",
         )
         await self.test_client.create_instance(test_pa_args)
         mock_post.assert_called_once_with(
@@ -152,6 +153,7 @@ class TestBoltGraphAPIClient(unittest.IsolatedAsyncioTestCase):
                 "access_token": ACCESS_TOKEN,
                 "attribution_rule": "attribution_rule",
                 "timestamp": "0",
+                "run_id": test_pa_args.run_id,
             },
         )
 

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -306,6 +306,7 @@ async def _run_attribution_async_helper(
                 dataset_id,
                 int(dt_arg),
                 attribution_rule_val,
+                run_id,
                 client,
                 logger,
             )
@@ -342,6 +343,7 @@ async def _run_attribution_async_helper(
             dataset_id=dataset_id,
             timestamp=str(dt_arg),
             attribution_rule=attribution_rule.name,
+            run_id=run_id,
         )
     )
     partner_args = BoltPlayerArgs(
@@ -445,6 +447,7 @@ async def _create_new_instance(
     dataset_id: str,
     timestamp: int,
     attribution_rule: str,
+    run_id: Optional[str],
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs],
     logger: logging.Logger,
 ) -> str:
@@ -454,6 +457,7 @@ async def _create_new_instance(
             dataset_id=dataset_id,
             timestamp=str(timestamp),
             attribution_rule=attribution_rule,
+            run_id=run_id,
         )
     )
     logger.info(

--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -50,7 +50,8 @@ class TestPlStudyRunner(TestCase):
         mock_graph_api_client,
         mock_logger,
     ) -> None:
-        self.config = {}
+        # this is the start of a valid private computation config.yml file
+        self.config = {"private_computation": {"dependency": {}}}
         self.test_logger = logging.getLogger(__name__)
         self.client_mock = MagicMock()
         valid_start_date = datetime.datetime.now() - datetime.timedelta(hours=1)


### PR DESCRIPTION
Summary:
## What

- see title

## Why

- I assume we want to support attribution?

## What is this stack

Add a decorator that can magically trace log with instance id and run id to the correct trace logger - no need to pass trace logging services all around the place:

```
bolt_checkpoint()
def my_func(...):
   ...

bolt_checkpoint(dump_params=True, dump_return_val=True)
def my_func(...):
   ...

# and much more ;)
```

I built the API so that it can be used in PCS as well, but I only added checkpointing in Bolt, since that is a mega gap right now.

{F802371475}

Reviewed By: joe1234wu

Differential Revision:
D41440515

LaMa Project: L416713

