### PR TITLE
Adding destroy pce function from deploy.sh

### DIFF
--- a/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/deploy_library/terraform_library/terraform_deployment_utils.py
@@ -85,7 +85,8 @@ class TerraformDeploymentUtils:
             commands_list.extend(func(key, value))
 
         # Add args to commands list
-        commands_list.extend(args)
+        # Check if args is None
+        commands_list.extend([x for x in args if x is not None])
         return commands_list
 
     def get_default_options(
@@ -119,10 +120,12 @@ class TerraformDeploymentUtils:
         t.get_command_list("terraform apply")
 
         Returns:
-        => ['terraform', 'apply', '-backend-config "region=us-west-2"', '-backend-config "access_key=fake_access_key"']
+        => ['terraform', 'apply', '-backend-config', 'region=us-west-2', '-backend-config', 'access_key=fake_access_key']
         """
         commands_list: List[str] = []
-        commands_list.extend([f'-{key} "{k}={v}"' for k, v in value.items()])
+        for k, v in value.items():
+            commands_list.append(f"-{key}")
+            commands_list.append(f"{k}={v}")
         return commands_list
 
     def add_list_options(self, key: str, value: List[str]) -> List[str]:

--- a/fbpcs/infra/pce_deployment_library/errors_library/terraform_errors.py
+++ b/fbpcs/infra/pce_deployment_library/errors_library/terraform_errors.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+class TerraformCommandExectionError(Exception):
+    pass

--- a/fbpcs/infra/pce_deployment_library/publisher_pce/deploy.py
+++ b/fbpcs/infra/pce_deployment_library/publisher_pce/deploy.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+from typing import Any, Dict
+
+from fbpcs.infra.pce_deployment_library.cloud_library.aws.aws import AWS
+from fbpcs.infra.pce_deployment_library.deploy_library.models import (
+    FlaggedOption,
+    TerraformCommand,
+)
+from fbpcs.infra.pce_deployment_library.deploy_library.terraform_library.terraform_deployment import (
+    TerraformDeployment,
+)
+from fbpcs.infra.pce_deployment_library.publisher_pce.publisher_pce_defaults import (
+    TerraformDefaults,
+)
+from fbpcs.infra.pce_deployment_library.publisher_pce.publisher_pce_utils import (
+    PublisherPceUtils,
+)
+
+
+class Deploy:
+    """
+    Class to store the arguments used for deployment and undeployment
+    """
+
+    def __init__(
+        self,
+        s3_bucket_name: str = None,
+        s3_bucket_region: str = None,
+        account_id: str = None,
+        partner_account_id: str = None,
+        aws_region: str = None,
+        tag: str = None,
+        vpc_cidr: str = None,
+        partner_vpc_cidr: str = None,
+        vpc_logging_enabled: bool = False,
+        vpc_log_bucket_arn: str = None,
+    ):
+        self.s3_bucket_name = s3_bucket_name
+        self.s3_bucket_region = s3_bucket_region
+        self.account_id = account_id
+        self.partner_account_id = partner_account_id
+        self.aws_region = aws_region
+        self.tag = tag
+        self.vpc_cidr = vpc_cidr
+        self.partner_vpc_cidr = partner_vpc_cidr
+        self.vpc_logging_enabled = vpc_logging_enabled
+        self.vpc_log_bucket_arn = vpc_log_bucket_arn
+
+        self.tag_postfix = f"-{self.tag}"
+
+        self.log: logging.Logger = logging.getLogger(__name__)
+
+        self.aws = AWS(aws_region=self.aws_region)
+        self.terraform = TerraformDeployment()
+        self.publishe_pce_utils = PublisherPceUtils()
+
+    def deploy_pce(self, bucket_version: bool = True) -> None:
+        self.log.info(
+            "########################Started AWS Infrastructure Deployment########################"
+        )
+        self.log.info("Creating S3 bucket...")
+        self.aws.check_s3_buckets_exists(
+            s3_bucket_name=self.s3_bucket_name, bucket_version=bucket_version
+        )
+        self.terraform.working_directory = TerraformDefaults.PCE_TERRAFORM_FILE_LOCATION
+
+        self.log.info(
+            f"Changing terraform working directory to {self.terraform.working_directory}"
+        )
+        backend_config = self._get_init_backend_config()
+
+        self.log.info("Running terraform init...")
+        terraform_init_log = self.terraform.terraform_init(
+            backend_config=backend_config, reconfigure=FlaggedOption
+        )
+        self.log.info(
+            f"Terraform init output is: {self.publishe_pce_utils.parse_command_output(TerraformCommand.INIT, terraform_init_log)}"
+        )
+
+        var_dict = self._get_apply_var()
+        if self.vpc_logging_enabled:
+            opt_params = self._get_vpc_var()
+            var_dict.update(opt_params)
+
+        self.log.debug(f"Running terraform apply with vars: {var_dict}")
+        terraform_create_log = self.terraform.create(var=var_dict)
+        self.log.info(
+            f"Terraform apply output is: {self.publishe_pce_utils.parse_command_output(TerraformCommand.APPLY, terraform_create_log)}"
+        )
+
+        self.log.info(
+            "######################## PCE terraform output ########################"
+        )
+        terraform_output_result = self.terraform.terraform_output()
+        self.log.info(
+            f"Terraform output is: {self.publishe_pce_utils.parse_command_output(TerraformCommand.OUTPUT, terraform_output_result)}"
+        )
+
+        self.log.info(
+            "########################Finished AWS Infrastructure Deployment########################"
+        )
+
+    def _get_init_backend_config(self) -> Dict[str, Any]:
+        return {
+            "bucket": self.s3_bucket_name,
+            "region": self.aws_region,
+            "key": f"tfstate/pce-{self.tag_postfix}.tfstate",
+        }
+
+    def _get_apply_var(self) -> Dict[str, Any]:
+        return {
+            "aws_region": self.aws_region,
+            "tag_postfix": self.tag_postfix,
+            "vpc_cidr": self.vpc_cidr,
+            "otherparty_vpc_cidr": self.partner_vpc_cidr,
+            "pce_id": self.tag,
+        }
+
+    def _get_vpc_var(self) -> Dict[str, Any]:
+        return {
+            "vpc_logging": {
+                "enabled": self.vpc_logging_enabled,
+                "bucket_arn": self.vpc_log_bucket_arn,
+            }
+        }

--- a/fbpcs/infra/pce_deployment_library/publisher_pce/publisher_pce_defaults.py
+++ b/fbpcs/infra/pce_deployment_library/publisher_pce/publisher_pce_defaults.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from enum import Enum
+
+DIR = os.path.dirname
+PCE_TERRAFORM_FILES = "pce/aws_terraform_template/common/pce"
+
+
+class TerraformDefaults(str, Enum):
+    PCE_TERRAFORM_FILE_LOCATION = os.path.join(
+        DIR(DIR(DIR(os.path.realpath(__file__)))), PCE_TERRAFORM_FILES
+    )

--- a/fbpcs/infra/pce_deployment_library/publisher_pce/publisher_pce_utils.py
+++ b/fbpcs/infra/pce_deployment_library/publisher_pce/publisher_pce_utils.py
@@ -14,6 +14,12 @@ from fbpcs.infra.pce_deployment_library.errors_library.terraform_errors import (
 class PublisherPceUtils:
     def __init__(self):
         self.log: logging.Logger = logging.getLogger(__name__)
+        # set logger
+        self.log.setLevel(logging.DEBUG)
+        # create file handler which logs even debug messages
+        fh = logging.FileHandler("test.log")
+        fh.setLevel(logging.DEBUG)
+        self.log.addHandler(fh)
 
     def parse_command_output(self, command, command_result) -> str:
         ret_code = command_result.return_code

--- a/fbpcs/infra/pce_deployment_library/publisher_pce/publisher_pce_utils.py
+++ b/fbpcs/infra/pce_deployment_library/publisher_pce/publisher_pce_utils.py
@@ -1,0 +1,46 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import re
+
+from fbpcs.infra.pce_deployment_library.errors_library.terraform_errors import (
+    TerraformCommandExectionError,
+)
+
+
+class PublisherPceUtils:
+    def __init__(self):
+        self.log: logging.Logger = logging.getLogger(__name__)
+
+    def parse_command_output(self, command, command_result) -> str:
+        ret_code = command_result.return_code
+        if ret_code != 0:
+            self.log.error(f"Failed to run terraform {command}")
+            error = f"Command terraform {command} execution failed with error, {command_result.error}"
+            self.log.error(f"{error}")
+            raise TerraformCommandExectionError(f"{error}")
+
+        return self.sanitize_command_output_logs(command_result.output)
+
+    def sanitize_command_output_logs(self, command_output_log: str) -> str:
+        if not command_output_log:
+            return ""
+
+        ansi_escape = re.compile(
+            r"""
+            \x1B  # ESC
+            (?:   # 7-bit C1 Fe (except CSI)
+                [@-Z\\-_]
+            |     # or [ for CSI, followed by a control sequence
+                \[
+                [0-?]*  # Parameter bytes
+                [ -/]*  # Intermediate bytes
+                [@-~]   # Final byte
+            )
+        """,
+            re.VERBOSE,
+        )
+        return ansi_escape.sub("", command_output_log)

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment.py
@@ -40,6 +40,7 @@ class TestTerraformDeployment(unittest.TestCase):
                 #  `Union[bytes, str]`.
                 error=test_error if test_error else "",
             )
+
             func_ret = self.terraform_deployment.run_command(command=command)
             self.assertEqual(test_command_return.return_code, func_ret.return_code)
             self.assertEqual(test_command_return.output, func_ret.output)
@@ -101,7 +102,7 @@ class TestTerraformDeployment(unittest.TestCase):
                 "region": "fake_region",
                 "access_key": "fake_access_key",
             }
-            expected_command = 'terraform init -input=false -dry-run=true -backend-config "region=fake_region" -backend-config "access_key=fake_access_key" -reconfigure'
+            expected_command = "terraform init -input=false -dry-run=true -backend-config region=fake_region -backend-config access_key=fake_access_key -reconfigure"
             expected_value = RunCommandResult(
                 return_code=0, output=f"Dry run command: {expected_command}", error=""
             )
@@ -115,7 +116,7 @@ class TestTerraformDeployment(unittest.TestCase):
                 "region": "fake_region ",
                 "access_key": "fake_access_key ",
             }
-            expected_command = 'terraform init -input=false -dry-run=true -backend-config "region=fake_region " -backend-config "access_key=fake_access_key " -reconfigure'
+            expected_command = "terraform init -input=false -dry-run=true -backend-config region=fake_region  -backend-config access_key=fake_access_key  -reconfigure"
             expected_value = RunCommandResult(
                 return_code=0, output=f"Dry run command: {expected_command}", error=""
             )

--- a/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
+++ b/fbpcs/infra/pce_deployment_library/test/test_terraform_deployment_utils.py
@@ -35,8 +35,10 @@ class TestTerraformDeploymentUtils(unittest.TestCase):
             expected_value = [
                 "terraform",
                 "apply",
-                '-backend-config "region=fake_region"',
-                '-backend-config "access_key=fake_access_key"',
+                "-backend-config",
+                "region=fake_region",
+                "-backend-config",
+                "access_key=fake_access_key",
             ]
             return_value = self.terraform_deployment_utils.get_command_list(
                 command, **kwargs
@@ -83,8 +85,10 @@ class TestTerraformDeploymentUtils(unittest.TestCase):
             expected_value = [
                 "terraform",
                 "apply",
-                '-backend-config "region=fake_region"',
-                '-backend-config "access_key=fake_access_key"',
+                "-backend-config",
+                "region=fake_region",
+                "-backend-config",
+                "access_key=fake_access_key",
                 "test_test",
             ]
             return_value = self.terraform_deployment_utils.get_command_list(


### PR DESCRIPTION
Summary:
**Context:**
Adding python code for function undeploy.sh in file deploy,sh (https://www.internalfb.com/code/fbsource/[7ff3f743651b12202e9b379ce12b4432e789ce69]/fbcode/fbpcs/infra/publisher/deploy.sh)

Calling terraform and AWS APIs to create PCE instances.

**Change:**
Refactors function: https://www.internalfb.com/code/fbsource/[d4c705f09286e221d5c72315afb924016d5f1d7f]/fbcode/fbpcs/infra/publisher/deploy.sh?lines=69

This function is used to delete pce instances using the terraform files in location https://www.internalfb.com/code/fbsource/[7ff3f743651b12202e9b379ce12b4432e789ce69]/fbcode/fbpcs/infra/pce/aws_terraform_template/common/pce/

**More context**
One pager on the BE task: https://docs.google.com/document/d/19YnphIPaS_iZWdYQnUe9bb1Ob8Q0xy6fRDF3yACSZKU/edit?usp=sharing

Differential Revision: D42088804

