### PR TITLE
Gradually remove 'usingBatch' - attribution game and metrics

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -50,8 +50,7 @@ class AttributionApp {
               MY_ROLE, *communicationAgentFactory_, metricCollector_)
               .create();
 
-    AttributionGame<schedulerId, true, inputEncryption> game(
-        std::move(scheduler));
+    AttributionGame<schedulerId, inputEncryption> game(std::move(scheduler));
 
     // Compute attributions sequentially on numFiles files, starting from
     // startFileIndex
@@ -92,12 +91,11 @@ class AttributionApp {
   }
 
  protected:
-  AttributionInputMetrics<true, inputEncryption> getInputData(
-      std::string inputPath) {
+  AttributionInputMetrics<inputEncryption> getInputData(std::string inputPath) {
     XLOG(INFO) << "MY_ROLE: " << MY_ROLE << ", schedulerId: " << schedulerId
                << ", attributionRules_: " << attributionRules_
                << ", input_path: " << inputPath;
-    return AttributionInputMetrics<true, inputEncryption>{
+    return AttributionInputMetrics<inputEncryption>{
         MY_ROLE, attributionRules_, inputPath};
   }
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -17,11 +17,7 @@
 
 namespace pcf2_attribution {
 
-template <
-    int MY_ROLE,
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int MY_ROLE, int schedulerId, common::InputEncryption inputEncryption>
 class AttributionApp {
  public:
   AttributionApp(
@@ -54,7 +50,7 @@ class AttributionApp {
               MY_ROLE, *communicationAgentFactory_, metricCollector_)
               .create();
 
-    AttributionGame<schedulerId, usingBatch, inputEncryption> game(
+    AttributionGame<schedulerId, true, inputEncryption> game(
         std::move(scheduler));
 
     // Compute attributions sequentially on numFiles files, starting from
@@ -96,12 +92,12 @@ class AttributionApp {
   }
 
  protected:
-  AttributionInputMetrics<usingBatch, inputEncryption> getInputData(
+  AttributionInputMetrics<true, inputEncryption> getInputData(
       std::string inputPath) {
     XLOG(INFO) << "MY_ROLE: " << MY_ROLE << ", schedulerId: " << schedulerId
                << ", attributionRules_: " << attributionRules_
                << ", input_path: " << inputPath;
-    return AttributionInputMetrics<usingBatch, inputEncryption>{
+    return AttributionInputMetrics<true, inputEncryption>{
         MY_ROLE, attributionRules_, inputPath};
   }
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -20,10 +20,7 @@
 
 namespace pcf2_attribution {
 
-template <
-    int schedulerId,
-    bool usingBatch,
-    common::InputEncryption inputEncryption>
+template <int schedulerId, common::InputEncryption inputEncryption>
 class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
  public:
   explicit AttributionGame(
@@ -32,21 +29,19 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   AttributionOutputMetrics computeAttributions(
       const int myRole,
-      const AttributionInputMetrics<usingBatch, inputEncryption>& inputData);
+      const AttributionInputMetrics<inputEncryption>& inputData);
 
-  using PrivateTouchpointT = ConditionalVector<
-      PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>,
-      !usingBatch>;
+  using PrivateTouchpointT =
+      PrivateTouchpoint<schedulerId, true, inputEncryption>;
 
-  using PrivateConversionT = ConditionalVector<
-      PrivateConversion<schedulerId, usingBatch, inputEncryption>,
-      !usingBatch>;
+  using PrivateConversionT =
+      PrivateConversion<schedulerId, true, inputEncryption>;
 
   /**
    * Publisher shares attribution rules with partner.
    */
   std::vector<std::shared_ptr<
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>>>
+      const AttributionRule<schedulerId, true, inputEncryption>>>
   shareAttributionRules(
       const int myRole,
       const std::vector<std::string>& attributionRuleNames);
@@ -55,23 +50,23 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    * Publisher shares touchpoints with partner.
    */
   std::vector<PrivateTouchpointT> privatelyShareTouchpoints(
-      const std::vector<TouchpointT<usingBatch>>& touchpoints);
+      const std::vector<TouchpointT<true>>& touchpoints);
 
   /**
    * Partner shares conversions with publisher.
    */
   std::vector<PrivateConversionT> privatelyShareConversions(
-      const std::vector<ConversionT<usingBatch>>& conversions);
+      const std::vector<ConversionT<true>>& conversions);
 
   /**
    * Publisher shares touchpoints thresholds, to optimize attribution
    * computation.
    */
-  std::vector<std::vector<SecTimestampT<schedulerId, usingBatch>>>
+  std::vector<std::vector<SecTimestampT<schedulerId, true>>>
   privatelyShareThresholds(
-      const std::vector<TouchpointT<usingBatch>>& touchpoints,
+      const std::vector<TouchpointT<true>>& touchpoints,
       const std::vector<PrivateTouchpointT>& privateTouchpoints,
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>&
+      const AttributionRule<schedulerId, true, inputEncryption>&
           attributionRule,
       size_t batchSize);
 
@@ -80,13 +75,13 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    */
   const std::vector<uint64_t> retrieveValidOriginalAdIds(
       const int myRole,
-      std::vector<TouchpointT<usingBatch>>& touchpoints);
+      std::vector<TouchpointT<true>>& touchpoints);
   /**
    * Create a compression map of the original Ad Id with the compressed Ad ID
    */
 
   void replaceAdIdWithCompressedAdId(
-      std::vector<TouchpointT<usingBatch>>& touchpoints,
+      std::vector<TouchpointT<true>>& touchpoints,
       std::vector<uint64_t>& validOriginalAdIds);
 
   void putAdIdMappingJson(
@@ -96,30 +91,26 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   /**
    * Helper method for computing attributions.
    */
-  const std::vector<SecBit<schedulerId, usingBatch>> computeAttributionsHelper(
-      const std::vector<
-          PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>>&
+  const std::vector<SecBit<schedulerId, true>> computeAttributionsHelper(
+      const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,
-      const std::vector<
-          PrivateConversion<schedulerId, usingBatch, inputEncryption>>&
+      const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
           conversions,
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>&
+      const AttributionRule<schedulerId, true, inputEncryption>&
           attributionRule,
-      const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
+      const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
           thresholds,
       size_t batchSize);
 
-  const std::vector<AttributionReformattedOutputFmt<schedulerId, usingBatch>>
+  const std::vector<AttributionReformattedOutputFmt<schedulerId, true>>
   computeAttributionsHelperV2(
-      const std::vector<
-          PrivateTouchpoint<schedulerId, usingBatch, inputEncryption>>&
+      const std::vector<PrivateTouchpoint<schedulerId, true, inputEncryption>>&
           touchpoints,
-      const std::vector<
-          PrivateConversion<schedulerId, usingBatch, inputEncryption>>&
+      const std::vector<PrivateConversion<schedulerId, true, inputEncryption>>&
           conversions,
-      const AttributionRule<schedulerId, usingBatch, inputEncryption>&
+      const AttributionRule<schedulerId, true, inputEncryption>&
           attributionRule,
-      const std::vector<std::vector<SecTimestamp<schedulerId, usingBatch>>>&
+      const std::vector<std::vector<SecTimestamp<schedulerId, true>>>&
           thresholds,
       size_t batchSize);
 };

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
@@ -25,7 +25,7 @@ namespace pcf2_attribution {
  * This class represents input data for a Private Attribution computation.
  * It processes an input csv and generates the std::vectors for each column
  */
-template <bool usingBatch, common::InputEncryption inputEncryption>
+template <common::InputEncryption inputEncryption>
 class AttributionInputMetrics {
  public:
   // Constructor -- input is a path to a CSV
@@ -42,19 +42,19 @@ class AttributionInputMetrics {
     return attributionRules_;
   }
 
-  const std::vector<ConversionT<usingBatch>>& getConversionArrays() const {
+  const std::vector<ConversionT<true>>& getConversionArrays() const {
     return convArrays_;
   }
 
-  const std::vector<TouchpointT<usingBatch>>& getTouchpointArrays() const {
+  const std::vector<TouchpointT<true>>& getTouchpointArrays() const {
     return tpArrays_;
   }
 
  private:
   std::vector<int64_t> ids_;
   std::vector<std::string> attributionRules_;
-  std::vector<TouchpointT<usingBatch>> tpArrays_;
-  std::vector<ConversionT<usingBatch>> convArrays_;
+  std::vector<TouchpointT<true>> tpArrays_;
+  std::vector<ConversionT<true>> convArrays_;
 
   /**
    * Parse touchpoints and add padding if necessary.
@@ -76,15 +76,13 @@ class AttributionInputMetrics {
   /**
    * Convert parsed touchpoints into touchpoints.
    */
-  const std::vector<TouchpointT<usingBatch>>
-  convertParsedTouchpointsToTouchpoints(
+  const std::vector<TouchpointT<true>> convertParsedTouchpointsToTouchpoints(
       const std::vector<std::vector<ParsedTouchpoint>>& parsedTouchpoints);
 
   /**
    * Convert parsed conversions into conversions.
    */
-  const std::vector<ConversionT<usingBatch>>
-  convertParsedConversionsToConversions(
+  const std::vector<ConversionT<true>> convertParsedConversionsToConversions(
       const std::vector<std::vector<ParsedConversion>>& parsedConversions);
 };
 

--- a/fbpcs/emp_games/pcf2_attribution/MainUtil.h
+++ b/fbpcs/emp_games/pcf2_attribution/MainUtil.h
@@ -99,7 +99,7 @@ inline common::SchedulerStatistics startAttributionAppsForShardedFilesHelper(
     // Publisher uses even schedulerId and partner uses odd schedulerId
     auto app = std::make_unique<
         pcf2_attribution::
-            AttributionApp<PARTY, 2 * index + PARTY, true, inputEncryption>>(
+            AttributionApp<PARTY, 2 * index + PARTY, inputEncryption>>(
         std::move(communicationAgentFactory),
         attributionRules,
         inputFilenames,

--- a/fbpcs/emp_games/pcf2_attribution/main.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/main.cpp
@@ -51,7 +51,6 @@ int main(int argc, char* argv[]) {
   common::SchedulerStatistics schedulerStatistics;
 
   // use batched attribution by default
-  const bool usingBatch = true;
   bool useXorEncryption = FLAGS_use_xor_encryption;
   try {
     auto [inputFilenames, outputFilenames] = pcf2_attribution::getIOFilenames(
@@ -81,7 +80,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::PartnerXor>(
                 useXorEncryption,
                 inputFilenames,
@@ -95,7 +94,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::Xor>(
                 useXorEncryption,
                 inputFilenames,
@@ -109,7 +108,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PUBLISHER,
-                usingBatch,
+
                 common::InputEncryption::Plaintext>(
                 useXorEncryption,
                 inputFilenames,
@@ -129,7 +128,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::PartnerXor>(
                 useXorEncryption,
                 inputFilenames,
@@ -143,7 +142,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::Xor>(
                 useXorEncryption,
                 inputFilenames,
@@ -158,7 +157,7 @@ int main(int argc, char* argv[]) {
         schedulerStatistics =
             pcf2_attribution::startAttributionAppsForShardedFiles<
                 common::PARTNER,
-                usingBatch,
+
                 common::InputEncryption::Plaintext>(
                 useXorEncryption,
                 inputFilenames,


### PR DESCRIPTION
Summary:
Context: in attribution games, we always use batch mode for the sake of performance. IN this stack of diffs, we are gradually remove the code for non-batch path and hardcode usingbatch = true.

We are taking a top-down approach to delete this flag layer by layer.

This diff contains the change to the attribution game and attribution metrics class

Reviewed By: zhangpuhan

Differential Revision: D43103054

