### PR TITLE
Update FBPCS Binaries to be Built with the Haswell Architecture

### DIFF
--- a/.github/workflows/build_fbpcs_images.yml
+++ b/.github/workflows/build_fbpcs_images.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  FBPCF_VERSION: 2.1.88  # Please also update line 29 in .github/workflows/docker-publish.yml
+  FBPCF_VERSION: 2.1.117  # Please also update line 29 in .github/workflows/docker-publish.yml
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.88  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
+  FBPCF_VERSION: 2.1.117  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
   PID_VERSION: 0.0.8
 
 jobs:

--- a/docker/data_processing/CMakeLists.txt
+++ b/docker/data_processing/CMakeLists.txt
@@ -10,8 +10,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Don't compile with AVX512 instructions since many of the AWS
 # instances won't have access to that instruction set.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-avx512f")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx512f")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-avx512f -march=haswell")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx512f -march=haswell")
 
 find_file(fbpcf_cmake NAMES cmake/fbpcf.cmake)
 include(${fbpcf_cmake})

--- a/docker/emp_games/CMakeLists.txt
+++ b/docker/emp_games/CMakeLists.txt
@@ -10,8 +10,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Don't compile with AVX512 instructions since many of the AWS
 # instances won't have access to that instruction set.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-avx512f")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx512f")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-avx512f -march=haswell")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-avx512f -march=haswell")
 
 include("common.cmake")
 include("perf_tools.cmake")


### PR DESCRIPTION
Summary:
## Context
After attempting to build the images with the "x86-64" architecture for a while, I determined that we wouldn't be able to make it work as the EMP library used an instruction that wasing included in the "x86-64" architecture (specifically ). This meant that I needed to explore other options. My next choice was to find the architecture of the current build machines that we use (c4.4xlarge) and go with that since we know that we were building it previously natively for those machines. The c4.4xlarge uses an Intel Xeon E5-2666 based on the cpu info from the machine:
```
ubuntu@ip-172-31-15-42:~$ lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
...
Model name:                      Intel(R) Xeon(R) CPU E5-2666 v3 @ 2.90GHz
...
```

According to the Intel website, this processor uses the Haswell architecture: https://www.intel.com/content/www/us/en/products/sku/81706/intel-xeon-processor-e52660-v3-25m-cache-2-60-ghz/specifications.html

With that information, I decided to rebuild everything for the haswell architecture since it should match our current build system and allow us all the symbols necessary to run the computation.

## This Diff
This diff updates the FBPCS binaries to specify the C and C++ flags to build with the haswell architecture.

Differential Revision: D42713487

