### PR TITLE
read intersection size from PID metrics logging

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_udp_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_udp_stage_flow.py
@@ -161,7 +161,7 @@ class PrivateComputationPCF2LiftUDPStageFlow(PrivateComputationBaseStageFlow):
             )
         elif self is self.SECURE_RANDOM_RESHARDER:
             return SecureRandomShardStageService(
-                args.onedocker_binary_config_map, args.mpc_svc
+                args.storage_svc, args.onedocker_binary_config_map, args.mpc_svc
             )
         else:
             return self.get_default_stage_service(args)

--- a/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
@@ -6,11 +6,13 @@
 
 # pyre-strict
 
+import json
 import math
 from collections import defaultdict
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 
@@ -42,10 +44,49 @@ from fbpcs.private_computation.service.secure_random_sharder_stage_service impor
 
 class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
     @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
-    def setUp(self, mock_mpc_svc: MPCService) -> None:
+    @patch("fbpcp.service.storage.StorageService")
+    def setUp(self, mock_storage_svc: StorageService, mock_mpc_svc: MPCService) -> None:
+        self.mock_storage_svc = mock_storage_svc
         self.mock_mpc_svc = mock_mpc_svc
         self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())
         self.mock_mpc_svc.create_instance = MagicMock()
+        self.magic_mocks_read = []
+        # normal case when intersection rate is over 1%, number of shards per file is determined by union_file_size
+        self.magic_mocks_read.append(
+            MagicMock(
+                return_value=json.dumps(
+                    {
+                        "union_file_size": 1894,
+                        "partner_input_size": 196,
+                        "publisher_input_size": 1793,
+                    }
+                )
+            )
+        )
+        # edge case when intersection = 0
+        self.magic_mocks_read.append(
+            MagicMock(
+                return_value=json.dumps(
+                    {
+                        "union_file_size": 1894,
+                        "partner_input_size": 196,
+                        "publisher_input_size": 1698,
+                    }
+                )
+            )
+        )
+        # edge case when intersection rate is very low ( < 0.1%), number of shards per file is determined by intersection size and K_ANON
+        self.magic_mocks_read.append(
+            MagicMock(
+                return_value=json.dumps(
+                    {
+                        "union_file_size": 386240,
+                        "partner_input_size": 115872,
+                        "publisher_input_size": 270538,
+                    }
+                )
+            )
+        )
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
@@ -55,6 +96,7 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
             )
         )
         self.stage_svc = SecureRandomShardStageService(
+            self.mock_storage_svc,
             onedocker_binary_config_map,
             self.mock_mpc_svc,
         )
@@ -75,47 +117,73 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
             f"192.0.2.{i}"
             for i in range(private_computation_instance.infra_config.num_pid_containers)
         ]
-        await self.stage_svc.run_async(
-            private_computation_instance,
-            NullCertificateProvider(),
-            NullCertificateProvider(),
-            "",
-            "",
-            test_server_ips,
-        )
-
-        self.assertEqual(
-            mpc_instance, private_computation_instance.infra_config.instances[0]
-        )
-
-    def test_get_game_args_with_secure_random_sharding(self) -> None:
-        private_computation_instance = self._create_pc_instance()
-        shards_per_file = (
-            math.ceil(
-                private_computation_instance.infra_config.num_mpc_containers
-                / private_computation_instance.infra_config.num_pid_containers
+        for magic_mock in self.magic_mocks_read:
+            self.mock_storage_svc.read = magic_mock
+            await self.stage_svc.run_async(
+                private_computation_instance,
+                NullCertificateProvider(),
+                NullCertificateProvider(),
+                "",
+                "",
+                test_server_ips,
             )
-            * private_computation_instance.infra_config.num_files_per_mpc_container
-        )
-        test_game_args = [
-            {
-                "input_filename": f"{private_computation_instance.data_processing_output_path}_combine_{i}",
-                "output_base_path": f"{private_computation_instance.secure_random_sharder_output_base_path}",
-                "file_start_index": shards_per_file * i,
-                "num_output_files": shards_per_file,
-                "use_tls": False,
-                "ca_cert_path": "",
-                "server_cert_path": "",
-                "private_key_path": "",
-            }
-            for i in range(private_computation_instance.infra_config.num_pid_containers)
+
+            self.assertEqual(
+                mpc_instance, private_computation_instance.infra_config.instances[0]
+            )
+
+    async def test_get_game_args_with_secure_random_sharding(self) -> None:
+        private_computation_instance = self._create_pc_instance()
+        for i in range(len(self.magic_mocks_read)):
+            self.mock_storage_svc.read = self.magic_mocks_read[i]
+            shards_per_file = (
+                math.ceil(
+                    private_computation_instance.infra_config.num_mpc_containers
+                    / private_computation_instance.infra_config.num_pid_containers
+                )
+                * private_computation_instance.infra_config.num_files_per_mpc_container
+            )
+            test_game_args = [
+                {
+                    "input_filename": f"{private_computation_instance.data_processing_output_path}_combine_{i}",
+                    "output_base_path": f"{private_computation_instance.secure_random_sharder_output_base_path}",
+                    "file_start_index": shards_per_file * i,
+                    "num_output_files": shards_per_file,
+                    "use_tls": False,
+                    "ca_cert_path": "",
+                    "server_cert_path": "",
+                    "private_key_path": "",
+                }
+                for i in range(
+                    private_computation_instance.infra_config.num_pid_containers
+                )
+            ]
+            self.assertEqual(
+                test_game_args,
+                await self.stage_svc._get_secure_random_sharder_args(
+                    private_computation_instance, "", ""
+                ),
+            )
+
+    async def test_get_union_stats(self) -> None:
+        private_computation_instance = self._create_pc_instance()
+        test_union_sizes = [
+            [1894] * private_computation_instance.infra_config.num_pid_containers,
+            [1894] * private_computation_instance.infra_config.num_pid_containers,
+            [386240] * private_computation_instance.infra_config.num_pid_containers,
         ]
-        self.assertEqual(
-            test_game_args,
-            self.stage_svc._get_secure_random_sharder_args(
-                private_computation_instance, "", ""
-            ),
-        )
+        test_intersection_sizes = [
+            [95] * private_computation_instance.infra_config.num_pid_containers,
+            [0] * private_computation_instance.infra_config.num_pid_containers,
+            [170] * private_computation_instance.infra_config.num_pid_containers,
+        ]
+        for i in range(len(self.magic_mocks_read)):
+            self.mock_storage_svc.read = self.magic_mocks_read[i]
+            union_sizes, intersection_sizes = await (
+                self.stage_svc.get_union_stats(private_computation_instance)
+            )
+            self.assertEqual(test_union_sizes[i], union_sizes)
+            self.assertEqual(test_intersection_sizes[i], intersection_sizes)
 
     def _create_pc_instance(self) -> PrivateComputationInstance:
 


### PR DESCRIPTION
Summary:
This diff added a logic to read information about ID_spine output from PID metrics logging. This information will be used for dynamically determining the number of shards. The corresponding unit test is also included.

In more details, we add a function `get_pid_metrics` in pid_utils to
read information from `pc_instance.pid_stage_output_spine_path`. Then, we extract `union_file_size`, `partner_input_size`, and `publisher_input_size` from the pid metrics. The `intersection_size` is calculated as `partner_input_size + partner_input_size - union_file_size`.

Reviewed By: musebc, robotal

Differential Revision:
D41127060

LaMa Project: L416713

