### PR TITLE
stage canceller hook

### DIFF
--- a/fbpcs/bolt/bolt_checkpoint.py
+++ b/fbpcs/bolt/bolt_checkpoint.py
@@ -7,6 +7,8 @@
 
 from typing import Any, Dict, Optional
 
+from fbpcs.bolt.bolt_hook import BoltHookCommonInjectionArgs
+
 from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs, BoltJob, BoltPlayerArgs
 from fbpcs.common.service.trace_logging_registry import (
     InstanceIdtoRunIdRegistry,
@@ -24,6 +26,7 @@ class bolt_checkpoint(write_checkpoint):
         "partner_id",
         "job",
         "instance_args",
+        "injection_args",
     ]
     _DEFAULT_COMPONENT_NAME = "Bolt"
 
@@ -42,6 +45,8 @@ class bolt_checkpoint(write_checkpoint):
             return instance_id_obj.create_instance_args.instance_id
         elif isinstance(instance_id_obj, BoltJob):
             return instance_id_obj.publisher_bolt_args.create_instance_args.instance_id
+        elif isinstance(instance_id_obj, BoltHookCommonInjectionArgs):
+            return instance_id_obj.publisher_id
         else:
             return super()._param_to_instance_id(
                 instance_id_param=instance_id_param, kwargs=kwargs

--- a/fbpcs/bolt/bolt_hook.py
+++ b/fbpcs/bolt/bolt_hook.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+# postpone evaluation of type hint annotations until runtime (support forward reference)
+# This will become the default in python 4.0: https://peps.python.org/pep-0563/
+from __future__ import annotations
+
+import abc
+import asyncio
+import logging
+import random
+
+from dataclasses import dataclass
+from typing import Generic, Optional, TYPE_CHECKING, TypeVar
+
+from dataclasses_json import DataClassJsonMixin
+
+# only do these imports when type checking (support forward reference)
+if TYPE_CHECKING:
+    from fbpcs.bolt.bolt_client import BoltClient
+    from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs, BoltJob
+
+
+@dataclass
+class BoltHookInjectionFrequencyArgs:
+    """This class is used by the BoltHook interface to modify the behavior of
+    arbitrary hooks, e.g. delaying when their execution begins or defining the
+    probability with which they trigger.
+
+    These should be kept "private" to the BoltHook interface, meaning implementers
+    of the BoltHook interface don't need to worry about managing this behavior.
+    """
+
+    delay: Optional[float] = None
+    inject_every_n: Optional[int] = None
+    maximum_injections: Optional[int] = None
+    # this must be between 0 and 1 (inclusive)
+    inject_with_probability_p: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.inject_every_n and self.inject_with_probability_p:
+            raise ValueError(
+                "You cannot set both inject_every_n and inject_with_probability_p"
+            )
+
+        probability = self.inject_with_probability_p or 0
+        if probability < 0 or probability > 1:
+            raise ValueError(
+                f"{self.inject_with_probability_p=} must be between 0 and 1 (inclusive)"
+            )
+
+
+@dataclass
+class BoltHookArgs(DataClassJsonMixin):
+    """Hook specific args, as defined by implementers of the BoltHook interface."""
+
+    pass
+
+
+T = TypeVar("T", bound="BoltCreateInstanceArgs")
+U = TypeVar("U", bound="BoltCreateInstanceArgs")
+
+
+@dataclass
+class BoltHookCommonInjectionArgs(Generic[T, U]):
+    """Common args intended to be used by implementers of the BoltHook interface"""
+
+    job: "BoltJob[T, U]"
+    publisher_client: "BoltClient[T]"
+    partner_client: "BoltClient[U]"
+
+    @property
+    def publisher_id(self) -> str:
+        return self.job.publisher_bolt_args.create_instance_args.instance_id
+
+    @property
+    def partner_id(self) -> str:
+        return self.job.partner_bolt_args.create_instance_args.instance_id
+
+
+H = TypeVar("H", bound=BoltHookArgs)
+
+
+class BoltHook(abc.ABC, Generic[H]):
+    """Interface for injecting arbitrary behavior (such as failures) into the BoltRunner.
+
+    hooks_args: Hook specific args, as defined by implementers of the BoltHook interface
+    hook_injection_frequency_args: Modify the frequency/cadence at which hooks execute.
+        Intended to be insisible to implementers of the BoltHook interface.
+    """
+
+    def __init__(
+        self,
+        hook_args: H,
+        hook_injection_frequency_args: Optional[BoltHookInjectionFrequencyArgs] = None,
+    ) -> None:
+        self.hook_args = hook_args
+        self._injection_frequency_args: BoltHookInjectionFrequencyArgs = (
+            hook_injection_frequency_args or self._default_frequency_args
+        )
+
+        self._num_calls: int = 0
+        self._num_injections: int = 0
+
+        self.logger: logging.Logger = logging.getLogger(f"BoltHook_{self.hook_name}")
+
+    @abc.abstractmethod
+    async def _inject(
+        self,
+        injection_args: BoltHookCommonInjectionArgs[T, U],
+    ) -> None:
+        """Defines the behavior / purpose of the Hook. This must be implemented by
+        each BoltHook subclass.
+
+        Arguments:
+            injection_args: Arguments passed by the BoltRunner that are used by the
+                hook to perform various actions
+        """
+        ...
+
+    async def inject(self, injection_args: BoltHookCommonInjectionArgs[T, U]) -> None:
+        """Inject the hook behavior into the private computation run.
+
+        Note that, depending on the settings provided in BoltHookInjectionFrequencyArgs,
+        the hook may not execute every time.
+
+        Arguments:
+            injection_args: Arguments passed by the BoltRunner that are used by the
+                hook to perform various actions
+        """
+        self._num_calls += 1
+        if not self._should_inject():
+            return
+
+        await self._delay()
+        self.logger.info(
+            f"Running {self.hook_name} on job {injection_args.job.job_name} with"
+            f" {self.hook_args=}"
+        )
+        self._num_injections += 1
+
+        await self._inject(injection_args)
+
+    async def _delay(self) -> None:
+        """If a hook delay is configured, async sleep prior to executing hook"""
+
+        if delay := self._injection_frequency_args.delay:
+            self.logger.info(f"Waiting {delay} seconds before running {self.hook_name}")
+            await asyncio.sleep(delay)
+
+    def _should_inject(self) -> bool:
+        """Logic to determine if the hook should be injected or skip injection."""
+
+        if max_injections := self._injection_frequency_args.maximum_injections:
+            if self._num_injections >= max_injections:
+                self.logger.info(f"Skipping {self.hook_name}: max injections surpassed")
+                return False
+
+        if inject_every_n := self._injection_frequency_args.inject_every_n:
+            if self._num_calls % inject_every_n != 1:
+                self.logger.info(
+                    f"Skipping {self.hook_name}: only inject every {inject_every_n} calls"
+                )
+                return False
+
+        if p := self._injection_frequency_args.inject_with_probability_p:
+            if random.random() > p:
+                self.logger.info(
+                    f"Skipping {self.hook_name}: only inject with probability {p}"
+                )
+                return False
+
+        return True
+
+    @property
+    def hook_name(self) -> str:
+        return self.__class__.__name__
+
+    @property
+    def _default_frequency_args(self) -> BoltHookInjectionFrequencyArgs:
+        """Define the default frequency args for the hook. This allows subclasses
+        to define sane defaults and reduce user/caller burden.
+        """
+        return BoltHookInjectionFrequencyArgs()

--- a/fbpcs/bolt/hooks/exception_thrower.py
+++ b/fbpcs/bolt/hooks/exception_thrower.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from typing import TypeVar
+
+from fbpcs.bolt.bolt_checkpoint import bolt_checkpoint
+
+from fbpcs.bolt.bolt_hook import (
+    BoltHook,
+    BoltHookArgs,
+    BoltHookCommonInjectionArgs,
+    BoltHookInjectionFrequencyArgs,
+)
+from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
+
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+U = TypeVar("U", bound=BoltCreateInstanceArgs)
+
+
+@dataclass
+class BoltExceptionThrowerHookArgs(BoltHookArgs):
+    exception: BaseException = Exception(
+        "Generic exception thrown by BoltExceptionThrowerHook"
+    )
+
+
+class BoltExceptionThrowerHook(BoltHook[BoltExceptionThrowerHookArgs]):
+    @bolt_checkpoint()
+    async def _inject(self, injection_args: BoltHookCommonInjectionArgs[T, U]) -> None:
+        raise self.hook_args.exception
+
+    @property
+    def _default_frequency_args(self) -> BoltHookInjectionFrequencyArgs:
+        # two second delay, inject exception on every other attempt
+        return BoltHookInjectionFrequencyArgs(delay=2, inject_every_n=2)

--- a/fbpcs/bolt/hooks/stage_canceller.py
+++ b/fbpcs/bolt/hooks/stage_canceller.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional, TypeVar
+
+from fbpcs.bolt.bolt_checkpoint import bolt_checkpoint
+
+from fbpcs.bolt.bolt_hook import (
+    BoltHook,
+    BoltHookArgs,
+    BoltHookCommonInjectionArgs,
+    BoltHookInjectionFrequencyArgs,
+)
+from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
+from fbpcs.private_computation.entity.infra_config import PrivateComputationRole
+
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+U = TypeVar("U", bound=BoltCreateInstanceArgs)
+
+
+@dataclass
+class BoltStageCancellerHookArgs(BoltHookArgs):
+    role: Optional[PrivateComputationRole] = None
+
+
+class BoltStageCancellerHook(BoltHook[BoltStageCancellerHookArgs]):
+    @bolt_checkpoint()
+    async def _inject(self, injection_args: BoltHookCommonInjectionArgs[T, U]) -> None:
+        cancel_coros = []
+        if self.hook_args.role in (PrivateComputationRole.PUBLISHER, None):
+            cancel_coros.append(
+                injection_args.publisher_client.cancel_current_stage(
+                    injection_args.publisher_id
+                )
+            )
+
+        if self.hook_args.role in (PrivateComputationRole.PARTNER, None):
+            cancel_coros.append(
+                injection_args.partner_client.cancel_current_stage(
+                    injection_args.partner_id
+                )
+            )
+
+        await asyncio.gather(*cancel_coros)
+
+    @property
+    def _default_frequency_args(self) -> BoltHookInjectionFrequencyArgs:
+        # only inject once (one way to avoid cancelling containers every time)
+        return BoltHookInjectionFrequencyArgs(maximum_injections=1)

--- a/fbpcs/bolt/hooks/test/test_exception_thrower.py
+++ b/fbpcs/bolt/hooks/test/test_exception_thrower.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import Mock
+
+from fbpcs.bolt.hooks.exception_thrower import (
+    BoltExceptionThrowerHook,
+    BoltExceptionThrowerHookArgs,
+)
+
+
+class TestException(Exception):
+    pass
+
+
+class TestBoltExceptionThrowerHook(IsolatedAsyncioTestCase):
+    async def test_throw_exception(self) -> None:
+        exception = TestException()
+        test_hook = BoltExceptionThrowerHook(
+            hook_args=BoltExceptionThrowerHookArgs(exception=exception)
+        )
+        with self.assertRaises(TestException):
+            await test_hook._inject(injection_args=Mock())

--- a/fbpcs/bolt/hooks/test/test_stage_canceller.py
+++ b/fbpcs/bolt/hooks/test/test_stage_canceller.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+from fbpcs.bolt.hooks.stage_canceller import (
+    BoltStageCancellerHook,
+    BoltStageCancellerHookArgs,
+)
+from fbpcs.private_computation.entity.infra_config import PrivateComputationRole
+
+
+class TestBoltStageCancellerHook(IsolatedAsyncioTestCase):
+    async def test_cancel_stage_partner(self) -> None:
+        injection_args = AsyncMock()
+        test_hook = BoltStageCancellerHook(
+            BoltStageCancellerHookArgs(role=PrivateComputationRole.PARTNER)
+        )
+
+        await test_hook._inject(injection_args)
+
+        injection_args.partner_client.cancel_current_stage.assert_called_once()
+        injection_args.publisher_client.cancel_current_stage.assert_not_called()
+
+    async def test_cancel_stage_publisher(self) -> None:
+        injection_args = AsyncMock()
+        test_hook = BoltStageCancellerHook(
+            BoltStageCancellerHookArgs(role=PrivateComputationRole.PUBLISHER)
+        )
+
+        await test_hook._inject(injection_args)
+
+        injection_args.publisher_client.cancel_current_stage.assert_called_once()
+        injection_args.partner_client.cancel_current_stage.assert_not_called()
+
+    async def test_cancel_stage_both(self) -> None:
+        injection_args = AsyncMock()
+        test_hook = BoltStageCancellerHook(BoltStageCancellerHookArgs(role=None))
+
+        await test_hook._inject(injection_args)
+
+        injection_args.publisher_client.cancel_current_stage.assert_called_once()
+        injection_args.partner_client.cancel_current_stage.assert_called_once()

--- a/fbpcs/bolt/test/test_bolt_hook.py
+++ b/fbpcs/bolt/test/test_bolt_hook.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import List, TypeVar
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock, patch
+
+from fbpcs.bolt.bolt_checkpoint import bolt_checkpoint
+
+from fbpcs.bolt.bolt_hook import (
+    BoltHook,
+    BoltHookArgs,
+    BoltHookCommonInjectionArgs,
+    BoltHookInjectionFrequencyArgs,
+)
+from fbpcs.bolt.bolt_job import BoltCreateInstanceArgs
+
+T = TypeVar("T", bound=BoltCreateInstanceArgs)
+U = TypeVar("U", bound=BoltCreateInstanceArgs)
+
+
+@dataclass
+class BoltTestHookArgs(BoltHookArgs):
+    state: List[int]
+
+
+class BoltTestHook(BoltHook[BoltTestHookArgs]):
+    @bolt_checkpoint()
+    async def _inject(self, injection_args: BoltHookCommonInjectionArgs[T, U]) -> None:
+        self.hook_args.state.append(0)
+
+
+class TestBoltHook(IsolatedAsyncioTestCase):
+    def test_should_inject_max_injections(self) -> None:
+        max_injections = 2
+        test_hook = BoltTestHook(
+            BoltTestHookArgs(state=[]),
+            BoltHookInjectionFrequencyArgs(maximum_injections=max_injections),
+        )
+        for num_injections in range(max_injections + 2):
+            with self.subTest(num_injections=num_injections):
+                test_hook._num_injections = num_injections
+                self.assertEqual(
+                    num_injections < max_injections, test_hook._should_inject()
+                )
+
+    def test_should_inject_every_n(self) -> None:
+        inject_every_n = 3
+        test_hook = BoltTestHook(
+            BoltTestHookArgs(state=[]),
+            BoltHookInjectionFrequencyArgs(inject_every_n=inject_every_n),
+        )
+        for num_calls in range(10):
+            with self.subTest(num_calls=num_calls):
+                test_hook._num_calls = num_calls
+                self.assertEqual(
+                    num_calls % inject_every_n == 1, test_hook._should_inject()
+                )
+
+    @patch("random.random")
+    def test_should_inject_with_probability(self, mock_random: Mock) -> None:
+        test_hook = BoltTestHook(
+            BoltTestHookArgs(state=[]),
+            BoltHookInjectionFrequencyArgs(inject_with_probability_p=0.7),
+        )
+
+        for random_val in (0.0, 0.134, 0.68):
+            with self.subTest(random_val=random_val):
+                mock_random.return_value = random_val
+                self.assertTrue(test_hook._should_inject())
+
+        random_val = 0.75
+        with self.subTest(random_val=random_val):
+            mock_random.return_value = random_val
+            self.assertFalse(test_hook._should_inject())
+
+    async def test_inject(self) -> None:
+        state = []
+        test_hook = BoltTestHook(
+            BoltTestHookArgs(state=state),
+            BoltHookInjectionFrequencyArgs(inject_every_n=2),
+        )
+
+        self.assertEqual(0, test_hook._num_calls)
+        self.assertEqual(0, test_hook._num_injections)
+        self.assertEqual(state, [])
+
+        await test_hook.inject(injection_args=AsyncMock())
+        self.assertEqual(1, test_hook._num_calls)
+        self.assertEqual(1, test_hook._num_injections)
+        self.assertEqual(state, [0])
+
+        await test_hook.inject(injection_args=AsyncMock())
+        self.assertEqual(2, test_hook._num_calls)
+        self.assertEqual(1, test_hook._num_injections)
+        self.assertEqual(state, [0])
+
+        await test_hook.inject(injection_args=AsyncMock())
+        self.assertEqual(3, test_hook._num_calls)
+        self.assertEqual(2, test_hook._num_injections)
+        self.assertEqual(state, [0, 0])


### PR DESCRIPTION
Summary:
## What

- Create BoltHook that kills containers

## Why

- This can be used to simulate various container failures (and the corresponding retry logic)

## Diff stack context

- We've had SEVs in the past where our retry logic did not work as we expected. Failure injection can help with the creation of tests that invoke the retry logic.
- https://docs.google.com/document/d/1tfvxFL2k0BnnYPlVhZyK7a18J79vbooB7jyqcqSeSl0/edit

Reviewed By: calebzj

Differential Revision:
D41792015

Privacy Context Container: L416713

