### PR TITLE
Fix -Wbitwise-instead-of-logical in 5 files starting w/ fbpcf/engine/tuple_generator/TwoPartyTupleGenerator.cpp

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
@@ -89,7 +89,7 @@ void InputProcessor<schedulerId>::privatelyShareTimestampsStep() {
     for (uint32_t purchaseTs : purchaseTimestampArray) {
       // compute whether each row contains at least one valid (positive)
       // purchase timestamp
-      anyValidPurchaseTs = anyValidPurchaseTs | (purchaseTs > 0);
+      anyValidPurchaseTs = anyValidPurchaseTs || (purchaseTs > 0);
     }
     anyValidPurchaseTimestamp.push_back(anyValidPurchaseTs);
   }


### PR DESCRIPTION
Summary:
With LLVM-15, `&&` and `||` are required for boolean operands, rather than `&` and `|` which can be confused for bitwise operations. Fixing such ambiguity helps makes our code more readable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D42347736

