### PR TITLE
Gradually remove 'usingBatch' - conversion

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -50,8 +50,7 @@ class AttributionApp {
               MY_ROLE, *communicationAgentFactory_, metricCollector_)
               .create();
 
-    AttributionGame<schedulerId, true, inputEncryption> game(
-        std::move(scheduler));
+    AttributionGame<schedulerId, inputEncryption> game(std::move(scheduler));
 
     // Compute attributions sequentially on numFiles files, starting from
     // startFileIndex
@@ -92,12 +91,11 @@ class AttributionApp {
   }
 
  protected:
-  AttributionInputMetrics<true, inputEncryption> getInputData(
-      std::string inputPath) {
+  AttributionInputMetrics<inputEncryption> getInputData(std::string inputPath) {
     XLOG(INFO) << "MY_ROLE: " << MY_ROLE << ", schedulerId: " << schedulerId
                << ", attributionRules_: " << attributionRules_
                << ", input_path: " << inputPath;
-    return AttributionInputMetrics<true, inputEncryption>{
+    return AttributionInputMetrics<inputEncryption>{
         MY_ROLE, attributionRules_, inputPath};
   }
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -17,11 +17,7 @@
 
 namespace pcf2_attribution {
 
-template <
-    int MY_ROLE,
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int MY_ROLE, int schedulerId, common::InputEncryption inputEncryption>
 class AttributionApp {
  public:
   AttributionApp(
@@ -54,7 +50,7 @@ class AttributionApp {
               MY_ROLE, *communicationAgentFactory_, metricCollector_)
               .create();
 
-    AttributionGame<schedulerId, usingBatch, inputEncryption> game(
+    AttributionGame<schedulerId, true, inputEncryption> game(
         std::move(scheduler));
 
     // Compute attributions sequentially on numFiles files, starting from
@@ -96,12 +92,12 @@ class AttributionApp {
   }
 
  protected:
-  AttributionInputMetrics<usingBatch, inputEncryption> getInputData(
+  AttributionInputMetrics<true, inputEncryption> getInputData(
       std::string inputPath) {
     XLOG(INFO) << "MY_ROLE: " << MY_ROLE << ", schedulerId: " << schedulerId
                << ", attributionRules_: " << attributionRules_
                << ", input_path: " << inputPath;
-    return AttributionInputMetrics<usingBatch, inputEncryption>{
+    return AttributionInputMetrics<true, inputEncryption>{
         MY_ROLE, attributionRules_, inputPath};
   }
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -40,8 +40,8 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   /**
    * Publisher shares attribution rules with partner.
    */
-  std::vector<std::shared_ptr<
-      const AttributionRule<schedulerId, true, inputEncryption>>>
+  std::vector<
+      std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>
   shareAttributionRules(
       const int myRole,
       const std::vector<std::string>& attributionRuleNames);
@@ -66,8 +66,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   privatelyShareThresholds(
       const std::vector<TouchpointT<true>>& touchpoints,
       const std::vector<PrivateTouchpointT>& privateTouchpoints,
-      const AttributionRule<schedulerId, true, inputEncryption>&
-          attributionRule,
+      const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       size_t batchSize);
 
   /**
@@ -96,8 +95,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
           touchpoints,
       const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
           conversions,
-      const AttributionRule<schedulerId, true, inputEncryption>&
-          attributionRule,
+      const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
           thresholds,
       size_t batchSize);
@@ -108,8 +106,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
           touchpoints,
       const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
           conversions,
-      const AttributionRule<schedulerId, true, inputEncryption>&
-          attributionRule,
+      const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
           thresholds,
       size_t batchSize);

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -20,10 +20,7 @@
 
 namespace pcf2_attribution {
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
  public:
   explicit AttributionGame(
@@ -32,21 +29,19 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   AttributionOutputMetrics computeAttributions(
       const int myRole,
-      const AttributionInputMetrics<usingBatch, inputEncryption>& inputData);
+      const AttributionInputMetrics<inputEncryption>& inputData);
 
-  using PrivateTouchpointT = ConditionalVector<
-      PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
-      !usingBatch>;
+  using PrivateTouchpointT =
+      PrivateTouchpoint<schedulerId, true, inputEncryption>;
 
-  using PrivateConversionT = ConditionalVector<
-      PrivateConversion<schedulerId, usingBatch, inputEncryption>,
-      !usingBatch>;
+  using PrivateConversionT =
+      PrivateConversion<schedulerId, true, inputEncryption>;
 
   /**
    * Publisher shares attribution rules with partner.
    */
   std::vector<std::shared_ptr<
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>>>
+      const AttributionRule<schedulerId, true, inputEncryption>>>
   shareAttributionRules(
       const int myRole,
       const std::vector<std::string>& attributionRuleNames);
@@ -55,23 +50,23 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    * Publisher shares touchpoints with partner.
    */
   std::vector<PrivateTouchpointT> privatelyShareTouchpoints(
-      const std::vector<TouchpointT<usingBatch>>& touchpoints);
+      const std::vector<TouchpointT<true>>& touchpoints);
 
   /**
    * Partner shares conversions with publisher.
    */
   std::vector<PrivateConversionT> privatelyShareConversions(
-      const std::vector<ConversionT<usingBatch>>& conversions);
+      const std::vector<ConversionT<true>>& conversions);
 
   /**
    * Publisher shares touchpoints thresholds, to optimize attribution
    * computation.
    */
-  std::vector<std::vector<SecTimestampT<schedulerId, usingBatch>>>
+  std::vector<std::vector<SecTimestampT<schedulerId, true>>>
   privatelyShareThresholds(
-      const std::vector<TouchpointT<usingBatch>>& touchpoints,
+      const std::vector<TouchpointT<true>>& touchpoints,
       const std::vector<PrivateTouchpointT>& privateTouchpoints,
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>&
+      const AttributionRule<schedulerId, true, inputEncryption>&
           attributionRule,
       size_t batchSize);
 
@@ -80,13 +75,13 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    */
   const std::vector<uint64_t> retrieveValidOriginalAdIds(
       const int myRole,
-      std::vector<TouchpointT<usingBatch>>& touchpoints);
+      std::vector<TouchpointT<true>>& touchpoints);
   /**
    * Create a compression map of the original Ad Id with the compressed Ad ID
    */
 
   void replaceAdIdWithCompressedAdId(
-      std::vector<TouchpointT<usingBatch>>& touchpoints,
+      std::vector<TouchpointT<true>>& touchpoints,
       std::vector<uint64_t>& validOriginalAdIds);
 
   void putAdIdMappingJson(
@@ -96,30 +91,26 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   /**
    * Helper method for computing attributions.
    */
-  const std::vector<SecBit<schedulerId, usingBatch>> computeAttributionsHelper(
-      const std::vector<
-          PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>>&
+  const std::vector<SecBit<schedulerId, true>> computeAttributionsHelper(
+      const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,
-      const std::vector<
-          PrivateConversion<schedulerId, usingBatch, inputEncryption>>&
+      const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
           conversions,
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>&
+      const AttributionRule<schedulerId, true, inputEncryption>&
           attributionRule,
-      const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
+      const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
           thresholds,
       size_t batchSize);
 
-  const std::vector<AttributionReformattedOutputFmt<schedulerId, usingBatch>>
+  const std::vector<AttributionReformattedOutputFmt<schedulerId, true>>
   computeAttributionsHelperV2(
-      const std::vector<
-          PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>>&
+      const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,
-      const std::vector<
-          PrivateConversion<schedulerId, usingBatch, inputEncryption>>&
+      const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
           conversions,
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>&
+      const AttributionRule<schedulerId, true, inputEncryption>&
           attributionRule,
-      const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
+      const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
           thresholds,
       size_t batchSize);
 };

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -34,8 +34,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   using PrivateTouchpointT =
       PrivateTouchpoint<schedulerId, true, inputEncryption>;
 
-  using PrivateConversionT =
-      PrivateConversion<schedulerId, true, inputEncryption>;
+  using PrivateConversionT = PrivateConversion<schedulerId, inputEncryption>;
 
   /**
    * Publisher shares attribution rules with partner.
@@ -56,7 +55,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    * Partner shares conversions with publisher.
    */
   std::vector<PrivateConversionT> privatelyShareConversions(
-      const std::vector<ConversionT<true>>& conversions);
+      const std::vector<Conversion>& conversions);
 
   /**
    * Publisher shares touchpoints thresholds, to optimize attribution
@@ -93,7 +92,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   const std::vector<SecBit<schedulerId, true>> computeAttributionsHelper(
       const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,
-      const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
+      const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
           conversions,
       const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
@@ -104,7 +103,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   computeAttributionsHelperV2(
       const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,
-      const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
+      const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
           conversions,
       const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -102,7 +102,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
           thresholds,
       size_t batchSize);
 
-  const std::vector<AttributionReformattedOutputFmt<schedulerId, true>>
+  const std::vector<AttributionReformattedOutputFmt<schedulerId>>
   computeAttributionsHelperV2(
       const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -414,7 +414,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributions(
       attributions = computeAttributionsHelper(
           tpArrays, convArrays, *attributionRule, thresholdArrays, numIds);
 
-      AttributionOutput<schedulerId, true> attributionOutput{ids, attributions};
+      AttributionOutput<schedulerId> attributionOutput{ids, attributions};
 
       XLOGF(
           INFO,

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -254,7 +254,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
-const std::vector<AttributionReformattedOutputFmt<schedulerId, true>>
+const std::vector<AttributionReformattedOutputFmt<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
     const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
         touchpoints,
@@ -267,8 +267,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
     throw std::invalid_argument(
         "Must provide positive batch size for batch execution!");
   }
-  std::vector<AttributionReformattedOutputFmt<schedulerId, true>>
-      attributionsOutput;
+  std::vector<AttributionReformattedOutputFmt<schedulerId>> attributionsOutput;
   // We will be attributing on a sorted vector of touchpoints and conversions
   // (based on timestamps).
   // The preferred touchpoint for a conversion will be a valid attributable
@@ -327,11 +326,10 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
 
       attributedAdId = attributedAdId.mux(isAttributed, tp.adId);
     }
-    attributionsOutput.push_back(
-        AttributionReformattedOutputFmt<schedulerId, true>{
-            .ad_id = attributedAdId,
-            .conv_value = conv.convValue,
-            .is_attributed = hasAttributedTouchpoint});
+    attributionsOutput.push_back(AttributionReformattedOutputFmt<schedulerId>{
+        .ad_id = attributedAdId,
+        .conv_value = conv.convValue,
+        .is_attributed = hasAttributedTouchpoint});
   }
   std::reverse(attributionsOutput.begin(), attributionsOutput.end());
   return attributionsOutput;
@@ -395,14 +393,14 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributions(
         << "threshold arrays and touchpoint arrays are not the same length.";
 
     if (FLAGS_use_new_output_format) {
-      std::vector<AttributionReformattedOutputFmtT<schedulerId, true>>
+      std::vector<AttributionReformattedOutputFmtT<schedulerId>>
           attributionsReformatted;
 
       attributionsReformatted = computeAttributionsHelperV2(
           tpArrays, convArrays, *attributionRule, thresholdArrays, numIds);
 
-      AttributionReformattedOutput<schedulerId, true>
-          attributionReformattedOutput{ids, attributionsReformatted};
+      AttributionReformattedOutput<schedulerId> attributionReformattedOutput{
+          ids, attributionsReformatted};
       XLOGF(
           INFO,
           "Retrieving attribution results for rule {}.",

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -30,10 +30,10 @@ template <int schedulerId, common::InputEncryption inputEncryption>
 std::vector<
     typename AttributionGame<schedulerId, inputEncryption>::PrivateConversionT>
 AttributionGame<schedulerId, inputEncryption>::privatelyShareConversions(
-    const std::vector<ConversionT<true>>& conversions) {
+    const std::vector<Conversion>& conversions) {
   return common::privatelyShareArray<
-      Conversion<true>,
-      PrivateConversion<schedulerId, true, inputEncryption>>(conversions);
+      Conversion,
+      PrivateConversion<schedulerId, inputEncryption>>(conversions);
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -186,7 +186,7 @@ const std::vector<SecBit<schedulerId, true>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
     const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
         touchpoints,
-    const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
+    const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
         conversions,
     const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId, true>>>& thresholds,
@@ -258,7 +258,7 @@ const std::vector<AttributionReformattedOutputFmt<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
     const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
         touchpoints,
-    const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
+    const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
         conversions,
     const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId, true>>>& thresholds,

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -41,7 +41,7 @@ std::vector<std::vector<SecTimestampT<schedulerId, true>>>
 AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
     const std::vector<TouchpointT<true>>& touchpoints,
     const std::vector<PrivateTouchpointT>& privateTouchpoints,
-    const AttributionRule<schedulerId, true, inputEncryption>& attributionRule,
+    const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     size_t batchSize) {
   std::vector<std::vector<SecTimestampT<schedulerId, true>>> output;
 
@@ -70,19 +70,19 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
 
 template <int schedulerId, common::InputEncryption inputEncryption>
 std::vector<
-    std::shared_ptr<const AttributionRule<schedulerId, true, inputEncryption>>>
+    std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>
 AttributionGame<schedulerId, inputEncryption>::shareAttributionRules(
     const int myRole,
     const std::vector<std::string>& attributionRuleNames) {
   // Publisher converts attribution rule names to attribution rules and ids
-  std::vector<std::shared_ptr<
-      const AttributionRule<schedulerId, true, inputEncryption>>>
+  std::vector<
+      std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>
       attributionRules;
   std::vector<uint64_t> attributionRuleIds;
   if (myRole == common::PUBLISHER) {
     for (auto attributionRuleName : attributionRuleNames) {
       auto attributionRule =
-          AttributionRule<schedulerId, true, inputEncryption>::fromNameOrThrow(
+          AttributionRule<schedulerId, inputEncryption>::fromNameOrThrow(
               attributionRuleName);
       attributionRules.push_back(attributionRule);
       attributionRuleIds.push_back(attributionRule->id);
@@ -91,7 +91,7 @@ AttributionGame<schedulerId, inputEncryption>::shareAttributionRules(
 
   const size_t attributionRuleIdWidth = 3; // currently we only support 4 rules
   CHECK_LT(
-      (SUPPORTED_ATTRIBUTION_RULES<schedulerId, true, inputEncryption>).size(),
+      (SUPPORTED_ATTRIBUTION_RULES<schedulerId, inputEncryption>).size(),
       (1 << attributionRuleIdWidth));
 
   // Publisher shares attribution rule ids
@@ -104,7 +104,7 @@ AttributionGame<schedulerId, inputEncryption>::shareAttributionRules(
   if (myRole == common::PARTNER) {
     for (auto sharedId : sharedAttributionRuleIds) {
       attributionRules.push_back(
-          AttributionRule<schedulerId, true, inputEncryption>::fromIdOrThrow(
+          AttributionRule<schedulerId, inputEncryption>::fromIdOrThrow(
               sharedId));
     }
   }
@@ -188,7 +188,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
         touchpoints,
     const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
         conversions,
-    const AttributionRule<schedulerId, true, inputEncryption>& attributionRule,
+    const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId, true>>>& thresholds,
     size_t batchSize) {
   if (batchSize == 0) {
@@ -260,7 +260,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
         touchpoints,
     const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
         conversions,
-    const AttributionRule<schedulerId, true, inputEncryption>& attributionRule,
+    const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId, true>>>& thresholds,
     size_t batchSize) {
   if (batchSize == 0) {

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
@@ -42,7 +42,7 @@ class AttributionInputMetrics {
     return attributionRules_;
   }
 
-  const std::vector<ConversionT<true>>& getConversionArrays() const {
+  const std::vector<Conversion>& getConversionArrays() const {
     return convArrays_;
   }
 
@@ -54,7 +54,7 @@ class AttributionInputMetrics {
   std::vector<int64_t> ids_;
   std::vector<std::string> attributionRules_;
   std::vector<TouchpointT<true>> tpArrays_;
-  std::vector<ConversionT<true>> convArrays_;
+  std::vector<Conversion> convArrays_;
 
   /**
    * Parse touchpoints and add padding if necessary.
@@ -82,7 +82,7 @@ class AttributionInputMetrics {
   /**
    * Convert parsed conversions into conversions.
    */
-  const std::vector<ConversionT<true>> convertParsedConversionsToConversions(
+  const std::vector<Conversion> convertParsedConversionsToConversions(
       const std::vector<std::vector<ParsedConversion>>& parsedConversions);
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
@@ -25,7 +25,7 @@ namespace pcf2_attribution {
  * This class represents input data for a Private Attribution computation.
  * It processes an input csv and generates the std::vectors for each column
  */
-template <bool usingBatch, common::InputEncryption inputEncryption>
+template <common::InputEncryption inputEncryption>
 class AttributionInputMetrics {
  public:
   // Constructor -- input is a path to a CSV
@@ -42,19 +42,19 @@ class AttributionInputMetrics {
     return attributionRules_;
   }
 
-  const std::vector<ConversionT<usingBatch>>& getConversionArrays() const {
+  const std::vector<ConversionT<true>>& getConversionArrays() const {
     return convArrays_;
   }
 
-  const std::vector<TouchpointT<usingBatch>>& getTouchpointArrays() const {
+  const std::vector<TouchpointT<true>>& getTouchpointArrays() const {
     return tpArrays_;
   }
 
  private:
   std::vector<int64_t> ids_;
   std::vector<std::string> attributionRules_;
-  std::vector<TouchpointT<usingBatch>> tpArrays_;
-  std::vector<ConversionT<usingBatch>> convArrays_;
+  std::vector<TouchpointT<true>> tpArrays_;
+  std::vector<ConversionT<true>> convArrays_;
 
   /**
    * Parse touchpoints and add padding if necessary.
@@ -76,15 +76,13 @@ class AttributionInputMetrics {
   /**
    * Convert parsed touchpoints into touchpoints.
    */
-  const std::vector<TouchpointT<usingBatch>>
-  convertParsedTouchpointsToTouchpoints(
+  const std::vector<TouchpointT<true>> convertParsedTouchpointsToTouchpoints(
       const std::vector<std::vector<ParsedTouchpoint>>& parsedTouchpoints);
 
   /**
    * Convert parsed conversions into conversions.
    */
-  const std::vector<ConversionT<usingBatch>>
-  convertParsedConversionsToConversions(
+  const std::vector<ConversionT<true>> convertParsedConversionsToConversions(
       const std::vector<std::vector<ParsedConversion>>& parsedConversions);
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h
@@ -229,10 +229,10 @@ AttributionInputMetrics<inputEncryption>::convertParsedTouchpointsToTouchpoints(
 }
 
 template <common::InputEncryption inputEncryption>
-const std::vector<ConversionT<true>>
+const std::vector<Conversion>
 AttributionInputMetrics<inputEncryption>::convertParsedConversionsToConversions(
     const std::vector<std::vector<ParsedConversion>>& parsedConversions) {
-  std::vector<ConversionT<true>> conversions;
+  std::vector<Conversion> conversions;
 
   std::vector<std::vector<uint64_t>> timestamps(
       FLAGS_max_num_conversions, std::vector<uint64_t>{});
@@ -254,7 +254,7 @@ AttributionInputMetrics<inputEncryption>::convertParsedConversionsToConversions(
     }
   }
   for (size_t i = 0; i < timestamps.size(); ++i) {
-    conversions.push_back(Conversion<true>{
+    conversions.push_back(Conversion{
         timestamps.at(i), targetIds.at(i), actionTypes.at(i), values.at(i)});
   }
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
@@ -40,7 +40,7 @@ struct AttributionRule {
   // to the given conversion
   virtual SecBit<schedulerId, true> isAttributable(
       const PrivateTouchpoint<schedulerId, true, inputEncryption>&,
-      const PrivateConversion<schedulerId, true, inputEncryption>&,
+      const PrivateConversion<schedulerId, inputEncryption>&,
       const std::vector<SecTimestamp<schedulerId, true>>&) const = 0;
 
   // Compute touchpoint thresholds from plaintext touchpoints based on

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
@@ -21,10 +21,7 @@ const uint32_t kSecondsInOneDay = 86400; // 60 * 60 * 24
 const uint32_t kSecondsInTwentyEightDays = 2419200; // 60 * 60 * 24 * 28
 const uint32_t kSecondsInSevenDays = 604800; // 60 * 60 * 24 * 7
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 struct AttributionRule {
   AttributionRule(std::uint64_t _id, std::string _name)
       : id(_id), name(std::move(_name)) {}
@@ -41,22 +38,21 @@ struct AttributionRule {
 
   // Should return true if the given touchpoint is eligible to be attributed
   // to the given conversion
-  virtual SecBit<schedulerId, usingBatch> isAttributable(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&,
-      const PrivateConversion<schedulerId, usingBatch, inputEncryption>&,
-      const std::vector<SecTimestamp<schedulerId, usingBatch>>&) const = 0;
+  virtual SecBit<schedulerId, true> isAttributable(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>&,
+      const PrivateConversion<schedulerId, true, inputEncryption>&,
+      const std::vector<SecTimestamp<schedulerId, true>>&) const = 0;
 
   // Compute touchpoint thresholds from plaintext touchpoints based on
   // attribution rule
-  virtual std::vector<SecTimestamp<schedulerId, usingBatch>>
-  computeThresholdsPlaintext(const Touchpoint<usingBatch>&) const = 0;
+  virtual std::vector<SecTimestamp<schedulerId, true>>
+  computeThresholdsPlaintext(const Touchpoint<true>&) const = 0;
 
   // Compute touchpoint thresholds from private touchpoints based on attribution
   // rule
-  virtual std::vector<SecTimestamp<schedulerId, usingBatch>>
-  computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&,
-      const PrivateIsClick<schedulerId, usingBatch, inputEncryption>&,
+  virtual std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPrivate(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>&,
+      const PrivateIsClick<schedulerId, true, inputEncryption>&,
       size_t batchSize) const = 0;
 
   // Constructors for attribution rules, which can be found in

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
@@ -26,7 +26,7 @@ class LastClickRule : public AttributionRule<schedulerId, inputEncryption> {
 
   SecBit<schedulerId, true> isAttributable(
       const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     return (tp.ts < conv.ts) & (conv.ts <= thresholds.at(0));
@@ -83,7 +83,7 @@ class LastTouch_ClickNDays_ImpressionMDays
   /* if click within 28d, if touch within 1d */
   SecBit<schedulerId, true> isAttributable(
       const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     auto validConv = tp.ts < conv.ts;
@@ -160,7 +160,7 @@ class LastClick_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
   /* if click is within 7d but after 1d */
   SecBit<schedulerId, true> isAttributable(
       const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     auto validConv = tp.ts < conv.ts;
@@ -234,7 +234,7 @@ class LastTouch_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
 
   SecBit<schedulerId, true> isAttributable(
       const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     auto validConv = tp.ts < conv.ts;
@@ -319,7 +319,7 @@ class LastClick_1Day_TargetId
 
   SecBit<schedulerId, true> isAttributable(
       const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     return (tp.targetId == conv.targetId) & (tp.actionType == conv.actionType) &

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
@@ -14,97 +14,77 @@
 
 namespace pcf2_attribution {
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
-class LastClickRule
-    : public AttributionRule<schedulerId, usingBatch, inputEncryption> {
+template <int schedulerId, common::InputEncryption inputEncryption>
+class LastClickRule : public AttributionRule<schedulerId, inputEncryption> {
  public:
   LastClickRule(
       std::int64_t id,
       const std::string& name,
       const std::chrono::seconds& thresholdInSeconds)
-      : AttributionRule<schedulerId, usingBatch, inputEncryption>(id, name),
+      : AttributionRule<schedulerId, inputEncryption>(id, name),
         threshold_(thresholdInSeconds) {}
 
-  SecBit<schedulerId, usingBatch> isAttributable(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, usingBatch, inputEncryption>& conv,
-      const std::vector<SecTimestamp<schedulerId, usingBatch>>& thresholds)
+  SecBit<schedulerId, true> isAttributable(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
+      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     return (tp.ts < conv.ts) & (conv.ts <= thresholds.at(0));
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPlaintext(
-      const Touchpoint<usingBatch>& tp) const override {
-    ConditionalVector<uint32_t, usingBatch> thresholdNDaysClick;
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < tp.ts.size(); ++i) {
-        bool isValidClick = tp.isClick.at(i) && (tp.ts.at(i) > 0);
-        uint32_t thresholdNDays = tp.ts.at(i) + threshold_.count();
-        thresholdNDaysClick.push_back(isValidClick ? thresholdNDays : 0);
-      }
-    } else {
-      bool isValidClick = tp.isClick & (tp.ts > 0);
-      uint32_t thresholdNDays = tp.ts + threshold_.count();
-      thresholdNDaysClick = isValidClick ? thresholdNDays : 0;
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPlaintext(
+      const Touchpoint<true>& tp) const override {
+    std::vector<uint32_t> thresholdNDaysClick;
+    for (size_t i = 0; i < tp.ts.size(); ++i) {
+      bool isValidClick = tp.isClick.at(i) && (tp.ts.at(i) > 0);
+      uint32_t thresholdNDays = tp.ts.at(i) + threshold_.count();
+      thresholdNDaysClick.push_back(isValidClick ? thresholdNDays : 0);
     }
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        SecTimestamp<schedulerId, usingBatch>(
+
+    return std::vector<SecTimestamp<schedulerId, true>>{
+        SecTimestamp<schedulerId, true>(
             thresholdNDaysClick, common::PUBLISHER)};
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&
-          privateTp,
-      const PrivateIsClick<schedulerId, usingBatch, inputEncryption>&
-          privateIsClick,
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPrivate(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& privateTp,
+      const PrivateIsClick<schedulerId, true, inputEncryption>& privateIsClick,
       size_t batchSize) const override {
-    PubTimestamp<schedulerId, usingBatch> zero;
-    PubTimestamp<schedulerId, usingBatch> secondsInThreshold;
-    if constexpr (usingBatch) {
-      zero = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, 0));
-      secondsInThreshold = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, threshold_.count()));
-    } else {
-      zero = PubTimestamp<schedulerId, usingBatch>(uint32_t(0));
-      secondsInThreshold = PubTimestamp<schedulerId, usingBatch>(
-          static_cast<std::uint32_t>(threshold_.count()));
-    }
+    PubTimestamp<schedulerId, true> zero;
+    PubTimestamp<schedulerId, true> secondsInThreshold;
+
+    zero = PubTimestamp<schedulerId, true>(std::vector<uint32_t>(batchSize, 0));
+    secondsInThreshold = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, threshold_.count()));
+
     auto isValidClick = privateIsClick.isClick & (zero < privateTp.ts);
     auto thresholdNDays = privateTp.ts + secondsInThreshold;
     auto thresholdNDaysClick = zero.mux(isValidClick, thresholdNDays);
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        thresholdNDaysClick};
+    return std::vector<SecTimestamp<schedulerId, true>>{thresholdNDaysClick};
   }
 
  private:
   std::chrono::seconds threshold_;
 };
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 class LastTouch_ClickNDays_ImpressionMDays
-    : public AttributionRule<schedulerId, usingBatch, inputEncryption> {
+    : public AttributionRule<schedulerId, inputEncryption> {
  public:
   LastTouch_ClickNDays_ImpressionMDays(
       std::int64_t id,
       const std::string& name,
       std::chrono::seconds clickThreshold,
       std::chrono::seconds impressionThreshold)
-      : AttributionRule<schedulerId, usingBatch, inputEncryption>(id, name),
+      : AttributionRule<schedulerId, inputEncryption>(id, name),
         clickThreshold_(clickThreshold),
         impressionThreshold_(impressionThreshold) {}
 
   /* if click within 28d, if touch within 1d */
-  SecBit<schedulerId, usingBatch> isAttributable(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, usingBatch, inputEncryption>& conv,
-      const std::vector<SecTimestamp<schedulerId, usingBatch>>& thresholds)
+  SecBit<schedulerId, true> isAttributable(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
+      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     auto validConv = tp.ts < conv.ts;
     auto touchWithinMDays = conv.ts <= thresholds.at(0);
@@ -113,62 +93,42 @@ class LastTouch_ClickNDays_ImpressionMDays
     return validConv & (touchWithinMDays | clickWithinNDays);
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPlaintext(
-      const Touchpoint<usingBatch>& tp) const override {
-    ConditionalVector<uint32_t, usingBatch> thresholdMDaysTouch;
-    ConditionalVector<uint32_t, usingBatch> thresholdNDaysClick;
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < tp.ts.size(); ++i) {
-        bool isValid = tp.ts.at(i) > 0;
-        bool isValidClick = tp.isClick.at(i) & isValid;
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPlaintext(
+      const Touchpoint<true>& tp) const override {
+    std::vector<uint32_t> thresholdMDaysTouch;
+    std::vector<uint32_t> thresholdNDaysClick;
 
-        auto thresholdMDays = tp.ts.at(i) + impressionThreshold_.count();
-        thresholdMDaysTouch.push_back(isValid ? thresholdMDays : 0);
+    for (size_t i = 0; i < tp.ts.size(); ++i) {
+      bool isValid = tp.ts.at(i) > 0;
+      bool isValidClick = tp.isClick.at(i) & isValid;
 
-        auto thresholdNDays = tp.ts.at(i) + clickThreshold_.count();
-        thresholdNDaysClick.push_back(isValidClick ? thresholdNDays : 0);
-      }
-    } else {
-      bool isValid = tp.ts > 0;
-      bool isValidClick = tp.isClick & isValid;
+      auto thresholdMDays = tp.ts.at(i) + impressionThreshold_.count();
+      thresholdMDaysTouch.push_back(isValid ? thresholdMDays : 0);
 
-      auto thresholdMDays = tp.ts + impressionThreshold_.count();
-      thresholdMDaysTouch = isValid ? thresholdMDays : 0;
-
-      auto thresholdNDays = tp.ts + clickThreshold_.count();
-      thresholdNDaysClick = isValidClick ? thresholdNDays : 0;
+      auto thresholdNDays = tp.ts.at(i) + clickThreshold_.count();
+      thresholdNDaysClick.push_back(isValidClick ? thresholdNDays : 0);
     }
 
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        SecTimestamp<schedulerId, usingBatch>(
-            thresholdMDaysTouch, common::PUBLISHER),
-        SecTimestamp<schedulerId, usingBatch>(
+    return std::vector<SecTimestamp<schedulerId, true>>{
+        SecTimestamp<schedulerId, true>(thresholdMDaysTouch, common::PUBLISHER),
+        SecTimestamp<schedulerId, true>(
             thresholdNDaysClick, common::PUBLISHER)};
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&
-          privateTp,
-      const PrivateIsClick<schedulerId, usingBatch, inputEncryption>&
-          privateIsClick,
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPrivate(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& privateTp,
+      const PrivateIsClick<schedulerId, true, inputEncryption>& privateIsClick,
       size_t batchSize) const override {
-    PubTimestamp<schedulerId, usingBatch> zero;
-    PubTimestamp<schedulerId, usingBatch> secondsInMDays;
-    PubTimestamp<schedulerId, usingBatch> secondsInNDays;
-    if constexpr (usingBatch) {
-      zero = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, 0));
-      secondsInMDays = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, impressionThreshold_.count()));
-      secondsInNDays = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, clickThreshold_.count()));
-    } else {
-      zero = PubTimestamp<schedulerId, usingBatch>(uint32_t(0));
-      secondsInMDays = PubTimestamp<schedulerId, usingBatch>(
-          static_cast<std::uint32_t>(impressionThreshold_.count()));
-      secondsInNDays = PubTimestamp<schedulerId, usingBatch>(
-          static_cast<std::uint32_t>(clickThreshold_.count()));
-    }
+    PubTimestamp<schedulerId, true> zero;
+    PubTimestamp<schedulerId, true> secondsInMDays;
+    PubTimestamp<schedulerId, true> secondsInNDays;
+
+    zero = PubTimestamp<schedulerId, true>(std::vector<uint32_t>(batchSize, 0));
+    secondsInMDays = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, impressionThreshold_.count()));
+    secondsInNDays = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, clickThreshold_.count()));
+
     auto isValid = zero < privateTp.ts;
     auto isValidClick = privateIsClick.isClick & isValid;
     auto thresholdMDays = privateTp.ts + secondsInMDays;
@@ -176,7 +136,7 @@ class LastTouch_ClickNDays_ImpressionMDays
 
     auto thresholdNDays = privateTp.ts + secondsInNDays;
     auto thresholdNDaysClick = zero.mux(isValidClick, thresholdNDays);
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
+    return std::vector<SecTimestamp<schedulerId, true>>{
         thresholdMDaysTouch, thresholdNDaysClick};
   }
 
@@ -189,23 +149,19 @@ class LastTouch_ClickNDays_ImpressionMDays
   Attribute if the conversion took place within 7 days but
   more than 1 day after the touchpoint
 */
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
-class LastClick_2_7Days
-    : public AttributionRule<schedulerId, usingBatch, inputEncryption> {
+template <int schedulerId, common::InputEncryption inputEncryption>
+class LastClick_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
  public:
   LastClick_2_7Days()
-      : AttributionRule<schedulerId, usingBatch, inputEncryption>(
+      : AttributionRule<schedulerId, inputEncryption>(
             /* id */ 5,
             /* name */ common::LAST_CLICK_2_7D) {}
 
   /* if click is within 7d but after 1d */
-  SecBit<schedulerId, usingBatch> isAttributable(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, usingBatch, inputEncryption>& conv,
-      const std::vector<SecTimestamp<schedulerId, usingBatch>>& thresholds)
+  SecBit<schedulerId, true> isAttributable(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
+      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     auto validConv = tp.ts < conv.ts;
     auto clickAfterOneDay = thresholds.at(0) < conv.ts;
@@ -214,59 +170,41 @@ class LastClick_2_7Days
     return validConv & clickAfterOneDay & clickWithinSevenDays;
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPlaintext(
-      const Touchpoint<usingBatch>& tp) const override {
-    ConditionalVector<uint32_t, usingBatch> lowerBoundOneDayClick;
-    ConditionalVector<uint32_t, usingBatch> upperBoundSevenDaysClick;
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPlaintext(
+      const Touchpoint<true>& tp) const override {
+    std::vector<uint32_t> lowerBoundOneDayClick;
+    std::vector<uint32_t> upperBoundSevenDaysClick;
 
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < tp.ts.size(); ++i) {
-        bool isValidClick = tp.isClick.at(i) && (tp.ts.at(i) > 0);
-        uint32_t lowerBoundOneDay = tp.ts.at(i) + kSecondsInOneDay;
-        uint32_t upperBoundSevenDays = tp.ts.at(i) + kSecondsInSevenDays;
+    for (size_t i = 0; i < tp.ts.size(); ++i) {
+      bool isValidClick = tp.isClick.at(i) && (tp.ts.at(i) > 0);
+      uint32_t lowerBoundOneDay = tp.ts.at(i) + kSecondsInOneDay;
+      uint32_t upperBoundSevenDays = tp.ts.at(i) + kSecondsInSevenDays;
 
-        lowerBoundOneDayClick.push_back(isValidClick ? lowerBoundOneDay : 0);
-        upperBoundSevenDaysClick.push_back(
-            isValidClick ? upperBoundSevenDays : 0);
-      }
-    } else {
-      bool isValidClick = tp.isClick & (tp.ts > 0);
-      uint32_t lowerBoundOneDay = tp.ts + kSecondsInOneDay;
-      uint32_t upperBoundSevenDays = tp.ts + kSecondsInSevenDays;
-
-      lowerBoundOneDayClick = isValidClick ? lowerBoundOneDay : 0;
-      upperBoundSevenDaysClick = isValidClick ? upperBoundSevenDays : 0;
+      lowerBoundOneDayClick.push_back(isValidClick ? lowerBoundOneDay : 0);
+      upperBoundSevenDaysClick.push_back(
+          isValidClick ? upperBoundSevenDays : 0);
     }
 
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        SecTimestamp<schedulerId, usingBatch>(
+    return std::vector<SecTimestamp<schedulerId, true>>{
+        SecTimestamp<schedulerId, true>(
             lowerBoundOneDayClick, common::PUBLISHER),
-        SecTimestamp<schedulerId, usingBatch>(
+        SecTimestamp<schedulerId, true>(
             upperBoundSevenDaysClick, common::PUBLISHER)};
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&
-          privateTp,
-      const PrivateIsClick<schedulerId, usingBatch, inputEncryption>&
-          privateIsClick,
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPrivate(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& privateTp,
+      const PrivateIsClick<schedulerId, true, inputEncryption>& privateIsClick,
       size_t batchSize) const override {
-    PubTimestamp<schedulerId, usingBatch> zero;
-    PubTimestamp<schedulerId, usingBatch> secondsInOneDay;
-    PubTimestamp<schedulerId, usingBatch> secondsInSevenDays;
-    if constexpr (usingBatch) {
-      zero = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, 0));
-      secondsInOneDay = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, kSecondsInOneDay));
-      secondsInSevenDays = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, kSecondsInSevenDays));
-    } else {
-      zero = PubTimestamp<schedulerId, usingBatch>(uint32_t(0));
-      secondsInOneDay = PubTimestamp<schedulerId, usingBatch>(kSecondsInOneDay);
-      secondsInSevenDays =
-          PubTimestamp<schedulerId, usingBatch>(kSecondsInSevenDays);
-    }
+    PubTimestamp<schedulerId, true> zero;
+    PubTimestamp<schedulerId, true> secondsInOneDay;
+    PubTimestamp<schedulerId, true> secondsInSevenDays;
+
+    zero = PubTimestamp<schedulerId, true>(std::vector<uint32_t>(batchSize, 0));
+    secondsInOneDay = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, kSecondsInOneDay));
+    secondsInSevenDays = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, kSecondsInSevenDays));
 
     auto isValidClick = privateIsClick.isClick & (zero < privateTp.ts);
 
@@ -276,7 +214,7 @@ class LastClick_2_7Days
     auto upperBoundSevenDay = privateTp.ts + secondsInSevenDays;
     auto upperBoundSevenDayClick = zero.mux(isValidClick, upperBoundSevenDay);
 
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
+    return std::vector<SecTimestamp<schedulerId, true>>{
         lowerBoundOneDayClick, upperBoundSevenDayClick};
   }
 };
@@ -286,22 +224,18 @@ class LastClick_2_7Days
   most recent. If no such clicks exist, attribute to any
   impression in 1d, favoring the most recent.
 */
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
-class LastTouch_2_7Days
-    : public AttributionRule<schedulerId, usingBatch, inputEncryption> {
+template <int schedulerId, common::InputEncryption inputEncryption>
+class LastTouch_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
  public:
   LastTouch_2_7Days()
-      : AttributionRule<schedulerId, usingBatch, inputEncryption>(
+      : AttributionRule<schedulerId, inputEncryption>(
             /* id */ 6,
             /* name */ common::LAST_TOUCH_2_7D) {}
 
-  SecBit<schedulerId, usingBatch> isAttributable(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, usingBatch, inputEncryption>& conv,
-      const std::vector<SecTimestamp<schedulerId, usingBatch>>& thresholds)
+  SecBit<schedulerId, true> isAttributable(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
+      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     auto validConv = tp.ts < conv.ts;
     auto clickAfterOneDay = thresholds.at(0) < conv.ts;
@@ -313,69 +247,48 @@ class LastTouch_2_7Days
         ((clickAfterOneDay & clickWithinSevenDays) | touchWithinOneDay);
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPlaintext(
-      const Touchpoint<usingBatch>& tp) const override {
-    ConditionalVector<uint32_t, usingBatch> lowerBoundOneDayClick;
-    ConditionalVector<uint32_t, usingBatch> upperBoundSevenDaysClick;
-    ConditionalVector<uint32_t, usingBatch> upperBoundOneDayTouch;
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPlaintext(
+      const Touchpoint<true>& tp) const override {
+    std::vector<uint32_t> lowerBoundOneDayClick;
+    std::vector<uint32_t> upperBoundSevenDaysClick;
+    std::vector<uint32_t> upperBoundOneDayTouch;
 
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < tp.ts.size(); ++i) {
-        bool isValid = tp.ts.at(i) > 0;
-        bool isValidClick = tp.isClick.at(i) & isValid;
-        uint32_t lowerBoundAndUpperBoundOneDay = tp.ts.at(i) + kSecondsInOneDay;
-        uint32_t upperBoundSevenDays = tp.ts.at(i) + kSecondsInSevenDays;
+    for (size_t i = 0; i < tp.ts.size(); ++i) {
+      bool isValid = tp.ts.at(i) > 0;
+      bool isValidClick = tp.isClick.at(i) & isValid;
+      uint32_t lowerBoundAndUpperBoundOneDay = tp.ts.at(i) + kSecondsInOneDay;
+      uint32_t upperBoundSevenDays = tp.ts.at(i) + kSecondsInSevenDays;
 
-        lowerBoundOneDayClick.push_back(
-            isValidClick ? lowerBoundAndUpperBoundOneDay : 0);
-        upperBoundSevenDaysClick.push_back(
-            isValidClick ? upperBoundSevenDays : 0);
-        upperBoundOneDayTouch.push_back(
-            (isValid && !isValidClick) ? lowerBoundAndUpperBoundOneDay : 0);
-      }
-    } else {
-      bool isValid = tp.ts > 0;
-      bool isValidClick = tp.isClick & isValid;
-      uint32_t lowerBoundAndUpperBoundOneDay = tp.ts + kSecondsInOneDay;
-      uint32_t upperBoundSevenDays = tp.ts + kSecondsInSevenDays;
-
-      lowerBoundOneDayClick = isValidClick ? lowerBoundAndUpperBoundOneDay : 0;
-      upperBoundSevenDaysClick = isValidClick ? upperBoundSevenDays : 0;
-      upperBoundOneDayTouch =
-          (isValid & !isValidClick) ? lowerBoundAndUpperBoundOneDay : 0;
+      lowerBoundOneDayClick.push_back(
+          isValidClick ? lowerBoundAndUpperBoundOneDay : 0);
+      upperBoundSevenDaysClick.push_back(
+          isValidClick ? upperBoundSevenDays : 0);
+      upperBoundOneDayTouch.push_back(
+          (isValid && !isValidClick) ? lowerBoundAndUpperBoundOneDay : 0);
     }
 
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        SecTimestamp<schedulerId, usingBatch>(
+    return std::vector<SecTimestamp<schedulerId, true>>{
+        SecTimestamp<schedulerId, true>(
             lowerBoundOneDayClick, common::PUBLISHER),
-        SecTimestamp<schedulerId, usingBatch>(
+        SecTimestamp<schedulerId, true>(
             upperBoundSevenDaysClick, common::PUBLISHER),
-        SecTimestamp<schedulerId, usingBatch>(
+        SecTimestamp<schedulerId, true>(
             upperBoundOneDayTouch, common::PUBLISHER)};
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&
-          privateTp,
-      const PrivateIsClick<schedulerId, usingBatch, inputEncryption>&
-          privateIsClick,
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPrivate(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& privateTp,
+      const PrivateIsClick<schedulerId, true, inputEncryption>& privateIsClick,
       size_t batchSize) const override {
-    PubTimestamp<schedulerId, usingBatch> zero;
-    PubTimestamp<schedulerId, usingBatch> secondsInOneDay;
-    PubTimestamp<schedulerId, usingBatch> secondsInSevenDays;
-    if constexpr (usingBatch) {
-      zero = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, 0));
-      secondsInOneDay = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, kSecondsInOneDay));
-      secondsInSevenDays = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, kSecondsInSevenDays));
-    } else {
-      zero = PubTimestamp<schedulerId, usingBatch>(uint32_t(0));
-      secondsInOneDay = PubTimestamp<schedulerId, usingBatch>(kSecondsInOneDay);
-      secondsInSevenDays =
-          PubTimestamp<schedulerId, usingBatch>(kSecondsInSevenDays);
-    }
+    PubTimestamp<schedulerId, true> zero;
+    PubTimestamp<schedulerId, true> secondsInOneDay;
+    PubTimestamp<schedulerId, true> secondsInSevenDays;
+
+    zero = PubTimestamp<schedulerId, true>(std::vector<uint32_t>(batchSize, 0));
+    secondsInOneDay = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, kSecondsInOneDay));
+    secondsInSevenDays = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, kSecondsInSevenDays));
 
     auto isValid = zero < privateTp.ts;
     auto isValidClick = privateIsClick.isClick & isValid;
@@ -390,73 +303,59 @@ class LastTouch_2_7Days
     auto upperBoundOneDayTouch =
         zero.mux((isValid & !isValidClick), lowerBoundAndUpperBoundOneDay);
 
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
+    return std::vector<SecTimestamp<schedulerId, true>>{
         lowerBoundOneDayClick, upperBoundSevenDayClick, upperBoundOneDayTouch};
   }
 };
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 class LastClick_1Day_TargetId
-    : public AttributionRule<schedulerId, usingBatch, inputEncryption> {
+    : public AttributionRule<schedulerId, inputEncryption> {
  public:
   LastClick_1Day_TargetId()
-      : AttributionRule<schedulerId, usingBatch, inputEncryption>(
+      : AttributionRule<schedulerId, inputEncryption>(
             /* id */ 7,
             /* name */ common::LAST_CLICK_1D_TARGETID) {}
 
-  SecBit<schedulerId, usingBatch> isAttributable(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>& tp,
-      const PrivateConversion<schedulerId, usingBatch, inputEncryption>& conv,
-      const std::vector<SecTimestamp<schedulerId, usingBatch>>& thresholds)
+  SecBit<schedulerId, true> isAttributable(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& tp,
+      const PrivateConversion<schedulerId, true, inputEncryption>& conv,
+      const std::vector<SecTimestamp<schedulerId, true>>& thresholds)
       const override {
     return (tp.targetId == conv.targetId) & (tp.actionType == conv.actionType) &
         (tp.ts < conv.ts) & (conv.ts <= thresholds.at(0));
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPlaintext(
-      const Touchpoint<usingBatch>& tp) const override {
-    ConditionalVector<uint32_t, usingBatch> thresholdOneDayClick;
-    if constexpr (usingBatch) {
-      for (size_t i = 0; i < tp.ts.size(); ++i) {
-        bool isValidClick = tp.isClick.at(i) && (tp.ts.at(i) > 0);
-        uint32_t thresholdOneDay = tp.ts.at(i) + kSecondsInOneDay;
-        thresholdOneDayClick.push_back(isValidClick ? thresholdOneDay : 0);
-      }
-    } else {
-      bool isValidClick = tp.isClick & (tp.ts > 0);
-      uint32_t thresholdOneDay = tp.ts + kSecondsInOneDay;
-      thresholdOneDayClick = isValidClick ? thresholdOneDay : 0;
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPlaintext(
+      const Touchpoint<true>& tp) const override {
+    std::vector<uint32_t> thresholdOneDayClick;
+
+    for (size_t i = 0; i < tp.ts.size(); ++i) {
+      bool isValidClick = tp.isClick.at(i) && (tp.ts.at(i) > 0);
+      uint32_t thresholdOneDay = tp.ts.at(i) + kSecondsInOneDay;
+      thresholdOneDayClick.push_back(isValidClick ? thresholdOneDay : 0);
     }
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        SecTimestamp<schedulerId, usingBatch>(
+
+    return std::vector<SecTimestamp<schedulerId, true>>{
+        SecTimestamp<schedulerId, true>(
             thresholdOneDayClick, common::PUBLISHER)};
   }
 
-  std::vector<SecTimestamp<schedulerId, usingBatch>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>&
-          privateTp,
-      const PrivateIsClick<schedulerId, usingBatch, inputEncryption>&
-          privateIsClick,
+  std::vector<SecTimestamp<schedulerId, true>> computeThresholdsPrivate(
+      const PrivateTouchpoint<schedulerId, true, inputEncryption>& privateTp,
+      const PrivateIsClick<schedulerId, true, inputEncryption>& privateIsClick,
       size_t batchSize) const override {
-    PubTimestamp<schedulerId, usingBatch> zero;
-    PubTimestamp<schedulerId, usingBatch> secondsInOneDay;
-    if constexpr (usingBatch) {
-      zero = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, 0));
-      secondsInOneDay = PubTimestamp<schedulerId, usingBatch>(
-          std::vector<uint32_t>(batchSize, kSecondsInOneDay));
-    } else {
-      zero = PubTimestamp<schedulerId, usingBatch>(uint32_t(0));
-      secondsInOneDay = PubTimestamp<schedulerId, usingBatch>(kSecondsInOneDay);
-    }
+    PubTimestamp<schedulerId, true> zero;
+    PubTimestamp<schedulerId, true> secondsInOneDay;
+
+    zero = PubTimestamp<schedulerId, true>(std::vector<uint32_t>(batchSize, 0));
+    secondsInOneDay = PubTimestamp<schedulerId, true>(
+        std::vector<uint32_t>(batchSize, kSecondsInOneDay));
+
     auto isValidClick = privateIsClick.isClick & (zero < privateTp.ts);
     auto thresholdOneDay = privateTp.ts + secondsInOneDay;
     auto thresholdOneDayClick = zero.mux(isValidClick, thresholdOneDay);
-    return std::vector<SecTimestamp<schedulerId, usingBatch>>{
-        thresholdOneDayClick};
+    return std::vector<SecTimestamp<schedulerId, true>>{thresholdOneDayClick};
   }
 };
 
@@ -470,52 +369,40 @@ auto days = [](std::uint64_t numDays) {
 
 } // namespace detail
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 inline const auto SUPPORTED_ATTRIBUTION_RULES = std::vector<
-    std::shared_ptr<AttributionRule<schedulerId, usingBatch, inputEncryption>>>{
-    std::make_shared<LastClickRule<schedulerId, usingBatch, inputEncryption>>(
+    std::shared_ptr<AttributionRule<schedulerId, inputEncryption>>>{
+    std::make_shared<LastClickRule<schedulerId, inputEncryption>>(
         /* id */ 1,
         /* name */ common::LAST_CLICK_1D,
         detail::days(1)),
-    std::make_shared<LastClickRule<schedulerId, usingBatch, inputEncryption>>(
+    std::make_shared<LastClickRule<schedulerId, inputEncryption>>(
         /* id */ 2,
         /* name */ common::LAST_CLICK_28D,
         detail::days(28)),
     std::make_shared<LastTouch_ClickNDays_ImpressionMDays<
         schedulerId,
-        usingBatch,
+
         inputEncryption>>(
         /* id */ 3,
         /* name */ common::LAST_TOUCH_1D,
         detail::days(1),
         detail::days(1)),
-    std::make_shared<LastTouch_ClickNDays_ImpressionMDays<
-        schedulerId,
-        usingBatch,
-        inputEncryption>>(
+    std::make_shared<
+        LastTouch_ClickNDays_ImpressionMDays<schedulerId, inputEncryption>>(
         /* id */ 4,
         /* name */ common::LAST_TOUCH_28D,
         detail::days(28),
         detail::days(1)),
-    std::make_shared<
-        LastClick_2_7Days<schedulerId, usingBatch, inputEncryption>>(),
-    std::make_shared<
-        LastTouch_2_7Days<schedulerId, usingBatch, inputEncryption>>(),
-    std::make_shared<
-        LastClick_1Day_TargetId<schedulerId, usingBatch, inputEncryption>>()};
+    std::make_shared<LastClick_2_7Days<schedulerId, inputEncryption>>(),
+    std::make_shared<LastTouch_2_7Days<schedulerId, inputEncryption>>(),
+    std::make_shared<LastClick_1Day_TargetId<schedulerId, inputEncryption>>()};
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
-std::shared_ptr<const AttributionRule<schedulerId, usingBatch, inputEncryption>>
-AttributionRule<schedulerId, usingBatch, inputEncryption>::fromNameOrThrow(
+template <int schedulerId, common::InputEncryption inputEncryption>
+std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>
+AttributionRule<schedulerId, inputEncryption>::fromNameOrThrow(
     const std::string& name) {
-  for (auto& rule :
-       SUPPORTED_ATTRIBUTION_RULES<schedulerId, usingBatch, inputEncryption>) {
+  for (auto& rule : SUPPORTED_ATTRIBUTION_RULES<schedulerId, inputEncryption>) {
     if (rule->name == name) {
       return rule;
     }
@@ -524,15 +411,10 @@ AttributionRule<schedulerId, usingBatch, inputEncryption>::fromNameOrThrow(
   throw std::runtime_error("Unknown attribution rule name: " + name);
 }
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
-std::shared_ptr<const AttributionRule<schedulerId, usingBatch, inputEncryption>>
-AttributionRule<schedulerId, usingBatch, inputEncryption>::fromIdOrThrow(
-    std::int64_t id) {
-  for (auto& rule :
-       SUPPORTED_ATTRIBUTION_RULES<schedulerId, usingBatch, inputEncryption>) {
+template <int schedulerId, common::InputEncryption inputEncryption>
+std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>
+AttributionRule<schedulerId, inputEncryption>::fromIdOrThrow(std::int64_t id) {
+  for (auto& rule : SUPPORTED_ATTRIBUTION_RULES<schedulerId, inputEncryption>) {
     if (rule->id == id) {
       return rule;
     }

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -12,51 +12,42 @@
 
 namespace pcf2_attribution {
 
-template <bool usingBatch>
 struct Conversion {
-  ConditionalVector<uint64_t, usingBatch> ts;
-  ConditionalVector<uint64_t, usingBatch> targetId;
-  ConditionalVector<uint64_t, usingBatch> actionType;
-  ConditionalVector<uint64_t, usingBatch> convValue;
+  std::vector<uint64_t> ts;
+  std::vector<uint64_t> targetId;
+  std::vector<uint64_t> actionType;
+  std::vector<uint64_t> convValue;
 };
 
-template <bool usingBatch>
-using ConversionT = ConditionalVector<Conversion<usingBatch>, !usingBatch>;
-
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 struct PrivateConversion {
-  SecTimestamp<schedulerId, usingBatch> ts;
-  SecTargetId<schedulerId, usingBatch> targetId;
-  SecActionType<schedulerId, usingBatch> actionType;
-  SecConvValue<schedulerId, usingBatch> convValue;
+  SecTimestamp<schedulerId, true> ts;
+  SecTargetId<schedulerId, true> targetId;
+  SecActionType<schedulerId, true> actionType;
+  SecConvValue<schedulerId, true> convValue;
 
-  explicit PrivateConversion(const Conversion<usingBatch>& conversion) {
+  explicit PrivateConversion(const Conversion& conversion) {
     if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
-      ts =
-          SecTimestamp<schedulerId, usingBatch>(conversion.ts, common::PARTNER);
-      targetId = SecTargetId<schedulerId, usingBatch>(
-          conversion.targetId, common::PARTNER);
-      actionType = SecActionType<schedulerId, usingBatch>(
+      ts = SecTimestamp<schedulerId, true>(conversion.ts, common::PARTNER);
+      targetId =
+          SecTargetId<schedulerId, true>(conversion.targetId, common::PARTNER);
+      actionType = SecActionType<schedulerId, true>(
           conversion.actionType, common::PARTNER);
-      convValue = SecConvValue<schedulerId, usingBatch>(
+      convValue = SecConvValue<schedulerId, true>(
           conversion.convValue, common::PARTNER);
     } else {
-      typename SecTimestamp<schedulerId, usingBatch>::ExtractedInt extractedTs(
+      typename SecTimestamp<schedulerId, true>::ExtractedInt extractedTs(
           conversion.ts);
-      ts = SecTimestamp<schedulerId, usingBatch>(std::move(extractedTs));
-      typename SecTargetId<schedulerId, usingBatch>::ExtractedInt extractedTids(
+      ts = SecTimestamp<schedulerId, true>(std::move(extractedTs));
+      typename SecTargetId<schedulerId, true>::ExtractedInt extractedTids(
           conversion.targetId);
-      targetId = SecTargetId<schedulerId, usingBatch>(std::move(extractedTids));
-      typename SecActionType<schedulerId, usingBatch>::ExtractedInt
-          extractedAids(conversion.actionType);
-      actionType =
-          SecActionType<schedulerId, usingBatch>(std::move(extractedAids));
-      typename SecConvValue<schedulerId, usingBatch>::ExtractedInt extractedVs(
+      targetId = SecTargetId<schedulerId, true>(std::move(extractedTids));
+      typename SecActionType<schedulerId, true>::ExtractedInt extractedAids(
+          conversion.actionType);
+      actionType = SecActionType<schedulerId, true>(std::move(extractedAids));
+      typename SecConvValue<schedulerId, true>::ExtractedInt extractedVs(
           conversion.convValue);
-      convValue = SecConvValue<schedulerId, usingBatch>(std::move(extractedVs));
+      convValue = SecConvValue<schedulerId, true>(std::move(extractedVs));
     }
   }
 };

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -99,7 +99,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     // Publisher uses even schedulerId and partner uses odd schedulerId
     auto app = std::make_unique<
         pcf2_attribution::
-            AttributionApp<PARTY, 2 * index + PARTY, true, inputEncryption>>(
+            AttributionApp<PARTY, 2 * index + PARTY, inputEncryption>>(
         std::move(communicationAgentFactory),
         attributionRules,
         inputFilenames,

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -51,7 +51,6 @@ int main(int argc, char* argv[]) {
   common::SchedulerStatistics schedulerStatistics;
 
   // use batched attribution by default
-  const bool usingBatch = true;
   bool useXorEncryption = FLAGS_use_xor_encryption;
   try {
     auto [inputFilenames, outputFilenames] = pcf2_attribution::getIOFilenames(
@@ -81,7 +80,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::PartnerXor>(
                 useXorEncryption,
                 inputFilenames,
@@ -95,7 +94,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::Xor>(
                 useXorEncryption,
                 inputFilenames,
@@ -109,7 +108,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::Plaintext>(
                 useXorEncryption,
                 inputFilenames,
@@ -129,7 +128,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::PartnerXor>(
                 useXorEncryption,
                 inputFilenames,
@@ -143,7 +142,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::Xor>(
                 useXorEncryption,
                 inputFilenames,
@@ -158,7 +157,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::Plaintext>(
                 useXorEncryption,
                 inputFilenames,

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -133,16 +133,12 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
       false,
       false};
 
-  auto lastClick1D = AttributionRule<
-      common::PUBLISHER,
-      true,
-      common::InputEncryption::Plaintext>::
-      fromNameOrThrow(common::LAST_CLICK_1D);
-  auto lastTouch1D = AttributionRule<
-      common::PUBLISHER,
-      true,
-      common::InputEncryption::Plaintext>::
-      fromNameOrThrow(common::LAST_TOUCH_1D);
+  auto lastClick1D =
+      AttributionRule<common::PUBLISHER, common::InputEncryption::Plaintext>::
+          fromNameOrThrow(common::LAST_CLICK_1D);
+  auto lastTouch1D =
+      AttributionRule<common::PUBLISHER, common::InputEncryption::Plaintext>::
+          fromNameOrThrow(common::LAST_TOUCH_1D);
   auto thresholdsLastClick1D = game.privatelyShareThresholds(
       touchpoints, privateTouchpoints, *lastClick1D, 2);
   auto thresholdsLastTouch1D = game.privatelyShareThresholds(
@@ -231,12 +227,12 @@ TEST(AttributionGameTest, TestAttributionReformattedOutputLogicPlaintextBatch) {
 
   auto lastClick1D = AttributionRule<
       common::PUBLISHER,
-      true,
+
       common::InputEncryption::Plaintext>::
       fromNameOrThrow(common::LAST_CLICK_1D);
   auto lastTouch1D = AttributionRule<
       common::PUBLISHER,
-      true,
+
       common::InputEncryption::Plaintext>::
       fromNameOrThrow(common::LAST_TOUCH_1D);
   auto thresholdsLastClick1D = game.privatelyShareThresholds(

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -72,8 +72,8 @@ TEST(AttributionGameTest, TestPrivateConversionPlaintextBatch) {
   std::vector<uint64_t> timestamp0{100, 50, 0};
   std::vector<uint64_t> timestamp1{99, 49, 3};
 
-  std::vector<Conversion<true>> conversions{
-      Conversion<true>{.ts = timestamp0}, Conversion<true>{.ts = timestamp1}};
+  std::vector<Conversion> conversions{
+      Conversion{.ts = timestamp0}, Conversion{.ts = timestamp1}};
 
   AttributionGame<common::PUBLISHER, common::InputEncryption::Plaintext> game(
       std::make_unique<fbpcf::scheduler::PlaintextScheduler>(
@@ -99,10 +99,8 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
       Touchpoint<true>{{1, 1}, {true, true}, {100, 100}},
       Touchpoint<true>{{2, 2}, {true, true}, {200, 200}}};
 
-  std::vector<Conversion<true>> conversions{
-      Conversion<true>{{50, 50}},
-      Conversion<true>{{150, 150}},
-      Conversion<true>{{87000, 87000}}};
+  std::vector<Conversion> conversions{
+      Conversion{{50, 50}}, Conversion{{150, 150}}, Conversion{{87000, 87000}}};
 
   AttributionGame<common::PUBLISHER, common::InputEncryption::Plaintext> game(
       std::make_unique<fbpcf::scheduler::PlaintextScheduler>(
@@ -201,10 +199,10 @@ TEST(AttributionGameTest, TestAttributionReformattedOutputLogicPlaintextBatch) {
           .ts = {200, 200},
           .adId = {3, 3}}};
 
-  std::vector<Conversion<true>> conversions{
-      Conversion<true>{.ts = {50, 50}, .convValue = {20, 20}},
-      Conversion<true>{.ts = {150, 150}, .convValue = {40, 40}},
-      Conversion<true>{.ts = {87000, 87000}, .convValue = {60, 60}}};
+  std::vector<Conversion> conversions{
+      Conversion{.ts = {50, 50}, .convValue = {20, 20}},
+      Conversion{.ts = {150, 150}, .convValue = {40, 40}},
+      Conversion{.ts = {87000, 87000}, .convValue = {60, 60}}};
 
   AttributionGame<common::PUBLISHER, common::InputEncryption::Plaintext> game(
       std::make_unique<fbpcf::scheduler::PlaintextScheduler>(


### PR DESCRIPTION
Summary:
Context: in attribution games, we always use batch mode for the sake of performance. IN this stack of diffs, we are gradually remove the code for non-batch path and hardcode usingbatch = true.

We are taking a top-down approach to delete this flag layer by layer.

This diff contains the change to the conversion-related objects

Reviewed By: zhangpuhan

Differential Revision: D43103048

