### PR TITLE
Fix misleading trace log entry in PCS

### DIFF
--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -692,7 +692,9 @@ class PrivateComputationService:
         )
         self.logger.info(repr(stage))
 
-        checkpoint_name = f"{pc_instance.infra_config.role.value}_{stage.name}"
+        checkpoint_name = (
+            f"{pc_instance.infra_config.role.value}_{stage.name}_run_async"
+        )
         self.trace_logging_svc.write_checkpoint(
             run_id=pc_instance.infra_config.run_id,
             instance_id=instance_id,


### PR DESCRIPTION
Summary: The run async method outputs COMPLETED when it kicks off a stage which is confusing since the stage is not compleate - rename the checkpoint to fix this.

Reviewed By: marksliva

Differential Revision: D41844976

