### PR TITLE
Add feature flags for PA and PL timestamp validation

### DIFF
--- a/fbpcs/common/service/input_data_service.py
+++ b/fbpcs/common/service/input_data_service.py
@@ -36,9 +36,18 @@ class InputDataService:
 
     @classmethod
     def get_lift_study_timestamps(
-        cls, study_start_timestamp: str, observation_end_timestamp: str
+        cls,
+        study_start_timestamp: str,
+        observation_end_timestamp: str,
+        is_feature_enabled: bool,
     ) -> TimestampValues:
         try:
+            if not is_feature_enabled:
+                cls._logger().info("The PL timestamp validation feature is not enabled")
+                return TimestampValues(
+                    start_timestamp=None,
+                    end_timestamp=None,
+                )
             start_timestamp = None
             end_timestamp = None
             if TIMESTAMP_REGEX.match(study_start_timestamp):
@@ -64,8 +73,18 @@ class InputDataService:
     """
 
     @classmethod
-    def get_attribution_timestamps(cls, dataset_timestamp: str) -> TimestampValues:
+    def get_attribution_timestamps(
+        cls,
+        dataset_timestamp: str,
+        is_feature_enabled: bool,
+    ) -> TimestampValues:
         try:
+            if not is_feature_enabled:
+                cls._logger().info("The PA timestamp validation feature is not enabled")
+                return TimestampValues(
+                    start_timestamp=None,
+                    end_timestamp=None,
+                )
             dataset_datetime = cls._datetime_from_string(dataset_timestamp)
             previous_day = timedelta(days=-1) + dataset_datetime
             previous_day_ts = cls._datetime_to_timestamp_string(previous_day)

--- a/fbpcs/common/tests/service/test_input_data_service.py
+++ b/fbpcs/common/tests/service/test_input_data_service.py
@@ -18,7 +18,7 @@ class TestInputDataService(unittest.TestCase):
     def test_get_lift_study_timestamps_returns_none_when_unparsable(
         self, _mock_logger
     ) -> None:
-        result = InputDataService.get_lift_study_timestamps("not", "valid")
+        result = InputDataService.get_lift_study_timestamps("not", "valid", True)
 
         self.assertIsNone(result.start_timestamp)
         self.assertIsNone(result.end_timestamp)
@@ -28,7 +28,7 @@ class TestInputDataService(unittest.TestCase):
         end_timestamp = "1658000000"
 
         result = InputDataService.get_lift_study_timestamps(
-            start_timestamp, end_timestamp
+            start_timestamp, end_timestamp, True
         )
 
         self.assertEqual(result.start_timestamp, start_timestamp)
@@ -38,7 +38,7 @@ class TestInputDataService(unittest.TestCase):
     def test_get_attribution_timestamps_returns_none_when_unparsable(
         self, _mock_logger
     ) -> None:
-        result = InputDataService.get_attribution_timestamps("not-valid")
+        result = InputDataService.get_attribution_timestamps("not-valid", True)
 
         self.assertIsNone(result.start_timestamp)
         self.assertIsNone(result.end_timestamp)
@@ -48,7 +48,31 @@ class TestInputDataService(unittest.TestCase):
         # Start + 2 days
         expected_end = str(int(expected_start) + (3600 * 48))
 
-        result = InputDataService.get_attribution_timestamps("2022-05-01T14:00:00+0000")
+        result = InputDataService.get_attribution_timestamps(
+            "2022-05-01T14:00:00+0000", True
+        )
 
         self.assertEqual(result.start_timestamp, expected_start)
         self.assertEqual(result.end_timestamp, expected_end)
+
+    @patch("fbpcs.common.service.input_data_service.logging.getLogger")
+    def test_when_pl_validation_is_not_enabled_it_returns_empty_timestamps(
+        self, _mock_logger
+    ):
+        result = InputDataService.get_lift_study_timestamps(
+            "1657090807", "1657090808", False
+        )
+
+        self.assertIsNone(result.start_timestamp)
+        self.assertIsNone(result.end_timestamp)
+
+    @patch("fbpcs.common.service.input_data_service.logging.getLogger")
+    def test_when_pa_validation_is_not_enabled_it_returns_empty_timestamps(
+        self, _mock_logger
+    ):
+        result = InputDataService.get_attribution_timestamps(
+            "2022-05-01T14:00:00+0000", False
+        )
+
+        self.assertIsNone(result.start_timestamp)
+        self.assertIsNone(result.end_timestamp)

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -710,10 +710,15 @@ async def _create_new_instances(
                     STATUS
                 ] = PrivateComputationInstanceStatus.CREATED.value
 
-            timestamps = InputDataService.get_lift_study_timestamps(
-                study_start_time, observation_end_time
-            )
             instance_id = cell_obj_instances[cell_id][objective_id]["instance_id"]
+            is_pl_timestamp_validation_enabled = client.has_feature(
+                instance_id, PCSFeature.PL_TIMESTAMP_VALIDATION
+            )
+            timestamps = InputDataService.get_lift_study_timestamps(
+                study_start_time,
+                observation_end_time,
+                is_pl_timestamp_validation_enabled,
+            )
             instance_ids_to_timestamps[instance_id] = timestamps
 
 

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -21,6 +21,8 @@ class PCSFeature(Enum):
     NUM_MPC_CONTAINER_MUTATION = "num_mpc_container_mutation"
     PID_SNMK_LARGER_CONTAINER_TYPE = "pid_snmk_larger_container_type"
     PCF_TLS = "pcf_tls"
+    PA_TIMESTAMP_VALIDATION = "pa_timestamp_validation"
+    PL_TIMESTAMP_VALIDATION = "pl_timestamp_validation"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -349,7 +349,12 @@ async def _run_attribution_async_helper(
     )
 
     data_ts = matched_data[TIMESTAMP]
-    timestamps = InputDataService.get_attribution_timestamps(data_ts)
+    is_pa_timestamp_validation_enabled = client.has_feature(
+        instance_id, PCSFeature.PA_TIMESTAMP_VALIDATION
+    )
+    timestamps = InputDataService.get_attribution_timestamps(
+        data_ts, is_pa_timestamp_validation_enabled
+    )
     partner_args = BoltPlayerArgs(
         create_instance_args=BoltPCSCreateInstanceArgs(
             instance_id=instance_id,


### PR DESCRIPTION
Summary:
In order to control the release process for the timestamp validations feature,
add 2 new feature flags so that it can be rolled out smoothly. These flags will
also enable us to quickly roll back the validations if needed.

For now, these feature flags are not returned from the Graph API. So they
will default to false in the meantime and empty timestamps will be sent to
the pre_validation CLI which makes it skip the timestamp validation.

In a followup after the code freeze, the new feature flags will be added into
the `www` layer so that this validation can be released.

Differential Revision: D41981227

