### PR TITLE
Fix '-Wbitwise-instead-of-logical' in fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
@@ -158,11 +158,11 @@ CompactionBasedInputProcessor<schedulerId>::preparePlaintextData(
       int inputIndex = reverseUnionMap[i];
 
       bool isValidOpportunityTimestamp =
-          (opportunityTimestampsPadded.at(inputIndex) > 0) &
-          (controlPopulationPadded.at(inputIndex) |
+          (opportunityTimestampsPadded.at(inputIndex) > 0) &&
+          (controlPopulationPadded.at(inputIndex) ||
            testPopulationPadded.at(inputIndex));
 
-      bool testReach = testPopulationPadded.at(inputIndex) &
+      bool testReach = testPopulationPadded.at(inputIndex) &&
           (numImpressionsPadded.at(inputIndex) > 0);
 
       PublisherRow publisherRow{


### PR DESCRIPTION
Summary:
LLVM-15 requires that we differentiate between `&&` and `&` as well as `||` and `|`. Logical operations are done with `&&` and `||` and bitwise operations are done with `&` and `|`. Confusing the two makes code harder to read and may lead to subtle bugs.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D42374520

