### PR TITLE
calculate number of shards and containers dynamically

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -122,7 +122,9 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
         end_ts: the time of the the end when finishing a computation run
         mpc_compute_concurrency: number of threads to run per container at the MPC compute metrics stage
         run_id: field that can be used to identify all the logs for a run.
-
+        num_secure_random_shards: total number of shards in secure random sharding stage, which is also the total number of files in following lift-udp stages
+        num_udp_containers: the number of containers used in udp
+        num_lift_containers: the number of containers used in lift with udp
     Private attributes:
         _stage_flow_cls_name: the name of a PrivateComputationBaseStageFlow subclass (cls.__name__)
     """
@@ -175,6 +177,10 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     ca_certificate: Optional[str] = immutable_field(default=None)
     server_key_ref: Optional[str] = immutable_field(default=None)
     server_domain: Optional[str] = immutable_field(default=None)
+
+    num_secure_random_shards: int = 1
+    num_udp_containers: int = 1
+    num_lift_containers: int = 1
 
     @property
     def stage_flow(self) -> Type["PrivateComputationBaseStageFlow"]:

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-
 from typing import DefaultDict, List, Optional
 
 from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
@@ -84,11 +83,13 @@ class AggregateShardsStageService(PrivateComputationStageService):
         Returns:
             An updated version of pc_instance that stores an MPCInstance
         """
-
-        num_shards = (
-            pc_instance.infra_config.num_mpc_containers
-            * pc_instance.infra_config.num_files_per_mpc_container
-        )
+        if pc_instance.has_feature(PCSFeature.PRIVATE_LIFT_UNIFIED_DATA_PROCESS):
+            num_shards = pc_instance.infra_config.num_secure_random_shards
+        else:
+            num_shards = (
+                pc_instance.infra_config.num_mpc_containers
+                * pc_instance.infra_config.num_files_per_mpc_container
+            )
 
         # TODO T101225989: map aggregation_type from the compute stage to metrics_format_type
         metrics_format_type = (

--- a/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
@@ -40,6 +40,7 @@ from fbpcs.private_computation.service.private_computation_service_data import (
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
 )
+from fbpcs.private_computation.service.utils import distribute_files_among_containers
 
 
 class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
@@ -124,7 +125,7 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
             mpc_party=map_private_computation_role_to_mpc_party(
                 pc_instance.infra_config.role
             ),
-            num_containers=pc_instance.infra_config.num_mpc_containers,
+            num_containers=pc_instance.infra_config.num_udp_containers,
             binary_version=binary_config.binary_version,
             server_certificate_provider=server_certificate_provider,
             ca_certificate_provider=ca_certificate_provider,
@@ -184,7 +185,7 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
 
         # id_combiner_output_path = pc_instance.data_processing_output_path + "_combine"
         sharder_output_path = pc_instance.secure_random_sharder_output_base_path
-        num_metadata_compaction_containers = pc_instance.infra_config.num_mpc_containers
+        num_metadata_compaction_containers = pc_instance.infra_config.num_udp_containers
         output_global_params_base_path = (
             pc_instance.pcf2_lift_metadata_compaction_output_base_path
             + "_global_params"
@@ -206,15 +207,21 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
             ca_certificate_path,
         )
 
+        num_secure_random_shards = pc_instance.infra_config.num_secure_random_shards
+        shards_per_container = distribute_files_among_containers(
+            num_secure_random_shards, num_metadata_compaction_containers
+        )
         cmd_args_list = []
         for shard in range(num_metadata_compaction_containers):
+            logging.info(
+                f"[{self}] {shard}-th metadata_compaction_containers stats: shards_per_container is {shards_per_container[shard]}"
+            )
             game_args: Dict[str, Any] = {
                 "input_base_path": sharder_output_path,
                 "output_global_params_base_path": output_global_params_base_path,
                 "output_secret_shares_base_path": output_secret_shares_base_path,
-                "file_start_index": shard
-                * pc_instance.infra_config.num_files_per_mpc_container,
-                "num_files": pc_instance.infra_config.num_files_per_mpc_container,
+                "file_start_index": sum(shards_per_container[0:shard]),
+                "num_files": shards_per_container[shard],
                 "concurrency": pc_instance.infra_config.mpc_compute_concurrency,
                 "num_conversions_per_user": pc_instance.product_config.common.padding_size,
                 "run_name": f"{run_name_base}_{shard}" if self._log_cost_to_s3 else "",
@@ -224,7 +231,6 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
                 # "run_id": private_computation_instance.infra_config.run_id,
                 **tls_args,
             }
-
             if pc_instance.feature_flags is not None:
                 game_args["pc_feature_flags"] = pc_instance.feature_flags
 

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -11,7 +11,7 @@ import asyncio
 import functools
 import re
 import warnings
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
@@ -265,3 +265,13 @@ def generate_env_vars_dict(
             env_vars[CA_CERTIFICATE_PATH_ENV_VAR] = ca_certificate_path
 
     return env_vars
+
+
+# distribute number_files files into number_containers of containers evenly so that the maximum difference will be at most 1
+def distribute_files_among_containers(
+    number_files: int, number_containers: int
+) -> List[int]:
+    files_per_container = [number_files // number_containers] * number_containers
+    for i in range(number_files % number_containers):
+        files_per_container[i] += 1
+    return files_per_container

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import random
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
@@ -50,6 +51,7 @@ from fbpcs.private_computation.service.mpc.mpc import (
     create_and_start_mpc_instance,
     MPCService,
 )
+from fbpcs.private_computation.service.utils import distribute_files_among_containers
 
 ca_cert_content = "ca certificate"
 server_cert_content = "server certificate"
@@ -186,6 +188,25 @@ class TestUtils(IsolatedAsyncioTestCase):
             game_args=game_args,
             server_uris=expected_server_uris,
         )
+
+    def test_distribute_files_among_containers(self) -> None:
+        test_size = random.randint(10, 20)
+        test_number_files = []
+        test_number_conatiners = []
+        for _ in range(test_size):
+            test_number_files.append(random.randint(1, 100))
+            test_number_conatiners.append(random.randint(1, 50))
+        test_files_per_conatiners = [
+            distribute_files_among_containers(
+                test_number_files[i], test_number_conatiners[i]
+            )
+            for i in range(test_size)
+        ]
+        for i in range(test_size):
+            self.assertEqual(test_number_files[i], sum(test_files_per_conatiners[i]))
+            self.assertLessEqual(
+                max(test_files_per_conatiners[i]) - min(test_files_per_conatiners[i]), 1
+            )
 
     def _create_pc_instance(self) -> PrivateComputationInstance:
         infra_config: InfraConfig = InfraConfig(


### PR DESCRIPTION
Summary:
This diff added a logic in secure random shard stage to dynamically calculate the number of shards and the number of containers in UDP and LIFT stage. This diff touches multiple stage services including `secure_random_shard_stage`, `pcf2_lift_metadata_compaction_stage`, `pcf2_lift_stage`, and `aggregate_shards_stage`.

1. In secure random shard stage, we added a function `get_dynamic_shards_num()` to calculate the number of shards per PID output files dynamically. More detail about this calculation is available here (https://docs.google.com/document/d/1fV65pb-71KGfblBye_TSYXGkwPtD0oXCzOvnRHG9CGw/edit#bookmark=id.2qriptz4so1c).

2. In secure random shard stage, we added another function `setup_udp_lift_stages()` to calculate the number of needed containers in UDP and LIFT stage. These numbers are determined based on the number of shards, total number of intersection rows, and some preset constants (TARGET_ROWS_UDP_THREAD and TARGET_ROWS_LIFT_THREAD). More detail is available in here (https://docs.google.com/document/d/1fV65pb-71KGfblBye_TSYXGkwPtD0oXCzOvnRHG9CGw/edit#bookmark=id.65gxomypvew7)

3. In UDP (`pcf2_lift_metadata_compaction_stage`) and LIFT stages, we distribute the shard files among UDP containers as even as possible. For example, 13 shards with 4 containers, the distribution will be [3,3,3,4].

A side note of the logic for calculating the upper bound of shards per file: the constant array `INTERSECTION_THRESHOLD` is calculated using notebook(https://www.internalfb.com/intern/anp/view/?id=2647420). The array should be updated when safety factor or K_ANON changed.

Reviewed By: robotal

Differential Revision:
D41310402

LaMa Project: L416713

