### PR TITLE
Migrate SecureRandomShardStageService stage to use StageStateInstance

### DIFF
--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
 from fbpcp.util.typing import checked_cast
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
@@ -31,8 +31,6 @@ from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 
 from fbpcs.private_computation.service.mpc.mpc import (
-    create_and_start_mpc_instance,
-    get_updated_pc_status_mpc_game,
     map_private_computation_role_to_mpc_party,
     MPCService,
 )
@@ -41,6 +39,11 @@ from fbpcs.private_computation.service.private_computation_service_data import (
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
+)
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+    stop_stage_service,
 )
 
 
@@ -116,34 +119,40 @@ class PCF2AggregationStageService(PrivateComputationStageService):
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )
-        mpc_instance = await create_and_start_mpc_instance(
-            mpc_svc=self._mpc_service,
-            instance_id=pc_instance.infra_config.instance_id
-            + "_"
-            + GameNames.PCF2_AGGREGATION.value,
+        _, cmd_args_list = self._mpc_service.convert_cmd_args_list(
             game_name=game_name,
+            game_args=game_args,
             mpc_party=map_private_computation_role_to_mpc_party(
                 pc_instance.infra_config.role
             ),
-            num_containers=len(game_args),
-            binary_version=binary_config.binary_version,
-            server_certificate_provider=server_certificate_provider,
-            ca_certificate_provider=ca_certificate_provider,
-            server_certificate_path=server_certificate_path,
-            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
-            game_args=game_args,
-            container_timeout=self._container_timeout,
+        )
+
+        env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
+            server_certificate_provider=server_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_provider=ca_certificate_provider,
+            ca_certificate_path=ca_certificate_path,
+        )
+
+        container_instances = await self._mpc_service.start_containers(
+            cmd_args_list=cmd_args_list,
+            onedocker_svc=self._mpc_service.onedocker_svc,
+            binary_version=binary_config.binary_version,
+            binary_name=binary_name,
+            timeout=self._container_timeout,
+            env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
-
+        stage_state = StageStateInstance(
+            pc_instance.infra_config.instance_id,
+            pc_instance.current_stage.name,
+            containers=container_instances,
+        )
+        pc_instance.infra_config.instances.append(stage_state)
         logging.info("MPC instance started running for pcf2.0 based aggregation stage.")
-
-        # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
-        pc_instance.infra_config.instances.append(
-            PCSMPCInstance.from_mpc_instance(mpc_instance)
-        )
         return pc_instance
 
     # For now, only passing the attribution game arguments, as this game is currently only used for PA.
@@ -244,4 +253,12 @@ class PCF2AggregationStageService(PrivateComputationStageService):
         Returns:
             The latest status for private_computation_instance
         """
-        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
+        return get_pc_status_from_stage_state(
+            pc_instance, self._mpc_service.onedocker_svc
+        )
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        stop_stage_service(pc_instance, self._mpc_service.onedocker_svc)

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any, DefaultDict, Dict, List, Optional
 
 from fbpcp.util.typing import checked_cast
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
@@ -30,8 +30,6 @@ from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 
 from fbpcs.private_computation.service.mpc.mpc import (
-    create_and_start_mpc_instance,
-    get_updated_pc_status_mpc_game,
     map_private_computation_role_to_mpc_party,
     MPCService,
 )
@@ -40,6 +38,11 @@ from fbpcs.private_computation.service.private_computation_service_data import (
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
+)
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+    stop_stage_service,
 )
 
 
@@ -114,32 +117,40 @@ class PCF2AttributionStageService(PrivateComputationStageService):
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )
-        mpc_instance = await create_and_start_mpc_instance(
-            mpc_svc=self._mpc_service,
-            instance_id=pc_instance.infra_config.instance_id + "_pcf2_attribution",
+        _, cmd_args_list = self._mpc_service.convert_cmd_args_list(
             game_name=game_name,
+            game_args=game_args,
             mpc_party=map_private_computation_role_to_mpc_party(
                 pc_instance.infra_config.role
             ),
-            num_containers=len(game_args),
-            binary_version=binary_config.binary_version,
-            server_certificate_provider=server_certificate_provider,
-            ca_certificate_provider=ca_certificate_provider,
-            server_certificate_path=server_certificate_path,
-            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
-            game_args=game_args,
-            container_timeout=self._container_timeout,
+        )
+
+        env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
+            server_certificate_provider=server_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_provider=ca_certificate_provider,
+            ca_certificate_path=ca_certificate_path,
+        )
+
+        container_instances = await self._mpc_service.start_containers(
+            cmd_args_list=cmd_args_list,
+            onedocker_svc=self._mpc_service.onedocker_svc,
+            binary_version=binary_config.binary_version,
+            binary_name=binary_name,
+            timeout=self._container_timeout,
+            env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
-
+        stage_state = StageStateInstance(
+            pc_instance.infra_config.instance_id,
+            pc_instance.current_stage.name,
+            containers=container_instances,
+        )
+        pc_instance.infra_config.instances.append(stage_state)
         logging.info("MPC instance started running for pcf2.0 attribution.")
-
-        # Push MPC instance to PrivateComputationInstance.instances and update PA Instance status
-        pc_instance.infra_config.instances.append(
-            PCSMPCInstance.from_mpc_instance(mpc_instance)
-        )
         return pc_instance
 
     def get_status(
@@ -154,7 +165,15 @@ class PCF2AttributionStageService(PrivateComputationStageService):
         Returns:
             The latest status for private_computation_instance
         """
-        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
+        return get_pc_status_from_stage_state(
+            pc_instance, self._mpc_service.onedocker_svc
+        )
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        stop_stage_service(pc_instance, self._mpc_service.onedocker_svc)
 
     # For now, only passing the attribution game arguments, as this game is currently only used for PA.
     def _get_compute_metrics_game_args(

--- a/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
+++ b/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
@@ -11,7 +11,7 @@ from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 from fbpcp.service.storage import StorageService
 
 from fbpcp.util.typing import checked_cast
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.pcs_feature import PCSFeature
@@ -24,8 +24,6 @@ from fbpcs.private_computation.service.argument_helper import get_tls_arguments
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 
 from fbpcs.private_computation.service.mpc.mpc import (
-    create_and_start_mpc_instance,
-    get_updated_pc_status_mpc_game,
     map_private_computation_role_to_mpc_party,
     MPCService,
 )
@@ -40,6 +38,11 @@ from fbpcs.private_computation.service.private_computation_service_data import (
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
+)
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+    stop_stage_service,
 )
 
 # This constant array are calcualted by SAFETY_FACTOR and K_ANON
@@ -139,28 +142,39 @@ class SecureRandomShardStageService(PrivateComputationStageService):
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )
 
-        mpc_instance = await create_and_start_mpc_instance(
-            mpc_svc=self._mpc_service,
-            instance_id=pc_instance.infra_config.instance_id + "_secure_random_sharder",
+        _, cmd_args_list = self._mpc_service.convert_cmd_args_list(
             game_name=game_name,
+            game_args=game_args,
             mpc_party=map_private_computation_role_to_mpc_party(
                 pc_instance.infra_config.role
             ),
-            num_containers=pc_instance.infra_config.num_pid_containers,
-            binary_version=binary_config.binary_version,
-            server_certificate_provider=server_certificate_provider,
-            ca_certificate_provider=ca_certificate_provider,
-            server_certificate_path=server_certificate_path,
-            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
-            game_args=game_args,
-            container_timeout=self._container_timeout,
+        )
+
+        env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
+            server_certificate_provider=server_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_provider=ca_certificate_provider,
+            ca_certificate_path=ca_certificate_path,
+        )
+
+        container_instances = await self._mpc_service.start_containers(
+            cmd_args_list=cmd_args_list,
+            onedocker_svc=self._mpc_service.onedocker_svc,
+            binary_version=binary_config.binary_version,
+            binary_name=binary_name,
+            timeout=self._container_timeout,
+            env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
-        pc_instance.infra_config.instances.append(
-            PCSMPCInstance.from_mpc_instance(mpc_instance)
+        stage_state = StageStateInstance(
+            pc_instance.infra_config.instance_id,
+            pc_instance.current_stage.name,
+            containers=container_instances,
         )
+        pc_instance.infra_config.instances.append(stage_state)
         return pc_instance
 
     def get_status(
@@ -175,7 +189,15 @@ class SecureRandomShardStageService(PrivateComputationStageService):
         Returns:
             The latest status for private computation instance
         """
-        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
+        return get_pc_status_from_stage_state(
+            pc_instance, self._mpc_service.onedocker_svc
+        )
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        stop_stage_service(pc_instance, self._mpc_service.onedocker_svc)
 
     async def _get_secure_random_sharder_args(
         self,

--- a/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_aggregation_stage_service.py
@@ -6,9 +6,9 @@
 
 from collections import defaultdict
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import (
@@ -31,18 +31,16 @@ from fbpcs.private_computation.entity.product_config import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
-
-from fbpcs.private_computation.service.mpc.entity.mpc_instance import MPCParty
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
     PCF2AggregationStageService,
 )
 
 
 class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
-    def setUp(self, mock_mpc_svc) -> None:
-        self.mock_mpc_svc = mock_mpc_svc
-        self.mock_mpc_svc.create_instance = MagicMock()
+    def setUp(self) -> None:
+        self.mock_mpc_svc = MagicMock(spec=MPCService)
+        self.mock_mpc_svc.onedocker_svc = MagicMock()
         self.run_id = "681ba82c-16d9-11ed-861d-0242ac120002"
 
         onedocker_binary_config_map = defaultdict(
@@ -57,23 +55,24 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
         )
 
     async def test_aggregation_stage(self) -> None:
+        containers = [
+            ContainerInstance(
+                instance_id="test_container_id", status=ContainerInstanceStatus.STARTED
+            )
+        ]
+        self.mock_mpc_svc.start_containers.return_value = containers
         private_computation_instance = self._create_pc_instance()
-        mpc_instance = PCSMPCInstance.create_instance(
-            instance_id=private_computation_instance.infra_config.instance_id
-            + "_"
-            + GameNames.PCF2_AGGREGATION.value
-            + "0",
-            game_name=GameNames.PCF2_AGGREGATION.value,
-            mpc_party=MPCParty.CLIENT,
-            num_workers=private_computation_instance.infra_config.num_mpc_containers,
-        )
-
-        self.mock_mpc_svc.start_instance_async = AsyncMock(return_value=mpc_instance)
-
+        binary_name = "private_attribution/pcf2_aggregation"
         test_server_ips = [
             f"192.0.2.{i}"
             for i in range(private_computation_instance.infra_config.num_mpc_containers)
         ]
+        self.mock_mpc_svc.convert_cmd_args_list.return_value = (
+            binary_name,
+            ["cmd_1", "cmd_2"],
+        )
+
+        # act
         await self.stage_svc.run_async(
             private_computation_instance,
             NullCertificateProvider(),
@@ -83,8 +82,26 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
             test_server_ips,
         )
 
+        # asserts
+        self.mock_mpc_svc.start_containers.assert_called_once_with(
+            cmd_args_list=["cmd_1", "cmd_2"],
+            onedocker_svc=self.mock_mpc_svc.onedocker_svc,
+            binary_version="latest",
+            binary_name=binary_name,
+            timeout=None,
+            env_vars={"ONEDOCKER_REPOSITORY_PATH": "test_path/"},
+            wait_for_containers_to_start_up=True,
+            existing_containers=None,
+        )
         self.assertEqual(
-            mpc_instance, private_computation_instance.infra_config.instances[0]
+            containers,
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].containers,
+        )
+        self.assertEqual(
+            "PCF2_AGGREGATION",
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].stage_name,
         )
 
     def test_get_game_args(self) -> None:
@@ -141,7 +158,8 @@ class TestPCF2AggregationStageService(IsolatedAsyncioTestCase):
         infra_config: InfraConfig = InfraConfig(
             instance_id="test_instance_123",
             role=PrivateComputationRole.PARTNER,
-            status=PrivateComputationInstanceStatus.PCF2_ATTRIBUTION_COMPLETED,
+            _stage_flow_cls_name="PrivateComputationPCF2StageFlow",
+            status=PrivateComputationInstanceStatus.PCF2_AGGREGATION_STARTED,
             status_update_ts=1600000000,
             instances=[],
             game_type=PrivateComputationGameType.ATTRIBUTION,

--- a/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_attribution_stage_service.py
@@ -6,9 +6,9 @@
 
 from collections import defaultdict
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import (
@@ -29,18 +29,16 @@ from fbpcs.private_computation.entity.product_config import (
 )
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
-
-from fbpcs.private_computation.service.mpc.entity.mpc_instance import MPCParty
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.pcf2_attribution_stage_service import (
     PCF2AttributionStageService,
 )
 
 
 class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
-    def setUp(self, mock_mpc_svc) -> None:
-        self.mock_mpc_svc = mock_mpc_svc
-        self.mock_mpc_svc.create_instance = MagicMock()
+    def setUp(self) -> None:
+        self.mock_mpc_svc = MagicMock(spec=MPCService)
+        self.mock_mpc_svc.onedocker_svc = MagicMock()
         self.run_id = "681ba82c-16d9-11ed-861d-0242ac120002"
 
         onedocker_binary_config_map = defaultdict(
@@ -55,21 +53,24 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
         )
 
     async def test_attribution_stage(self) -> None:
+        containers = [
+            ContainerInstance(
+                instance_id="test_container_id", status=ContainerInstanceStatus.STARTED
+            )
+        ]
+        self.mock_mpc_svc.start_containers.return_value = containers
         private_computation_instance = self._create_pc_instance()
-        mpc_instance = PCSMPCInstance.create_instance(
-            instance_id=private_computation_instance.infra_config.instance_id
-            + "_pcf2_attribution0",
-            game_name=GameNames.PCF2_ATTRIBUTION.value,
-            mpc_party=MPCParty.CLIENT,
-            num_workers=private_computation_instance.infra_config.num_mpc_containers,
-        )
-
-        self.mock_mpc_svc.start_instance_async = AsyncMock(return_value=mpc_instance)
-
+        binary_name = "private_attribution/pcf2_attribution"
         test_server_ips = [
             f"192.0.2.{i}"
             for i in range(private_computation_instance.infra_config.num_mpc_containers)
         ]
+        self.mock_mpc_svc.convert_cmd_args_list.return_value = (
+            binary_name,
+            ["cmd_1", "cmd_2"],
+        )
+
+        # act
         await self.stage_svc.run_async(
             private_computation_instance,
             NullCertificateProvider(),
@@ -79,8 +80,26 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
             test_server_ips,
         )
 
+        # asserts
+        self.mock_mpc_svc.start_containers.assert_called_once_with(
+            cmd_args_list=["cmd_1", "cmd_2"],
+            onedocker_svc=self.mock_mpc_svc.onedocker_svc,
+            binary_version="latest",
+            binary_name=binary_name,
+            timeout=None,
+            env_vars={"ONEDOCKER_REPOSITORY_PATH": "test_path/"},
+            wait_for_containers_to_start_up=True,
+            existing_containers=None,
+        )
         self.assertEqual(
-            mpc_instance, private_computation_instance.infra_config.instances[0]
+            containers,
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].containers,
+        )
+        self.assertEqual(
+            "PCF2_ATTRIBUTION",
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].stage_name,
         )
 
     def test_get_game_args(self) -> None:
@@ -137,7 +156,8 @@ class TestPCF2AttributionStageService(IsolatedAsyncioTestCase):
         infra_config: InfraConfig = InfraConfig(
             instance_id="test_instance_123",
             role=PrivateComputationRole.PARTNER,
-            status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+            _stage_flow_cls_name="PrivateComputationPCF2StageFlow",
+            status=PrivateComputationInstanceStatus.PCF2_ATTRIBUTION_STARTED,
             status_update_ts=1600000000,
             instances=[],
             game_type=PrivateComputationGameType.ATTRIBUTION,

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -8,9 +8,9 @@
 
 from collections import defaultdict
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -32,7 +32,6 @@ from fbpcs.private_computation.entity.product_config import (
 from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
 
-from fbpcs.private_computation.service.mpc.entity.mpc_instance import MPCParty
 from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 from fbpcs.private_computation.service.pcf2_lift_metadata_compaction_stage_service import (
@@ -42,11 +41,9 @@ from fbpcs.private_computation.service.utils import distribute_files_among_conta
 
 
 class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
-    def setUp(self, mock_mpc_svc: MPCService) -> None:
-        self.mock_mpc_svc = mock_mpc_svc
-        self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())
-        self.mock_mpc_svc.create_instance = MagicMock()
+    def setUp(self) -> None:
+        self.mock_mpc_svc = MagicMock(spec=MPCService)
+        self.mock_mpc_svc.onedocker_svc = MagicMock()
 
         onedocker_binary_config_map = defaultdict(
             lambda: OneDockerBinaryConfig(
@@ -61,21 +58,24 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
         )
 
     async def test_run_async_with_udp(self) -> None:
+        containers = [
+            ContainerInstance(
+                instance_id="test_container_id", status=ContainerInstanceStatus.STARTED
+            )
+        ]
+        self.mock_mpc_svc.start_containers.return_value = containers
         private_computation_instance = self._create_pc_instance()
-        mpc_instance = PCSMPCInstance.create_instance(
-            instance_id=private_computation_instance.infra_config.instance_id
-            + "_pcf2_lift_metadata_compaction",
-            game_name=GameNames.PCF2_LIFT_METADATA_COMPACTION.value,
-            mpc_party=MPCParty.CLIENT,
-            num_workers=private_computation_instance.infra_config.num_udp_containers,
-        )
-
-        self.mock_mpc_svc.start_instance_async = AsyncMock(return_value=mpc_instance)
-
+        binary_name = "private_lift/pcf2_lift_metadata_compaction"
         test_server_ips = [
             f"192.0.2.{i}"
             for i in range(private_computation_instance.infra_config.num_udp_containers)
         ]
+        self.mock_mpc_svc.convert_cmd_args_list.return_value = (
+            binary_name,
+            ["cmd_1", "cmd_2"],
+        )
+
+        # act
         await self.stage_svc.run_async(
             private_computation_instance,
             NullCertificateProvider(),
@@ -85,8 +85,26 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             test_server_ips,
         )
 
+        # asserts
+        self.mock_mpc_svc.start_containers.assert_called_once_with(
+            cmd_args_list=["cmd_1", "cmd_2"],
+            onedocker_svc=self.mock_mpc_svc.onedocker_svc,
+            binary_version="latest",
+            binary_name=binary_name,
+            timeout=None,
+            env_vars={"ONEDOCKER_REPOSITORY_PATH": "test_path/"},
+            wait_for_containers_to_start_up=True,
+            existing_containers=None,
+        )
         self.assertEqual(
-            mpc_instance, private_computation_instance.infra_config.instances[0]
+            containers,
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].containers,
+        )
+        self.assertEqual(
+            "PCF2_LIFT_METADATA_COMPACTION",
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].stage_name,
         )
 
     def test_get_game_args_with_udp(self) -> None:
@@ -137,7 +155,8 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
         infra_config: InfraConfig = InfraConfig(
             instance_id="test_instance_123",
             role=PrivateComputationRole.PARTNER,
-            status=PrivateComputationInstanceStatus.ID_MATCHING_COMPLETED,
+            _stage_flow_cls_name="PrivateComputationPCF2LiftUDPStageFlow",
+            status=PrivateComputationInstanceStatus.PCF2_LIFT_METADATA_COMPACTION_STARTED,
             status_update_ts=1600000000,
             instances=[],
             game_type=PrivateComputationGameType.LIFT,


### PR DESCRIPTION
Summary:
## Why
During the MPC migration, one of the goal is to remove PCMPCInstace to use unify StageStateInstance.
This diff is to migrate SecureRandomShardStageService stage from PCMPCInstace to StageStateInstance.
## What
migrate PCMPCInstance usage from SecureRandomShardStageService stage to StageStateInstance
fix UT due to the changes

Reviewed By: chennyc

Differential Revision: D41997334

