### PR TITLE
Add fail-fast validation for cohort count

### DIFF
--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -143,6 +143,11 @@ class InputDataValidator(Validator):
                             "Cohort Id Format is invalid. Cohort ID should start with 0 and increment by 1."
                         )
 
+                if len(cohort_id_set) > 7:
+                    raise InputDataValidationException(
+                        "Number of cohorts is higher than currently supported."
+                    )
+
         except InputDataValidationException as e:
             return self._format_validation_report(
                 f"File: {self._input_file_path} failed validation. Error: {e}",

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -206,6 +206,39 @@ class TestInputDataValidator(TestCase):
         self.assertEqual(report, expected_report)
 
     @patch("fbpcs.pc_pre_validation.input_data_validator.time")
+    def test_run_validations_fail_for_cohort_id_count_too_high(
+        self, time_mock: Mock
+    ) -> None:
+        time_mock.time.return_value = TEST_TIMESTAMP
+        lines = [
+            b"id_,value,event_timestamp,cohort_id\n",
+            b"abcd/1234+WXYZ=,100,1645157987,0\n",
+            b"abcd/1234+WXYZ=,100,1645157987,1\n",
+            b"abcd/1234+WXYZ=,100,1645157987,2\n",
+            b"abcd/1234+WXYZ=,100,1645157987,3\n",
+            b"abcd/1234+WXYZ=,100,1645157987,4\n",
+            b"abcd/1234+WXYZ=,100,1645157987,5\n",
+            b"abcd/1234+WXYZ=,100,1645157987,6\n",
+            b"abcd/1234+WXYZ=,100,1645157987,7\n",
+        ]
+        self.write_lines_to_file(lines)
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.FAILED,
+            validator_name=INPUT_DATA_VALIDATOR_NAME,
+            message=f"File: {TEST_INPUT_FILE_PATH} failed validation. Error: Number of cohorts is higher than currently supported.",
+            details={
+                "rows_processed_count": 8,
+            },
+        )
+
+        validator = InputDataValidator(
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+        )
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+
+    @patch("fbpcs.pc_pre_validation.input_data_validator.time")
     def test_run_validations_success_for_multikey_pl_fields(
         self, time_mock: Mock
     ) -> None:


### PR DESCRIPTION
Summary: Add fail-fast validation for cohort count to prevent timeouts.

Reviewed By: ajinkya-ghonge

Differential Revision: D41813466

