### PR TITLE
Update RC and RC UDP test timeouts to 90 minutes

### DIFF
--- a/.github/workflows/rc_one_command_runner_test.yml
+++ b/.github/workflows/rc_one_command_runner_test.yml
@@ -43,7 +43,7 @@ jobs:
   pl_test:
     name: Private Lift RC E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/rc_udp_one_command_runner_test.yml
+++ b/.github/workflows/rc_udp_one_command_runner_test.yml
@@ -43,7 +43,7 @@ jobs:
   pl_test:
     name: Private Lift RC E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Summary:
The RC and RC UDP tests were both ended at 60 minutes before they could complete in the last build:
* https://github.com/facebookresearch/fbpcs/actions/runs/4045546432
* https://github.com/facebookresearch/fbpcs/actions/runs/4045546354

This diff increases the timeout to 90 minutes

Differential Revision: D42850318

