### PR TITLE
Delete unused mpc instance APIs

### DIFF
--- a/fbpcs/CHANGELOG.md
+++ b/fbpcs/CHANGELOG.md
@@ -14,6 +14,9 @@ Types of changes
   [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased - 2.6.0] - put release date here
+### Removed
+* Removed deprecated MPCService APIs after MPCInstance usaged been moved to StageStateInstance. (create/start/stop/get/update_instance)
+* Removed `get_mpc` from private_computation_cli endpoint
 
 ## [2.5.0] - 2022-10-26
 ### Changed

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -882,24 +882,19 @@ class PrivateComputationService:
             )
 
         # cancel the running stage
-        last_instance = private_computation_instance.infra_config.instances[-1]
         stage = private_computation_instance.current_stage
         self.logger.info(
             f"Canceling the current stage {stage} of instance {instance_id}"
         )
-        # TODO: T124324848 move MPCInstance stop instance to StageService.stop_service()
-        if isinstance(last_instance, MPCInstance):
-            self.mpc_svc.stop_instance(instance_id=last_instance.instance_id)
-        else:
-            stage_svc = stage.get_stage_service(self.stage_service_args)
-            # TODO: T124322832 make stop service as abstract method and enforce all stage service to implement
-            try:
-                stage_svc.stop_service(private_computation_instance)
-            except NotImplementedError:
-                self.logger.warning(
-                    f"Canceling the current stage {stage} of instance {instance_id} is not supported yet."
-                )
-                return private_computation_instance
+        stage_svc = stage.get_stage_service(self.stage_service_args)
+        # TODO: T124322832 make stop service as abstract method and enforce all stage service to implement
+        try:
+            stage_svc.stop_service(private_computation_instance)
+        except NotImplementedError:
+            self.logger.warning(
+                f"Canceling the current stage {stage} of instance {instance_id} is not supported yet."
+            )
+            return private_computation_instance
 
         # post-checks to make sure the pl instance has the updated status
         private_computation_instance = self._update_instance(

--- a/fbpcs/private_computation/test/service/mpc/test_mpc.py
+++ b/fbpcs/private_computation/test/service/mpc/test_mpc.py
@@ -5,30 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
-from fbpcs.private_computation.service.mpc.entity.mpc_instance import (
-    MPCInstance,
-    MPCInstanceStatus,
-    MPCParty,
-)
+from fbpcs.private_computation.service.mpc.entity.mpc_instance import MPCParty
 from fbpcs.private_computation.service.mpc.mpc import MPCService
 
 
-TEST_INSTANCE_ID = "123"
 TEST_GAME_NAME = "lift"
 TEST_MPC_ROLE = MPCParty.SERVER
-TEST_NUM_WORKERS = 1
-TEST_SERVER_IPS = ["192.0.2.0", "192.0.2.1"]
 TEST_INPUT_ARGS = "test_input_file"
 TEST_OUTPUT_ARGS = "test_output_file"
 TEST_CONCURRENCY_ARGS = 1
 TEST_INPUT_DIRECTORY = "TEST_INPUT_DIRECTORY/"
 TEST_OUTPUT_DIRECTORY = "TEST_OUTPUT_DIRECTORY/"
-TEST_TASK_DEFINITION = "test_task_definition"
-INPUT_DIRECTORY = "input_directory"
-OUTPUT_DIRECTORY = "output_directory"
 GAME_ARGS = [
     {
         "input_filenames": TEST_INPUT_ARGS,
@@ -37,10 +26,6 @@ GAME_ARGS = [
         "output_directory": TEST_OUTPUT_DIRECTORY,
         "concurrency": TEST_CONCURRENCY_ARGS,
     }
-]
-TEST_SERVER_URIS = [
-    "node1.publisher.study1.pci.facebook.com",
-    "node2.publisher.study1.pci.facebook.com",
 ]
 
 
@@ -65,282 +50,28 @@ class TestMPCService(IsolatedAsyncioTestCase):
             mpc_game_svc,
         )
 
-    @staticmethod
-    def _get_sample_mpcinstance() -> MPCInstance:
-        return MPCInstance(
-            TEST_INSTANCE_ID,
-            TEST_GAME_NAME,
-            TEST_MPC_ROLE,
-            TEST_NUM_WORKERS,
-            TEST_SERVER_IPS,
-            [],
-            MPCInstanceStatus.CREATED,
-            GAME_ARGS,
-            TEST_SERVER_URIS,
-        )
-
-    @staticmethod
-    def _get_sample_mpcinstance_with_game_args() -> MPCInstance:
-        return MPCInstance(
-            TEST_INSTANCE_ID,
-            TEST_GAME_NAME,
-            TEST_MPC_ROLE,
-            TEST_NUM_WORKERS,
-            TEST_SERVER_IPS,
-            [],
-            MPCInstanceStatus.CREATED,
-            GAME_ARGS,
-            TEST_SERVER_URIS,
-        )
-
-    @staticmethod
-    def _get_sample_mpcinstance_client() -> MPCInstance:
-        return MPCInstance(
-            TEST_INSTANCE_ID,
-            TEST_GAME_NAME,
-            MPCParty.CLIENT,
-            TEST_NUM_WORKERS,
-            TEST_SERVER_IPS,
-            [],
-            MPCInstanceStatus.CREATED,
-            GAME_ARGS,
-            TEST_SERVER_URIS,
-        )
-
-    def test_create_instance_with_game_args(self) -> None:
-        self.mpc_service.create_instance(
-            instance_id=TEST_INSTANCE_ID,
-            game_name=TEST_GAME_NAME,
-            mpc_party=TEST_MPC_ROLE,
-            num_workers=TEST_NUM_WORKERS,
-            server_ips=TEST_SERVER_IPS,
-            game_args=GAME_ARGS,
-            server_uris=TEST_SERVER_URIS,
-        )
-        # pyre-ignore [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.create` has no attribute `assert_called`.
-        self.mpc_service.instance_repository.create.assert_called()
-        self.assertEqual(
-            self._get_sample_mpcinstance_with_game_args(),
-            # pyre-ignore [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.create` has no attribute `call_args`.
-            self.mpc_service.instance_repository.create.call_args[0][0],
-        )
-
-    def test_create_instance(self) -> None:
-        self.mpc_service.create_instance(
-            instance_id=TEST_INSTANCE_ID,
-            game_name=TEST_GAME_NAME,
-            mpc_party=TEST_MPC_ROLE,
-            num_workers=TEST_NUM_WORKERS,
-            server_ips=TEST_SERVER_IPS,
-            game_args=GAME_ARGS,
-            server_uris=TEST_SERVER_URIS,
-        )
-        # check that instance with correct instance_id was created
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.create` has no attribute `assert_called`.
-        self.mpc_service.instance_repository.create.assert_called()
-        self.assertEqual(
-            self._get_sample_mpcinstance(),
-            # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.create` has no attribute `call_args`.
-            self.mpc_service.instance_repository.create.call_args[0][0],
-        )
-
-    def _read_side_effect_start(self, instance_id: str) -> MPCInstance:
-        """mock MPCInstanceRepository.read for test_start"""
-        if instance_id == TEST_INSTANCE_ID:
-            return self._get_sample_mpcinstance()
-        else:
-            raise RuntimeError(f"{instance_id} does not exist")
-
-    def test_start_instance(self) -> None:
-        self.mpc_service.instance_repository.read = MagicMock(
-            side_effect=self._read_side_effect_start
-        )
-        created_instances = [
-            ContainerInstance(
-                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68",  # noqa
-                "10.0.1.130",
-                ContainerInstanceStatus.STARTED,
-            )
-        ]
-        self.mpc_service.onedocker_svc.start_containers = MagicMock(
-            return_value=created_instances
-        )
-        self.mpc_service.onedocker_svc.wait_for_pending_containers = AsyncMock(
-            return_value=created_instances
-        )
+    def test_convert_cmd_args_list(self) -> None:
+        # Prep
         built_onedocker_args = ("private_lift/lift", "test one docker arguments")
         self.mpc_service.mpc_game_svc.build_onedocker_args = MagicMock(
             return_value=built_onedocker_args
         )
-        # check that update is called with correct status
-        self.mpc_service.start_instance(TEST_INSTANCE_ID)
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `assert_called`.
-        self.mpc_service.instance_repository.update.assert_called()
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `call_args_list`.
-        latest_update = self.mpc_service.instance_repository.update.call_args_list[-1]
-        updated_status = latest_update[0][0].status
-        self.assertEqual(updated_status, MPCInstanceStatus.STARTED)
-
-    def test_start_instance_missing_ips(self) -> None:
-        self.mpc_service.instance_repository.read = MagicMock(
-            return_value=self._get_sample_mpcinstance_client()
+        # Ack
+        binary_name, cmd_args_list = self.mpc_service.convert_cmd_args_list(
+            game_name=TEST_GAME_NAME,
+            game_args=GAME_ARGS,
+            mpc_party=TEST_MPC_ROLE,
         )
-        # Exception because role is client but server ips are not given
-        with self.assertRaises(ValueError):
-            self.mpc_service.start_instance(TEST_INSTANCE_ID)
-
-    def test_start_instance_skip_start_up(self) -> None:
-        # prep
-        self.mpc_service.instance_repository.read = MagicMock(
-            side_effect=self._read_side_effect_start
-        )
-        created_instances = [
-            ContainerInstance(
-                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68",  # noqa
-                None,
-                ContainerInstanceStatus.UNKNOWN,
-            )
-        ]
-        self.mpc_service.onedocker_svc.start_containers = MagicMock(
-            return_value=created_instances
-        )
-        self.mpc_service.onedocker_svc.wait_for_pending_containers = AsyncMock()
-        built_onedocker_args = ("private_lift/lift", "test one docker arguments")
-        self.mpc_service.mpc_game_svc.build_onedocker_args = MagicMock(
-            return_value=built_onedocker_args
-        )
-        # check that update is called with correct status
-        self.mpc_service.start_instance(
-            instance_id=TEST_INSTANCE_ID, wait_for_containers_to_start_up=False
-        )
-        # asserts
-        self.mpc_service.onedocker_svc.wait_for_pending_containers.assert_not_called()
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `assert_called`.
-        self.mpc_service.instance_repository.update.assert_called()
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `call_args_list`.
-        latest_update = self.mpc_service.instance_repository.update.call_args_list[-1]
-        updated_status = latest_update[0][0].status
-        self.assertEqual(updated_status, MPCInstanceStatus.CREATED)
-
-    def _read_side_effect_update(self, instance_id) -> MPCInstance:
-        """
-        mock MPCInstanceRepository.read for test_update,
-        with instance.containers is not None
-        """
-        if instance_id == TEST_INSTANCE_ID:
-            mpc_instance = self._get_sample_mpcinstance()
-        else:
-            raise RuntimeError(f"{instance_id} does not exist")
-
-        mpc_instance.status = MPCInstanceStatus.STARTED
-        mpc_instance.containers = [
-            ContainerInstance(
-                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68",  # noqa
-                "10.0.1.130",
-                ContainerInstanceStatus.STARTED,
-            )
-        ]
-        return mpc_instance
-
-    def test_update_instance(self) -> None:
-        self.mpc_service.instance_repository.read = MagicMock(
-            side_effect=self._read_side_effect_update
-        )
-        container_instances = [
-            ContainerInstance(
-                "arn:aws:ecs:us-west-1:592513842793:task/cd34aed2-321f-49d1-8641-c54baff8b77b",  # noqa
-                "10.0.1.130",
-                ContainerInstanceStatus.STARTED,
-            )
-        ]
-        self.mpc_service.container_svc.get_instances = MagicMock(
-            return_value=container_instances
-        )
-        self.mpc_service.update_instance(TEST_INSTANCE_ID)
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `assert_called`.
-        self.mpc_service.instance_repository.update.assert_called()
-
-    def test_update_instance_from_unknown(self) -> None:
-        # prep
-        mpc_instance = self._get_sample_mpcinstance()
-        mpc_instance.containers = [
-            ContainerInstance(
-                "arn:aws:ecs:us-west-1:592513842793:task/cd34aed2-321f-49d1-8641-c54baff8b77b",  # noqa
-                None,
-                ContainerInstanceStatus.UNKNOWN,
-            )
-        ]
-        self.mpc_service.instance_repository.read = MagicMock(return_value=mpc_instance)
-        updated_container_instances = [
-            ContainerInstance(
-                "arn:aws:ecs:us-west-1:592513842793:task/cd34aed2-321f-49d1-8641-c54baff8b77b",  # noqa
-                "10.0.1.130",
-                ContainerInstanceStatus.STARTED,
-            )
-        ]
-        self.mpc_service.container_svc.get_instances = MagicMock(
-            return_value=updated_container_instances
-        )
-        # act
-        self.mpc_service.update_instance(TEST_INSTANCE_ID)
-        # asserts
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `assert_called`.
-        self.mpc_service.instance_repository.update.assert_called()
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `call_args_list`.
-        latest_update = self.mpc_service.instance_repository.update.call_args_list[-1]
-        updated_instance = latest_update[0][0]
-        self.assertEqual(updated_instance.status, MPCInstanceStatus.STARTED)
-        self.assertEqual(updated_instance.server_ips, ["10.0.1.130"])
-
-    def test_stop_instance(self) -> None:
-        self.mpc_service.instance_repository.read = MagicMock(
-            side_effect=self._read_side_effect_update
-        )
-        self.mpc_service.onedocker_svc.stop_containers = MagicMock(return_value=[None])
-        mpc_instance = self.mpc_service.stop_instance(TEST_INSTANCE_ID)
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.service.onedocker.OneDockerService.stop_containers` has no attribute `assert_called_with`.
-        self.mpc_service.onedocker_svc.stop_containers.assert_called_with(
-            [
-                "arn:aws:ecs:us-west-1:592513842793:task/57850450-7a81-43cc-8c73-2071c52e4a68"
-            ]
-        )
-        expected_mpc_instance = self._read_side_effect_update(TEST_INSTANCE_ID)
-        expected_mpc_instance.status = MPCInstanceStatus.CANCELED
-        self.assertEqual(expected_mpc_instance, mpc_instance)
-        # pyre-ignore Undefined attribute [16]: Callable `fbpcp.repository.mpc_instance.MPCInstanceRepository.update` has no attribute `assert_called_with`.
-        self.mpc_service.instance_repository.update.assert_called_with(
-            expected_mpc_instance
-        )
-
-    def test_get_updated_instance(self) -> None:
-        # Arrange
-        queried_container = ContainerInstance(
-            TEST_INSTANCE_ID,  # noqa
-            TEST_SERVER_IPS[0],
-            ContainerInstanceStatus.COMPLETED,
-        )
-        existing_container_started = ContainerInstance(
-            TEST_INSTANCE_ID,
-            TEST_SERVER_IPS[0],
-            ContainerInstanceStatus.STARTED,
-        )
-        existing_container_completed = ContainerInstance(
-            TEST_INSTANCE_ID,
-            TEST_SERVER_IPS[0],
-            ContainerInstanceStatus.COMPLETED,
-        )
-
-        # Act and Assert
-        self.assertEqual(
-            queried_container,
-            self.mpc_service._get_updated_container(
-                queried_container, existing_container_started
-            ),
-        )
-        self.assertIsNone(
-            self.mpc_service._get_updated_container(None, existing_container_started)
-        )
-        self.assertEqual(
-            existing_container_completed,
-            self.mpc_service._get_updated_container(None, existing_container_completed),
+        # Asserts
+        self.assertEqual(binary_name, built_onedocker_args[0])
+        self.assertEqual(cmd_args_list, [built_onedocker_args[1]])
+        self.mpc_service.mpc_game_svc.build_onedocker_args.assert_called_once_with(
+            game_name=TEST_GAME_NAME,
+            mpc_party=TEST_MPC_ROLE,
+            server_ip=None,
+            input_filenames=TEST_INPUT_ARGS,
+            input_directory=TEST_INPUT_DIRECTORY,
+            output_filenames=TEST_OUTPUT_ARGS,
+            output_directory=TEST_OUTPUT_DIRECTORY,
+            concurrency=TEST_CONCURRENCY_ARGS,
         )

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -16,7 +16,6 @@ Usage:
     pc-cli run_stage <instance_id> --stage=<stage> --config=<config_file> [--server_ips=<server_ips> --dry_run] [options]
     pc-cli get_instance <instance_id> --config=<config_file> [options]
     pc-cli get_server_ips <instance_id> --config=<config_file> [options]
-    pc-cli get_mpc <instance_id> --config=<config_file> [options]
     pc-cli run_study <study_id> --config=<config_file> --objective_ids=<objective_ids> --input_paths=<input_paths> [--output_dir=<output_dir> --tries_per_stage=<tries_per_stage> --result_visibility=<result_visibility> --run_id=<run_id> --graphapi_version=<graphapi_version> --graphapi_domain=<graphapi_domain> --dry_run] [options]
     pc-cli pre_validate [<study_id>] --config=<config_file> [--objective_ids=<objective_ids>] --input_paths=<input_paths> [--tries_per_stage=<tries_per_stage> --dry_run] [options]
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
@@ -86,7 +85,6 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
     cancel_current_stage,
     create_instance,
     get_instance,
-    get_mpc,
     get_server_ips,
     print_current_status,
     print_instance,
@@ -183,7 +181,6 @@ def main(argv: Optional[List[str]] = None) -> None:
             "run_stage": bool,
             "get_instance": bool,
             "get_server_ips": bool,
-            "get_mpc": bool,
             "run_study": bool,
             "pre_validate": bool,
             "run_attribution": bool,
@@ -380,9 +377,6 @@ def main(argv: Optional[List[str]] = None) -> None:
         logger.info(instance)
     elif arguments["get_server_ips"]:
         get_server_ips(config, instance_id, logger)
-    elif arguments["get_mpc"]:
-        logger.info(f"Get MPC instance: {instance_id}")
-        get_mpc(config, instance_id, logger)
     elif arguments["validate"]:
         logger.info(f"Validate instance: {instance_id}")
         validate(

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -277,26 +277,6 @@ def get_server_ips(
     return server_ips_list
 
 
-def get_mpc(config: Dict[str, Any], instance_id: str, logger: logging.Logger) -> None:
-    container_service = _build_container_service(
-        config["private_computation"]["dependency"]["ContainerService"]
-    )
-    storage_service = _build_storage_service(
-        config["private_computation"]["dependency"]["StorageService"]
-    )
-    mpc_service = _build_mpc_service(
-        config["mpc"],
-        _build_onedocker_service_cfg(
-            config["private_computation"]["dependency"]["OneDockerServiceConfig"]
-        ),
-        container_service,
-        storage_service,
-    )
-    # calling update_instance here to get the newest container information
-    instance = mpc_service.update_instance(instance_id)
-    logger.info(instance)
-
-
 def cancel_current_stage(
     config: Dict[str, Any], instance_id: str, logger: logging.Logger
 ) -> PrivateComputationInstance:

--- a/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
+++ b/fbpcs/private_computation_cli/tests/test_private_computation_cli.py
@@ -286,16 +286,6 @@ class TestPrivateComputationCli(TestCase):
         pc_cli.main(argv)
         get_ips_mock.assert_called_once()
 
-    @patch("fbpcs.private_computation_cli.private_computation_cli.get_mpc")
-    def test_get_mpc(self, get_mpc_mock) -> None:
-        argv = [
-            "get_mpc",
-            "instance123",
-            f"--config={self.temp_filename}",
-        ]
-        pc_cli.main(argv)
-        get_mpc_mock.assert_called_once()
-
     @patch("fbpcs.private_computation_cli.private_computation_cli.TokenValidator")
     @patch("fbpcs.private_computation_cli.private_computation_cli.BoltGraphAPIClient")
     @patch("fbpcs.private_computation_cli.private_computation_cli.run_study")


### PR DESCRIPTION
Summary:
## Why
During this mpc migration journey, I've already removed all of the MPC instance usage across PCS. the fbcps/mpc_service is no longer need those mpc instance APIs.
Having ths diff to start to clean up deprecated APIs. Make the furture refactor more easy

## What
- Removed deprecated MPCService APIs after MPCInstance usaged been moved to StageStateInstance. (create/start/stop/get/update_instance)
- Removed `get_mpc` from private_computation_cli endpoint

Differential Revision: D42379579

