### PR TITLE
Fix the OneDocker Build and Publish pipeline

### DIFF
--- a/.github/workflows/build_and_publish_onedocker.yml
+++ b/.github/workflows/build_and_publish_onedocker.yml
@@ -7,6 +7,10 @@ on:
         description: A list of tags to add to the docker image in CSV form (eg. latest,1234,rc)
         required: true
         type: string
+      tracker_hash:
+        description: "[Internal usage] Used for tracking workflow job status within Meta infra"
+        required: false
+        type: str
 
 
 env:
@@ -26,6 +30,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Print Tracker Hash
+        run: echo ${{ github.event.inputs.tracker_hash }}
 
       - name: Set Up Docker Tags
         id: set_up_tags


### PR DESCRIPTION
Summary: The build_and_publish_onedocker.yml file didn't support the tracker hash variable which is required to be called by MacGyver. Also, I changed the input parameter from tags to tags_csv in the workflow, but forgot to update MacGyver.

Differential Revision: D42810260

