### PR TITLE
Set private key path for container installation

### DIFF
--- a/fbpcs/infra/certificate/private_key.py
+++ b/fbpcs/infra/certificate/private_key.py
@@ -21,6 +21,9 @@ class PrivateKeyReference:
     region: str
     """The region where the private key can be accessed"""
 
+    install_path: str
+    """The path where the key should be installed"""
+
 
 class PrivateKeyReferenceProvider(ABC):
     @abstractmethod
@@ -40,14 +43,17 @@ class NullPrivateKeyReferenceProvider(PrivateKeyReferenceProvider):
 class StaticPrivateKeyReferenceProvider(PrivateKeyReferenceProvider):
     """A private key reference provider that returns a static reference"""
 
-    def __init__(self, resource_id: str, region: str) -> None:
+    def __init__(self, resource_id: str, region: str, install_path: str) -> None:
         if not resource_id:
             raise ValueError("Must provide a `resource_id`")
 
         if not region:
             raise ValueError("Must provide a `region`")
 
-        self.reference = PrivateKeyReference(resource_id, region)
+        if not install_path:
+            raise ValueError("Must provide an `install_path`")
+
+        self.reference = PrivateKeyReference(resource_id, region, install_path)
 
     def get_key_ref(self) -> Optional[PrivateKeyReference]:
         """Returns a private key reference"""

--- a/fbpcs/infra/certificate/tests/test_private_key.py
+++ b/fbpcs/infra/certificate/tests/test_private_key.py
@@ -20,21 +20,37 @@ class TestCertificateProviders(unittest.TestCase):
 
         # Act & Assert
         with self.assertRaises(ValueError):
-            StaticPrivateKeyReferenceProvider(resource_id="", region="region")
+            StaticPrivateKeyReferenceProvider(
+                resource_id="", region="region", install_path="a/path"
+            )
 
     def test_static_key_provider_missing_region(self) -> None:
         # Arrange
 
         # Act & Assert
         with self.assertRaises(ValueError):
-            StaticPrivateKeyReferenceProvider(resource_id="reference_id", region="")
+            StaticPrivateKeyReferenceProvider(
+                resource_id="reference_id", region="", install_path="a/path"
+            )
+
+    def test_static_key_provider_missing_install_path(self) -> None:
+        # Arrange
+
+        # Act & Assert
+        with self.assertRaises(ValueError):
+            StaticPrivateKeyReferenceProvider(
+                resource_id="reference_id", region="region", install_path=""
+            )
 
     def test_static_key_provider(self) -> None:
         # Arrange
         expected_resource_id = "123456"
         expected_region = "region"
+        expected_install_path = "a/path"
         provider = StaticPrivateKeyReferenceProvider(
-            resource_id=expected_resource_id, region=expected_region
+            resource_id=expected_resource_id,
+            region=expected_region,
+            install_path=expected_install_path,
         )
 
         # Act
@@ -44,6 +60,7 @@ class TestCertificateProviders(unittest.TestCase):
         self.assertIsNotNone(key_ref)
         self.assertEqual(expected_resource_id, key_ref.resource_id)
         self.assertEqual(expected_region, key_ref.region)
+        self.assertEqual(expected_install_path, key_ref.install_path)
 
     def test_null_provider(self) -> None:
         # Arrange

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -81,6 +81,7 @@ from fbpcs.private_computation.service.constants import (
     DEFAULT_K_ANONYMITY_THRESHOLD_PL,
     DEFAULT_PADDING_SIZE,
     NUM_NEW_SHARDS_PER_FILE,
+    PRIVATE_KEY_PATH,
     SERVER_CERT_PATH,
 )
 from fbpcs.private_computation.service.errors import (
@@ -664,6 +665,7 @@ class PrivateComputationService:
             return StaticPrivateKeyReferenceProvider(
                 resource_id=pc_instance.infra_config.server_key_ref,
                 region=pc_instance.infra_config.pce_config.region,
+                install_path=PRIVATE_KEY_PATH,
             )
         else:
             return NullPrivateKeyReferenceProvider()

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -29,6 +29,7 @@ from fbpcs.private_computation.service.constants import (
     SERVER_CERTIFICATE_PATH_ENV_VAR,
     SERVER_HOSTNAME_ENV_VAR,
     SERVER_IP_ADDRESS_ENV_VAR,
+    SERVER_PRIVATE_KEY_PATH_ENV_VAR,
     SERVER_PRIVATE_KEY_REF_ENV_VAR,
     SERVER_PRIVATE_KEY_REGION_ENV_VAR,
 )
@@ -245,6 +246,7 @@ def generate_env_vars_dict(
         if server_private_key is not None:
             env_vars[SERVER_PRIVATE_KEY_REF_ENV_VAR] = server_private_key.resource_id
             env_vars[SERVER_PRIVATE_KEY_REGION_ENV_VAR] = server_private_key.region
+            env_vars[SERVER_PRIVATE_KEY_PATH_ENV_VAR] = server_private_key.install_path
 
     if ca_certificate_provider is not None:
         ca_cert = ca_certificate_provider.get_certificate()
@@ -283,6 +285,7 @@ def generate_env_vars_dicts_list(
     ca_certificate_path: Optional[str] = None,
     server_ip_addresses: Optional[List[str]] = None,
     server_hostnames: Optional[List[str]] = None,
+    server_private_key_ref_provider: Optional[PrivateKeyReferenceProvider] = None,
 ) -> List[Dict[str, str]]:
 
     _validate_env_vars_length(
@@ -300,6 +303,7 @@ def generate_env_vars_dicts_list(
             ca_certificate_path=ca_certificate_path,
             server_ip_address=server_ip_addresses[i] if server_ip_addresses else None,
             server_hostname=server_hostnames[i] if server_hostnames else None,
+            server_private_key_ref_provider=server_private_key_ref_provider,
         )
         for i in range(num_containers)
     ]

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -38,6 +38,7 @@ from fbpcs.private_computation.service.constants import (
     SERVER_CERTIFICATE_PATH_ENV_VAR,
     SERVER_HOSTNAME_ENV_VAR,
     SERVER_IP_ADDRESS_ENV_VAR,
+    SERVER_PRIVATE_KEY_PATH_ENV_VAR,
     SERVER_PRIVATE_KEY_REF_ENV_VAR,
     SERVER_PRIVATE_KEY_REGION_ENV_VAR,
 )
@@ -135,6 +136,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
         expected_ca_certificate = "test_ca_cert"
         expected_server_key_resource_id = "test_key"
         expected_server_key_region = "test_region"
+        expected_server_key_install_path = "test/path"
         expected_server_certificate_path = "/test/server_certificate_path"
         expected_ca_certificate_path = "/test/server_certificate_path"
 
@@ -148,7 +150,9 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             test_server_ips,
             test_server_hostnames,
             StaticPrivateKeyReferenceProvider(
-                expected_server_key_resource_id, expected_server_key_region
+                expected_server_key_resource_id,
+                expected_server_key_region,
+                expected_server_key_install_path,
             ),
         )
 
@@ -176,6 +180,12 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
         self.assertTrue(SERVER_PRIVATE_KEY_REGION_ENV_VAR in call_env_args)
         self.assertEqual(
             expected_server_key_region, call_env_args[SERVER_PRIVATE_KEY_REGION_ENV_VAR]
+        )
+
+        self.assertTrue(SERVER_PRIVATE_KEY_PATH_ENV_VAR in call_env_args)
+        self.assertEqual(
+            expected_server_key_install_path,
+            call_env_args[SERVER_PRIVATE_KEY_PATH_ENV_VAR],
         )
 
         self.assertTrue(CA_CERTIFICATE_ENV_VAR in call_env_args)

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -41,6 +41,7 @@ from fbpcs.private_computation.service.constants import (
     SERVER_CERTIFICATE_PATH_ENV_VAR,
     SERVER_HOSTNAME_ENV_VAR,
     SERVER_IP_ADDRESS_ENV_VAR,
+    SERVER_PRIVATE_KEY_PATH_ENV_VAR,
     SERVER_PRIVATE_KEY_REF_ENV_VAR,
     SERVER_PRIVATE_KEY_REGION_ENV_VAR,
 )
@@ -168,6 +169,7 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                 expected_ca_certificate = "test_ca_cert"
                 expected_server_key_resource_id = "test_key"
                 expected_server_key_region = "test_region"
+                expected_server_key_install_path = "test/path"
                 expected_server_certificate_path = "/test/server_certificate_path"
                 expected_ca_certificate_path = "/test/server_certificate_path"
 
@@ -181,7 +183,9 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                     test_server_ips,
                     test_server_hostnames,
                     StaticPrivateKeyReferenceProvider(
-                        expected_server_key_resource_id, expected_server_key_region
+                        expected_server_key_resource_id,
+                        expected_server_key_region,
+                        expected_server_key_install_path,
                     ),
                 )
 
@@ -213,6 +217,12 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                 self.assertEqual(
                     expected_server_key_region,
                     call_env_args[SERVER_PRIVATE_KEY_REGION_ENV_VAR],
+                )
+
+                self.assertTrue(SERVER_PRIVATE_KEY_PATH_ENV_VAR in call_env_args)
+                self.assertEqual(
+                    expected_server_key_install_path,
+                    call_env_args[SERVER_PRIVATE_KEY_PATH_ENV_VAR],
                 )
 
                 self.assertTrue(CA_CERTIFICATE_ENV_VAR in call_env_args)

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -37,6 +37,7 @@ from fbpcs.private_computation.service.constants import (
     SERVER_CERTIFICATE_PATH_ENV_VAR,
     SERVER_HOSTNAME_ENV_VAR,
     SERVER_IP_ADDRESS_ENV_VAR,
+    SERVER_PRIVATE_KEY_PATH_ENV_VAR,
     SERVER_PRIVATE_KEY_REF_ENV_VAR,
     SERVER_PRIVATE_KEY_REGION_ENV_VAR,
 )
@@ -140,6 +141,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
         expected_ca_certificate = "test_ca_cert"
         expected_server_key_resource_id = "test_key"
         expected_server_key_region = "test_region"
+        expected_server_key_install_path = "test/path"
         expected_server_certificate_path = "/test/server_certificate_path"
         expected_ca_certificate_path = "/test/server_certificate_path"
 
@@ -153,7 +155,9 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             test_server_ips,
             test_server_hostnames,
             StaticPrivateKeyReferenceProvider(
-                expected_server_key_resource_id, expected_server_key_region
+                expected_server_key_resource_id,
+                expected_server_key_region,
+                expected_server_key_install_path,
             ),
         )
 
@@ -181,6 +185,12 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
         self.assertTrue(SERVER_PRIVATE_KEY_REGION_ENV_VAR in call_env_args)
         self.assertEqual(
             expected_server_key_region, call_env_args[SERVER_PRIVATE_KEY_REGION_ENV_VAR]
+        )
+
+        self.assertTrue(SERVER_PRIVATE_KEY_PATH_ENV_VAR in call_env_args)
+        self.assertEqual(
+            expected_server_key_install_path,
+            call_env_args[SERVER_PRIVATE_KEY_PATH_ENV_VAR],
         )
 
         self.assertTrue(CA_CERTIFICATE_ENV_VAR in call_env_args)

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -53,6 +53,7 @@ from fbpcs.private_computation.service.constants import (
     DEFAULT_LOG_COST_TO_S3,
     FBPCS_BUNDLE_ID,
     NUM_NEW_SHARDS_PER_FILE,
+    PRIVATE_KEY_PATH,
     SERVER_CERT_PATH,
 )
 from fbpcs.private_computation.service.errors import (
@@ -1033,6 +1034,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             expected_server_key_resource_id, server_private_key_ref.resource_id
         )
         self.assertEqual(expected_server_key_region, server_private_key_ref.region)
+        self.assertEqual(PRIVATE_KEY_PATH, server_private_key_ref.install_path)
 
         self.assertIsNotNone(ca_cert_provider)
         ca_cert = ca_cert_provider.get_certificate()

--- a/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
@@ -38,6 +38,7 @@ from fbpcs.private_computation.service.constants import (
     NUM_NEW_SHARDS_PER_FILE,
     SERVER_CERTIFICATE_ENV_VAR,
     SERVER_CERTIFICATE_PATH_ENV_VAR,
+    SERVER_PRIVATE_KEY_PATH_ENV_VAR,
     SERVER_PRIVATE_KEY_REF_ENV_VAR,
     SERVER_PRIVATE_KEY_REGION_ENV_VAR,
 )
@@ -295,6 +296,7 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
         expected_ca_certificate = "test_ca_cert"
         expected_server_key_resource_id = "test_key"
         expected_server_key_region = "test_region"
+        expected_server_key_install_path = "test/path"
         expected_server_certificate_path = "/test/server_certificate_path"
         expected_ca_certificate_path = "/test/server_certificate_path"
 
@@ -312,7 +314,9 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
                 test_server_ips,
                 test_server_hostnames,
                 StaticPrivateKeyReferenceProvider(
-                    expected_server_key_resource_id, expected_server_key_region
+                    expected_server_key_resource_id,
+                    expected_server_key_region,
+                    expected_server_key_install_path,
                 ),
             )
 
@@ -341,6 +345,12 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
             self.assertEqual(
                 expected_server_key_region,
                 call_env_args[SERVER_PRIVATE_KEY_REGION_ENV_VAR],
+            )
+
+            self.assertTrue(SERVER_PRIVATE_KEY_PATH_ENV_VAR in call_env_args)
+            self.assertEqual(
+                expected_server_key_install_path,
+                call_env_args[SERVER_PRIVATE_KEY_PATH_ENV_VAR],
             )
 
             self.assertTrue(CA_CERTIFICATE_ENV_VAR in call_env_args)


### PR DESCRIPTION
Summary: This change updates PCS to pass a path for installing the server private key on the container's filesystem, as an environment variable. This is only passed when the TLS feature is enabled, which is currently disabled by default.

Differential Revision: D42554619

