### PR TITLE
Add argument validation for permutations and unionMaps (#458)

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp_impl.h
@@ -92,8 +92,12 @@ template <int schedulerId>
 std::tuple<std::vector<int32_t>, std::vector<std::vector<unsigned char>>>
 UdpProcessApp<schedulerId>::dataGeneration() {
   std::vector<int32_t> unionMap(numberOfRows_, -1);
+  uint32_t unmatchedCount = numberOfRows_ - numberOfIntersection_;
+  uint32_t p0UmatchedCount = unmatchedCount / 2 + unmatchedCount % 2;
+  uint32_t p1UmatchedCount = unmatchedCount / 2;
+
   std::vector<std::vector<unsigned char>> metaData(
-      (numberOfRows_ - numberOfIntersection_) / 2 + numberOfIntersection_,
+      party_ == 0 ? p0UmatchedCount : p1UmatchedCount,
       std::vector<unsigned char>(sizeOfRow_));
 
   for (size_t i = 0; i < numberOfIntersection_; ++i) {
@@ -102,12 +106,17 @@ UdpProcessApp<schedulerId>::dataGeneration() {
       metaData[i][j] = i % 256;
     }
   }
-  for (size_t i = numberOfIntersection_; i < unionMap.size(); ++i) {
-    // If an entry is non-match, it means that only one party has a match.
-    // We use -party_ to represents a non-match entry so that publisher has 0
-    // (match) but partner has -1 (non-match)
-    unionMap[i] = -party_;
+
+  for (size_t i = 0; i < unmatchedCount; ++i) {
+    // assign the rest of the indexes in alternating order so there are no more
+    // matches
+    if (i % 2 == party_) {
+      unionMap[numberOfIntersection_ + i] = numberOfIntersection_ + i / 2;
+    } else {
+      unionMap[numberOfIntersection_ + i] = -1;
+    }
   }
+
   std::random_device rd;
   std::mt19937_64 e(rd());
   std::uniform_int_distribution<uint8_t> dist(0, 255);
@@ -116,6 +125,7 @@ UdpProcessApp<schedulerId>::dataGeneration() {
       metaData[i][j] = dist(e);
     }
   }
+
   return {unionMap, metaData};
 }
 


### PR DESCRIPTION
Summary:
In T139445158 the NCC brought to our attention that the permuter library does not actually verify that the user has provided a valid permutation (i.e. same size as dataset, each index from [0 to n-1] appears exactly once. This diff adds that input validation.

The other validation that is added is in the adapter is to check for a valid union map. A valid union map must have index that range from 0 -> `n-1` or -1. Furthermore each union index can only appear at most once.

Note: The other party that calls permute or adapt will just hang and timeout when this happens as it has no way to know the other party aborted.

X-link: https://github.com/facebookresearch/fbpcf/pull/458

Differential Revision: D42014843

