### PR TITLE
Fix the integer division that was causing the first Cron Run to fail

### DIFF
--- a/.github/workflows/e2e_test_cron.yml
+++ b/.github/workflows/e2e_test_cron.yml
@@ -22,7 +22,7 @@ jobs:
         id: select_pl_objective_id
         run: |
           hour=$(date -u +"%H")
-          let "idx = ($hour - 16)/2"
+          idx=$(( ($hour - 16)/2 ))
           objective_ids_array=(${{ env.PL_OBJECTIVE_IDS }})
           OBJECTIVE_ID=${objective_ids_array[$idx]}
           echo "objective_id=$OBJECTIVE_ID" >> $GITHUB_OUTPUT
@@ -36,8 +36,8 @@ jobs:
       - name: Select MK PL Objective ID
         id: select_pl_objective_id
         run: |
-          hour=$(date +"%H")
-          let "idx = ($hour - 16)/2"
+          hour=$(date -u +"%H")
+          idx=$(( ($hour - 16)/2 ))
           objective_ids_array=(${{ env.MK_PL_OBJECTIVE_IDS }})
           OBJECTIVE_ID=${objective_ids_array[$idx]}
           echo "objective_id=$OBJECTIVE_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Summary:
## Context
The first run of the cron E2E tests was failing every time. This was because using the `let` command to divide 0 by an integer would return a status code of 1.

## This Diff
This diff updates the way we do the subtraction to not fail on dividing 0.

Differential Revision: D42002682

