### PR TITLE
Logging Infra: fix secret scrubber pattern to avoid masking CloudWatch URL unexpectedly

### DIFF
--- a/fbpcs/common/service/secret_scrubber.py
+++ b/fbpcs/common/service/secret_scrubber.py
@@ -35,7 +35,7 @@ class ScrubSummary:
 class SecretScrubber:
     SECRETS: List[Secret] = [
         # https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/
-        Secret("AWS access key id", "(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])"),
+        Secret("AWS access key id", "(?<![A-Za-z0-9])[A-Z0-9]{20}(?![A-Za-z0-9])"),
         # https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/
         Secret(
             "AWS secret access key",

--- a/fbpcs/common/service/test/test_secret_scrubber.py
+++ b/fbpcs/common/service/test/test_secret_scrubber.py
@@ -55,6 +55,20 @@ class TestSecretScrubber(TestCase):
         for c in scrub_summary.name_to_num_subs.values():
             self.assertEqual(c, 1)
 
+    def test_scrub_nonmatch(self) -> None:
+        test_message = f"""
+        "access_key_id": "{self.aws_access_key_id}a"
+        https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fonedocker-container-pc-e2e-test/log-events/ecs$252Fonedocker-container-pc-e2e-test$252F3602965181734511a5b83196531b80df
+        """
+
+        scrub_summary = self.scrubber.scrub(test_message)
+
+        # output message should be the same as input
+        self.assertEqual(scrub_summary.scrubbed_output, test_message)
+        self.assertEqual(scrub_summary.total_substitutions, 0)
+        for c in scrub_summary.name_to_num_subs.values():
+            self.assertEqual(c, 0)
+
     def test_pii_scrubber_regex(self) -> None:
         # Adding Logging Service PII scubber related regex
         # These regex are not expected to be scrubbed


### PR DESCRIPTION
Summary:
**What:**
Narrow the secret scrubber pattern for the AWS access key id, to avoid matching and masking other substrings (e.g. AWS CloudWatch URL) expectedly.

**Why:**
The previous regex pattern was too wide.

Differential Revision: D41568273

