### PR TITLE
Update extract-docker-binaries.sh to pull from the correct image tag

### DIFF
--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -50,8 +50,8 @@ if [ -z "$DOCKER_IMAGE_NAME" ]; then
   case $PACKAGE in
     emp_games) DOCKER_IMAGE_NAME="fbpcs/emp-games";;
     data_processing) DOCKER_IMAGE_NAME="fbpcs/data-processing";;
-    pid) DOCKER_IMAGE_NAME="fbpcs/onedocker";;
-    validation) DOCKER_IMAGE_NAME="fbpcs/onedocker";;
+    pid) DOCKER_IMAGE_NAME="fbpcs/onedocker/test";;
+    validation) DOCKER_IMAGE_NAME="fbpcs/onedocker/test";;
   esac
 fi
 DOCKER_IMAGE_PATH="${DOCKER_IMAGE_NAME}:${TAG}"


### PR DESCRIPTION
Summary:
Building the local binaries was failng with:
```
Unable to find image 'fbpcs/onedocker:brian-standard-build' locally
Error response from daemon: pull access denied for fbpcs/onedocker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

This is because the local test onedocker image tag was changed to fbpcs/onedocker/test.

This won't affect prod because the [prod workflow](https://fburl.com/code/trv85s87) passes an image name so it doesn't use the default values.

Differential Revision: D42626642

