### PR TITLE
await has_feature

### DIFF
--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -711,7 +711,7 @@ async def _create_new_instances(
                 ] = PrivateComputationInstanceStatus.CREATED.value
 
             instance_id = cell_obj_instances[cell_id][objective_id]["instance_id"]
-            is_pl_timestamp_validation_enabled = client.has_feature(
+            is_pl_timestamp_validation_enabled = await client.has_feature(
                 instance_id, PCSFeature.PL_TIMESTAMP_VALIDATION
             )
             timestamps = InputDataService.get_lift_study_timestamps(

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -349,7 +349,7 @@ async def _run_attribution_async_helper(
     )
 
     data_ts = matched_data[TIMESTAMP]
-    is_pa_timestamp_validation_enabled = client.has_feature(
+    is_pa_timestamp_validation_enabled = await client.has_feature(
         instance_id, PCSFeature.PA_TIMESTAMP_VALIDATION
     )
     timestamps = InputDataService.get_attribution_timestamps(


### PR DESCRIPTION
Summary:
## What

- Await the coroutine generated by `client.has_feature`

## Why

- If you don't, the result is a coroutine, not a bool.
- Coroutines are truthy. Effectively, what this means is the subsequent usage of the result is treating the result as if it is "True," meaning the gatekeeper is always being activated.
- Because of this bug, the PCS CI/CD and EP graph API experiments are broken

{F829503782}

https://fb.workplace.com/groups/347899107359347/posts/528875445928378/?comment_id=528910729258183&reply_comment_id=530508612431728

Differential Revision: D42151511

