### PR TITLE
Refactor the attribution game

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -35,6 +35,27 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   using PrivateConversionT = PrivateConversion<schedulerId, inputEncryption>;
 
+  std::tuple<
+      std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>,
+      std::vector<PrivateTouchpointT>,
+      std::vector<PrivateConversionT>,
+      std::vector<
+          std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>,
+      std::vector<int64_t>>
+  prepareMpcInputs(
+      const int myRole,
+      const AttributionInputMetrics<inputEncryption>& inputData);
+
+  AttributionOutputMetrics computeAttributions_impl(
+      std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>&
+          thresholdArraysForEachRule,
+      std::vector<PrivateTouchpointT>& tpArrays,
+      std::vector<PrivateConversionT>& convArrays,
+      std::vector<
+          std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>&
+          attributionRules,
+      std::vector<int64_t>& ids);
+
   /**
    * Publisher shares attribution rules with partner.
    */


### PR DESCRIPTION
Summary:
As title.
This diff adds two functions to host the operations on non-MPC types (i.e. preparing the inputs) and MPC-types (i.e. running the actual computation).
This is a step stone for UDP PA project. The operations on non-MPC part will soon be refactored out into another object, which will eventually run before UDP.

Reviewed By: haochenuw

Differential Revision:
D43128080

Privacy Context Container: L416713

