### PR TITLE
Gradually remove 'usingBatch' - attribution app

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -17,11 +17,7 @@
 
 namespace pcf2_attribution {
 
-template <
-    int MY_ROLE,
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int MY_ROLE, int schedulerId, common::InputEncryption inputEncryption>
 class AttributionApp {
  public:
   AttributionApp(
@@ -54,7 +50,7 @@ class AttributionApp {
               MY_ROLE, *communicationAgentFactory_, metricCollector_)
               .create();
 
-    AttributionGame<schedulerId, usingBatch, inputEncryption> game(
+    AttributionGame<schedulerId, true, inputEncryption> game(
         std::move(scheduler));
 
     // Compute attributions sequentially on numFiles files, starting from
@@ -96,12 +92,12 @@ class AttributionApp {
   }
 
  protected:
-  AttributionInputMetrics<usingBatch, inputEncryption> getInputData(
+  AttributionInputMetrics<true, inputEncryption> getInputData(
       std::string inputPath) {
     XLOG(INFO) << "MY_ROLE: " << MY_ROLE << ", schedulerId: " << schedulerId
                << ", attributionRules_: " << attributionRules_
                << ", input_path: " << inputPath;
-    return AttributionInputMetrics<usingBatch, inputEncryption>{
+    return AttributionInputMetrics<true, inputEncryption>{
         MY_ROLE, attributionRules_, inputPath};
   }
 

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -99,7 +99,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     // Publisher uses even schedulerId and partner uses odd schedulerId
     auto app = std::make_unique<
         pcf2_attribution::
-            AttributionApp<PARTY, 2 * index + PARTY, true, inputEncryption>>(
+            AttributionApp<PARTY, 2 * index + PARTY, inputEncryption>>(
         std::move(communicationAgentFactory),
         attributionRules,
         inputFilenames,

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -51,7 +51,6 @@ int main(int argc, char* argv[]) {
   common::SchedulerStatistics schedulerStatistics;
 
   // use batched attribution by default
-  const bool usingBatch = true;
   bool useXorEncryption = FLAGS_use_xor_encryption;
   try {
     auto [inputFilenames, outputFilenames] = pcf2_attribution::getIOFilenames(
@@ -81,7 +80,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::PartnerXor>(
                 useXorEncryption,
                 inputFilenames,
@@ -95,7 +94,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::Xor>(
                 useXorEncryption,
                 inputFilenames,
@@ -109,7 +108,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::Plaintext>(
                 useXorEncryption,
                 inputFilenames,
@@ -129,7 +128,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::PartnerXor>(
                 useXorEncryption,
                 inputFilenames,
@@ -143,7 +142,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::Xor>(
                 useXorEncryption,
                 inputFilenames,
@@ -158,7 +157,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::Plaintext>(
                 useXorEncryption,
                 inputFilenames,


### PR DESCRIPTION
Summary:
Context: in attribution games, we always use batch mode for the sake of performance. IN this stack of diffs, we are gradually remove the code for non-batch path and hardcode usingbatch = true.

We are taking a top-down approach to delete this flag layer by layer.

This diff contains the change to attribution app class

Reviewed By: haochenuw

Differential Revision: D43103050

