### PR TITLE
Add new stage flow for MRPID + UDP

### DIFF
--- a/fbpcs/common/feature/pcs_feature_gate_utils.py
+++ b/fbpcs/common/feature/pcs_feature_gate_utils.py
@@ -15,6 +15,9 @@ from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow i
 from fbpcs.private_computation.stage_flows.private_computation_mr_pid_pcf2_lift_stage_flow import (
     PrivateComputationMrPidPCF2LiftStageFlow,
 )
+from fbpcs.private_computation.stage_flows.private_computation_mr_pid_udp_pcf2_lift_stage_flow import (
+    PrivateComputationMrPidUDPPCF2LiftStageFlow,
+)
 from fbpcs.private_computation.stage_flows.private_computation_mr_stage_flow import (
     PrivateComputationMRStageFlow,
 )
@@ -43,13 +46,22 @@ def get_stage_flow(
     )
 
     # warning, enabled feature gating will override stage flow, Please contact PSI team to have a similar adoption
-    if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID in pcs_feature_enums:
+    has_mr_pid = PCSFeature.PRIVATE_ATTRIBUTION_MR_PID in pcs_feature_enums
+    has_udp = PCSFeature.PRIVATE_LIFT_UNIFIED_DATA_PROCESS in pcs_feature_enums
+
+    if has_mr_pid and has_udp:
+        selected_stage_flow_cls = (
+            PrivateComputationMRStageFlow
+            if game_type is PrivateComputationGameType.ATTRIBUTION
+            else PrivateComputationMrPidUDPPCF2LiftStageFlow
+        )
+    elif has_mr_pid:
         selected_stage_flow_cls = (
             PrivateComputationMRStageFlow
             if game_type is PrivateComputationGameType.ATTRIBUTION
             else PrivateComputationMrPidPCF2LiftStageFlow
         )
-    if PCSFeature.PRIVATE_LIFT_UNIFIED_DATA_PROCESS in pcs_feature_enums:
+    elif has_udp:
         selected_stage_flow_cls = (
             PrivateComputationPCF2LiftUDPStageFlow
             if game_type is PrivateComputationGameType.LIFT

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -221,6 +221,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
             "PrivateComputationPCF2LiftUDPStageFlow",
             "PrivateComputationPCF2LiftLocalTestStageFlow",
             "PrivateComputationMrPidPCF2LiftStageFlow",
+            "PrivateComputationMrPidUDPPCF2LiftStageFlow",
         ]:
             return pc_instance.pcf2_lift_stage_output_base_path
         else:

--- a/fbpcs/private_computation/stage_flows/__init__.py
+++ b/fbpcs/private_computation/stage_flows/__init__.py
@@ -22,6 +22,7 @@ __all__ = [  # noqa: ignore=F405
     "private_computation_stage_flow",
     "private_computation_mr_stage_flow",
     "private_computation_mr_pid_pcf2_lift_stage_flow",
+    "private_computation_mr_pid_udp_pcf2_lift_stage_flow",
     "private_computation_pid_only_test_stage_flow",
     "private_computation_mrpid_only_test_stage_flow",
     "private_computation_private_id_dfca_local_test_stage_flow",

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_pid_udp_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_pid_udp_pcf2_lift_stage_flow.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from fbpcs.private_computation.entity.pid_mr_config import Protocol
+
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
+    IdSpineCombinerStageService,
+)
+from fbpcs.private_computation.service.pcf2_lift_metadata_compaction_stage_service import (
+    PCF2LiftMetadataCompactionStageService,
+)
+from fbpcs.private_computation.service.pcf2_lift_stage_service import (
+    PCF2LiftStageService,
+)
+from fbpcs.private_computation.service.pid_mr_stage_service import PIDMRStageService
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+    PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.service.secure_random_sharder_stage_service import (
+    SecureRandomShardStageService,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
+)
+
+
+class PrivateComputationMrPidUDPPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
+    """
+    - Private Lift Stage Flow with UNION_PID_MR_MULTIKEY -
+    This enum lists all of the supported stage types and maps to their possible statuses.
+    It also provides methods to get information about the next or previous stage.
+
+    NOTE: The order in which the enum members appear is the order in which the stages are intended
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    An exception is raised at runtime if _order_ is inconsistent with the actual member order.
+    """
+
+    # Specifies the order of the stages. Don't change this unless you know what you are doing.
+    # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
+    _order_ = "CREATED PC_PRE_VALIDATION UNION_PID_MR_MULTIKEY ID_SPINE_COMBINER SECURE_RANDOM_RESHARDER PCF2_LIFT_METADATA_COMPACTION PCF2_LIFT AGGREGATE POST_PROCESSING_HANDLERS"
+    # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
+    # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
+
+    CREATED = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.CREATION_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.CREATION_STARTED,
+        completed_status=PrivateComputationInstanceStatus.CREATED,
+        failed_status=PrivateComputationInstanceStatus.CREATION_FAILED,
+        is_joint_stage=False,
+    )
+    PC_PRE_VALIDATION = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.PC_PRE_VALIDATION_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.PC_PRE_VALIDATION_STARTED,
+        completed_status=PrivateComputationInstanceStatus.PC_PRE_VALIDATION_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.PC_PRE_VALIDATION_FAILED,
+        is_joint_stage=False,
+    )
+    UNION_PID_MR_MULTIKEY = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.PID_MR_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.PID_MR_STARTED,
+        completed_status=PrivateComputationInstanceStatus.PID_MR_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.PID_MR_FAILED,
+        is_joint_stage=False,
+    )
+    ID_SPINE_COMBINER = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_STARTED,
+        completed_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_FAILED,
+        is_joint_stage=False,
+    )
+    SECURE_RANDOM_RESHARDER = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.SECURE_RANDOM_SHARDER_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.SECURE_RANDOM_SHARDER_STARTED,
+        completed_status=PrivateComputationInstanceStatus.SECURE_RANDOM_SHARDER_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.SECURE_RANDOM_SHARDER_FAILED,
+        is_joint_stage=True,
+    )
+    PCF2_LIFT_METADATA_COMPACTION = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.PCF2_LIFT_METADATA_COMPACTION_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.PCF2_LIFT_METADATA_COMPACTION_STARTED,
+        completed_status=PrivateComputationInstanceStatus.PCF2_LIFT_METADATA_COMPACTION_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.PCF2_LIFT_METADATA_COMPACTION_FAILED,
+        is_joint_stage=True,
+    )
+    PCF2_LIFT = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.PCF2_LIFT_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.PCF2_LIFT_STARTED,
+        completed_status=PrivateComputationInstanceStatus.PCF2_LIFT_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.PCF2_LIFT_FAILED,
+        is_joint_stage=True,
+        timeout=DEFAULT_CONTAINER_TIMEOUT_IN_SEC,  # setting the timeout here to 12 hours, as lift stage can sometime take more time.
+    )
+    AGGREGATE = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.AGGREGATION_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.AGGREGATION_STARTED,
+        completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
+        is_joint_stage=True,
+    )
+    POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_STARTED,
+        completed_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_FAILED,
+        is_joint_stage=False,
+    )
+
+    def get_stage_service(
+        self, args: PrivateComputationStageServiceArgs
+    ) -> PrivateComputationStageService:
+        """
+        Maps PrivateComputationMrPidPCF2LiftStageFlow instances to StageService instances
+
+        Arguments:
+            args: Common arguments initialized in PrivateComputationService that are consumed by stage services
+
+        Returns:
+            An instantiated StageService object corresponding to the StageFlow enum member caller.
+
+        Raises:
+            NotImplementedError: The subclass doesn't implement a stage service for a given StageFlow enum member
+        """
+        if self is self.UNION_PID_MR_MULTIKEY:
+            if args.workflow_svc is None:
+                raise NotImplementedError("workflow_svc is None")
+
+            return PIDMRStageService(args.workflow_svc)
+        elif self is self.ID_SPINE_COMBINER:
+            return IdSpineCombinerStageService(
+                args.storage_svc,
+                args.onedocker_svc,
+                args.onedocker_binary_config_map,
+                protocol_type=Protocol.MR_PID_PROTOCOL.value,
+            )
+        elif self is self.PCF2_LIFT_METADATA_COMPACTION:
+            return PCF2LiftMetadataCompactionStageService(
+                args.onedocker_binary_config_map, args.mpc_svc
+            )
+        elif self is self.SECURE_RANDOM_RESHARDER:
+            return SecureRandomShardStageService(
+                args.storage_svc, args.onedocker_binary_config_map, args.mpc_svc
+            )
+        elif self is self.PCF2_LIFT:
+            return PCF2LiftStageService(
+                args.onedocker_binary_config_map,
+                args.mpc_svc,
+            )
+        else:
+            return self.get_default_stage_service(args)


### PR DESCRIPTION
Summary:
In H1 2023 the PID team is launching both MRPID as well as SNMK PID match method. The SNMK feature uses the same stage service, however MRPID uses a different one and therefore a different stage flow.

If both UDP and MRPID are enabled we need to run both the `PIDMRStageService` and `PCF2LiftMetadataCompactionStageService` / `SecureRandomShardService`.

- Just PCF2 -> `PrivateComputationPCF2LiftStageFlow`
- Just UDP -> `PrivateComputationPCF2LiftUDPStageFlow`
- Just MRPID -> `PrivateComputationMrPidPCF2LiftStageFlow`
- Both UDP and MRPID -> `PrivateComputationMrPidUDPPCF2LiftStageFlow`

I have tested that the E2E flow works

Differential Revision:
D41585679

LaMa Project: L416713

