### PR TITLE
Fix RC E2E tests

### DIFF
--- a/.github/workflows/rc_one_command_runner_test.yml
+++ b/.github/workflows/rc_one_command_runner_test.yml
@@ -41,7 +41,7 @@ on:
 env:
   FBPCS_CONTAINER_REPO_URL: ghcr.io/facebookresearch/fbpcs
   FBPCS_IMAGE_NAME: coordinator
-  FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_RC_GRAPH_API_TOKEN }}
+  FBPCS_GRAPH_API_TOKEN: ${{ secrets.FBPCS_GRAPH_API_TOKEN }}
 
 jobs:
   ### Private Lift E2E tests


### PR DESCRIPTION
Summary: The token used by this test expired. The RC study has been updated to support the token from the other tests.

Differential Revision: D43191133

