### PR TITLE
refactor the util functions to support passing in a constructor

### DIFF
--- a/fbpcs/emp_games/common/Util.h
+++ b/fbpcs/emp_games/common/Util.h
@@ -61,10 +61,12 @@ static const std::vector<T> getInnerArray(const std::string& str) {
  * can be constructed from T.
  */
 template <typename T, typename O>
-std::vector<O> privatelyShareArray(const std::vector<T>& inputArray) {
+std::vector<O> privatelyShareArray(
+    const std::vector<T>& inputArray,
+    std::function<O(const T&)> constructor) {
   std::vector<O> outputArray;
   for (size_t i = 0; i < inputArray.size(); ++i) {
-    outputArray.push_back(O{inputArray.at(i)});
+    outputArray.push_back(constructor(inputArray.at(i)));
   }
   return outputArray;
 }

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -23,7 +23,8 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareTouchpoints(
     const std::vector<Touchpoint>& touchpoints) {
   return common::privatelyShareArray<
       Touchpoint,
-      PrivateTouchpoint<schedulerId, inputEncryption>>(touchpoints);
+      PrivateTouchpoint<schedulerId, inputEncryption>>(
+      touchpoints, createPrivateTouchpoint<schedulerId, inputEncryption>);
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -33,7 +34,8 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareConversions(
     const std::vector<Conversion>& conversions) {
   return common::privatelyShareArray<
       Conversion,
-      PrivateConversion<schedulerId, inputEncryption>>(conversions);
+      PrivateConversion<schedulerId, inputEncryption>>(
+      conversions, createPrivateConversion<schedulerId, inputEncryption>);
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -58,7 +60,8 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
     }
     auto privateIsClick = common::privatelyShareArray<
         Touchpoint,
-        PrivateIsClick<schedulerId, inputEncryption>>(touchpoints);
+        PrivateIsClick<schedulerId, inputEncryption>>(
+        touchpoints, createPrivateIsClick<schedulerId, inputEncryption>);
     for (size_t i = 0; i < touchpoints.size(); ++i) {
       auto thresholds = attributionRule.computeThresholdsPrivate(
           privateTouchpoints.at(i), privateIsClick.at(i), batchSize);

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -25,31 +25,35 @@ struct PrivateConversion {
   SecTargetId<schedulerId> targetId;
   SecActionType<schedulerId> actionType;
   SecConvValue<schedulerId> convValue;
-
-  explicit PrivateConversion(const Conversion& conversion) {
-    if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
-      ts = SecTimestamp<schedulerId>(conversion.ts, common::PARTNER);
-      targetId = SecTargetId<schedulerId>(conversion.targetId, common::PARTNER);
-      actionType =
-          SecActionType<schedulerId>(conversion.actionType, common::PARTNER);
-      convValue =
-          SecConvValue<schedulerId>(conversion.convValue, common::PARTNER);
-    } else {
-      typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(
-          conversion.ts);
-      ts = SecTimestamp<schedulerId>(std::move(extractedTs));
-      typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
-          conversion.targetId);
-      targetId = SecTargetId<schedulerId>(std::move(extractedTids));
-      typename SecActionType<schedulerId>::ExtractedInt extractedAids(
-          conversion.actionType);
-      actionType = SecActionType<schedulerId>(std::move(extractedAids));
-      typename SecConvValue<schedulerId>::ExtractedInt extractedVs(
-          conversion.convValue);
-      convValue = SecConvValue<schedulerId>(std::move(extractedVs));
-    }
-  }
 };
+
+template <int schedulerId, common::InputEncryption inputEncryption>
+PrivateConversion<schedulerId, inputEncryption> createPrivateConversion(
+    const Conversion& conversion) {
+  PrivateConversion<schedulerId, inputEncryption> rst;
+  if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
+    rst.ts = SecTimestamp<schedulerId>(conversion.ts, common::PARTNER);
+    rst.targetId =
+        SecTargetId<schedulerId>(conversion.targetId, common::PARTNER);
+    rst.actionType =
+        SecActionType<schedulerId>(conversion.actionType, common::PARTNER);
+    rst.convValue =
+        SecConvValue<schedulerId>(conversion.convValue, common::PARTNER);
+  } else {
+    typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(conversion.ts);
+    rst.ts = SecTimestamp<schedulerId>(std::move(extractedTs));
+    typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
+        conversion.targetId);
+    rst.targetId = SecTargetId<schedulerId>(std::move(extractedTids));
+    typename SecActionType<schedulerId>::ExtractedInt extractedAids(
+        conversion.actionType);
+    rst.actionType = SecActionType<schedulerId>(std::move(extractedAids));
+    typename SecConvValue<schedulerId>::ExtractedInt extractedVs(
+        conversion.convValue);
+    rst.convValue = SecConvValue<schedulerId>(std::move(extractedVs));
+  }
+  return rst;
+}
 
 // Used for parsing conversions from input CSV files
 struct ParsedConversion {

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -30,50 +30,57 @@ struct PrivateTouchpoint {
   SecActionType<schedulerId> actionType;
   SecOriginalAdId<schedulerId> originalAdId;
   SecAdId<schedulerId> adId;
-
-  explicit PrivateTouchpoint(const Touchpoint& touchpoint) : id{touchpoint.id} {
-    if constexpr (inputEncryption == common::InputEncryption::Xor) {
-      typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(
-          touchpoint.ts);
-      ts = SecTimestamp<schedulerId>(std::move(extractedTs));
-      typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
-          touchpoint.targetId);
-      targetId = SecTargetId<schedulerId>(std::move(extractedTids));
-      typename SecActionType<schedulerId>::ExtractedInt extractedAids(
-          touchpoint.actionType);
-      actionType = SecActionType<schedulerId>(std::move(extractedAids));
-      typename SecOriginalAdId<schedulerId>::ExtractedInt
-          extractedOriginalAdIds(touchpoint.originalAdId);
-      originalAdId =
-          SecOriginalAdId<schedulerId>(std::move(extractedOriginalAdIds));
-    } else {
-      ts = SecTimestamp<schedulerId>(touchpoint.ts, common::PUBLISHER);
-      targetId =
-          SecTargetId<schedulerId>(touchpoint.targetId, common::PUBLISHER);
-      actionType =
-          SecActionType<schedulerId>(touchpoint.actionType, common::PUBLISHER);
-      originalAdId = SecOriginalAdId<schedulerId>(
-          touchpoint.originalAdId, common::PUBLISHER);
-    }
-    adId = SecAdId<schedulerId>(touchpoint.adId, common::PUBLISHER);
-  }
 };
+
+template <int schedulerId, common::InputEncryption inputEncryption>
+PrivateTouchpoint<schedulerId, inputEncryption> createPrivateTouchpoint(
+    const Touchpoint& touchpoint) {
+  PrivateTouchpoint<schedulerId, inputEncryption> rst{.id{touchpoint.id}};
+  if constexpr (inputEncryption == common::InputEncryption::Xor) {
+    typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(touchpoint.ts);
+    rst.ts = SecTimestamp<schedulerId>(std::move(extractedTs));
+    typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
+        touchpoint.targetId);
+    rst.targetId = SecTargetId<schedulerId>(std::move(extractedTids));
+    typename SecActionType<schedulerId>::ExtractedInt extractedAids(
+        touchpoint.actionType);
+    rst.actionType = SecActionType<schedulerId>(std::move(extractedAids));
+    typename SecOriginalAdId<schedulerId>::ExtractedInt extractedOriginalAdIds(
+        touchpoint.originalAdId);
+    rst.originalAdId =
+        SecOriginalAdId<schedulerId>(std::move(extractedOriginalAdIds));
+  } else {
+    rst.ts = SecTimestamp<schedulerId>(touchpoint.ts, common::PUBLISHER);
+    rst.targetId =
+        SecTargetId<schedulerId>(touchpoint.targetId, common::PUBLISHER);
+    rst.actionType =
+        SecActionType<schedulerId>(touchpoint.actionType, common::PUBLISHER);
+    rst.originalAdId = SecOriginalAdId<schedulerId>(
+        touchpoint.originalAdId, common::PUBLISHER);
+  }
+  rst.adId = SecAdId<schedulerId>(touchpoint.adId, common::PUBLISHER);
+  return rst;
+}
 
 // Used for privately sharing isClick for xor encrypted inputs
 template <int schedulerId, common::InputEncryption inputEncryption>
 struct PrivateIsClick {
   SecBit<schedulerId> isClick;
-
-  explicit PrivateIsClick(const Touchpoint& touchpoint) {
-    if constexpr (inputEncryption == common::InputEncryption::Xor) {
-      typename SecBit<schedulerId>::ExtractedBit extractedIsClick(
-          touchpoint.isClick);
-      isClick = SecBit<schedulerId>(std::move(extractedIsClick));
-    } else {
-      isClick = SecBit<schedulerId>(touchpoint.isClick, common::PUBLISHER);
-    }
-  }
 };
+
+template <int schedulerId, common::InputEncryption inputEncryption>
+PrivateIsClick<schedulerId, inputEncryption> createPrivateIsClick(
+    const Touchpoint& touchpoint) {
+  PrivateIsClick<schedulerId, inputEncryption> rst;
+  if constexpr (inputEncryption == common::InputEncryption::Xor) {
+    typename SecBit<schedulerId>::ExtractedBit extractedIsClick(
+        touchpoint.isClick);
+    rst.isClick = SecBit<schedulerId>(std::move(extractedIsClick));
+  } else {
+    rst.isClick = SecBit<schedulerId>(touchpoint.isClick, common::PUBLISHER);
+  }
+  return rst;
+}
 
 // Used for parsing touchpoints from input CSV files
 struct ParsedTouchpoint {


### PR DESCRIPTION
Summary:
In this stack of diff, we will gradually remove `inputEncyption` variable in the template as this should be a run time parameter.

This time we take a bottom-up approach to gradually propagate the changes upwards.

This diff will refactor the util functions to prepare for the change.

Differential Revision: D43256421

