### PR TITLE
Migrate PrivateIdDfcaAggregateStageService stage to use StageStateInstance

### DIFF
--- a/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
@@ -9,7 +9,7 @@
 
 from typing import DefaultDict, List, Optional
 
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
@@ -22,13 +22,16 @@ from fbpcs.private_computation.repository.private_computation_game import GameNa
 from fbpcs.private_computation.service.constants import DEFAULT_LOG_COST_TO_S3
 
 from fbpcs.private_computation.service.mpc.mpc import (
-    create_and_start_mpc_instance,
-    get_updated_pc_status_mpc_game,
     map_private_computation_role_to_mpc_party,
     MPCService,
 )
 from fbpcs.private_computation.service.private_computation_stage_service import (
     PrivateComputationStageService,
+)
+from fbpcs.private_computation.service.utils import (
+    generate_env_vars_dict,
+    get_pc_status_from_stage_state,
+    stop_stage_service,
 )
 
 
@@ -111,29 +114,39 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )
 
-        mpc_instance = await create_and_start_mpc_instance(
-            mpc_svc=self._mpc_service,
-            instance_id=f"{pc_instance.infra_config.instance_id}_private_id_dfca_aggregate",
+        _, cmd_args_list = self._mpc_service.convert_cmd_args_list(
             game_name=GameNames.PRIVATE_ID_DFCA_AGGREGATION.value,
+            game_args=game_args,
             mpc_party=map_private_computation_role_to_mpc_party(
                 pc_instance.infra_config.role
             ),
-            num_containers=pc_instance.infra_config.num_mpc_containers,
-            binary_version=binary_config.binary_version,
-            server_certificate_provider=server_certificate_provider,
-            ca_certificate_provider=ca_certificate_provider,
-            server_certificate_path=server_certificate_path,
-            ca_certificate_path=ca_certificate_path,
             server_ips=server_ips,
-            game_args=game_args,
-            container_timeout=self._container_timeout,
+        )
+
+        env_vars = generate_env_vars_dict(
             repository_path=binary_config.repository_path,
+            server_certificate_provider=server_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_provider=ca_certificate_provider,
+            ca_certificate_path=ca_certificate_path,
+        )
+
+        container_instances = await self._mpc_service.start_containers(
+            cmd_args_list=cmd_args_list,
+            onedocker_svc=self._mpc_service.onedocker_svc,
+            binary_version=binary_config.binary_version,
+            binary_name=binary_name,
+            timeout=self._container_timeout,
+            env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
+            existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
-        # Push MPC instance to PrivateComputationInstance.instances and update PL Instance status
-        pc_instance.infra_config.instances.append(
-            PCSMPCInstance.from_mpc_instance(mpc_instance)
+        stage_state = StageStateInstance(
+            pc_instance.infra_config.instance_id,
+            pc_instance.current_stage.name,
+            containers=container_instances,
         )
+        pc_instance.infra_config.instances.append(stage_state)
         return pc_instance
 
     def get_status(
@@ -148,4 +161,12 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
         Returns:
             The latest status for private_computation_instance
         """
-        return get_updated_pc_status_mpc_game(pc_instance, self._mpc_service)
+        return get_pc_status_from_stage_state(
+            pc_instance, self._mpc_service.onedocker_svc
+        )
+
+    def stop_service(
+        self,
+        pc_instance: PrivateComputationInstance,
+    ) -> None:
+        stop_stage_service(pc_instance, self._mpc_service.onedocker_svc)

--- a/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
@@ -6,9 +6,9 @@
 
 from collections import defaultdict
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
+from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import (
@@ -26,21 +26,18 @@ from fbpcs.private_computation.entity.product_config import (
     PrivateIdDfcaConfig,
     ProductConfig,
 )
-from fbpcs.private_computation.repository.private_computation_game import GameNames
 from fbpcs.private_computation.service.constants import NUM_NEW_SHARDS_PER_FILE
 
-from fbpcs.private_computation.service.mpc.entity.mpc_instance import MPCParty
+from fbpcs.private_computation.service.mpc.mpc import MPCService
 from fbpcs.private_computation.service.private_id_dfca_aggregate_stage_service import (
     PrivateIdDfcaAggregateStageService,
 )
 
 
 class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
-    @patch("fbpcs.private_computation.service.mpc.mpc.MPCService")
-    def setUp(self, mock_mpc_svc) -> None:
-        self.mock_mpc_svc = mock_mpc_svc
-        self.mock_mpc_svc.get_instance = MagicMock(side_effect=Exception())
-        self.mock_mpc_svc.create_instance = MagicMock()
+    def setUp(self) -> None:
+        self.mock_mpc_svc = MagicMock(spec=MPCService)
+        self.mock_mpc_svc.onedocker_svc = MagicMock()
         self.run_id = "681ba82c-16d9-11ed-861d-0242ac120002"
 
         onedocker_binary_config_map = defaultdict(
@@ -55,21 +52,24 @@ class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
         )
 
     async def test_private_id_dfca_aggregate(self) -> None:
+        containers = [
+            ContainerInstance(
+                instance_id="test_container_id", status=ContainerInstanceStatus.STARTED
+            )
+        ]
+        self.mock_mpc_svc.start_containers.return_value = containers
         private_computation_instance = self._create_pc_instance()
-        mpc_instance = PCSMPCInstance.create_instance(
-            instance_id=private_computation_instance.infra_config.instance_id
-            + "_private_id_dfca_aggregate",
-            game_name=GameNames.PRIVATE_ID_DFCA_AGGREGATION.value,
-            mpc_party=MPCParty.CLIENT,
-            num_workers=private_computation_instance.infra_config.num_mpc_containers,
-        )
-
-        self.mock_mpc_svc.start_instance_async = AsyncMock(return_value=mpc_instance)
-
+        binary_name = "private_id_dfca/private_id_dfca_aggregator"
         test_server_ips = [
             f"192.0.2.{i}"
             for i in range(private_computation_instance.infra_config.num_mpc_containers)
         ]
+        self.mock_mpc_svc.convert_cmd_args_list.return_value = (
+            binary_name,
+            ["cmd_1", "cmd_2"],
+        )
+
+        # act
         await self.stage_svc.run_async(
             private_computation_instance,
             NullCertificateProvider(),
@@ -78,36 +78,35 @@ class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
             "",
             test_server_ips,
         )
-        test_game_args = [
-            {
-                "input_path": f"{private_computation_instance.data_processing_output_path}_combine_{i}",
-                "output_path": f"{private_computation_instance.private_id_dfca_aggregate_stage_output_path}_{i}",
-                "run_name": private_computation_instance.infra_config.instance_id,
-                "log_cost": True,
-                "run_id": self.run_id,
-                "pc_feature_flags": private_computation_instance.feature_flags,
-            }
-            for i in range(private_computation_instance.infra_config.num_mpc_containers)
-        ]
 
-        self.assertEqual(
-            GameNames.PRIVATE_ID_DFCA_AGGREGATION.value,
-            self.mock_mpc_svc.create_instance.call_args[1]["game_name"],
+        # asserts
+        self.mock_mpc_svc.start_containers.assert_called_once_with(
+            cmd_args_list=["cmd_1", "cmd_2"],
+            onedocker_svc=self.mock_mpc_svc.onedocker_svc,
+            binary_version="latest",
+            binary_name=binary_name,
+            timeout=None,
+            env_vars={"ONEDOCKER_REPOSITORY_PATH": "test_path/"},
+            wait_for_containers_to_start_up=True,
+            existing_containers=None,
         )
         self.assertEqual(
-            test_game_args,
-            self.mock_mpc_svc.create_instance.call_args[1]["game_args"],
+            containers,
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].containers,
         )
-
         self.assertEqual(
-            mpc_instance, private_computation_instance.infra_config.instances[0]
+            "PRIVATE_ID_DFCA_AGGREGATE",
+            # pyre-ignore
+            private_computation_instance.infra_config.instances[-1].stage_name,
         )
 
     def _create_pc_instance(self) -> PrivateComputationInstance:
         infra_config: InfraConfig = InfraConfig(
             instance_id="test_instance_123",
             role=PrivateComputationRole.PARTNER,
-            status=PrivateComputationInstanceStatus.COMPUTATION_COMPLETED,
+            _stage_flow_cls_name="PrivateComputationPrivateIdDfcaStageFlow",
+            status=PrivateComputationInstanceStatus.PRIVATE_ID_DFCA_AGGREGATION_STARTED,
             status_update_ts=1600000000,
             instances=[],
             game_type=PrivateComputationGameType.PRIVATE_ID_DFCA,


### PR DESCRIPTION
Summary:
## Why
During the MPC migration, one of the goal is to remove PCMPCInstace to use unify StageStateInstance.
This diff is to migrate PrivateIdDfcaAggregateStageService stage from PCMPCInstace to StageStateInstance.
## What
migrate PCMPCInstance usage from PrivateIdDfcaAggregateStageService stage to StageStateInstance
fix UT due to the changes

Differential Revision: D42050080

