### PR TITLE
Bump GRAPHAPI_DEFAULT_VERSION to v15.0

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -31,7 +31,7 @@ from fbpcs.utils.config_yaml.exceptions import ConfigYamlBaseException
 
 GRAPHAPI_HTTPS = "https://"
 GRAPHAPI_DEFAULT_DOMAIN = "graph.facebook.com"
-GRAPHAPI_DEFAULT_VERSION = "v13.0"
+GRAPHAPI_DEFAULT_VERSION = "v15.0"
 
 GRAPHAPI_INSTANCE_STATUSES: Dict[str, PrivateComputationInstanceStatus] = {
     **{status.value: status for status in PrivateComputationInstanceStatus},


### PR DESCRIPTION
Summary:
## Why
Per recent observations, we noticed that the newly created app would require the min graphapi version to be v15.0 rather than v13.0 (in use). To unblock onboarding those advertisers we had to override the version in capig hub shell manually, which was not efficiently.

more context: T138958457

## What
- bumped GRAPHAPI_DEFAULT_VERSION to v15.0

Differential Revision: D41862704

