### PR TITLE
Add util function to generate list of env_var dicts

### DIFF
--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -249,6 +249,51 @@ def generate_env_vars_dict(
     return env_vars
 
 
+def _validate_env_vars_length(
+    num_containers: int, **kwargs: Optional[List[str]]
+) -> bool:
+    """
+    Validate length of all the non null arguments is the same as num_containers.
+    """
+    for k, v in kwargs.items():
+        if v and len(v) != num_containers:
+            raise ValueError(
+                f"Incorrect number of items in the env var list to match num_containers. num_contaienrs {num_containers}; {k} {len(v)};"
+            )
+    return True
+
+
+def generate_env_vars_dicts_list(
+    num_containers: int,
+    repository_path: Optional[str] = None,
+    server_certificate_provider: Optional[CertificateProvider] = None,
+    server_certificate_path: Optional[str] = None,
+    ca_certificate_provider: Optional[CertificateProvider] = None,
+    ca_certificate_path: Optional[str] = None,
+    server_ip_addresses: Optional[List[str]] = None,
+    server_hostnames: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
+
+    _validate_env_vars_length(
+        num_containers=num_containers,
+        server_ip_addresses=server_ip_addresses,
+        server_hostnames=server_hostnames,
+    )
+
+    return [
+        generate_env_vars_dict(
+            repository_path=repository_path,
+            server_certificate_provider=server_certificate_provider,
+            server_certificate_path=server_certificate_path,
+            ca_certificate_provider=ca_certificate_provider,
+            ca_certificate_path=ca_certificate_path,
+            server_ip_address=server_ip_addresses[i] if server_ip_addresses else None,
+            server_hostname=server_hostnames[i] if server_hostnames else None,
+        )
+        for i in range(num_containers)
+    ]
+
+
 # distribute number_files files into number_containers of containers evenly so that the maximum difference will be at most 1
 def distribute_files_among_containers(
     number_files: int, number_containers: int

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -7,14 +7,26 @@
 
 import random
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from fbpcs.onedocker_binary_config import ONEDOCKER_REPOSITORY_PATH
 
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationRole,
+)
+from fbpcs.private_computation.service.constants import (
+    CA_CERTIFICATE_ENV_VAR,
+    CA_CERTIFICATE_PATH_ENV_VAR,
+    SERVER_CERTIFICATE_ENV_VAR,
+    SERVER_CERTIFICATE_PATH_ENV_VAR,
+    SERVER_HOSTNAME_ENV_VAR,
+    SERVER_IP_ADDRESS_ENV_VAR,
 )
 
 from fbpcs.private_computation.service.utils import (
     distribute_files_among_containers,
     generate_env_vars_dict,
+    generate_env_vars_dicts_list,
     get_server_uris,
 )
 
@@ -116,3 +128,68 @@ class TestUtils(IsolatedAsyncioTestCase):
 
         self.assertTrue(expected_hostname_key_name in result)
         self.assertEqual(expected_hostname, result[expected_hostname_key_name])
+
+    def test_generate_env_vars_dicts_list(self) -> None:
+        # Arrange
+        num_containers = 2
+        server_ip_addresses = ["test_ip_1", "test_ip_2"]
+        server_ip_addresses_invalid = ["test_ip_1"]
+        server_hostnames = ["test_hostname_1", "test_hostname_2"]
+        repository_path = "test_path"
+        server_cert = "test_server_cert"
+        ca_cert = "test_ca_certificate"
+        cert_path = "test_path"
+        expected_result = [
+            {
+                ONEDOCKER_REPOSITORY_PATH: repository_path,
+                SERVER_CERTIFICATE_ENV_VAR: server_cert,
+                SERVER_CERTIFICATE_PATH_ENV_VAR: cert_path,
+                CA_CERTIFICATE_ENV_VAR: ca_cert,
+                CA_CERTIFICATE_PATH_ENV_VAR: cert_path,
+                SERVER_IP_ADDRESS_ENV_VAR: "test_ip_1",
+                SERVER_HOSTNAME_ENV_VAR: "test_hostname_1",
+            },
+            {
+                ONEDOCKER_REPOSITORY_PATH: repository_path,
+                SERVER_CERTIFICATE_ENV_VAR: server_cert,
+                SERVER_CERTIFICATE_PATH_ENV_VAR: cert_path,
+                CA_CERTIFICATE_ENV_VAR: ca_cert,
+                CA_CERTIFICATE_PATH_ENV_VAR: cert_path,
+                SERVER_IP_ADDRESS_ENV_VAR: "test_ip_2",
+                SERVER_HOSTNAME_ENV_VAR: "test_hostname_2",
+            },
+        ]
+        server_certificate_provider = MagicMock()
+        server_certificate_provider.get_certificate.return_value = server_cert
+        ca_certificate_provider = MagicMock()
+        ca_certificate_provider.get_certificate.return_value = ca_cert
+
+        # Act
+        result = generate_env_vars_dicts_list(
+            num_containers=num_containers,
+            repository_path=repository_path,
+            server_certificate_provider=server_certificate_provider,
+            server_certificate_path="test_path",
+            ca_certificate_provider=ca_certificate_provider,
+            ca_certificate_path="test_path",
+            server_ip_addresses=server_ip_addresses,
+            server_hostnames=server_hostnames,
+        )
+
+        # Assert
+        self.assertEqual(result, expected_result)
+        with self.assertRaises(ValueError) as e:
+            generate_env_vars_dicts_list(
+                num_containers=num_containers,
+                repository_path=repository_path,
+                server_certificate_provider=server_certificate_provider,
+                server_certificate_path="test_path",
+                ca_certificate_provider=ca_certificate_provider,
+                ca_certificate_path="test_path",
+                server_ip_addresses=server_ip_addresses_invalid,
+                server_hostnames=server_hostnames,
+            )
+            self.assertIn(
+                "num_contaienrs 2; {SERVER_IP_ADDRESS_ENV_VAR} 1",
+                str(e.exception),
+            )


### PR DESCRIPTION
Summary: As title. The goal is to be able to pass a list of env_var dicts from PCS to onedocker containers. Next diff will be to call this util function in TLS-relevant stage services.

Differential Revision: D42455124

