### PR TITLE
Update Binary image cache to key on branch instead of hash

### DIFF
--- a/.github/workflows/build_binary_image.yml
+++ b/.github/workflows/build_binary_image.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ inputs.image_to_build }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ inputs.image_to_build }}-${{ github.ref_name }}
           restore-keys: |
             ${{ runner.os }}-${{ inputs.image_to_build }}
 


### PR DESCRIPTION
Summary:
## Context
The binary build caches have been keyed on the commit hash. This means that we were creating a new Docker Builder cache for each commit on the main branch. This quickly fills up our alloted 10GB cache.

## This Diff
This change updates the cache key to be based on the `ref_name` which is the branch or tag the job is running on ([docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)). This will create a single cache for the main branch. This will not affect the builds at all as the cache is based on a hash of the files so any changes will trigger a full rebuild of that layer and any subsequent layers anyway.

Differential Revision: D42847337

