### PR TITLE
Change container layer interface to accept list of env_vars (#475)

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -61,6 +61,7 @@ class PCSContainerService(ContainerService):
 
         return PCSContainerInstance.from_container_instance(instance, log_url)
 
+    # pyre-ignore[14]: Inconsistent override
     def create_instances(
         self,
         container_definition: str,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcp/pull/475

One of the requirements of TLS/OPA integration is to be able to send a set of env_vars for each container. Currently, the infra only supports a single set of env_vars for all containers. This stack of diffs is to enable this feature for private lift runs.

This diff:
* modify the container interface to accept a list of env_vars in addition to a single env_vars dict in `create_instances`
* this diff only changes the interface and the functionality remains the same.

Next:
* changes in onedocker layer
* changes in pcs layer (note that this would have fbpcp release dependency)

Reviewed By: liliarizona

Differential Revision: D42199006

