### PR TITLE
Cost logging support for Experimentation Platform with multiple containers

### DIFF
--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -179,56 +179,58 @@ class PCF2AggregationStageService(PrivateComputationStageService):
 
         aggregation_type: AggregationType = attribution_config.aggregation_type
 
-        if self._log_cost_to_s3:
-            run_name = private_computation_instance.infra_config.instance_id
-            if private_computation_instance.product_config.common.post_processing_data:
-                private_computation_instance.product_config.common.post_processing_data.s3_cost_export_output_paths.add(
-                    f"agg-logs/{run_name}_{private_computation_instance.infra_config.role.value.title()}.json",
-                )
-        else:
-            run_name = ""
+        run_name_base = f"{private_computation_instance.infra_config.instance_id}_{GameNames.PCF2_AGGREGATION.value}"
 
-        common_game_args = {
-            "input_base_path": private_computation_instance.data_processing_output_path,
-            "output_base_path": private_computation_instance.pcf2_aggregation_stage_output_base_path,
-            "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
-            "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
-            "aggregators": aggregation_type.value,
-            "attribution_rules": attribution_rule.value,
-            "input_base_path_secret_share": private_computation_instance.pcf2_attribution_stage_output_base_path,
-            "use_xor_encryption": True,
-            "use_postfix": True,
-            "run_name": run_name,
-            "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
-            "max_num_conversions": private_computation_instance.product_config.common.padding_size,
-            "log_cost": self._log_cost_to_s3,
-            "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
-            "use_new_output_format": False,
-            "run_id": private_computation_instance.infra_config.run_id,
-        }
         tls_args = get_tls_arguments(
             private_computation_instance.has_feature(PCSFeature.PCF_TLS),
             server_certificate_path,
             ca_certificate_path,
         )
-        if private_computation_instance.feature_flags is not None:
-            common_game_args[
-                "pc_feature_flags"
-            ] = private_computation_instance.feature_flags
 
-        game_args = [
-            {
-                **common_game_args,
-                **{
-                    "file_start_index": i
-                    * private_computation_instance.infra_config.num_files_per_mpc_container,
-                },
+        cmd_args_list = []
+        for shard in range(
+            private_computation_instance.infra_config.num_mpc_containers
+        ):
+            run_name = f"{run_name_base}_{shard}" if self._log_cost_to_s3 else ""
+
+            game_args: Dict[str, Any] = {
+                "input_base_path": private_computation_instance.data_processing_output_path,
+                "output_base_path": private_computation_instance.pcf2_aggregation_stage_output_base_path,
+                "file_start_index": shard
+                * private_computation_instance.infra_config.num_files_per_mpc_container,
+                "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
+                "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
+                "aggregators": aggregation_type.value,
+                "attribution_rules": attribution_rule.value,
+                "input_base_path_secret_share": private_computation_instance.pcf2_attribution_stage_output_base_path,
+                "use_xor_encryption": True,
+                "use_postfix": True,
+                "run_name": run_name,
+                "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
+                "max_num_conversions": private_computation_instance.product_config.common.padding_size,
+                "log_cost": self._log_cost_to_s3,
+                "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
+                "use_new_output_format": False,
+                "run_id": private_computation_instance.infra_config.run_id,
                 **tls_args,
             }
-            for i in range(private_computation_instance.infra_config.num_mpc_containers)
-        ]
 
-        return game_args
+            if private_computation_instance.feature_flags is not None:
+                game_args[
+                    "pc_feature_flags"
+                ] = private_computation_instance.feature_flags
+
+            if (
+                self._log_cost_to_s3
+                and private_computation_instance.product_config.common.post_processing_data
+            ):
+                private_computation_instance.product_config.common.post_processing_data.s3_cost_export_output_paths.add(
+                    f"agg-logs/{run_name}_{private_computation_instance.infra_config.role.value.title()}.json",
+                )
+
+            cmd_args_list.append(game_args)
+
+        return cmd_args_list
 
     def get_status(
         self,

--- a/fbpcs/private_computation/stage_flows/__init__.py
+++ b/fbpcs/private_computation/stage_flows/__init__.py
@@ -18,6 +18,7 @@ __all__ = [  # noqa: ignore=F405
     "private_computation_decoupled_stage_flow",
     "private_computation_local_test_stage_flow",
     "private_computation_pcf2_lift_stage_flow",
+    "private_computation_pcf2_lift_udp_stage_flow",
     "private_computation_pcf2_local_test_stage_flow",
     "private_computation_pcf2_stage_flow",
     "private_computation_stage_flow",

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -96,9 +96,6 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             "output_base_path": private_computation_instance.pcf2_aggregation_stage_output_base_path,
             "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
             "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
-            "run_name": private_computation_instance.infra_config.instance_id
-            if self.stage_svc._log_cost_to_s3
-            else "",
             "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
             "max_num_conversions": private_computation_instance.product_config.common.padding_size,
             # pyre-fixme[16]: Optional type has no attribute `value`.
@@ -119,10 +116,16 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
         test_game_args = [
             {
                 **common_game_args,
+                "run_name": f"{private_computation_instance.infra_config.instance_id}_{GameNames.PCF2_AGGREGATION.value}_0"
+                if self.stage_svc._log_cost_to_s3
+                else "",
                 "file_start_index": 0,
             },
             {
                 **common_game_args,
+                "run_name": f"{private_computation_instance.infra_config.instance_id}_{GameNames.PCF2_AGGREGATION.value}_1"
+                if self.stage_svc._log_cost_to_s3
+                else "",
                 "file_start_index": private_computation_instance.infra_config.num_files_per_mpc_container,
             },
         ]

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -86,16 +86,17 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
     def test_get_game_args(self) -> None:
         private_computation_instance = self._create_pc_instance()
 
+        run_name_base = (
+            private_computation_instance.infra_config.instance_id
+            + "_"
+            + GameNames.PCF2_ATTRIBUTION.value
+        )
+
         common_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.pcf2_attribution_stage_output_base_path,
             "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
             "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
-            "run_name": private_computation_instance.infra_config.instance_id
-            + "_"
-            + GameNames.PCF2_ATTRIBUTION.value
-            if self.stage_svc._log_cost_to_s3
-            else "",
             "max_num_touchpoints": private_computation_instance.product_config.common.padding_size,
             "max_num_conversions": private_computation_instance.product_config.common.padding_size,
             "attribution_rules": AttributionRule.LAST_CLICK_1D.value,
@@ -112,10 +113,16 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
         test_game_args = [
             {
                 **common_game_args,
+                "run_name": f"{run_name_base}_0"
+                if self.stage_svc._log_cost_to_s3
+                else "",
                 "file_start_index": 0,
             },
             {
                 **common_game_args,
+                "run_name": f"{run_name_base}_1"
+                if self.stage_svc._log_cost_to_s3
+                else "",
                 "file_start_index": private_computation_instance.infra_config.num_files_per_mpc_container,
             },
         ]

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -107,20 +107,18 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
     def test_get_game_args(self) -> None:
         # TODO: add game args test for attribution args
         private_computation_instance = self._create_pc_instance()
-        run_name = (
+        run_name_base = (
             private_computation_instance.infra_config.instance_id
             + "_"
             + GameNames.PCF2_LIFT.value
-            if self.stage_svc._log_cost_to_s3
-            else ""
         )
+
         common_game_args = {
             "input_base_path": private_computation_instance.data_processing_output_path,
             "output_base_path": private_computation_instance.pcf2_lift_stage_output_base_path,
             "num_files": private_computation_instance.infra_config.num_files_per_mpc_container,
             "concurrency": private_computation_instance.infra_config.mpc_compute_concurrency,
             "num_conversions_per_user": private_computation_instance.product_config.common.padding_size,
-            "run_name": run_name,
             "log_cost": True,
             "run_id": self.run_id,
             "use_tls": False,
@@ -132,10 +130,16 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
         test_game_args = [
             {
                 **common_game_args,
+                "run_name": f"{run_name_base}_0"
+                if self.stage_svc._log_cost_to_s3
+                else "",
                 "file_start_index": 0,
             },
             {
                 **common_game_args,
+                "run_name": f"{run_name_base}_1"
+                if self.stage_svc._log_cost_to_s3
+                else "",
                 "file_start_index": private_computation_instance.infra_config.num_files_per_mpc_container,
             },
         ]


### PR DESCRIPTION
Summary:
The current PCF2 cost logging works as follows, each `run_name` will determine the s3 path that the `CostEstimation` library will log to the S3 bucket passed in by PCS layer at a specified folder path https://fburl.com/code/a3dnzmpw.

The PCS layer will queue up all the paths that it expects to be written to, and at the end of the run it will read all of these files and create entries (https://fburl.com/code/89hsryfh) in the following hive table. https://fburl.com/data/gid2rzxo.

When there are multiple containers running the same binary, they will all use the same `run_name` which gets written to the same s3 file. Our current CM pipeline only uses 1 MPC containers so this is ok, but an adhoc ExPlat run with multiple containers will be missing some of the cost logs.

Differential Revision:
D41670318

LaMa Project: L416713

