### PR TITLE
add identifier filter in PID PREPARE

### DIFF
--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
@@ -25,12 +25,14 @@ class UnionPIDDataPreparer {
       const std::string& outputPath,
       const std::filesystem::path& tmpDirectory,
       int64_t maxColumnCnt = 1,
+      int64_t idFilterThresh = -1,
       int64_t logEveryN = 1'000)
       : inputPath_{inputPath},
         outputPath_{outputPath},
         tmpDirectory_{tmpDirectory},
         logEveryN_{logEveryN},
-        maxColumnCnt_{maxColumnCnt} {}
+        maxColumnCnt_{maxColumnCnt},
+        idFilterThresh_{idFilterThresh} {}
 
   UnionPIDDataPreparerResults prepare() const;
 
@@ -44,6 +46,7 @@ class UnionPIDDataPreparer {
   std::filesystem::path tmpDirectory_;
   int64_t logEveryN_;
   int64_t maxColumnCnt_;
+  int64_t idFilterThresh_;
 };
 
 } // namespace measurement::pid

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
@@ -328,4 +328,26 @@ TEST(UnionPIDDataPreparerTest, AttributionIdSpineInputValidationWithMaxThree) {
   preparer.prepare();
   validateFileContents(expected, outpath);
 }
+
+TEST(UnionPIDDataPreparerTest, AttributionIdSpineInputValidationWithFilter) {
+  std::vector<std::string> lines = {
+      "id_email,id_phone,id_fn,ad_id,timestamp,is_click,campaign_metadata",
+      "email1,phone1,fn1,4,400,1,4",
+      "email1,,,1,100,1,1",
+      "email1,phone1,,2,200,1,2",
+      "email1,,fn1,3,300,1,3",
+      "email1,phone1,fn1,5,500,1,5",
+      ",phone2,fn2,2,300,0,4",
+      ",phone2,,1,200,1,3",
+      ",phone3,fn3,2,500,0,6",
+      ",,fn3,1,400,0,5"};
+  std::string expected{"phone1,fn1\nphone2,fn2\nphone3,fn3\n"};
+  std::filesystem::path inpath{tmpnam(nullptr)};
+  std::filesystem::path outpath{tmpnam(nullptr)};
+  writeLinesToFile(inpath, lines);
+
+  UnionPIDDataPreparer preparer{inpath, outpath, "/tmp/", 3, 5};
+  preparer.prepare();
+  validateFileContents(expected, outpath);
+}
 } // namespace measurement::pid

--- a/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
@@ -30,6 +30,10 @@ DEFINE_string(
     "",
     "A run_id used to identify all the logs in a PL/PA run.");
 DEFINE_int32(log_every_n, 1'000'000, "How frequently to log updates");
+DEFINE_int32(
+    id_filter_thresh,
+    -1,
+    "A threshold for number of times identifier can appear");
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
@@ -44,6 +48,7 @@ int main(int argc, char** argv) {
       FLAGS_output_path,
       tmpDirectory,
       FLAGS_max_column_cnt,
+      FLAGS_id_filter_thresh,
       FLAGS_log_every_n};
 
   preparer.prepare();


### PR DESCRIPTION
Summary:
# Context
Through pilot runs, we found that we have an issue of low quality identifiers for both publisher-side and partner-side. Therefore, we decided to add a change into PID PREPARE stage to have ability to filter out identifiers based on the number of appearances.

# Details
In order to achieve identifier filtering based on the number of appearances, we are additionally reading through an input file.
- Added new arg `id_filter_thresh`, which sets the threshold for the number of appearances allowed. The default value is -1m and it does not apply filtering by default.
- Added another file reader `bufferedReaderForFilter` to read through a file. It counts appearance of each identifier and store ones that exceeded `id_filter_thresh` in `filterIds`.
- The rest of the process is the same except that it drops an identifier if an identifier is in `filterIds`.
- Added a new unit test `AttributionIdSpineInputValidationWithFilter`. It makes sure the identifier is being filtered as expected.

Differential Revision: D42697977

