### PR TITLE
custom repr for BoltMetric

### DIFF
--- a/fbpcs/bolt/bolt_job_summary.py
+++ b/fbpcs/bolt/bolt_job_summary.py
@@ -32,6 +32,11 @@ class BoltMetric:
     stage: Optional[PrivateComputationBaseStageFlow] = None
     role: Optional[PrivateComputationRole] = None
 
+    def __repr__(self) -> str:
+        stage_name = self.stage.name if self.stage else None
+        role_name = self.role.name if self.role else None
+        return f"{self.metric_type.name}: ({self.value}, {stage_name}, {role_name})"
+
 
 @dataclass
 class BoltJobSummary:

--- a/fbpcs/bolt/test/test_bolt_job_summary.py
+++ b/fbpcs/bolt/test/test_bolt_job_summary.py
@@ -258,3 +258,29 @@ class TestBoltJobSummary(TestCase):
                 ),
                 self.publisher_metrics[0:2],
             )
+
+    def test_bolt_metrics_repr(self) -> None:
+        with self.subTest("No stage, no role"):
+            metric = BoltMetric(BoltMetricType.JOB_QUEUE_TIME, 1)
+            self.assertEqual("JOB_QUEUE_TIME: (1, None, None)", repr(metric))
+
+        with self.subTest("Stage, no role"):
+            metric = BoltMetric(
+                BoltMetricType.JOB_QUEUE_TIME, 1, stage=DummyStageFlow.STAGE_1
+            )
+            self.assertEqual("JOB_QUEUE_TIME: (1, STAGE_1, None)", repr(metric))
+
+        with self.subTest("No stage, Role"):
+            metric = BoltMetric(
+                BoltMetricType.JOB_QUEUE_TIME, 1, role=PrivateComputationRole.PUBLISHER
+            )
+            self.assertEqual("JOB_QUEUE_TIME: (1, None, PUBLISHER)", repr(metric))
+
+        with self.subTest("Stage, Role"):
+            metric = BoltMetric(
+                BoltMetricType.JOB_QUEUE_TIME,
+                1,
+                stage=DummyStageFlow.STAGE_1,
+                role=PrivateComputationRole.PUBLISHER,
+            )
+            self.assertEqual("JOB_QUEUE_TIME: (1, STAGE_1, PUBLISHER)", repr(metric))


### PR DESCRIPTION
Summary:
## What

- Implement a custom `repr` method for `BoltMetric`

## Why

Currently, in the trace logs, we get something like this:

```
BoltMetric(metric_type=<BoltMetricType.PLAYER_STAGE_START_UP_TIME: 'PLAYER_STAGE_START_UP_TIME'>,
value=46.27638292312622, stage=CREATED -> \\u001b[1m\\u001b[32m[**PC_PRE_VALIDATION**]\\u001b[0m -> PID_SHARD -> PID_PREPARE -> ID_MATCH -> ID_MATCH_POST_PROCESS -> ID_SPINE_COMBINER -> RESHARD -> PCF2_ATTRIBUTION -> PCF2_AGGREGATION
-> AGGREGATE -> POST_PROCESSING_HANDLERS, role=<PrivateComputationRole.PARTNER: 'PARTNER'>)
```

Instead, we can simplify it to this, else I go insane

```
PLAYER_STAGE_START_UP_TIME: (46.27638292312622, PC_PRE_VALIDATION, PARTNER)
```

Differential Revision:
D41864631

LaMa Project: L416713

