### PR TITLE
Delete unused create_and_start_mpc_instance methods

### DIFF
--- a/fbpcs/private_computation/service/mpc/mpc.py
+++ b/fbpcs/private_computation/service/mpc/mpc.py
@@ -17,16 +17,9 @@ from fbpcp.error.pcp import PcpError
 from fbpcp.service.container import ContainerService
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.util.typing import checked_cast
-from fbpcs.common.entity.pcs_mpc_instance import PCSMPCInstance
-
-from fbpcs.infra.certificate.certificate_provider import CertificateProvider
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationInstance,
-    PrivateComputationInstanceStatus,
     PrivateComputationRole,
 )
-
-from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.mpc.entity.mpc_instance import (
     MPCInstance,
     MPCInstanceStatus,
@@ -38,10 +31,6 @@ from fbpcs.private_computation.service.mpc.repository.mpc_instance import (
 )
 from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
-)
-from fbpcs.private_computation.service.utils import (
-    generate_env_vars_dict,
-    get_server_uris,
 )
 
 DEFAULT_BINARY_VERSION = "latest"
@@ -397,77 +386,6 @@ class MPCService(RunBinaryBaseService):
         return status
 
 
-async def create_and_start_mpc_instance(
-    mpc_svc: MPCService,
-    instance_id: str,
-    game_name: str,
-    mpc_party: MPCParty,
-    num_containers: int,
-    binary_version: str,
-    server_certificate_provider: CertificateProvider,
-    ca_certificate_provider: CertificateProvider,
-    server_certificate_path: str,
-    ca_certificate_path: str,
-    server_ips: Optional[List[str]] = None,
-    game_args: Optional[List[Dict[str, Any]]] = None,
-    container_timeout: Optional[int] = None,
-    repository_path: Optional[str] = None,
-    certificate_request: Optional[CertificateRequest] = None,
-    wait_for_containers_to_start_up: bool = True,
-    server_domain: Optional[str] = None,
-) -> MPCInstance:
-    """Creates an MPC instance and runs MPC service with it
-
-    Args:
-        mpc_svc: creates and runs MPC instances
-        instance_id: unique id used to identify MPC instances
-        game_name: the name of the MPC game to run, e.g. lift
-        mpc_party: The role played by the MPC instance, e.g. SERVER or CLIENT
-        num_containers: number of cloud containers to spawn and run mpc with
-        binary_version: Onedocker version tag, e.g. latest
-        server_ips: ip addresses of the publisher's containers.
-        game_args: arguments that are passed to game binaries by onedocker
-        container_timeout: optional duration in seconds before cloud containers timeout
-        repository_path: Path from where we can download the required executable.
-        certificate_request: Arguments to create a TLS certificate/key pair
-
-    Returns:
-        return: an mpc instance started by mpc service
-    """
-    try:
-        mpc_svc.get_instance(instance_id)
-    except Exception:
-        logging.info(f"Failed to fetch MPC instance {instance_id} - trying to create")
-        role = map_mpc_party_to_private_computation_role(mpc_party)
-        server_uris = get_server_uris(server_domain, role, num_containers)
-        mpc_svc.create_instance(
-            instance_id=instance_id,
-            game_name=game_name,
-            mpc_party=mpc_party,
-            num_workers=num_containers,
-            game_args=game_args,
-            server_uris=server_uris,
-        )
-
-    env_vars = generate_env_vars_dict(
-        repository_path=repository_path,
-        server_certificate_provider=server_certificate_provider,
-        server_certificate_path=server_certificate_path,
-        ca_certificate_provider=ca_certificate_provider,
-        ca_certificate_path=ca_certificate_path,
-    )
-
-    return await mpc_svc.start_instance_async(
-        instance_id=instance_id,
-        server_ips=server_ips,
-        timeout=container_timeout or DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
-        version=binary_version,
-        env_vars=env_vars,
-        certificate_request=certificate_request,
-        wait_for_containers_to_start_up=wait_for_containers_to_start_up,
-    )
-
-
 def map_private_computation_role_to_mpc_party(
     private_computation_role: PrivateComputationRole,
 ) -> MPCParty:
@@ -488,71 +406,3 @@ def map_private_computation_role_to_mpc_party(
         return MPCParty.CLIENT
     else:
         raise ValueError(f"No mpc party defined for {private_computation_role}")
-
-
-def map_mpc_party_to_private_computation_role(
-    mpc_party: MPCParty,
-) -> PrivateComputationRole:
-    """Convert MPCParty to PrivateComputationRole
-
-    Args:
-        mpc_party: The party in the MPC game, e.g. server or client
-
-    Returns:
-        The PrivateComputationRole that corresponds to the given mpc_party, e.g. publisher or partner
-
-    Exceptions:
-        ValueError: raised when there is no PrivateComputationRole associated with mpc_party
-    """
-    if mpc_party is MPCParty.SERVER:
-        return PrivateComputationRole.PUBLISHER
-    elif mpc_party is MPCParty.CLIENT:
-        return PrivateComputationRole.PARTNER
-    else:
-        raise ValueError(f"No private computation role defined for {mpc_party}")
-
-
-def get_updated_pc_status_mpc_game(
-    private_computation_instance: PrivateComputationInstance,
-    mpc_svc: MPCService,
-) -> PrivateComputationInstanceStatus:
-    """Updates the MPCInstances and gets latest PrivateComputationInstance status
-
-    Arguments:
-        private_computation_instance: The PC instance that is being updated
-        mpc_svc: Used to update MPC instances stored on private_computation_instance
-
-    Returns:
-        The latest status for private_computation_instance
-    """
-    status = private_computation_instance.infra_config.status
-    if private_computation_instance.infra_config.instances:
-        # Only need to update the last stage/instance
-        last_instance = private_computation_instance.infra_config.instances[-1]
-        if not isinstance(last_instance, MPCInstance):
-            return status
-
-        # MPC service has to call update_instance to get the newest containers
-        # information in case they are still running
-        private_computation_instance.infra_config.instances[
-            -1
-        ] = PCSMPCInstance.from_mpc_instance(
-            mpc_svc.update_instance(last_instance.instance_id)
-        )
-
-        mpc_instance_status = private_computation_instance.infra_config.instances[
-            -1
-        ].status
-
-        current_stage = private_computation_instance.current_stage
-        if mpc_instance_status is MPCInstanceStatus.STARTED:
-            status = current_stage.started_status
-        elif mpc_instance_status is MPCInstanceStatus.COMPLETED:
-            status = current_stage.completed_status
-        elif mpc_instance_status in (
-            MPCInstanceStatus.FAILED,
-            MPCInstanceStatus.CANCELED,
-        ):
-            status = current_stage.failed_status
-
-    return status

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -7,191 +7,22 @@
 
 import random
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
 
-from fbpcs.infra.certificate.basic_ca_certificate_provider import (
-    BasicCaCertificateProvider,
-)
-from fbpcs.infra.certificate.pc_instance_server_certificate import (
-    PCInstanceServerCertificateProvider,
-)
-
-from fbpcs.private_computation.entity.infra_config import (
-    InfraConfig,
-    PrivateComputationGameType,
-)
-from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
-    PrivateComputationInstance,
-    PrivateComputationInstanceStatus,
     PrivateComputationRole,
 )
-from fbpcs.private_computation.entity.product_config import (
-    CommonProductConfig,
-    LiftConfig,
-    ProductConfig,
-)
-from fbpcs.private_computation.service.argument_helper import (
-    TLS_ARG_KEY_CA_CERT_PATH,
-    TLS_ARG_KEY_SERVER_CERT_PATH,
-)
 
-from fbpcs.private_computation.service.constants import (
-    CA_CERT_PATH,
-    CA_CERTIFICATE_ENV_VAR,
-    CA_CERTIFICATE_PATH_ENV_VAR,
-    SERVER_CERT_PATH,
-    SERVER_CERTIFICATE_ENV_VAR,
-    SERVER_CERTIFICATE_PATH_ENV_VAR,
-)
-
-from fbpcs.private_computation.service.mpc.entity.mpc_instance import MPCParty
-
-from fbpcs.private_computation.service.mpc.mpc import (
-    create_and_start_mpc_instance,
-    MPCService,
-)
 from fbpcs.private_computation.service.utils import (
     distribute_files_among_containers,
     generate_env_vars_dict,
     get_server_uris,
 )
 
-ca_cert_content = "ca certificate"
-server_cert_content = "server certificate"
-
 
 class TestUtils(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.instance_id = "test_instance_123"
-        self.pc_instance = self._create_pc_instance()
-        # TODO: replace this with checked in certificates
-
-        self.ca_certificate_provider = BasicCaCertificateProvider(ca_cert_content)
-        self.server_certificate_provider = PCInstanceServerCertificateProvider(
-            self.pc_instance
-        )
-        self.test_binary_version = "latest"
-        self.mpc_svc = self._create_mpc_svc()
         self.server_domain = "study123.pci.facebook.com"
-        self.game_name = "private_lift"
-
-    @patch.object(MPCService, "start_instance_async")
-    @patch.object(
-        BasicCaCertificateProvider, "get_certificate", return_value=ca_cert_content
-    )
-    @patch.object(
-        PCInstanceServerCertificateProvider,
-        "get_certificate",
-        return_value=server_cert_content,
-    )
-    @patch.object(MPCService, "get_instance")
-    async def test_create_and_start_mpc_instance_env_vars_setup(
-        self,
-        getInstanceMock,
-        serverCertProviderMock,
-        caCertProviderMock,
-        startInstanceAsyncMock,
-    ) -> None:
-        # Arrange
-        expected_env_vars = {
-            SERVER_CERTIFICATE_ENV_VAR: server_cert_content,
-            SERVER_CERTIFICATE_PATH_ENV_VAR: SERVER_CERT_PATH,
-            CA_CERTIFICATE_ENV_VAR: ca_cert_content,
-            CA_CERTIFICATE_PATH_ENV_VAR: CA_CERT_PATH,
-        }
-        game_args = [
-            {
-                TLS_ARG_KEY_CA_CERT_PATH: CA_CERT_PATH,
-                TLS_ARG_KEY_SERVER_CERT_PATH: SERVER_CERT_PATH,
-            }
-        ]
-        # Act
-        await create_and_start_mpc_instance(
-            self.mpc_svc,
-            self.instance_id,
-            "private_lift",
-            MPCParty.SERVER,
-            num_containers=1,
-            binary_version=self.test_binary_version,
-            server_certificate_path=SERVER_CERT_PATH,
-            ca_certificate_path=CA_CERT_PATH,
-            game_args=game_args,
-            server_certificate_provider=self.server_certificate_provider,
-            ca_certificate_provider=self.ca_certificate_provider,
-            server_domain=self.server_domain,
-        )
-
-        # Assert
-        getInstanceMock.assert_called_once_with(self.instance_id)
-        startInstanceAsyncMock.assert_awaited_once_with(
-            instance_id=self.instance_id,
-            server_ips=None,
-            timeout=43200,
-            version=self.test_binary_version,
-            env_vars=expected_env_vars,
-            certificate_request=None,
-            wait_for_containers_to_start_up=True,
-        )
-
-    @patch.object(MPCService, "start_instance_async")
-    @patch.object(
-        BasicCaCertificateProvider, "get_certificate", return_value=ca_cert_content
-    )
-    @patch.object(
-        PCInstanceServerCertificateProvider,
-        "get_certificate",
-        return_value=server_cert_content,
-    )
-    @patch.object(MPCService, "create_instance")
-    @patch.object(
-        MPCService, "get_instance", side_effect=Exception("Instance Not Found")
-    )
-    async def test_create_and_start_mpc_instance_server_uris(
-        self,
-        getInstanceMock,
-        createInstanceMock,
-        serverCertProviderMock,
-        caCertProviderMock,
-        startInstanceAsyncMock,
-    ) -> None:
-        # Arrange
-        game_args = [
-            {
-                TLS_ARG_KEY_CA_CERT_PATH: CA_CERT_PATH,
-                TLS_ARG_KEY_SERVER_CERT_PATH: SERVER_CERT_PATH,
-            }
-        ]
-        expected_server_uris = [
-            f"node0.{self.server_domain}",
-            f"node1.{self.server_domain}",
-        ]
-        # Act
-        await create_and_start_mpc_instance(
-            self.mpc_svc,
-            self.instance_id,
-            self.game_name,
-            MPCParty.SERVER,
-            num_containers=2,
-            binary_version=self.test_binary_version,
-            server_certificate_path=SERVER_CERT_PATH,
-            ca_certificate_path=CA_CERT_PATH,
-            game_args=game_args,
-            server_certificate_provider=self.server_certificate_provider,
-            ca_certificate_provider=self.ca_certificate_provider,
-            server_domain=self.server_domain,
-        )
-
-        # Assert
-        getInstanceMock.assert_called_once_with(self.instance_id)
-        createInstanceMock.assert_called_once_with(
-            instance_id=self.instance_id,
-            game_name=self.game_name,
-            mpc_party=MPCParty.SERVER,
-            num_workers=2,
-            game_args=game_args,
-            server_uris=expected_server_uris,
-        )
 
     def test_distribute_files_among_containers(self) -> None:
         test_size = random.randint(10, 20)
@@ -211,62 +42,6 @@ class TestUtils(IsolatedAsyncioTestCase):
             self.assertLessEqual(
                 max(test_files_per_conatiners[i]) - min(test_files_per_conatiners[i]), 1
             )
-
-    @patch.object(MPCService, "start_instance_async")
-    @patch.object(
-        BasicCaCertificateProvider, "get_certificate", return_value=ca_cert_content
-    )
-    @patch.object(
-        PCInstanceServerCertificateProvider,
-        "get_certificate",
-        return_value=server_cert_content,
-    )
-    @patch.object(MPCService, "create_instance")
-    @patch.object(
-        MPCService, "get_instance", side_effect=Exception("Instance Not Found")
-    )
-    async def test_create_and_start_mpc_instance_null_server_domain(
-        self,
-        getInstanceMock,
-        createInstanceMock,
-        serverCertProviderMock,
-        caCertProviderMock,
-        startInstanceAsyncMock,
-    ) -> None:
-        # Arrange
-        game_args = [
-            {
-                TLS_ARG_KEY_CA_CERT_PATH: CA_CERT_PATH,
-                TLS_ARG_KEY_SERVER_CERT_PATH: SERVER_CERT_PATH,
-            }
-        ]
-
-        # Act
-        await create_and_start_mpc_instance(
-            self.mpc_svc,
-            self.instance_id,
-            self.game_name,
-            MPCParty.SERVER,
-            num_containers=2,
-            binary_version=self.test_binary_version,
-            server_certificate_path=SERVER_CERT_PATH,
-            ca_certificate_path=CA_CERT_PATH,
-            game_args=game_args,
-            server_certificate_provider=self.server_certificate_provider,
-            ca_certificate_provider=self.ca_certificate_provider,
-            server_domain=None,
-        )
-
-        # Assert
-        getInstanceMock.assert_called_once_with(self.instance_id)
-        createInstanceMock.assert_called_once_with(
-            instance_id=self.instance_id,
-            game_name=self.game_name,
-            mpc_party=MPCParty.SERVER,
-            num_workers=2,
-            game_args=game_args,
-            server_uris=None,
-        )
 
     def test_get_server_uris(self) -> None:
         # Arrange
@@ -289,33 +64,6 @@ class TestUtils(IsolatedAsyncioTestCase):
         self.assertEqual(expected_result_1, actual_result_1)
         self.assertEqual(expected_result_2, actual_result_2)
         self.assertEqual(expected_result_2, actual_result_3)
-
-    def _create_pc_instance(self) -> PrivateComputationInstance:
-        infra_config: InfraConfig = InfraConfig(
-            instance_id=self.instance_id,
-            role=PrivateComputationRole.PARTNER,
-            status=PrivateComputationInstanceStatus.PID_PREPARE_COMPLETED,
-            status_update_ts=1600000000,
-            instances=[],
-            game_type=PrivateComputationGameType.LIFT,
-            num_pid_containers=2,
-            num_mpc_containers=2,
-            num_files_per_mpc_container=4,
-            status_updates=[],
-            run_id="681ba82c-16d9-11ed-861d-0242ac120002",
-            pcs_features={PCSFeature.PCF_TLS},
-        )
-        common: CommonProductConfig = CommonProductConfig(
-            input_path="456",
-            output_dir="789",
-        )
-        product_config: ProductConfig = LiftConfig(
-            common=common,
-        )
-        return PrivateComputationInstance(
-            infra_config=infra_config,
-            product_config=product_config,
-        )
 
     def test_generate_env_vars_missing_parameters(self) -> None:
         # Act
@@ -368,23 +116,3 @@ class TestUtils(IsolatedAsyncioTestCase):
 
         self.assertTrue(expected_hostname_key_name in result)
         self.assertEqual(expected_hostname, result[expected_hostname_key_name])
-
-    def _create_mpc_svc(self) -> MPCService:
-        cspatcher = patch("fbpcp.service.container.ContainerService")
-        irpatcher = patch(
-            "fbpcs.private_computation.service.mpc.repository.mpc_instance.MPCInstanceRepository"
-        )
-        gspatcher = patch(
-            "fbpcs.private_computation.service.mpc.mpc_game.MPCGameService"
-        )
-        container_svc = cspatcher.start()
-        instance_repository = irpatcher.start()
-        mpc_game_svc = gspatcher.start()
-        for patcher in (cspatcher, irpatcher, gspatcher):
-            self.addCleanup(patcher.stop)
-        return MPCService(
-            container_svc,
-            instance_repository,
-            "test_task_definition",
-            mpc_game_svc,
-        )


### PR DESCRIPTION
Summary:
## Why
During this mpc migration journey, I've removed all of the usage of create_and_start_mpc_instance in PCS stage serice. This diff is starting to clean up deprecated helper method and keep the code base cleaner

## What
- remove unused `create_and_start_mpc_instance` in mpc.py
- remove unused `get_updated_pc_status_mpc_game` in mpc.py
- remove unused related unit tests

mrclean

Differential Revision: D42173627

