### PR TITLE
Change SimpleMetricService to emit debug level log

### DIFF
--- a/fbpcs/common/service/simple_metric_service.py
+++ b/fbpcs/common/service/simple_metric_service.py
@@ -19,7 +19,7 @@ class SimpleMetricService(MetricService):
             "key": key,
             "value": value,
         }
-        self.logger.info(json.dumps(result))
+        self.logger.debug(json.dumps(result))
 
     def bump_entity_key_avg(self, entity: str, key: str, value: int) -> None:
         result = {
@@ -28,4 +28,4 @@ class SimpleMetricService(MetricService):
             "key": key,
             "value": value,
         }
-        self.logger.info(json.dumps(result))
+        self.logger.debug(json.dumps(result))

--- a/fbpcs/common/service/test/test_simple_metric_service.py
+++ b/fbpcs/common/service/test/test_simple_metric_service.py
@@ -35,7 +35,7 @@ class TestSimpleMetricService(TestCase):
         self.svc.bump_entity_key("entity", "key")
 
         # Assert
-        self.logger.info.assert_called_once_with(expected_dump)
+        self.logger.debug.assert_called_once_with(expected_dump)
 
     def test_bump_entity_key_custom_value(self) -> None:
         # Arrange
@@ -52,7 +52,7 @@ class TestSimpleMetricService(TestCase):
         self.svc.bump_entity_key("entity", "key", 123)
 
         # Assert
-        self.logger.info.assert_called_once_with(expected_dump)
+        self.logger.debug.assert_called_once_with(expected_dump)
 
     def test_bump_entity_key_avg_custom_value(self) -> None:
         # Arrange
@@ -69,7 +69,7 @@ class TestSimpleMetricService(TestCase):
         self.svc.bump_entity_key_avg("entity", "key", 123)
 
         # Assert
-        self.logger.info.assert_called_once_with(expected_dump)
+        self.logger.debug.assert_called_once_with(expected_dump)
 
     @mock.patch(
         "time.perf_counter_ns",
@@ -91,7 +91,7 @@ class TestSimpleMetricService(TestCase):
             pass
 
         # Assert
-        self.logger.info.assert_called_once_with(expected_dump)
+        self.logger.debug.assert_called_once_with(expected_dump)
 
     def test_bump_num_times_called_and_error_count(self) -> None:
         # Arrange
@@ -120,7 +120,7 @@ class TestSimpleMetricService(TestCase):
             pass
 
         # Assert
-        self.assertEqual(2, self.logger.info.call_count)
-        self.logger.info.assert_has_calls(
+        self.assertEqual(2, self.logger.debug.call_count)
+        self.logger.debug.assert_has_calls(
             [call(expected_err_dump), call(expected_dump)]
         )


### PR DESCRIPTION
Summary:
## Why
SimpleMetricService was using `info` log level.
from partner side log it has too many metric log which is irrevelant for tracking status.

i.e
```
...

INFO:fbpcs.common.service.metric_service:{"operation": "bump_entity_key", "entity": "default.pcservice", "key": "validate_metrics", "value": 1}
INFO:root:2022-12-09 07:28:55,308 INFO measurement.private_measurement.private_computation_service.handler: [publisher_joewu_1670598653_0] Validating result metrics on instance publisher_joewu_1670598653_0
INFO:fbpcs.common.service.metric_service:{"operation": "bump_entity_key_avg", "entity": "default.pcservice", "key": "instance_repo_read.time_ms", "value": 34}
INFO:fbpcs.common.service.metric_service:{"operation": "bump_entity_key", "entity": "default.pcservice", "key": "instance_repo_read.num_calls", "value": 1}
...
```

## What
- Change SimpleMetricService to Debug level

Differential Revision: D41875349

