### PR TITLE
Add StageFlow + PostProcessingHandler for continuous measurement

### DIFF
--- a/fbpcs/private_computation/stage_flows/__init__.py
+++ b/fbpcs/private_computation/stage_flows/__init__.py
@@ -26,6 +26,7 @@ __all__ = [  # noqa: ignore=F405
     "private_computation_mrpid_only_test_stage_flow",
     "private_computation_private_id_dfca_local_test_stage_flow",
     "private_computation_private_id_dfca_stage_flow",
+    "private_computation_pid_continuous_measurement_stage_flow",
 ]
 
 from . import *  # noqa: ignore=F403

--- a/fbpcs/private_computation/stage_flows/private_computation_pid_continuous_measurement_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pid_continuous_measurement_stage_flow.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+from fbpcs.private_computation.entity.private_computation_status import (
+    PrivateComputationInstanceStatus,
+)
+from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.private_computation_stage_service import (
+    PrivateComputationStageService,
+    PrivateComputationStageServiceArgs,
+)
+from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
+    PrivateComputationBaseStageFlow,
+    PrivateComputationStageFlowData,
+)
+
+
+class PrivateComputationPIDContinuousMeasurementStageFlow(
+    PrivateComputationBaseStageFlow
+):
+    """
+    - PID Continuous Measurement Stage Flow -
+    This enum lists all of the supported stage types and maps to their possible statuses.
+    It also provides methods to get information about the next or previous stage.
+
+    NOTE: The order in which the enum members appear is the order in which the stages are intended
+    to run. The _order_ variable is used to ensure member order is consistent (class attribute, removed during class creation).
+    An exception is raised at runtime if _order_ is inconsistent with the actual member order.
+    """
+
+    # Specifies the order of the stages. Don't change this unless you know what you are doing.
+    # pyre-fixme[15]: `_order_` overrides attribute defined in `Enum` inconsistently.
+    _order_ = (
+        "CREATED PID_SHARD PID_PREPARE ID_MATCH ID_SPINE_COMBINER ID_MATCH_POST_PROCESS"
+    )
+    # Regarding typing fixme above, Pyre appears to be wrong on this one. _order_ only appears in the EnumMeta metaclass __new__ method
+    # and is not actually added as a variable on the enum class. I think this is why pyre gets confused.
+
+    CREATED = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.CREATION_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.CREATION_STARTED,
+        completed_status=PrivateComputationInstanceStatus.CREATED,
+        failed_status=PrivateComputationInstanceStatus.CREATION_FAILED,
+        is_joint_stage=False,
+    )
+    PID_SHARD = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.PID_SHARD_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.PID_SHARD_STARTED,
+        completed_status=PrivateComputationInstanceStatus.PID_SHARD_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.PID_SHARD_FAILED,
+        is_joint_stage=False,
+    )
+    PID_PREPARE = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.PID_PREPARE_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.PID_PREPARE_STARTED,
+        completed_status=PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.PID_PREPARE_FAILED,
+        is_joint_stage=False,
+    )
+    ID_MATCH = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.ID_MATCHING_STARTED,
+        completed_status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.ID_MATCHING_FAILED,
+        is_joint_stage=True,
+        is_retryable=True,
+        timeout=DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
+    )
+    ID_SPINE_COMBINER = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_STARTED,
+        completed_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.ID_SPINE_COMBINER_FAILED,
+        is_joint_stage=False,
+    )
+    ID_MATCH_POST_PROCESS = PrivateComputationStageFlowData(
+        initialized_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_INITIALIZED,
+        started_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_STARTED,
+        completed_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_COMPLETED,
+        failed_status=PrivateComputationInstanceStatus.ID_MATCHING_POST_PROCESS_FAILED,
+        is_joint_stage=False,
+    )
+
+    def get_stage_service(
+        self, args: PrivateComputationStageServiceArgs
+    ) -> PrivateComputationStageService:
+        """
+        Maps PrivateComputationPIDContinuousMeasurementStageFlow instances to StageService instances
+
+        Arguments:
+            args: Common arguments initialized in PrivateComputationService that are consumed by stage services
+
+        Returns:
+            An instantiated StageService object corresponding to the StageFlow enum member caller.
+        """
+        logging.info("Start PID Continuous Measurement stage flow")
+        return self.get_default_stage_service(args)


### PR DESCRIPTION
Summary:
# Context
In this diff, we are exporting ID combiner results as part of the PID continuous measurement system. For the design of continuous measurement, please visit [the doc](https://docs.google.com/document/d/1e1P1H5Xm79TNJv2R2rI6CZboDmA8Pe2z_b-9TzmsacI/edit?usp=sharing). For the complete context, please review L1132844PRV and [the doc](https://docs.google.com/document/d/19wgFnLh-0tbo-REmMsNZvcwBWmNConGM3OVz9sktW3o/edit?usp=sharing).

# Description
This diff contains 3 changes.
1. Creating a new StageFlow `PrivateComputationPIDContinuousMeasurementStageFlow`. This StageFlow would include PID SHARD, PREPARE, ID MATCH, ID COMBINER, and PID POST PROCESS.
2. Creating a new PostProcessingHandler `PIDExportCombinedResultToScribeHandler`. It's reading combiner result and sending it to Scribe.
3. Creating two yml files. These yml files include the new PostProcessingHandler, and meant to be specified via `fbpcs_e2e_runner.par` in Dataswarm after this diff.

In addition to above, we created new Scribe category to send the data from Scribe to Hive.
- https://www.internalfb.com/intern/scribe/view/?category=pid_continuous_measurement_publisher_combiner_output
- https://www.internalfb.com/intern/scribe/view/?category=pid_continuous_measurement_partner_combiner_output

This diff is not touching production code and only planned to be used internally via Experimentation Platform.

Differential Revision:
D41635915

LaMa Project: L1132844

