### PR TITLE
Fix unsigned char printing in global sharing utils

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/GlobalSharingUtils.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/GlobalSharingUtils.h
@@ -105,9 +105,10 @@ inline void shareBitsForValuesStep(
       numBitsForValuesWidth,
       common::PARTNER,
       common::PUBLISHER>(myRole, valueSquaredBits);
-  XLOG(INFO) << "Num bits for values: " << liftGameProcessedData.valueBits;
+  XLOG(INFO) << "Num bits for values: "
+             << (int32_t)liftGameProcessedData.valueBits;
   XLOG(INFO) << "Num bits for values squared: "
-             << liftGameProcessedData.valueSquaredBits;
+             << (int32_t)liftGameProcessedData.valueSquaredBits;
 }
 
 template <int schedulerId>


### PR DESCRIPTION
Summary:
Quick fix for the logs. Currently it prints out the ascii value as uint8t_t is a char.

i.e.

```
1675250973379,I0201 03:29:33.378980  2576 GlobalSharingUtils.h:108] Num bits for values: \x1d
1675250973379,I0201 03:29:33.379007  2576 GlobalSharingUtils.h:109] Num bits for values squared: 0
```

Reviewed By: haochenuw

Differential Revision:
D42940109

Privacy Context Container: L416713

