### PR TITLE
Increase Computation timeout from 12 hours to 24 hours.

### DIFF
--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -21,8 +21,8 @@ to run partner containers and humans can be slow;
 2) during development, we add logic or complexity to the binaries running inside the containers
 so that they take more than a few hours to run.
 """
-
-DEFAULT_CONTAINER_TIMEOUT_IN_SEC = 43200
+# TODO: T142284889 Reduce this timeout back to 12 hours after we finishe the POC run in January and have a better idea for a solution.
+DEFAULT_CONTAINER_TIMEOUT_IN_SEC = 86400
 DEFAULT_SERVER_PORT_NUMBER = 15200
 MAX_ROWS_PER_PID_CONTAINER = 10_000_000
 TARGET_ROWS_PER_MPC_CONTAINER = 250_000

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -56,7 +56,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         self.input_path = "in"
         self.output_path = "out"
         self.pc_instance_id = "test_instance_123"
-        self.container_timeout = 43200
+        self.container_timeout = 86400
 
     async def test_pid_prepare_stage_service(self) -> None:
         async def _run_sub_test(


### PR DESCRIPTION
Summary:
## Context

For a run of large cohorts in January, we are temporarily increasing the lift timeout to 24 hours from 12 hours. This has some risk that we could burn through extra cash if we run into the situation of partner pods failing to connect and containers just wait around for a connection that will never happen. T142284889 was created to revert this change as soon as we are done with the current run and have a better solution.

Differential Revision: D42479105

