### PR TITLE
Update the EMP Games and Data Processing builds to use all the cores on the EC2 instance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   building_image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -13,7 +13,7 @@ GITHUB_PACKAGES="ghcr.io/facebookresearch"
 PROG_NAME=$0
 usage() {
   cat << EOF >&2
-Usage: $PROG_NAME <package: emp_games|data_processing|pce_deployment|onedocker> [-u] [-g] [-t TAG] [-p PLATFORM] [-v FBPCF_VERSION]
+Usage: $PROG_NAME <package: emp_games|data_processing|pce_deployment|onedocker> [-u] [-f] [-g] [-t TAG] [-p PLATFORM] [-v FBPCF_VERSION]
 
 package:
   emp_games - builds the emp-games docker image

--- a/docker/data_processing/Dockerfile.ubuntu
+++ b/docker/data_processing/Dockerfile.ubuntu
@@ -12,6 +12,8 @@ WORKDIR /root/build/data_processing
 
 # cmake files
 COPY docker/data_processing/CMakeLists.txt .
+# make options
+COPY docker/make_and_install_binary.sh .
 # data processing build and install
 COPY fbpcs/performance_tools/ ./fbpcs/performance_tools
 COPY fbpcs/data_processing/attribution_id_combiner/ ./fbpcs/data_processing/attribution_id_combiner
@@ -25,7 +27,7 @@ COPY fbpcs/data_processing/load_testing_utils/ ./fbpcs/data_processing/load_test
 COPY fbpcs/data_processing/private_id_dfca_id_combiner/ ./fbpcs/data_processing/private_id_dfca_id_combiner
 
 RUN cmake . -DTHREADING=ON -DUSE_RANDOM_DEVICE=ON
-RUN make && make install
+RUN ./make_and_install_binary.sh
 
 CMD ["/bin/sh"]
 

--- a/docker/emp_games/Dockerfile.ubuntu
+++ b/docker/emp_games/Dockerfile.ubuntu
@@ -14,6 +14,8 @@ WORKDIR /root/build/emp_game
 COPY docker/emp_games/CMakeLists.txt .
 COPY docker/emp_games/common.cmake .
 COPY docker/emp_games/perf_tools.cmake .
+# make options
+COPY docker/make_and_install_binary.sh .
 # attribution, lift and shard aggregator build and install
 COPY fbpcs/performance_tools/ ./fbpcs/performance_tools
 COPY fbpcs/emp_games/attribution/ ./fbpcs/emp_games/attribution
@@ -25,7 +27,7 @@ COPY fbpcs/emp_games/lift/ ./fbpcs/emp_games/lift
 COPY fbpcs/emp_games/common/ ./fbpcs/emp_games/common
 
 RUN cmake . -DTHREADING=ON -DUSE_RANDOM_DEVICE=ON
-RUN make && make install
+RUN ./make_and_install_binary.sh
 
 CMD ["/bin/sh"]
 

--- a/docker/make_and_install_binary.sh
+++ b/docker/make_and_install_binary.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+BYTES_PER_MEGABYTE=1000000
+
+# We need up to 7000 MB (less than 7GB) per thread.
+MAX_THREAD_MEMORY_IN_BYTES=$((7000 * BYTES_PER_MEGABYTE))
+
+# The functionality below calculates the number of bytes of memory available by getting the number
+# Of physical pages available, multiplying it by the page size (in bytes) and dividing that by the
+# number of bytes per thread that we want available to give us the maximum number of threads
+MAX_THREADS=$(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / MAX_THREAD_MEMORY_IN_BYTES))
+
+# Get the number of possible threads by pulling the online processors
+EFFECTIVE_THREADS=$(getconf _NPROCESSORS_ONLN)
+
+# Use the lesser of the maximum allowed threads by memory or available processors
+MAKE_JOBS=$((MAX_THREADS < EFFECTIVE_THREADS ? MAX_THREADS : EFFECTIVE_THREADS))
+
+# Set the maximum load average on the CPU as 9/10ths of the available cores
+# This ensures that we don't saturate the CPU with processes that are greater
+# than the cores available
+MAKE_MAX_LOAD=$((EFFECTIVE_THREADS * 9 / 10))
+
+echo "make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install"
+make -j $MAKE_JOBS -l $MAKE_MAX_LOAD && make -j $MAKE_JOBS -l $MAKE_MAX_LOAD install


### PR DESCRIPTION
Summary:
## Summary
While working on T133501570 I noticed that we were maxing out a single core for an extended time while building the FBPCF image. This led me to investigate our other builds and I noticed that we were doing the same here. The EC2 instance we use to build has 16 cores and we were only using one, leading us to only use ~6.5% of the available CPU. By increasing the number of make jobs to match the number of cores, I was able to increase the amount of CPU used to ~23% and reduce the build time from an average of around 40 minutes to ~19 minutes.

Differential Revision: D42626512

