### PR TITLE
pass identifier filter to PID PREPARE

### DIFF
--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.h
@@ -25,12 +25,14 @@ class UnionPIDDataPreparer {
       const std::string& outputPath,
       const std::filesystem::path& tmpDirectory,
       int64_t maxColumnCnt = 1,
+      int64_t idFilterThresh = -1,
       int64_t logEveryN = 1'000)
       : inputPath_{inputPath},
         outputPath_{outputPath},
         tmpDirectory_{tmpDirectory},
         logEveryN_{logEveryN},
-        maxColumnCnt_{maxColumnCnt} {}
+        maxColumnCnt_{maxColumnCnt},
+        idFilterThresh_{idFilterThresh} {}
 
   UnionPIDDataPreparerResults prepare() const;
 
@@ -44,6 +46,7 @@ class UnionPIDDataPreparer {
   std::filesystem::path tmpDirectory_;
   int64_t logEveryN_;
   int64_t maxColumnCnt_;
+  int64_t idFilterThresh_;
 };
 
 } // namespace measurement::pid

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparerTest.cpp
@@ -328,4 +328,26 @@ TEST(UnionPIDDataPreparerTest, AttributionIdSpineInputValidationWithMaxThree) {
   preparer.prepare();
   validateFileContents(expected, outpath);
 }
+
+TEST(UnionPIDDataPreparerTest, AttributionIdSpineInputValidationWithFilter) {
+  std::vector<std::string> lines = {
+      "id_email,id_phone,id_fn,ad_id,timestamp,is_click,campaign_metadata",
+      "email1,phone1,fn1,4,400,1,4",
+      "email1,,,1,100,1,1",
+      "email1,phone1,,2,200,1,2",
+      "email1,,fn1,3,300,1,3",
+      "email1,phone1,fn1,5,500,1,5",
+      ",phone2,fn2,2,300,0,4",
+      ",phone2,,1,200,1,3",
+      ",phone3,fn3,2,500,0,6",
+      ",,fn3,1,400,0,5"};
+  std::string expected{"phone1,fn1\nphone2,fn2\nphone3,fn3\n"};
+  std::filesystem::path inpath{tmpnam(nullptr)};
+  std::filesystem::path outpath{tmpnam(nullptr)};
+  writeLinesToFile(inpath, lines);
+
+  UnionPIDDataPreparer preparer{inpath, outpath, "/tmp/", 3, 5};
+  preparer.prepare();
+  validateFileContents(expected, outpath);
+}
 } // namespace measurement::pid

--- a/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/union_pid_data_preparer.cpp
@@ -30,6 +30,10 @@ DEFINE_string(
     "",
     "A run_id used to identify all the logs in a PL/PA run.");
 DEFINE_int32(log_every_n, 1'000'000, "How frequently to log updates");
+DEFINE_int32(
+    id_filter_thresh,
+    -1,
+    "A threshold for number of times identifier can appear");
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
@@ -44,6 +48,7 @@ int main(int argc, char** argv) {
       FLAGS_output_path,
       tmpDirectory,
       FLAGS_max_column_cnt,
+      FLAGS_id_filter_thresh,
       FLAGS_log_every_n};
 
   preparer.prepare();

--- a/fbpcs/data_processing/service/pid_prepare_binary_service.py
+++ b/fbpcs/data_processing/service/pid_prepare_binary_service.py
@@ -20,6 +20,7 @@ class PIDPrepareBinaryService(RunBinaryBaseService):
         output_path: str,
         tmp_directory: str = "/tmp/",
         max_column_count: int = 1,
+        id_filter_thresh: int = -1,
         run_id: Optional[str] = None,
     ) -> str:
         cmd_args = " ".join(
@@ -28,6 +29,7 @@ class PIDPrepareBinaryService(RunBinaryBaseService):
                 f"--output_path={output_path}",
                 f"--tmp_directory={tmp_directory}",
                 f"--max_column_cnt={max_column_count}",
+                f"--id_filter_thresh={id_filter_thresh}",
             ]
         )
         if run_id is not None:

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -24,6 +24,9 @@ class PCSFeature(Enum):
     PA_TIMESTAMP_VALIDATION = "pa_timestamp_validation"
     PL_TIMESTAMP_VALIDATION = "pl_timestamp_validation"
     PRE_VALIDATION_FILE_STREAM = "pre_validation_file_stream"
+    PID_FILTER_LOW_QUALITY_IDENTIFIER_THRESH166 = (
+        "pid_filter_low_quality_identifier_thresh166"
+    )
     UNKNOWN = "unknown"
 
     @classmethod

--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -44,6 +44,10 @@ DEFAULT_PADDING_SIZE: typing.Dict[PrivateComputationGameType, typing.Optional[in
 DEFAULT_LOG_COST_TO_S3 = True
 DEFAULT_SORT_STRATEGY = "sort"
 DEFAULT_MULTIKEY_PROTOCOL_MAX_COLUMN_COUNT = 6
+
+# based on the the test we run, we decided to use 50 as a threshold.
+# since DEFAULT_PADDING_SIZE is lower than 50, we may adjust it in the future.
+DEFAULT_IDENTIFIER_FILTER_THRESH = 50
 FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"
 
 # RUN PID has separate timeout to accommodate for 20M rows capacity on SNMK

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -75,6 +75,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 if pid_protocol is PIDProtocol.UNION_PID_MULTIKEY
                 else 1
             )
+            id_filter_thresh_expect = -1
             pc_instance = self.create_sample_pc_instance(
                 pc_role=pc_role,
                 test_num_containers=test_num_containers,
@@ -110,6 +111,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 pc_role,
                 test_num_containers,
                 max_col_cnt_expect,
+                id_filter_thresh_expect,
                 test_run_id,
             )
             # test the start_containers is called with expected parameters
@@ -213,17 +215,18 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         pc_role: PrivateComputationRole,
         test_num_containers: int,
         max_col_cnt_expected: int,
+        id_filter_thresh_expect: int,
         test_run_id: Optional[str] = None,
     ) -> List[str]:
         arg_ls = []
         if pc_role is PrivateComputationRole.PUBLISHER:
             arg_ls = [
-                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_prepared_{i} --tmp_directory=/tmp --max_column_cnt={max_col_cnt_expected}"
+                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_publisher_prepared_{i} --tmp_directory=/tmp --max_column_cnt={max_col_cnt_expected} --id_filter_thresh={id_filter_thresh_expect}"
                 for i in range(test_num_containers)
             ]
         elif pc_role is PrivateComputationRole.PARTNER:
             arg_ls = [
-                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_prepared_{i} --tmp_directory=/tmp --max_column_cnt={max_col_cnt_expected}"
+                f"--input_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_sharded_{i} --output_path=out/test_instance_123_out_dir/pid_stage/out.csv_advertiser_prepared_{i} --tmp_directory=/tmp --max_column_cnt={max_col_cnt_expected} --id_filter_thresh={id_filter_thresh_expect}"
                 for i in range(test_num_containers)
             ]
 


### PR DESCRIPTION
Summary:
# Context
Through pilot runs, we found that we have an issue of low quality identifiers for both publisher-side and partner-side. Therefore, we decided to add a change into PID PREPARE stage to have ability to filter out identifiers based on the number of appearances. For overall context, please visit [the doc](https://docs.google.com/document/d/1Zr34S5AjOSt_Kjt-dX2-dllypfImQPLN600ycNJrfQM/edit?usp=sharing).

# Details
We have added a PCS feature `pid_filter_low_quality_identifier_thresh166`. When the feature is turned on, we will be sending the threshold of 166. Otherwise, we will be sending the threshold of -1 to do no filtering.

Differential Revision: D42854941

