### PR TITLE
Update RC E2E tests to use the new RC production OneDocker Image and the Public Coordinator image

### DIFF
--- a/.github/workflows/one_command_runner_test.yml
+++ b/.github/workflows/one_command_runner_test.yml
@@ -90,8 +90,8 @@ on:
         type: string
 
 env:
-  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
-  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_CONTAINER_REPO_URL: public.ecr.aws/t7b1w5a4
+  FBPCS_IMAGE_NAME: pc-coordinator-prod
   FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
   CONSOLE_OUTPUT_FILE: /tmp/output.txt
 

--- a/.github/workflows/pa_one_command_runner_test.yml
+++ b/.github/workflows/pa_one_command_runner_test.yml
@@ -83,8 +83,8 @@ on:
         type: string
 
 env:
-  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
-  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_CONTAINER_REPO_URL: public.ecr.aws/t7b1w5a4
+  FBPCS_IMAGE_NAME: pc-coordinator-prod
   FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
 
 jobs:

--- a/.github/workflows/publish_image_to_ecr.yml
+++ b/.github/workflows/publish_image_to_ecr.yml
@@ -17,6 +17,14 @@ on:
         required: false
         type: string
         default: pl-coordinator-env
+      ecr_repo_type:
+        description: 'The type of ECR repository it is (private or public)'
+        required: true
+        type: choice
+        default: private
+        options:
+          - private
+          - public
       new_tag:
         description: 'The new tag of the docker image'
         required: true
@@ -29,14 +37,18 @@ on:
       tracker_hash:
         description: '[Internal usage] Used for tracking workflow job status within Meta infra'
         required: false
-        type: str
+        type: string
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/${{ github.event.inputs.image_name }}
-  IMAGE_TAG: ${{ github.event.inputs.existing_tag }}
-  ECR_REPOSITORY: ${{ github.event.inputs.ecr_repo }}
-  NEW_IMAGE_TAG: ${{ github.event.inputs.new_tag }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/${{ inputs.image_name }}
+  IMAGE_TAG: ${{ inputs.existing_tag }}
+  # The line below is intended to make it easier for developers to understand the inputs that they are putting in for the ECR repo.
+  # Our public ECR registry has the prefix of t7b1w5a4 and this code prepends that to the actual name of the image repository
+  # if the developer puts in the repostiory type of "public". This allows the developer to just specify the image repository like
+  # onedocker-prod or pc-coordinator-prod
+  ECR_REPOSITORY: ${{ inputs.ecr_repo_type == 'private' && inputs.ecr_repo || format('t7b1w5a4/{0}', inputs.ecr_repo) }}
+  NEW_IMAGE_TAG: ${{ inputs.new_tag }}
 
 jobs:
 
@@ -47,9 +59,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
     - name: Print Tracker Hash
-      run: echo ${{ github.event.inputs.tracker_hash}}
+      run: echo ${{ inputs.tracker_hash}}
 
     - uses: docker/login-action@v1
       with:
@@ -64,11 +75,13 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-        aws-region: ${{ github.event.inputs.aws_region }}
+        aws-region: ${{ inputs.aws_region }}
 
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+      with:
+          registry-type: ${{ inputs.ecr_repo_type }}
 
     - name: Tag docker image
       env:

--- a/.github/workflows/rc_one_command_runner_test.yml
+++ b/.github/workflows/rc_one_command_runner_test.yml
@@ -39,8 +39,8 @@ on:
         default: "test build"
 
 env:
-  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
-  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_CONTAINER_REPO_URL: public.ecr.aws/t7b1w5a4
+  FBPCS_IMAGE_NAME: pc-coordinator-prod
   FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
 
 jobs:

--- a/.github/workflows/rc_udp_one_command_runner_test.yml
+++ b/.github/workflows/rc_udp_one_command_runner_test.yml
@@ -39,8 +39,8 @@ on:
         default: "test build"
 
 env:
-  FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
-  FBPCS_IMAGE_NAME: coordinator
+  FBPCS_CONTAINER_REPO_URL: public.ecr.aws/t7b1w5a4
+  FBPCS_IMAGE_NAME: pc-coordinator-prod
   FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_RC_UDP_GRAPH_API_TOKEN }}
 
 jobs:

--- a/fbpcs/tests/github/config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/config_one_command_runner_test.yml
@@ -28,7 +28,7 @@ private_computation:
           binary_version: latest
     OneDockerServiceConfig:
       constructor:
-        task_definition: onedocker-task-pc-e2e-test:1#onedocker-container-pc-e2e-test
+        task_definition: onedocker-task-pc-e2e-test:2#onedocker-container-pc-e2e-test
     LogRetriever:
       class: fbpcs.experimental.cloud_logs.aws_log_retriever.AWSLogRetriever
       constructor:

--- a/fbpcs/tests/github/rc_config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/rc_config_one_command_runner_test.yml
@@ -28,7 +28,7 @@ private_computation:
           binary_version: latest
     OneDockerServiceConfig:
       constructor:
-        task_definition: onedocker-task-qae2e:1#onedocker-container-qae2e
+        task_definition: onedocker-task-qae2e:2#onedocker-container-qae2e
 pid:
   dependency:
 mpc:

--- a/fbpcs/tests/github/rc_udp_config_one_command_runner_test.yml
+++ b/fbpcs/tests/github/rc_udp_config_one_command_runner_test.yml
@@ -28,7 +28,7 @@ private_computation:
           binary_version: latest
     OneDockerServiceConfig:
       constructor:
-        task_definition: onedocker-task-udp-pl-rc-test2:1#onedocker-container-udp-pl-rc-test2
+        task_definition: onedocker-task-udp-pl-rc-test2:2#onedocker-container-udp-pl-rc-test2
 pid:
   dependency:
 mpc:


### PR DESCRIPTION
Summary:
## Context
As part of T124573483 I have created a new Public ECR repository for both the OneDocker and Coordinator docker images. This will allow new partners to onboard without BE manually adding them to our private ECR repositories. I have updated the pipelines earlier in this stack to push the images to both the private and public ECR repositories. One piece that is not tested is the new OneDocker images that are built with each bundle. The current RC E2E tests just use the production latest OneDocker image.

## This Diff
This diff updates the RC E2E tests to use the new public OneDocker and Coordinator images. This should not be a big change for Coordinator as it is just the same test image from a different repository. The larger change is the weekly pushes of new OneDocker images to the ECR repository. Updating the tests to use the new image will allow us to make changes to the image and feel secure in our testing that the image works.

Differential Revision: D42933443

