### PR TITLE
Adding run_id and pcs_features flag to pcf2_shard_combiner game.

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
@@ -83,6 +83,15 @@ DEFINE_string(
     "",
     "Relative file path where private key is stored. It will be prefixed with $HOME.");
 
+DEFINE_string(
+    run_id,
+    "",
+    "A run_id used to identify all the logs in a PL/PA run.");
+DEFINE_string(
+    pc_feature_flags,
+    "",
+    "A String of PC Feature Flags passing from PCS, separated by comma");
+
 using namespace shard_combiner;
 
 int main(int argc, char* argv[]) {
@@ -106,6 +115,8 @@ int main(int argc, char* argv[]) {
   XLOGF(INFO, "Number of shards: {}", FLAGS_num_shards);
   XLOGF(INFO, "Output path: {}", FLAGS_output_path);
   XLOGF(INFO, "K-anonymity threshold: {}", FLAGS_threshold);
+  XLOGF(INFO, "Run Id: {}", FLAGS_run_id);
+  XLOGF(INFO, "PC Feature Flags: {}", FLAGS_pc_feature_flags);
 
   // we use scheduler thats either 0 or 1,
   FLAGS_party--;

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -224,11 +224,6 @@ class AggregateShardsStageService(PrivateComputationStageService):
             for arg in game_args:
                 arg["visibility"] = result_visibility
 
-        # remove shard_combiner_pcf2 unsupported arguments
-        if pc_instance.has_feature(PCSFeature.SHARD_COMBINER_PCF2_RELEASE):
-            arg.pop("run_id", None)
-            arg.pop("pc_feature_flags", None)
-
         return game_args
 
     @classmethod


### PR DESCRIPTION
Summary:
Before rolling out the PCF 2.0 SA, we need to make sure that the binary has necessary updated input flags.
Thus adding run_id and pcs_features flag in this diff.

Differential Revision:
D42445672

Privacy Context Container: L416713

