### PR TITLE
Add a feature flag for streaming the file contents

### DIFF
--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -53,6 +53,7 @@ class InputDataValidator(Validator):
         input_file_path: str,
         cloud_provider: CloudProvider,
         region: str,
+        stream_file: bool,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
         start_timestamp: Optional[str] = None,

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -21,6 +21,7 @@ Usage:
         [--start-timestamp=<start-timestamp>]
         [--end-timestamp=<end-timestamp>]
         [--binary-version=<binary-version>]
+        [--pre-validation-file-stream=<pre-validation-file-stream>]
 """
 
 
@@ -43,6 +44,8 @@ ACCESS_KEY_DATA = "--access-key-data"
 START_TIMESTAMP = "--start-timestamp"
 END_TIMESTAMP = "--end-timestamp"
 BINARY_VERSION = "--binary-version"
+PRE_VALIDATION_FILE_STREAM_FLAG = "--pre-validation-file-stream"
+PRE_VALIDATION_FILE_STREAM_ENABLED = "enabled"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -59,11 +62,15 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(START_TIMESTAMP): optional_string,
             Optional(END_TIMESTAMP): optional_string,
             Optional(BINARY_VERSION): optional_string,
+            Optional(PRE_VALIDATION_FILE_STREAM_FLAG): optional_string,
         }
     )
     arguments = s.validate(docopt(__doc__, argv))
     assert arguments
     print("Parsed pc_pre_validation_cli arguments")
+    stream_file = (
+        arguments[PRE_VALIDATION_FILE_STREAM_FLAG] == PRE_VALIDATION_FILE_STREAM_ENABLED
+    )
 
     validators = [
         cast(
@@ -72,6 +79,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 input_file_path=arguments[INPUT_FILE_PATH],
                 cloud_provider=arguments[CLOUD_PROVIDER],
                 region=arguments[REGION],
+                stream_file=stream_file,
                 start_timestamp=arguments[START_TIMESTAMP],
                 end_timestamp=arguments[END_TIMESTAMP],
                 access_key_id=arguments[ACCESS_KEY_ID],

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -31,6 +31,7 @@ TEST_FILE_SIZE = 1234
 TEST_CLOUD_PROVIDER: CloudProvider = CloudProvider.AWS
 TEST_INPUT_FILE_PATH = f"s3://test-bucket/{TEST_FILENAME}"
 TEST_REGION = "us-west-2"
+TEST_STREAM_FILE = False
 TEST_TIMESTAMP: float = time.time()
 TEST_TEMP_FILEPATH = f"{INPUT_DATA_TMP_FILE_PATH}/{TEST_FILENAME}-{TEST_TIMESTAMP}"
 
@@ -65,6 +66,7 @@ class TestInputDataValidator(TestCase):
             TEST_INPUT_FILE_PATH,
             TEST_CLOUD_PROVIDER,
             TEST_REGION,
+            TEST_STREAM_FILE,
             access_key_id,
             access_key_data,
         )
@@ -89,7 +91,7 @@ class TestInputDataValidator(TestCase):
         self.storage_service_mock.copy.side_effect = Exception(exception_message)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -115,7 +117,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -143,7 +145,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -171,7 +173,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -199,7 +201,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -232,7 +234,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -265,7 +267,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -298,7 +300,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -336,7 +338,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -364,7 +366,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -392,7 +394,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -412,7 +414,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -440,7 +442,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -485,7 +487,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -529,7 +531,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -574,7 +576,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -604,7 +606,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -650,7 +652,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -674,7 +676,7 @@ class TestInputDataValidator(TestCase):
         count_empty_field_mock.side_effect = Exception(expected_exception_message)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -707,7 +709,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -733,7 +735,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION
+            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -760,7 +762,7 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION
+            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
         )
         report = validator.validate()
 
@@ -774,6 +776,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="1650000000",
             end_timestamp="1640000000",
         )
@@ -787,6 +790,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="bad-timestamp",
             end_timestamp="",
         )
@@ -828,6 +832,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )
@@ -870,6 +875,7 @@ class TestInputDataValidator(TestCase):
             input_file_path=TEST_INPUT_FILE_PATH,
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -44,6 +44,7 @@ class TestPCPreValidationCLI(TestCase):
             input_file_path=expected_input_file_path,
             cloud_provider=expected_cloud_provider,
             region=expected_region,
+            stream_file=False,
             start_timestamp=None,
             end_timestamp=None,
             access_key_id=None,
@@ -91,6 +92,7 @@ class TestPCPreValidationCLI(TestCase):
             f"--access-key-id={expected_access_key_id}",
             f"--access-key-data={expected_access_key_data}",
             f"--binary-version={expected_binary_version}",
+            "--pre-validation-file-stream=enabled",
         ]
 
         validation_cli.main(argv)
@@ -99,6 +101,7 @@ class TestPCPreValidationCLI(TestCase):
             input_file_path=expected_input_file_path,
             cloud_provider=expected_cloud_provider,
             region=expected_region,
+            stream_file=True,
             start_timestamp=expected_start_timestamp,
             end_timestamp=expected_end_timestamp,
             access_key_id=expected_access_key_id,

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -23,6 +23,7 @@ class PCSFeature(Enum):
     PCF_TLS = "pcf_tls"
     PA_TIMESTAMP_VALIDATION = "pa_timestamp_validation"
     PL_TIMESTAMP_VALIDATION = "pl_timestamp_validation"
+    PRE_VALIDATION_FILE_STREAM = "pre_validation_file_stream"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -20,6 +20,7 @@ from fbpcs.infra.certificate.private_key import PrivateKeyReferenceProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
 from fbpcs.private_computation.entity.pc_validator_config import PCValidatorConfig
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstance,
     PrivateComputationRole,
@@ -112,12 +113,16 @@ class PCPreValidationStageService(PrivateComputationStageService):
         region = self._pc_validator_config.region
         binary_name = OneDockerBinaryNames.PC_PRE_VALIDATION.value
         binary_config = self._onedocker_binary_config_map[binary_name]
+        pre_validation_file_stream_flag = pc_instance.has_feature(
+            PCSFeature.PRE_VALIDATION_FILE_STREAM
+        )
         cmd_args = get_cmd_args(
-            pc_instance.product_config.common.input_path,
-            region,
-            binary_config,
-            pc_instance.product_config.common.input_path_start_ts,
-            pc_instance.product_config.common.input_path_end_ts,
+            input_path=pc_instance.product_config.common.input_path,
+            region=region,
+            binary_config=binary_config,
+            pre_validation_file_stream_flag=pre_validation_file_stream_flag,
+            input_path_start_ts=pc_instance.product_config.common.input_path_start_ts,
+            input_path_end_ts=pc_instance.product_config.common.input_path_end_ts,
         )
         env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
         should_wait_spin_up: bool = (

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -43,11 +43,12 @@ class PreValidateService:
 
         cmd_args = [
             get_cmd_args(
-                input_path,
-                region,
-                binary_config,
-                None,
-                None,
+                input_path=input_path,
+                region=region,
+                binary_config=binary_config,
+                pre_validation_file_stream_flag=True,
+                input_path_start_ts=None,
+                input_path_end_ts=None,
             )
             for input_path in input_paths
         ]

--- a/fbpcs/private_computation/service/pre_validation_util.py
+++ b/fbpcs/private_computation/service/pre_validation_util.py
@@ -15,6 +15,7 @@ def get_cmd_args(
     input_path: str,
     region: str,
     binary_config: OneDockerBinaryConfig,
+    pre_validation_file_stream_flag: bool,
     input_path_start_ts: Optional[str],
     input_path_end_ts: Optional[str],
 ) -> str:
@@ -25,6 +26,7 @@ def get_cmd_args(
         # pc_pre_validation assumes all other binaries runs on the same version tag as its own
         f"--binary-version={binary_config.binary_version}",
     ]
+
     if input_path_start_ts and input_path_end_ts:
         args.extend(
             [
@@ -32,4 +34,8 @@ def get_cmd_args(
                 f"--end-timestamp={input_path_end_ts}",
             ]
         )
+
+    if pre_validation_file_stream_flag:
+        args.append("--pre-validation-file-stream=enabled")
+
     return " ".join(args)


### PR DESCRIPTION
Summary:
The value of this new feature flag is sent to the pc_pre_validation_cli and
when enabled the CLI's input_data_validator will use the new method of file
streaming to fetch the file contents instead of downloading the file locally.

Differential Revision: D43014261

