### PR TITLE
don't allow duplicate statuses

### DIFF
--- a/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_decoupled_stage_flow.py
@@ -103,7 +103,7 @@ class PrivateComputationDecoupledStageFlow(PrivateComputationBaseStageFlow):
         is_joint_stage=False,
     )
     DECOUPLED_ATTRIBUTION = PrivateComputationStageFlowData(
-        initialized_status=PrivateComputationInstanceStatus.DECOUPLED_AGGREGATION_INITIALIZED,
+        initialized_status=PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_INITIALIZED,
         started_status=PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_STARTED,
         completed_status=PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.DECOUPLED_ATTRIBUTION_FAILED,

--- a/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_local_test_stage_flow.py
@@ -38,7 +38,7 @@ class PrivateComputationLocalTestStageFlow(PrivateComputationBaseStageFlow):
     # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
 
     CREATED = PrivateComputationStageFlowData(
-        initialized_status=PrivateComputationInstanceStatus.CREATION_STARTED,
+        initialized_status=PrivateComputationInstanceStatus.CREATION_INITIALIZED,
         started_status=PrivateComputationInstanceStatus.CREATION_STARTED,
         completed_status=PrivateComputationInstanceStatus.CREATED,
         failed_status=PrivateComputationInstanceStatus.CREATION_FAILED,

--- a/fbpcs/stage_flow/exceptions.py
+++ b/fbpcs/stage_flow/exceptions.py
@@ -13,3 +13,7 @@ class StageFlowException(Exception):
 
 class StageFlowStageNotFoundError(KeyError, StageFlowException):
     pass
+
+
+class StageFlowDuplicateStatusError(ValueError, StageFlowException):
+    pass

--- a/fbpcs/stage_flow/test/test_stage_flow.py
+++ b/fbpcs/stage_flow/test/test_stage_flow.py
@@ -6,8 +6,16 @@
 
 from unittest import TestCase
 
-from fbpcs.stage_flow.exceptions import StageFlowStageNotFoundError
-from fbpcs.stage_flow.test.dummy_stage_flow import DummyStageFlow, DummyStageFlowStatus
+from fbpcs.stage_flow.exceptions import (
+    StageFlowDuplicateStatusError,
+    StageFlowStageNotFoundError,
+)
+from fbpcs.stage_flow.stage_flow import StageFlow
+from fbpcs.stage_flow.test.dummy_stage_flow import (
+    DummyStageFlow,
+    DummyStageFlowData,
+    DummyStageFlowStatus,
+)
 
 
 class TestStageFlow(TestCase):
@@ -182,3 +190,20 @@ class TestStageFlow(TestCase):
             DummyStageFlow.get_stage_from_str(
                 "do not name your stage this or you will be fired"
             )
+
+    def test_duplicate_status_stage_flow(self) -> None:
+        with self.assertRaises(StageFlowDuplicateStatusError):
+
+            class DoNotCreateAStageFlowLikeThisOrYouWillBeFired(StageFlow):
+                STAGE_1 = DummyStageFlowData(
+                    initialized_status=DummyStageFlowStatus.STAGE_1_INITIALIZED,
+                    started_status=DummyStageFlowStatus.STAGE_1_STARTED,
+                    completed_status=DummyStageFlowStatus.STAGE_1_COMPLETED,
+                    failed_status=DummyStageFlowStatus.STAGE_1_FAILED,
+                )
+                CLOWNY_STAGE = DummyStageFlowData(
+                    initialized_status=DummyStageFlowStatus.STAGE_1_INITIALIZED,  # bad
+                    started_status=DummyStageFlowStatus.STAGE_2_STARTED,
+                    completed_status=DummyStageFlowStatus.STAGE_2_COMPLETED,
+                    failed_status=DummyStageFlowStatus.STAGE_2_FAILED,
+                )


### PR DESCRIPTION
Summary:
## What

- Do not allow a stage flow to be created if there are duplicate statuses

## Why

- Currently, there is an implicit assumption in the API that there aren't duplicates.
- If there are duplicates, it completely breaks the coordination logic, resulting in the computation hanging at the first stage where the duplicate status appears (which I discovered when testing the decoupled attribution stage flow)
- "explicit is better than implicit"

Differential Revision:
D41643321

LaMa Project: L416713

