### PR TITLE
Revert retry throttled request every 3 minutes instead (30 mins total)

### DIFF
--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -426,13 +426,13 @@ async def _run_study_async_helper(
     ## Step 4: Print out the initial and end states
 
     # Wait to resolve throttling issue
-    # - Re-attempts every 5 minutes for 75 minutes total before failing
+    # - Re-attempts every 3 minutes for 30 minutes total before failing
     # - https://developers.facebook.com/docs/graph-api/overview/rate-limiting/
     with RetryHandler(
         logger=logger,
-        backoff_seconds=300,
+        backoff_seconds=180,
         backoff_type=BackoffType.CONSTANT,
-        max_attempts=15,
+        max_attempts=10,
     ) as retry_handler:
         end_state_study_data = await retry_handler.execute_sync(
             _get_study_data, study_id, client


### PR DESCRIPTION
Summary:
## Why
In previous diff D42754540 (https://github.com/facebookresearch/fbpcs/commit/922a557de9cdc835b64a392c4e0e22f10f411ede) we added 5 mins backoff for total 75 minutes.
After the enhanced write checkpoint in batch mode D42949675 (https://github.com/facebookresearch/fbpcs/commit/c6fb682bd15b40fcb104fe3cd872815e8cf36b77) landed. this throttled request retry could be relaxed.

## What
-  Revert retry throttled request every 3 minutes instead (30 mins total) in diff D42754540 (https://github.com/facebookresearch/fbpcs/commit/922a557de9cdc835b64a392c4e0e22f10f411ede)

Reviewed By: musebc

Differential Revision: D43201017

