### PR TITLE
Complete hostname provisioning to Partner containers

### DIFF
--- a/fbpcs/private_computation/service/pcf2_base_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_base_stage_service.py
@@ -103,7 +103,7 @@ class PCF2BaseStageService(PrivateComputationStageService):
             server_certificate_path: The path to write server certificate on a container.
             ca_certificate_path: The path to write CA certificate on a container.
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
-            server_hostnames: ignored
+            server_hostnames: only used by the partner role. These are hostname addresses of the publisher's containers.
             server_private_key_ref_provider: Provides a reference to the server private key, if applicable.
 
         Returns:

--- a/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
+++ b/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
@@ -118,7 +118,7 @@ class SecureRandomShardStageService(PrivateComputationStageService):
         Args:
             pc_instance: the private computation instance to run secure random sharding with
             server_ips: only used by the partner role. These are the ip addresses of the publisher's containers.
-            server_hostnames: ignored, TODO: T141115702 - configure hostname for TLS when supported by env vars
+            server_hostnames: only used by the partner role. These are hostname addresses of the publisher's containers.
             server_private_key_ref_provider: Provides a reference to the server private key, if applicable.
 
         Returns:


### PR DESCRIPTION
Summary: We need to pass server_hostnames in all pcf2 joint stages. This diff is the final step that finishes off this work.

Differential Revision: D42862448

