### PR TITLE
Add the optional stream-file flag to the CLI

### DIFF
--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -53,6 +53,7 @@ class InputDataValidator(Validator):
         input_file_path: str,
         cloud_provider: CloudProvider,
         region: str,
+        stream_file: bool,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         start_timestamp: Optional[str] = None,

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -21,6 +21,7 @@ Usage:
         [--start-timestamp=<start-timestamp>]
         [--end-timestamp=<end-timestamp>]
         [--binary-version=<binary-version>]
+        [--pre-validation-file-stream=<pre-validation-file-stream>]
 """
 
 
@@ -43,6 +44,8 @@ ACCESS_KEY_DATA = "--access-key-data"
 START_TIMESTAMP = "--start-timestamp"
 END_TIMESTAMP = "--end-timestamp"
 BINARY_VERSION = "--binary-version"
+PRE_VALIDATION_FILE_STREAM_FLAG = "--pre-validation-file-stream"
+PRE_VALIDATION_FILE_STREAM_ENABLED = "enabled"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -59,11 +62,15 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(START_TIMESTAMP): optional_string,
             Optional(END_TIMESTAMP): optional_string,
             Optional(BINARY_VERSION): optional_string,
+            Optional(PRE_VALIDATION_FILE_STREAM_FLAG): optional_string,
         }
     )
     arguments = s.validate(docopt(__doc__, argv))
     assert arguments
     print("Parsed pc_pre_validation_cli arguments")
+    stream_file = (
+        arguments[PRE_VALIDATION_FILE_STREAM_FLAG] == PRE_VALIDATION_FILE_STREAM_ENABLED
+    )
 
     validators = [
         cast(
@@ -72,6 +79,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 input_file_path=arguments[INPUT_FILE_PATH],
                 cloud_provider=arguments[CLOUD_PROVIDER],
                 region=arguments[REGION],
+                stream_file=stream_file,
                 start_timestamp=arguments[START_TIMESTAMP],
                 end_timestamp=arguments[END_TIMESTAMP],
                 access_key_id=arguments[ACCESS_KEY_ID],

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -31,6 +31,7 @@ TEST_FILE_SIZE = 1234
 TEST_CLOUD_PROVIDER: CloudProvider = CloudProvider.AWS
 TEST_INPUT_FILE_PATH = f"s3://test-bucket/{TEST_FILENAME}"
 TEST_REGION = "us-west-2"
+TEST_STREAM_FILE = False
 TEST_TIMESTAMP: float = time.time()
 TEST_TEMP_FILEPATH = f"{INPUT_DATA_TMP_FILE_PATH}/{TEST_FILENAME}-{TEST_TIMESTAMP}"
 
@@ -65,6 +66,7 @@ class TestInputDataValidator(TestCase):
             TEST_INPUT_FILE_PATH,
             TEST_CLOUD_PROVIDER,
             TEST_REGION,
+            TEST_STREAM_FILE,
             access_key_id,
             access_key_data,
         )
@@ -89,7 +91,7 @@ class TestInputDataValidator(TestCase):
         self.storage_service_mock.copy.side_effect = Exception(exception_message)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -115,7 +117,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -143,7 +145,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -171,7 +173,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -199,7 +201,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -232,7 +234,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -265,7 +267,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -298,7 +300,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -336,7 +338,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -364,7 +366,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -392,7 +394,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -412,7 +414,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -440,7 +442,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -485,7 +487,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -529,7 +531,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -574,7 +576,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -604,7 +606,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -650,7 +652,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -674,7 +676,7 @@ class TestInputDataValidator(TestCase):
         count_empty_field_mock.side_effect = Exception(expected_exception_message)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -707,7 +709,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -733,7 +735,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -760,7 +762,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -774,6 +776,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="1650000000",
             end_timestamp="1640000000",
         )
@@ -787,6 +790,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="bad-timestamp",
             end_timestamp="",
         )
@@ -828,6 +832,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )
@@ -870,6 +875,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -44,6 +44,7 @@ class TestPCPreValidationCLI(TestCase):
             input_file_path=expected_input_file_path,
             cloud_provider=expected_cloud_provider,
             region=expected_region,
+            stream_file=False,
             start_timestamp=None,
             end_timestamp=None,
             access_key_id=None,
@@ -91,6 +92,7 @@ class TestPCPreValidationCLI(TestCase):
             f"--access-key-id={expected_access_key_id}",
             f"--access-key-data={expected_access_key_data}",
             f"--binary-version={expected_binary_version}",
+            "--pre-validation-file-stream=enabled",
         ]
 
         validation_cli.main(argv)
@@ -99,6 +101,7 @@ class TestPCPreValidationCLI(TestCase):
             input_file_path=expected_input_file_path,
             cloud_provider=expected_cloud_provider,
             region=expected_region,
+            stream_file=True,
             start_timestamp=expected_start_timestamp,
             end_timestamp=expected_end_timestamp,
             access_key_id=expected_access_key_id,


### PR DESCRIPTION
Summary:
When passed in as 'enabled', the input_data_validator will stream the file
instead of downloading it. The streaming will be implemented in a future
diff.

Differential Revision: D43014260

