### PR TITLE
Move deprecated to util TARGET to solve cyclic dependencies

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -17,7 +17,7 @@ from fbpcp.service.container_aws import AWSContainerService
 from fbpcs.common.entity.pcs_container_instance import PCSContainerInstance
 from fbpcs.experimental.cloud_logs.aws_log_retriever import AWSLogRetriever
 from fbpcs.experimental.cloud_logs.log_retriever import LogRetriever
-from fbpcs.private_computation.service.utils import deprecated
+from fbpcs.utils.deprecated import deprecated
 
 
 class PCSContainerService(ContainerService):

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -8,9 +8,7 @@
 
 
 import asyncio
-import functools
 import re
-import warnings
 from typing import Dict, List, Optional
 
 from fbpcp.service.onedocker import OneDockerService
@@ -70,39 +68,6 @@ def get_pc_status_from_stage_state(
         status = current_stage.failed_status
 
     return status
-
-
-# pyre-ignore return typing
-def deprecated_msg(msg: str):
-    warning_color = "\033[93m"  # orange/yellow ascii escape sequence
-    end = "\033[0m"  # end ascii escape sequence
-    warnings.simplefilter("always", DeprecationWarning)
-    warnings.warn(
-        f"{warning_color}{msg}{end}",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-    warnings.simplefilter("default", DeprecationWarning)
-
-
-# decorators are a serious pain to add typing for, so I'm not going to bother...
-# pyre-ignore return typing
-def deprecated(reason: str):
-    """
-    Logs a warning that a function is deprecated
-    """
-
-    # pyre-ignore return typing
-    def wrap(func):
-        @functools.wraps(func)
-        # pyre-ignore typing on args, kwargs, and return
-        def wrapped(*args, **kwargs):
-            deprecated_msg(msg=f"{func.__name__} is deprecated! explanation: {reason}")
-            return func(*args, **kwargs)
-
-        return wrapped
-
-    return wrap
 
 
 def transform_file_path(file_path: str, aws_region: Optional[str] = None) -> str:

--- a/fbpcs/utils/config_yaml/reflect.py
+++ b/fbpcs/utils/config_yaml/reflect.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Type, TypeVar
 from fbpcp.util.reflect import (  # @manual=//measurement/private_measurement/pcp:pcp"
     get_class as fbpcp_get_class,
 )
-from fbpcs.private_computation.service.utils import deprecated_msg
 from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/private_measurement/pcp:pcp"
     ConfigYamlClassNotFoundError,
     ConfigYamlModuleImportError,
@@ -19,6 +18,7 @@ from fbpcs.utils.config_yaml.exceptions import (  # @manual=//measurement/privat
     ConfigYamlWrongClassConfiguredError,
     ConfigYamlWrongConstructorError,
 )
+from fbpcs.utils.deprecated import deprecated_msg
 
 
 # Backward compatible for partners still using the old config settins

--- a/fbpcs/utils/deprecated.py
+++ b/fbpcs/utils/deprecated.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import warnings
+
+
+def deprecated_msg(msg: str):
+    warning_color = "\033[93m"  # orange/yellow ascii escape sequence
+    end = "\033[0m"  # end ascii escape sequence
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        f"{warning_color}{msg}{end}",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    warnings.simplefilter("default", DeprecationWarning)
+
+
+def deprecated(reason: str):
+    """
+    Logs a warning that a function is deprecated
+    """
+
+    def wrap(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            deprecated_msg(msg=f"{func.__name__} is deprecated! explanation: {reason}")
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return wrap


### PR DESCRIPTION
Summary:
## Why
deprecated util methods lives in `service/utils` which seems not the right place to place those common utils.
Which would case cyclic dependencies when `//fbpcs/utils:` would use deprecated util and explict in util TARGET
moved to `//fbpcs/utils:` to solve cyclic dependencies in Task T139762836

# What
- move `deprecated` methods to `//fbpcs/utils:`
- change imports

Differential Revision: D42364772

