### PR TITLE
Increase AGGREGATE stage timeout

### DIFF
--- a/fbpcs/private_computation/service/constants.py
+++ b/fbpcs/private_computation/service/constants.py
@@ -51,6 +51,9 @@ FBPCS_BUNDLE_ID = "FBPCS_BUNDLE_ID"
 # We set default time out to 5 hrs as the buffer.
 DEFAULT_RUN_PID_TIMEOUT_IN_SEC = 18000
 
+# Since this stage is not sharded, larger inputs can cause it to exceed the default timeout
+DEFAULT_AGGREGATE_TIMEOUT_IN_SEC = 7200
+
 CA_CERT_PATH = "tls/ca_cert.pem"
 SERVER_CERT_PATH = "tls/server_cert.pem"
 PRIVATE_KEY_PATH = "tls/private_key.pem"

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_pid_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_pid_pcf2_lift_stage_flow.py
@@ -9,7 +9,10 @@ from fbpcs.private_computation.entity.pid_mr_config import Protocol
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_CONTAINER_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
+    DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
+)
 from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
     IdSpineCombinerStageService,
 )
@@ -93,6 +96,7 @@ class PrivateComputationMrPidPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         is_joint_stage=True,
+        timeout=DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_mr_stage_flow.py
@@ -11,6 +11,7 @@ from fbpcs.private_computation.entity.pid_mr_config import Protocol
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
+from fbpcs.private_computation.service.constants import DEFAULT_AGGREGATE_TIMEOUT_IN_SEC
 from fbpcs.private_computation.service.id_spine_combiner_stage_service import (
     IdSpineCombinerStageService,
 )
@@ -103,6 +104,7 @@ class PrivateComputationMRStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         is_joint_stage=True,
+        timeout=DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_stage_flow.py
@@ -8,6 +8,7 @@ from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.service.constants import (
+    DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
 )
@@ -113,6 +114,7 @@ class PrivateComputationPCF2LiftStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         is_joint_stage=True,
+        timeout=DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_udp_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_lift_udp_stage_flow.py
@@ -8,6 +8,7 @@ from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
 from fbpcs.private_computation.service.constants import (
+    DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
 )
@@ -126,6 +127,7 @@ class PrivateComputationPCF2LiftUDPStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         is_joint_stage=True,
+        timeout=DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_pcf2_stage_flow.py
@@ -7,7 +7,10 @@
 from fbpcs.private_computation.entity.private_computation_status import (
     PrivateComputationInstanceStatus,
 )
-from fbpcs.private_computation.service.constants import DEFAULT_RUN_PID_TIMEOUT_IN_SEC
+from fbpcs.private_computation.service.constants import (
+    DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
+    DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
+)
 from fbpcs.private_computation.service.pcf2_aggregation_stage_service import (
     PCF2AggregationStageService,
 )
@@ -121,6 +124,7 @@ class PrivateComputationPCF2StageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         is_joint_stage=True,
+        timeout=DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,

--- a/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
+++ b/fbpcs/private_computation/stage_flows/private_computation_stage_flow.py
@@ -11,6 +11,7 @@ from fbpcs.private_computation.service.compute_metrics_stage_service import (
     ComputeMetricsStageService,
 )
 from fbpcs.private_computation.service.constants import (
+    DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     DEFAULT_CONTAINER_TIMEOUT_IN_SEC,
     DEFAULT_RUN_PID_TIMEOUT_IN_SEC,
 )
@@ -113,6 +114,7 @@ class PrivateComputationStageFlow(PrivateComputationBaseStageFlow):
         completed_status=PrivateComputationInstanceStatus.AGGREGATION_COMPLETED,
         failed_status=PrivateComputationInstanceStatus.AGGREGATION_FAILED,
         is_joint_stage=True,
+        timeout=DEFAULT_AGGREGATE_TIMEOUT_IN_SEC,
     )
     POST_PROCESSING_HANDLERS = PrivateComputationStageFlowData(
         initialized_status=PrivateComputationInstanceStatus.POST_PROCESSING_HANDLERS_INITIALIZED,


### PR DESCRIPTION
Summary: Since this stage is not sharded, larger inputs can cause it to exceed the default timeout.  We have seen this happen for the recent Amazon runs.  Increasing it to 2 hours.

Differential Revision: D43242691

