### PR TITLE
Create a Build and Publish Production OneDocker task in MacGyver

### DIFF
--- a/.github/workflows/build_and_publish_onedocker.yml
+++ b/.github/workflows/build_and_publish_onedocker.yml
@@ -1,12 +1,12 @@
 name: Build and Publish the Production OneDocker Image
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'docker/onedocker/prod/**'
   workflow_dispatch:
+    inputs:
+      tags_csv:
+        description: A list of tags to add to the docker image in CSV form (eg. latest,1234,rc)
+        required: true
+        type: string
 
 
 env:
@@ -22,20 +22,21 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Repo
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - name: Set Up Docker Tags
+        id: set_up_tags
+        run: |
+          unformatted_tags=${{ inputs.tags_csv }}
+          formatted_tags=${{ env.GH_REGISTRY_IMAGE_NAME }}:${{ github.sha }},${{ env.GH_REGISTRY_IMAGE_NAME }}:${unformatted_tags/,/,${{ env.GH_REGISTRY_IMAGE_NAME }}:}
+          echo $formatted_tags
+          echo "docker_tags=$formatted_tags" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-onedocker-prod-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-onedocker-prod
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2
@@ -49,19 +50,7 @@ jobs:
         with:
           context: docker/onedocker/prod
           file: docker/onedocker/prod/Dockerfile.ubuntu
-          tags: |
-            ${{ env.GH_REGISTRY_IMAGE_NAME }}:${{ github.sha }}
-            ${{ env.GH_REGISTRY_IMAGE_NAME }}:latest
+          tags: ${{ steps.set_up_tags.outputs.docker_tags}}
           push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # This ugly bit is necessary or else our cache will grow forever
-      # until it hits GitHub's limit of 5GB.
-      # Temp fix: T135482742
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha,scope=$GITHUB_REF_NAME-onedocker-prod
+          cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-onedocker-prod


### PR DESCRIPTION
Summary: This diff updates the build_and_publish_onedocker.yml to be called from conveyor and adds a new task to MacGyver that can call the production OneDocker build and publish.

Differential Revision: D42649535

