### PR TITLE
Fix the workflow_call for PA E2E tests and add debug info to PL

### DIFF
--- a/.github/workflows/e2e_test_cron.yml
+++ b/.github/workflows/e2e_test_cron.yml
@@ -70,7 +70,7 @@ jobs:
     name: PA Test Run
     uses: ./.github/workflows/pa_one_command_runner_test.yml
     with:
-      dataset_id: 1127612294482487
+      dataset_id: '1127612294482487'
       build_id: cron
       test_name: PA E2E Tests
     secrets: inherit # pass all secrets
@@ -79,7 +79,7 @@ jobs:
     name: Multi Key PA Test Run
     uses: ./.github/workflows/pa_one_command_runner_test.yml
     with:
-      dataset_id: 3204590196477122
+      dataset_id: '3204590196477122'
       input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/partner_e2e_multikey_input.csv
       expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result_last_click_multikey.json
       build_id: cron

--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -113,6 +113,7 @@ jobs:
           --version=${{ inputs.tag }} > ${{env.CONSOLE_OUTPUT_FILE}} 2>&1
 
       - name: Print runner console output
+        if: ${{ always() }}
         continue-on-error: true
         run: |
           cat ${{env.CONSOLE_OUTPUT_FILE}}

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -7,7 +7,7 @@ on:
       dataset_id:
         description: Attribution Dataset id
         required: true
-        type: number
+        type: string
       input_path:
         description: S3 path to synthetic attribution data
         required: false


### PR DESCRIPTION
Summary:
## Context
The E2E Chron tests failed in 2 different ways.

The PA tests failed because it was expecting the dataset id to be a string, not a number:
```
Traceback (most recent call last):
  File "/home/pcs/pl_coordinator_env/fbpcs/private_computation/pc_attribution_runner.py", line 151, in run_attribution_async
    datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
  File "/home/pcs/pl_coordinator_env/fbpcs/private_computation/pc_attribution_runner.py", line 476, in _get_attribution_dataset_info
    client.get_attribution_dataset_info(
  File "/home/pcs/pl_coordinator_env/fbpcs/pl_coordinator/bolt_graphapi_client.py", line 276, in get_attribution_dataset_info
    self._check_err(r, "getting dataset information")
  File "/home/pcs/pl_coordinator_env/fbpcs/pl_coordinator/bolt_graphapi_client.py", line 247, in _check_err
    raise GraphAPIGenericException(err_msg)
fbpcs.pl_coordinator.exceptions.GraphAPIGenericException: Error getting dataset information: b'{"error":{"message":"Unsupported get request. Object with ID \'3.20459019647712E+15\' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https:\/\/developers.facebook.com\/docs\/graph-api","type":"GraphMethodException","code":100,"error_subcode":33,"fbtrace_id":"AEe7pX9ZnGrm644TXMqnEqa"}}'
```

The first run the PL tests just timed out and never printed the output file so it's unclear why it failed:
https://pxl.cl/2kWdP

On the second run, the PL test succeeded which makes me think the timeout was a transient issue, but I still wanted to add the debugging code anyway.

## This Diff
This diff adds a couple things for this problem. It fixes the PA issue by converting the dataset ids to strings. It also adds a condition to the PL E2E tests that causes it to print the console log even when the previous stage has been cancelled.

Differential Revision: D41561866

