### PR TITLE
Removing unused logging infra code from pl-service container

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -63,7 +63,6 @@ COPY config.yml /terraform_deployment/config
 COPY cli.py /terraform_deployment
 RUN mkdir -p /terraform_deployment/fbpcs/infra/cloud_bridge
 COPY deployment_helper /terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper
-COPY logging_service /terraform_deployment/fbpcs/infra/logging_service
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -41,7 +41,6 @@ image-build: $(SERVER_JAR) external_deps
 	@echo "\nCleaning up dependencies..."
 	$(RM) -r aws_terraform_template
 	$(RM) config.yml
-	$(RM) -r logging_service
 	@echo "Done"
 
 image-run: image-build
@@ -52,14 +51,13 @@ clean:
 	server/gradlew -p server clean
 	$(RM) -r aws_terraform_template
 	$(RM) config.yml
-	$(RM) -r logging_service
 
 distclean: clean
 	docker rmi $(CONTAINER_IMAGE)
 
 
 # Dockerfile will not accept these resources as links, so they need to be copied in
-external_deps: config.yml aws_terraform_template logging_service
+external_deps: config.yml aws_terraform_template
 	@echo "Dependencies Copied\n"
 
 config.yml:
@@ -67,6 +65,3 @@ config.yml:
 
 aws_terraform_template:
 	cp -r ../pce/aws_terraform_template .
-
-logging_service:
-	cp -r ../logging_service .


### PR DESCRIPTION
Summary:
**What**
We had initially plans of running logging service from pl-service pod which was later changed.

Removing the dead code from the dockerfile

Differential Revision: D41884827

