### PR TITLE
Generate server_hostnames in PID joint stage

### DIFF
--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -37,10 +37,10 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 
 from fbpcs.private_computation.service.utils import (
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
     get_pc_status_from_stage_state,
-    get_server_uris,
     stop_stage_service,
 )
 
@@ -143,7 +143,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
             existing_containers=pc_instance.get_existing_containers_for_retry(),
             env_vars_list=env_vars_list,
         )
-        server_uris = get_server_uris(
+        server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,
             role=pc_instance.infra_config.role,
             num_containers=len(cmd_args_list),

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -44,10 +44,10 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
     get_pc_status_from_stage_state,
-    get_server_uris,
     stop_stage_service,
 )
 
@@ -189,7 +189,7 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
-        server_uris = get_server_uris(
+        server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,
             role=pc_instance.infra_config.role,
             num_containers=len(cmd_args_list),

--- a/fbpcs/private_computation/service/pcf2_base_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_base_stage_service.py
@@ -40,10 +40,10 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 
 from fbpcs.private_computation.service.utils import (
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
     get_pc_status_from_stage_state,
-    get_server_uris,
 )
 
 
@@ -149,7 +149,7 @@ class PCF2BaseStageService(PrivateComputationStageService):
             ),
             server_ips=server_hostnames if enable_tls else server_ips,
         )
-        server_uris = get_server_uris(
+        server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,
             role=pc_instance.infra_config.role,
             num_containers=len(cmd_args_list),

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -37,6 +37,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
     stop_stage_service,
@@ -93,11 +94,17 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
             pc_instance=pc_instance,
             server_ips=server_ips,
         )
+        server_uris = gen_tls_server_hostnames_for_publisher(
+            server_domain=pc_instance.infra_config.server_domain,
+            role=pc_instance.infra_config.role,
+            num_containers=len(container_instances),
+        )
         self._logger.info("PIDRunProtocolStageService finished")
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,
             pc_instance.current_stage.name,
             containers=container_instances,
+            server_uris=server_uris,
         )
         pc_instance.infra_config.instances.append(stage_state)
         return pc_instance

--- a/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
@@ -30,9 +30,9 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
-    get_server_uris,
     stop_stage_service,
 )
 
@@ -147,7 +147,7 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
         )
-        server_uris = get_server_uris(
+        server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,
             role=pc_instance.infra_config.role,
             num_containers=len(cmd_args_list),

--- a/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
+++ b/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
@@ -41,10 +41,10 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
     get_pc_status_from_stage_state,
-    get_server_uris,
     stop_stage_service,
 )
 
@@ -158,7 +158,7 @@ class SecureRandomShardStageService(PrivateComputationStageService):
             server_ips=server_ips,
         )
 
-        server_uris = get_server_uris(
+        server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,
             role=pc_instance.infra_config.role,
             num_containers=len(cmd_args_list),

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -319,7 +319,7 @@ def distribute_files_among_containers(
     return files_per_container
 
 
-def get_server_uris(
+def gen_tls_server_hostnames_for_publisher(
     server_domain: Optional[str], role: PrivateComputationRole, num_containers: int
 ) -> Optional[List[str]]:
     """For each container, create a unique server_uri based

--- a/fbpcs/private_computation/test/service/test_utils.py
+++ b/fbpcs/private_computation/test/service/test_utils.py
@@ -33,9 +33,9 @@ from fbpcs.private_computation.service.constants import (
 
 from fbpcs.private_computation.service.utils import (
     distribute_files_among_containers,
+    gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
-    get_server_uris,
 )
 
 
@@ -75,13 +75,15 @@ class TestUtils(IsolatedAsyncioTestCase):
         expected_result_2 = None
 
         # Act
-        actual_result_1 = get_server_uris(
+        actual_result_1 = gen_tls_server_hostnames_for_publisher(
             self.server_domain, PrivateComputationRole.PUBLISHER, 2
         )
-        actual_result_2 = get_server_uris(
+        actual_result_2 = gen_tls_server_hostnames_for_publisher(
             self.server_domain, PrivateComputationRole.PARTNER, 2
         )
-        actual_result_3 = get_server_uris(None, PrivateComputationRole.PUBLISHER, 2)
+        actual_result_3 = gen_tls_server_hostnames_for_publisher(
+            None, PrivateComputationRole.PUBLISHER, 2
+        )
 
         # Assert
         self.assertEqual(expected_result_1, actual_result_1)


### PR DESCRIPTION
Summary:
This change is needed for e2e testing. Without this change, error will be thrown [here](https://www.internalfb.com/code/fbsource/[731813aaf7e9]/fbcode/fbpcs/private_computation/service/private_computation.py?lines=633-634) in private_computation.py because this check will run for any joint stage.
```
            if not server_hostnames:
                raise ValueError("Missing server_hostnames, required for TLS")
```

Differential Revision: D42620164

