### PR TITLE
Pass server domain from PCInstance to MPC service in stage services

### DIFF
--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -38,6 +38,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -124,10 +125,16 @@ class AggregateShardsStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         logging.info(

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -45,6 +45,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -168,10 +169,16 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
 
         logging.info("MPC instance started running.")

--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -43,6 +43,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -127,6 +128,11 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             ),
             server_ips=server_ips,
         )
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
 
         env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
@@ -150,6 +156,7 @@ class PCF2AggregationStageService(PrivateComputationStageService):
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         logging.info("MPC instance started running for pcf2.0 based aggregation stage.")

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -42,6 +42,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -126,6 +127,12 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             server_ips=server_ips,
         )
 
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
+
         env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
             server_certificate_provider=server_certificate_provider,
@@ -148,6 +155,7 @@ class PCF2AttributionStageService(PrivateComputationStageService):
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         logging.info("MPC instance started running for pcf2.0 attribution.")

--- a/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_metadata_compaction_stage_service.py
@@ -42,6 +42,7 @@ from fbpcs.private_computation.service.utils import (
     distribute_files_among_containers,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -129,6 +130,12 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
             server_ips=server_ips,
         )
 
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
+
         env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
             server_certificate_provider=server_certificate_provider,
@@ -151,6 +158,7 @@ class PCF2LiftMetadataCompactionStageService(PrivateComputationStageService):
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         logging.info(

--- a/fbpcs/private_computation/service/pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_lift_stage_service.py
@@ -42,6 +42,7 @@ from fbpcs.private_computation.service.utils import (
     distribute_files_among_containers,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -150,10 +151,16 @@ class PCF2LiftStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
 
         logging.info("MPC instance started running for PCF2.0 Lift.")

--- a/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
@@ -31,6 +31,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -141,10 +142,16 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         return pc_instance

--- a/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
+++ b/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
@@ -42,6 +42,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 from fbpcs.private_computation.service.utils import (
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
+    get_server_uris,
     stop_stage_service,
 )
 
@@ -151,6 +152,12 @@ class SecureRandomShardStageService(PrivateComputationStageService):
             server_ips=server_ips,
         )
 
+        server_uris = get_server_uris(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(cmd_args_list),
+        )
+
         env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
             server_certificate_provider=server_certificate_provider,
@@ -173,6 +180,7 @@ class SecureRandomShardStageService(PrivateComputationStageService):
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         return pc_instance

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -18,6 +18,7 @@ from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.stage_state_instance import StageStateInstanceStatus
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
+from fbpcs.private_computation.entity.infra_config import PrivateComputationRole
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationInstanceStatus,
@@ -280,3 +281,15 @@ def distribute_files_among_containers(
     for i in range(number_files % number_containers):
         files_per_container[i] += 1
     return files_per_container
+
+
+def get_server_uris(
+    server_domain: Optional[str], role: PrivateComputationRole, num_containers: int
+) -> Optional[List[str]]:
+    """For each container, create a unique server_uri based
+    on the server_domain when the MPCParty is server.
+    """
+    if role is PrivateComputationRole.PARTNER or not server_domain:
+        return None
+    else:
+        return [f"node{i}.{server_domain}" for i in range(num_containers)]


### PR DESCRIPTION
Summary: we need to pass the server domain stored in the pcinstance to mpc service. The mpc service will then create a service uri for each container aribitrarily [here](https://fburl.com/code/3j6igbjn)

Reviewed By: joe1234wu

Differential Revision: D41635937

