### PR TITLE
remove encryption method in attribution metrics

### DIFF
--- a/fbpcs/emp_games/common/Util.h
+++ b/fbpcs/emp_games/common/Util.h
@@ -61,10 +61,12 @@ static const std::vector<T> getInnerArray(const std::string& str) {
  * can be constructed from T.
  */
 template <typename T, typename O>
-std::vector<O> privatelyShareArray(const std::vector<T>& inputArray) {
+std::vector<O> privatelyShareArray(
+    const std::vector<T>& inputArray,
+    std::function<O(const T&)> constructor) {
   std::vector<O> outputArray;
   for (size_t i = 0; i < inputArray.size(); ++i) {
-    outputArray.push_back(O{inputArray.at(i)});
+    outputArray.push_back(constructor(inputArray.at(i)));
   }
   return outputArray;
 }

--- a/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionApp.h
@@ -91,12 +91,12 @@ class AttributionApp {
   }
 
  protected:
-  AttributionInputMetrics<inputEncryption> getInputData(std::string inputPath) {
+  AttributionInputMetrics getInputData(std::string inputPath) {
     XLOG(INFO) << "MY_ROLE: " << MY_ROLE << ", schedulerId: " << schedulerId
                << ", attributionRules_: " << attributionRules_
                << ", input_path: " << inputPath;
-    return AttributionInputMetrics<inputEncryption>{
-        MY_ROLE, attributionRules_, inputPath};
+    return AttributionInputMetrics{
+        MY_ROLE, attributionRules_, inputPath, inputEncryption};
   }
 
   void putOutputData(

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -33,7 +33,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   using PrivateTouchpointT = PrivateTouchpoint<schedulerId>;
 
-  using PrivateConversionT = PrivateConversion<schedulerId, inputEncryption>;
+  using PrivateConversionT = PrivateConversion<schedulerId>;
 
   std::tuple<
       std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>,
@@ -110,8 +110,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    */
   const std::vector<SecBit<schedulerId>> computeAttributionsHelper(
       const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
-      const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
-          conversions,
+      const std::vector<PrivateConversion<schedulerId>>& conversions,
       const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
       size_t batchSize);
@@ -119,8 +118,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   const std::vector<AttributionReformattedOutputFmt<schedulerId>>
   computeAttributionsHelperV2(
       const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
-      const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
-          conversions,
+      const std::vector<PrivateConversion<schedulerId>>& conversions,
       const AttributionRule<schedulerId, inputEncryption>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
       size_t batchSize);

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -31,7 +31,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       const int myRole,
       const AttributionInputMetrics<inputEncryption>& inputData);
 
-  using PrivateTouchpointT = PrivateTouchpoint<schedulerId, inputEncryption>;
+  using PrivateTouchpointT = PrivateTouchpoint<schedulerId>;
 
   using PrivateConversionT = PrivateConversion<schedulerId, inputEncryption>;
 
@@ -109,8 +109,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
    * Helper method for computing attributions.
    */
   const std::vector<SecBit<schedulerId>> computeAttributionsHelper(
-      const std::vector<PrivateTouchpoint<schedulerId, inputEncryption>>&
-          touchpoints,
+      const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
       const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
           conversions,
       const AttributionRule<schedulerId, inputEncryption>& attributionRule,
@@ -119,8 +118,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   const std::vector<AttributionReformattedOutputFmt<schedulerId>>
   computeAttributionsHelperV2(
-      const std::vector<PrivateTouchpoint<schedulerId, inputEncryption>>&
-          touchpoints,
+      const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
       const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
           conversions,
       const AttributionRule<schedulerId, inputEncryption>& attributionRule,

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -39,8 +39,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>,
       std::vector<PrivateTouchpointT>,
       std::vector<PrivateConversionT>,
-      std::vector<
-          std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>,
+      std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>,
       std::vector<int64_t>>
   prepareMpcInputs(
       const int myRole,
@@ -51,16 +50,14 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
           thresholdArraysForEachRule,
       std::vector<PrivateTouchpointT>& tpArrays,
       std::vector<PrivateConversionT>& convArrays,
-      std::vector<
-          std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>&
+      std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>&
           attributionRules,
       std::vector<int64_t>& ids);
 
   /**
    * Publisher shares attribution rules with partner.
    */
-  std::vector<
-      std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>
+  std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>
   shareAttributionRules(
       const int myRole,
       const std::vector<std::string>& attributionRuleNames);
@@ -84,7 +81,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   std::vector<std::vector<SecTimestamp<schedulerId>>> privatelyShareThresholds(
       const std::vector<Touchpoint>& touchpoints,
       const std::vector<PrivateTouchpointT>& privateTouchpoints,
-      const AttributionRule<schedulerId, inputEncryption>& attributionRule,
+      const AttributionRule<schedulerId>& attributionRule,
       size_t batchSize);
 
   /**
@@ -111,7 +108,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   const std::vector<SecBit<schedulerId>> computeAttributionsHelper(
       const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
       const std::vector<PrivateConversion<schedulerId>>& conversions,
-      const AttributionRule<schedulerId, inputEncryption>& attributionRule,
+      const AttributionRule<schedulerId>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
       size_t batchSize);
 
@@ -119,7 +116,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
   computeAttributionsHelperV2(
       const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
       const std::vector<PrivateConversion<schedulerId>>& conversions,
-      const AttributionRule<schedulerId, inputEncryption>& attributionRule,
+      const AttributionRule<schedulerId>& attributionRule,
       const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
       size_t batchSize);
 };

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -29,7 +29,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
 
   AttributionOutputMetrics computeAttributions(
       const int myRole,
-      const AttributionInputMetrics<inputEncryption>& inputData);
+      const AttributionInputMetrics& inputData);
 
   using PrivateTouchpointT = PrivateTouchpoint<schedulerId>;
 
@@ -41,9 +41,7 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       std::vector<PrivateConversionT>,
       std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>,
       std::vector<int64_t>>
-  prepareMpcInputs(
-      const int myRole,
-      const AttributionInputMetrics<inputEncryption>& inputData);
+  prepareMpcInputs(const int myRole, const AttributionInputMetrics& inputData);
 
   AttributionOutputMetrics computeAttributions_impl(
       std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>&

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -49,7 +49,7 @@ std::vector<std::vector<SecTimestamp<schedulerId>>>
 AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
     const std::vector<Touchpoint>& touchpoints,
     const std::vector<PrivateTouchpointT>& privateTouchpoints,
-    const AttributionRule<schedulerId, inputEncryption>& attributionRule,
+    const AttributionRule<schedulerId>& attributionRule,
     size_t batchSize) {
   std::vector<std::vector<SecTimestamp<schedulerId>>> output;
 
@@ -81,21 +81,18 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
-std::vector<
-    std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>
+std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>
 AttributionGame<schedulerId, inputEncryption>::shareAttributionRules(
     const int myRole,
     const std::vector<std::string>& attributionRuleNames) {
   // Publisher converts attribution rule names to attribution rules and ids
-  std::vector<
-      std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>
+  std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>
       attributionRules;
   std::vector<uint64_t> attributionRuleIds;
   if (myRole == common::PUBLISHER) {
     for (auto attributionRuleName : attributionRuleNames) {
       auto attributionRule =
-          AttributionRule<schedulerId, inputEncryption>::fromNameOrThrow(
-              attributionRuleName);
+          AttributionRule<schedulerId>::fromNameOrThrow(attributionRuleName);
       attributionRules.push_back(attributionRule);
       attributionRuleIds.push_back(attributionRule->id);
     }
@@ -103,7 +100,7 @@ AttributionGame<schedulerId, inputEncryption>::shareAttributionRules(
 
   const size_t attributionRuleIdWidth = 3; // currently we only support 4 rules
   CHECK_LT(
-      (SUPPORTED_ATTRIBUTION_RULES<schedulerId, inputEncryption>).size(),
+      (SUPPORTED_ATTRIBUTION_RULES<schedulerId>).size(),
       (1 << attributionRuleIdWidth));
 
   // Publisher shares attribution rule ids
@@ -116,8 +113,7 @@ AttributionGame<schedulerId, inputEncryption>::shareAttributionRules(
   if (myRole == common::PARTNER) {
     for (auto sharedId : sharedAttributionRuleIds) {
       attributionRules.push_back(
-          AttributionRule<schedulerId, inputEncryption>::fromIdOrThrow(
-              sharedId));
+          AttributionRule<schedulerId>::fromIdOrThrow(sharedId));
     }
   }
   return attributionRules;
@@ -198,7 +194,7 @@ const std::vector<SecBit<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
     const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
     const std::vector<PrivateConversion<schedulerId>>& conversions,
-    const AttributionRule<schedulerId, inputEncryption>& attributionRule,
+    const AttributionRule<schedulerId>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
     size_t batchSize) {
   if (batchSize == 0) {
@@ -268,7 +264,7 @@ const std::vector<AttributionReformattedOutputFmt<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
     const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
     const std::vector<PrivateConversion<schedulerId>>& conversions,
-    const AttributionRule<schedulerId, inputEncryption>& attributionRule,
+    const AttributionRule<schedulerId>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
     size_t batchSize) {
   if (batchSize == 0) {
@@ -366,8 +362,7 @@ std::tuple<
                     PrivateTouchpointT>,
     std::vector<typename AttributionGame<schedulerId, inputEncryption>::
                     PrivateConversionT>,
-    std::vector<
-        std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>,
+    std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>,
     std::vector<int64_t>>
 AttributionGame<schedulerId, inputEncryption>::prepareMpcInputs(
     const int myRole,
@@ -430,8 +425,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributions_impl(
                     PrivateTouchpointT>& tpArrays,
     std::vector<typename AttributionGame<schedulerId, inputEncryption>::
                     PrivateConversionT>& convArrays,
-    std::vector<
-        std::shared_ptr<const AttributionRule<schedulerId, inputEncryption>>>&
+    std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>&
         attributionRules,
     std::vector<int64_t>& ids) {
   auto numIds = ids.size();

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -21,10 +21,13 @@ std::vector<
     typename AttributionGame<schedulerId, inputEncryption>::PrivateTouchpointT>
 AttributionGame<schedulerId, inputEncryption>::privatelyShareTouchpoints(
     const std::vector<Touchpoint>& touchpoints) {
-  return common::privatelyShareArray<
-      Touchpoint,
-      PrivateTouchpoint<schedulerId, inputEncryption>>(
-      touchpoints, createPrivateTouchpoint<schedulerId, inputEncryption>);
+  return common::
+      privatelyShareArray<Touchpoint, PrivateTouchpoint<schedulerId>>(
+          touchpoints,
+          std::bind(
+              createPrivateTouchpoint<schedulerId>,
+              inputEncryption,
+              std::placeholders::_1));
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -58,10 +61,13 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
       throw std::invalid_argument(
           "Must provide positive batch size for batch execution!");
     }
-    auto privateIsClick = common::privatelyShareArray<
-        Touchpoint,
-        PrivateIsClick<schedulerId, inputEncryption>>(
-        touchpoints, createPrivateIsClick<schedulerId, inputEncryption>);
+    auto privateIsClick =
+        common::privatelyShareArray<Touchpoint, PrivateIsClick<schedulerId>>(
+            touchpoints,
+            std::bind(
+                createPrivateIsClick<schedulerId>,
+                inputEncryption,
+                std::placeholders::_1));
     for (size_t i = 0; i < touchpoints.size(); ++i) {
       auto thresholds = attributionRule.computeThresholdsPrivate(
           privateTouchpoints.at(i), privateIsClick.at(i), batchSize);
@@ -187,8 +193,7 @@ void AttributionGame<schedulerId, inputEncryption>::putAdIdMappingJson(
 template <int schedulerId, common::InputEncryption inputEncryption>
 const std::vector<SecBit<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
-    const std::vector<PrivateTouchpoint<schedulerId, inputEncryption>>&
-        touchpoints,
+    const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
     const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
         conversions,
     const AttributionRule<schedulerId, inputEncryption>& attributionRule,
@@ -259,8 +264,7 @@ AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
 template <int schedulerId, common::InputEncryption inputEncryption>
 const std::vector<AttributionReformattedOutputFmt<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
-    const std::vector<PrivateTouchpoint<schedulerId, inputEncryption>>&
-        touchpoints,
+    const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
     const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
         conversions,
     const AttributionRule<schedulerId, inputEncryption>& attributionRule,

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -35,10 +35,13 @@ std::vector<
     typename AttributionGame<schedulerId, inputEncryption>::PrivateConversionT>
 AttributionGame<schedulerId, inputEncryption>::privatelyShareConversions(
     const std::vector<Conversion>& conversions) {
-  return common::privatelyShareArray<
-      Conversion,
-      PrivateConversion<schedulerId, inputEncryption>>(
-      conversions, createPrivateConversion<schedulerId, inputEncryption>);
+  return common::
+      privatelyShareArray<Conversion, PrivateConversion<schedulerId>>(
+          conversions,
+          std::bind(
+              createPrivateConversion<schedulerId>,
+              inputEncryption,
+              std::placeholders::_1));
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -194,8 +197,7 @@ template <int schedulerId, common::InputEncryption inputEncryption>
 const std::vector<SecBit<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelper(
     const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
-    const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
-        conversions,
+    const std::vector<PrivateConversion<schedulerId>>& conversions,
     const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
     size_t batchSize) {
@@ -265,8 +267,7 @@ template <int schedulerId, common::InputEncryption inputEncryption>
 const std::vector<AttributionReformattedOutputFmt<schedulerId>>
 AttributionGame<schedulerId, inputEncryption>::computeAttributionsHelperV2(
     const std::vector<PrivateTouchpoint<schedulerId>>& touchpoints,
-    const std::vector<PrivateConversion<schedulerId, inputEncryption>>&
-        conversions,
+    const std::vector<PrivateConversion<schedulerId>>& conversions,
     const AttributionRule<schedulerId, inputEncryption>& attributionRule,
     const std::vector<std::vector<SecTimestamp<schedulerId>>>& thresholds,
     size_t batchSize) {

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -23,7 +23,8 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareTouchpoints(
     const std::vector<Touchpoint>& touchpoints) {
   return common::privatelyShareArray<
       Touchpoint,
-      PrivateTouchpoint<schedulerId, inputEncryption>>(touchpoints);
+      PrivateTouchpoint<schedulerId, inputEncryption>>(
+      touchpoints, createPrivateTouchpoint<schedulerId, inputEncryption>);
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -33,7 +34,8 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareConversions(
     const std::vector<Conversion>& conversions) {
   return common::privatelyShareArray<
       Conversion,
-      PrivateConversion<schedulerId, inputEncryption>>(conversions);
+      PrivateConversion<schedulerId, inputEncryption>>(
+      conversions, createPrivateConversion<schedulerId, inputEncryption>);
 }
 
 template <int schedulerId, common::InputEncryption inputEncryption>
@@ -58,7 +60,8 @@ AttributionGame<schedulerId, inputEncryption>::privatelyShareThresholds(
     }
     auto privateIsClick = common::privatelyShareArray<
         Touchpoint,
-        PrivateIsClick<schedulerId, inputEncryption>>(touchpoints);
+        PrivateIsClick<schedulerId, inputEncryption>>(
+        touchpoints, createPrivateIsClick<schedulerId, inputEncryption>);
     for (size_t i = 0; i < touchpoints.size(); ++i) {
       auto thresholds = attributionRule.computeThresholdsPrivate(
           privateTouchpoints.at(i), privateIsClick.at(i), batchSize);

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -343,7 +343,7 @@ template <int schedulerId, common::InputEncryption inputEncryption>
 AttributionOutputMetrics
 AttributionGame<schedulerId, inputEncryption>::computeAttributions(
     const int myRole,
-    const AttributionInputMetrics<inputEncryption>& inputData) {
+    const AttributionInputMetrics& inputData) {
   auto
       [thresholdArraysForEachRule,
        tpArrays,
@@ -366,7 +366,7 @@ std::tuple<
     std::vector<int64_t>>
 AttributionGame<schedulerId, inputEncryption>::prepareMpcInputs(
     const int myRole,
-    const AttributionInputMetrics<inputEncryption>& inputData) {
+    const AttributionInputMetrics& inputData) {
   XLOG(INFO, "Running attribution");
   auto ids = inputData.getIds();
 

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.h
@@ -25,14 +25,14 @@ namespace pcf2_attribution {
  * This class represents input data for a Private Attribution computation.
  * It processes an input csv and generates the std::vectors for each column
  */
-template <common::InputEncryption inputEncryption>
 class AttributionInputMetrics {
  public:
   // Constructor -- input is a path to a CSV
   explicit AttributionInputMetrics(
       int myRole,
       std::string attributionRulesStr,
-      std::filesystem::path filepath);
+      std::filesystem::path filepath,
+      common::InputEncryption inputEncryption);
 
   const std::vector<int64_t>& getIds() const {
     return ids_;
@@ -63,7 +63,8 @@ class AttributionInputMetrics {
       const int myRole,
       const int lineNo,
       const std::vector<std::string>& header,
-      const std::vector<std::string>& parts);
+      const std::vector<std::string>& parts,
+      common::InputEncryption inputEncryption);
 
   /**
    * Parse conversions and add padding if necessary.
@@ -71,7 +72,8 @@ class AttributionInputMetrics {
   const std::vector<ParsedConversion> parseConversions(
       const int myRole,
       const std::vector<std::string>& header,
-      const std::vector<std::string>& parts);
+      const std::vector<std::string>& parts,
+      common::InputEncryption inputEncryption);
 
   /**
    * Convert parsed touchpoints into touchpoints.
@@ -200,5 +202,3 @@ struct CompressedAdIdToOriginalAdId {
 };
 
 } // namespace pcf2_attribution
-
-#include "fbpcs/emp_games/pcf2_attribution/AttributionMetrics_impl.h"

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
@@ -40,7 +40,7 @@ struct AttributionRule {
   // to the given conversion
   virtual SecBit<schedulerId> isAttributable(
       const PrivateTouchpoint<schedulerId>&,
-      const PrivateConversion<schedulerId, inputEncryption>&,
+      const PrivateConversion<schedulerId>&,
       const std::vector<SecTimestamp<schedulerId>>&) const = 0;
 
   // Compute touchpoint thresholds from plaintext touchpoints based on

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
@@ -21,7 +21,7 @@ const uint32_t kSecondsInOneDay = 86400; // 60 * 60 * 24
 const uint32_t kSecondsInTwentyEightDays = 2419200; // 60 * 60 * 24 * 28
 const uint32_t kSecondsInSevenDays = 604800; // 60 * 60 * 24 * 7
 
-template <int schedulerId, common::InputEncryption inputEncryption>
+template <int schedulerId>
 struct AttributionRule {
   AttributionRule(std::uint64_t _id, std::string _name)
       : id(_id), name(std::move(_name)) {}

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule.h
@@ -39,7 +39,7 @@ struct AttributionRule {
   // Should return true if the given touchpoint is eligible to be attributed
   // to the given conversion
   virtual SecBit<schedulerId> isAttributable(
-      const PrivateTouchpoint<schedulerId, inputEncryption>&,
+      const PrivateTouchpoint<schedulerId>&,
       const PrivateConversion<schedulerId, inputEncryption>&,
       const std::vector<SecTimestamp<schedulerId>>&) const = 0;
 
@@ -51,8 +51,8 @@ struct AttributionRule {
   // Compute touchpoint thresholds from private touchpoints based on attribution
   // rule
   virtual std::vector<SecTimestamp<schedulerId>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, inputEncryption>&,
-      const PrivateIsClick<schedulerId, inputEncryption>&,
+      const PrivateTouchpoint<schedulerId>&,
+      const PrivateIsClick<schedulerId>&,
       size_t batchSize) const = 0;
 
   // Constructors for attribution rules, which can be found in

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
@@ -25,7 +25,7 @@ class LastClickRule : public AttributionRule<schedulerId, inputEncryption> {
         threshold_(thresholdInSeconds) {}
 
   SecBit<schedulerId> isAttributable(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& tp,
+      const PrivateTouchpoint<schedulerId>& tp,
       const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     return (tp.ts < conv.ts) & (conv.ts <= thresholds.at(0));
@@ -45,8 +45,8 @@ class LastClickRule : public AttributionRule<schedulerId, inputEncryption> {
   }
 
   std::vector<SecTimestamp<schedulerId>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& privateTp,
-      const PrivateIsClick<schedulerId, inputEncryption>& privateIsClick,
+      const PrivateTouchpoint<schedulerId>& privateTp,
+      const PrivateIsClick<schedulerId>& privateIsClick,
       size_t batchSize) const override {
     PubTimestamp<schedulerId> zero;
     PubTimestamp<schedulerId> secondsInThreshold;
@@ -80,7 +80,7 @@ class LastTouch_ClickNDays_ImpressionMDays
 
   /* if click within 28d, if touch within 1d */
   SecBit<schedulerId> isAttributable(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& tp,
+      const PrivateTouchpoint<schedulerId>& tp,
       const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     auto validConv = tp.ts < conv.ts;
@@ -112,8 +112,8 @@ class LastTouch_ClickNDays_ImpressionMDays
   }
 
   std::vector<SecTimestamp<schedulerId>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& privateTp,
-      const PrivateIsClick<schedulerId, inputEncryption>& privateIsClick,
+      const PrivateTouchpoint<schedulerId>& privateTp,
+      const PrivateIsClick<schedulerId>& privateIsClick,
       size_t batchSize) const override {
     PubTimestamp<schedulerId> zero;
     PubTimestamp<schedulerId> secondsInMDays;
@@ -155,7 +155,7 @@ class LastClick_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
 
   /* if click is within 7d but after 1d */
   SecBit<schedulerId> isAttributable(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& tp,
+      const PrivateTouchpoint<schedulerId>& tp,
       const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     auto validConv = tp.ts < conv.ts;
@@ -186,8 +186,8 @@ class LastClick_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
   }
 
   std::vector<SecTimestamp<schedulerId>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& privateTp,
-      const PrivateIsClick<schedulerId, inputEncryption>& privateIsClick,
+      const PrivateTouchpoint<schedulerId>& privateTp,
+      const PrivateIsClick<schedulerId>& privateIsClick,
       size_t batchSize) const override {
     PubTimestamp<schedulerId> zero;
     PubTimestamp<schedulerId> secondsInOneDay;
@@ -226,7 +226,7 @@ class LastTouch_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
             /* name */ common::LAST_TOUCH_2_7D) {}
 
   SecBit<schedulerId> isAttributable(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& tp,
+      const PrivateTouchpoint<schedulerId>& tp,
       const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     auto validConv = tp.ts < conv.ts;
@@ -266,8 +266,8 @@ class LastTouch_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
   }
 
   std::vector<SecTimestamp<schedulerId>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& privateTp,
-      const PrivateIsClick<schedulerId, inputEncryption>& privateIsClick,
+      const PrivateTouchpoint<schedulerId>& privateTp,
+      const PrivateIsClick<schedulerId>& privateIsClick,
       size_t batchSize) const override {
     PubTimestamp<schedulerId> zero;
     PubTimestamp<schedulerId> secondsInOneDay;
@@ -307,7 +307,7 @@ class LastClick_1Day_TargetId
             /* name */ common::LAST_CLICK_1D_TARGETID) {}
 
   SecBit<schedulerId> isAttributable(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& tp,
+      const PrivateTouchpoint<schedulerId>& tp,
       const PrivateConversion<schedulerId, inputEncryption>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     return (tp.targetId == conv.targetId) & (tp.actionType == conv.actionType) &
@@ -329,8 +329,8 @@ class LastClick_1Day_TargetId
   }
 
   std::vector<SecTimestamp<schedulerId>> computeThresholdsPrivate(
-      const PrivateTouchpoint<schedulerId, inputEncryption>& privateTp,
-      const PrivateIsClick<schedulerId, inputEncryption>& privateIsClick,
+      const PrivateTouchpoint<schedulerId>& privateTp,
+      const PrivateIsClick<schedulerId>& privateIsClick,
       size_t batchSize) const override {
     PubTimestamp<schedulerId> zero;
     PubTimestamp<schedulerId> secondsInOneDay;

--- a/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionRule_impl.h
@@ -26,7 +26,7 @@ class LastClickRule : public AttributionRule<schedulerId, inputEncryption> {
 
   SecBit<schedulerId> isAttributable(
       const PrivateTouchpoint<schedulerId>& tp,
-      const PrivateConversion<schedulerId, inputEncryption>& conv,
+      const PrivateConversion<schedulerId>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     return (tp.ts < conv.ts) & (conv.ts <= thresholds.at(0));
   }
@@ -81,7 +81,7 @@ class LastTouch_ClickNDays_ImpressionMDays
   /* if click within 28d, if touch within 1d */
   SecBit<schedulerId> isAttributable(
       const PrivateTouchpoint<schedulerId>& tp,
-      const PrivateConversion<schedulerId, inputEncryption>& conv,
+      const PrivateConversion<schedulerId>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     auto validConv = tp.ts < conv.ts;
     auto touchWithinMDays = conv.ts <= thresholds.at(0);
@@ -156,7 +156,7 @@ class LastClick_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
   /* if click is within 7d but after 1d */
   SecBit<schedulerId> isAttributable(
       const PrivateTouchpoint<schedulerId>& tp,
-      const PrivateConversion<schedulerId, inputEncryption>& conv,
+      const PrivateConversion<schedulerId>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     auto validConv = tp.ts < conv.ts;
     auto clickAfterOneDay = thresholds.at(0) < conv.ts;
@@ -227,7 +227,7 @@ class LastTouch_2_7Days : public AttributionRule<schedulerId, inputEncryption> {
 
   SecBit<schedulerId> isAttributable(
       const PrivateTouchpoint<schedulerId>& tp,
-      const PrivateConversion<schedulerId, inputEncryption>& conv,
+      const PrivateConversion<schedulerId>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     auto validConv = tp.ts < conv.ts;
     auto clickAfterOneDay = thresholds.at(0) < conv.ts;
@@ -308,7 +308,7 @@ class LastClick_1Day_TargetId
 
   SecBit<schedulerId> isAttributable(
       const PrivateTouchpoint<schedulerId>& tp,
-      const PrivateConversion<schedulerId, inputEncryption>& conv,
+      const PrivateConversion<schedulerId>& conv,
       const std::vector<SecTimestamp<schedulerId>>& thresholds) const override {
     return (tp.targetId == conv.targetId) & (tp.actionType == conv.actionType) &
         (tp.ts < conv.ts) & (conv.ts <= thresholds.at(0));

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -25,31 +25,35 @@ struct PrivateConversion {
   SecTargetId<schedulerId> targetId;
   SecActionType<schedulerId> actionType;
   SecConvValue<schedulerId> convValue;
-
-  explicit PrivateConversion(const Conversion& conversion) {
-    if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
-      ts = SecTimestamp<schedulerId>(conversion.ts, common::PARTNER);
-      targetId = SecTargetId<schedulerId>(conversion.targetId, common::PARTNER);
-      actionType =
-          SecActionType<schedulerId>(conversion.actionType, common::PARTNER);
-      convValue =
-          SecConvValue<schedulerId>(conversion.convValue, common::PARTNER);
-    } else {
-      typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(
-          conversion.ts);
-      ts = SecTimestamp<schedulerId>(std::move(extractedTs));
-      typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
-          conversion.targetId);
-      targetId = SecTargetId<schedulerId>(std::move(extractedTids));
-      typename SecActionType<schedulerId>::ExtractedInt extractedAids(
-          conversion.actionType);
-      actionType = SecActionType<schedulerId>(std::move(extractedAids));
-      typename SecConvValue<schedulerId>::ExtractedInt extractedVs(
-          conversion.convValue);
-      convValue = SecConvValue<schedulerId>(std::move(extractedVs));
-    }
-  }
 };
+
+template <int schedulerId, common::InputEncryption inputEncryption>
+PrivateConversion<schedulerId, inputEncryption> createPrivateConversion(
+    const Conversion& conversion) {
+  PrivateConversion<schedulerId, inputEncryption> rst;
+  if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
+    rst.ts = SecTimestamp<schedulerId>(conversion.ts, common::PARTNER);
+    rst.targetId =
+        SecTargetId<schedulerId>(conversion.targetId, common::PARTNER);
+    rst.actionType =
+        SecActionType<schedulerId>(conversion.actionType, common::PARTNER);
+    rst.convValue =
+        SecConvValue<schedulerId>(conversion.convValue, common::PARTNER);
+  } else {
+    typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(conversion.ts);
+    rst.ts = SecTimestamp<schedulerId>(std::move(extractedTs));
+    typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
+        conversion.targetId);
+    rst.targetId = SecTargetId<schedulerId>(std::move(extractedTids));
+    typename SecActionType<schedulerId>::ExtractedInt extractedAids(
+        conversion.actionType);
+    rst.actionType = SecActionType<schedulerId>(std::move(extractedAids));
+    typename SecConvValue<schedulerId>::ExtractedInt extractedVs(
+        conversion.convValue);
+    rst.convValue = SecConvValue<schedulerId>(std::move(extractedVs));
+  }
+  return rst;
+}
 
 // Used for parsing conversions from input CSV files
 struct ParsedConversion {

--- a/fbpcs/emp_games/pcf2_attribution/Conversion.h
+++ b/fbpcs/emp_games/pcf2_attribution/Conversion.h
@@ -19,7 +19,7 @@ struct Conversion {
   std::vector<uint64_t> convValue;
 };
 
-template <int schedulerId, common::InputEncryption inputEncryption>
+template <int schedulerId>
 struct PrivateConversion {
   SecTimestamp<schedulerId> ts;
   SecTargetId<schedulerId> targetId;
@@ -27,11 +27,12 @@ struct PrivateConversion {
   SecConvValue<schedulerId> convValue;
 };
 
-template <int schedulerId, common::InputEncryption inputEncryption>
-PrivateConversion<schedulerId, inputEncryption> createPrivateConversion(
+template <int schedulerId>
+PrivateConversion<schedulerId> createPrivateConversion(
+    common::InputEncryption inputEncryption,
     const Conversion& conversion) {
-  PrivateConversion<schedulerId, inputEncryption> rst;
-  if constexpr (inputEncryption == common::InputEncryption::Plaintext) {
+  PrivateConversion<schedulerId> rst;
+  if (inputEncryption == common::InputEncryption::Plaintext) {
     rst.ts = SecTimestamp<schedulerId>(conversion.ts, common::PARTNER);
     rst.targetId =
         SecTargetId<schedulerId>(conversion.targetId, common::PARTNER);

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -30,50 +30,57 @@ struct PrivateTouchpoint {
   SecActionType<schedulerId> actionType;
   SecOriginalAdId<schedulerId> originalAdId;
   SecAdId<schedulerId> adId;
-
-  explicit PrivateTouchpoint(const Touchpoint& touchpoint) : id{touchpoint.id} {
-    if constexpr (inputEncryption == common::InputEncryption::Xor) {
-      typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(
-          touchpoint.ts);
-      ts = SecTimestamp<schedulerId>(std::move(extractedTs));
-      typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
-          touchpoint.targetId);
-      targetId = SecTargetId<schedulerId>(std::move(extractedTids));
-      typename SecActionType<schedulerId>::ExtractedInt extractedAids(
-          touchpoint.actionType);
-      actionType = SecActionType<schedulerId>(std::move(extractedAids));
-      typename SecOriginalAdId<schedulerId>::ExtractedInt
-          extractedOriginalAdIds(touchpoint.originalAdId);
-      originalAdId =
-          SecOriginalAdId<schedulerId>(std::move(extractedOriginalAdIds));
-    } else {
-      ts = SecTimestamp<schedulerId>(touchpoint.ts, common::PUBLISHER);
-      targetId =
-          SecTargetId<schedulerId>(touchpoint.targetId, common::PUBLISHER);
-      actionType =
-          SecActionType<schedulerId>(touchpoint.actionType, common::PUBLISHER);
-      originalAdId = SecOriginalAdId<schedulerId>(
-          touchpoint.originalAdId, common::PUBLISHER);
-    }
-    adId = SecAdId<schedulerId>(touchpoint.adId, common::PUBLISHER);
-  }
 };
+
+template <int schedulerId, common::InputEncryption inputEncryption>
+PrivateTouchpoint<schedulerId, inputEncryption> createPrivateTouchpoint(
+    const Touchpoint& touchpoint) {
+  PrivateTouchpoint<schedulerId, inputEncryption> rst{.id{touchpoint.id}};
+  if constexpr (inputEncryption == common::InputEncryption::Xor) {
+    typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(touchpoint.ts);
+    rst.ts = SecTimestamp<schedulerId>(std::move(extractedTs));
+    typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
+        touchpoint.targetId);
+    rst.targetId = SecTargetId<schedulerId>(std::move(extractedTids));
+    typename SecActionType<schedulerId>::ExtractedInt extractedAids(
+        touchpoint.actionType);
+    rst.actionType = SecActionType<schedulerId>(std::move(extractedAids));
+    typename SecOriginalAdId<schedulerId>::ExtractedInt extractedOriginalAdIds(
+        touchpoint.originalAdId);
+    rst.originalAdId =
+        SecOriginalAdId<schedulerId>(std::move(extractedOriginalAdIds));
+  } else {
+    rst.ts = SecTimestamp<schedulerId>(touchpoint.ts, common::PUBLISHER);
+    rst.targetId =
+        SecTargetId<schedulerId>(touchpoint.targetId, common::PUBLISHER);
+    rst.actionType =
+        SecActionType<schedulerId>(touchpoint.actionType, common::PUBLISHER);
+    rst.originalAdId = SecOriginalAdId<schedulerId>(
+        touchpoint.originalAdId, common::PUBLISHER);
+  }
+  rst.adId = SecAdId<schedulerId>(touchpoint.adId, common::PUBLISHER);
+  return rst;
+}
 
 // Used for privately sharing isClick for xor encrypted inputs
 template <int schedulerId, common::InputEncryption inputEncryption>
 struct PrivateIsClick {
   SecBit<schedulerId> isClick;
-
-  explicit PrivateIsClick(const Touchpoint& touchpoint) {
-    if constexpr (inputEncryption == common::InputEncryption::Xor) {
-      typename SecBit<schedulerId>::ExtractedBit extractedIsClick(
-          touchpoint.isClick);
-      isClick = SecBit<schedulerId>(std::move(extractedIsClick));
-    } else {
-      isClick = SecBit<schedulerId>(touchpoint.isClick, common::PUBLISHER);
-    }
-  }
 };
+
+template <int schedulerId, common::InputEncryption inputEncryption>
+PrivateIsClick<schedulerId, inputEncryption> createPrivateIsClick(
+    const Touchpoint& touchpoint) {
+  PrivateIsClick<schedulerId, inputEncryption> rst;
+  if constexpr (inputEncryption == common::InputEncryption::Xor) {
+    typename SecBit<schedulerId>::ExtractedBit extractedIsClick(
+        touchpoint.isClick);
+    rst.isClick = SecBit<schedulerId>(std::move(extractedIsClick));
+  } else {
+    rst.isClick = SecBit<schedulerId>(touchpoint.isClick, common::PUBLISHER);
+  }
+  return rst;
+}
 
 // Used for parsing touchpoints from input CSV files
 struct ParsedTouchpoint {

--- a/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
+++ b/fbpcs/emp_games/pcf2_attribution/Touchpoint.h
@@ -22,7 +22,7 @@ struct Touchpoint {
   std::vector<uint64_t> adId;
 };
 
-template <int schedulerId, common::InputEncryption inputEncryption>
+template <int schedulerId>
 struct PrivateTouchpoint {
   std::vector<int64_t> id;
   SecTimestamp<schedulerId> ts;
@@ -32,11 +32,12 @@ struct PrivateTouchpoint {
   SecAdId<schedulerId> adId;
 };
 
-template <int schedulerId, common::InputEncryption inputEncryption>
-PrivateTouchpoint<schedulerId, inputEncryption> createPrivateTouchpoint(
+template <int schedulerId>
+PrivateTouchpoint<schedulerId> createPrivateTouchpoint(
+    common::InputEncryption inputEncryption,
     const Touchpoint& touchpoint) {
-  PrivateTouchpoint<schedulerId, inputEncryption> rst{.id{touchpoint.id}};
-  if constexpr (inputEncryption == common::InputEncryption::Xor) {
+  PrivateTouchpoint<schedulerId> rst{.id = touchpoint.id};
+  if (inputEncryption == common::InputEncryption::Xor) {
     typename SecTimestamp<schedulerId>::ExtractedInt extractedTs(touchpoint.ts);
     rst.ts = SecTimestamp<schedulerId>(std::move(extractedTs));
     typename SecTargetId<schedulerId>::ExtractedInt extractedTids(
@@ -63,16 +64,17 @@ PrivateTouchpoint<schedulerId, inputEncryption> createPrivateTouchpoint(
 }
 
 // Used for privately sharing isClick for xor encrypted inputs
-template <int schedulerId, common::InputEncryption inputEncryption>
+template <int schedulerId>
 struct PrivateIsClick {
   SecBit<schedulerId> isClick;
 };
 
-template <int schedulerId, common::InputEncryption inputEncryption>
-PrivateIsClick<schedulerId, inputEncryption> createPrivateIsClick(
+template <int schedulerId>
+PrivateIsClick<schedulerId> createPrivateIsClick(
+    common::InputEncryption inputEncryption,
     const Touchpoint& touchpoint) {
-  PrivateIsClick<schedulerId, inputEncryption> rst;
-  if constexpr (inputEncryption == common::InputEncryption::Xor) {
+  PrivateIsClick<schedulerId> rst;
+  if (inputEncryption == common::InputEncryption::Xor) {
     typename SecBit<schedulerId>::ExtractedBit extractedIsClick(
         touchpoint.isClick);
     rst.isClick = SecBit<schedulerId>(std::move(extractedIsClick));

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -299,7 +299,7 @@ template <
     common::InputEncryption inputEncryption>
 AttributionOutputMetrics computeAttributionsWithScheduler(
     int myId,
-    AttributionInputMetrics<inputEncryption> inputData,
+    AttributionInputMetrics inputData,
     std::reference_wrapper<
         fbpcf::engine::communication::IPartyCommunicationAgentFactory> factory,
     fbpcf::SchedulerCreator schedulerCreator) {
@@ -331,10 +331,13 @@ void testCorrectnessWithScheduler(
   std::string partnerInputFileName = filePrefix + ".partner.csv";
 
   // read input files
-  AttributionInputMetrics<inputEncryption> publisherInputData{
-      common::PUBLISHER, attributionRule, publisherInputFileName};
-  AttributionInputMetrics<inputEncryption> partnerInputData{
-      common::PARTNER, attributionRule, partnerInputFileName};
+  AttributionInputMetrics publisherInputData{
+      common::PUBLISHER,
+      attributionRule,
+      publisherInputFileName,
+      inputEncryption};
+  AttributionInputMetrics partnerInputData{
+      common::PARTNER, attributionRule, partnerInputFileName, inputEncryption};
 
   // compute attributions
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);
@@ -399,10 +402,13 @@ void testInputColumnsWithScheduler(
   std::string partnerInputFileName = filePrefix + ".partner.csv";
 
   // read input files
-  AttributionInputMetrics<inputEncryption> publisherInputData{
-      common::PUBLISHER, attributionRule, publisherInputFileName};
-  AttributionInputMetrics<inputEncryption> partnerInputData{
-      common::PARTNER, attributionRule, partnerInputFileName};
+  AttributionInputMetrics publisherInputData{
+      common::PUBLISHER,
+      attributionRule,
+      publisherInputFileName,
+      inputEncryption};
+  AttributionInputMetrics partnerInputData{
+      common::PARTNER, attributionRule, partnerInputFileName, inputEncryption};
 
   // compute attributions
   auto factories = fbpcf::engine::communication::getInMemoryAgentFactory(2);

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -131,12 +131,10 @@ TEST(AttributionGameTest, TestAttributionLogicPlaintextBatch) {
       false,
       false};
 
-  auto lastClick1D =
-      AttributionRule<common::PUBLISHER, common::InputEncryption::Plaintext>::
-          fromNameOrThrow(common::LAST_CLICK_1D);
-  auto lastTouch1D =
-      AttributionRule<common::PUBLISHER, common::InputEncryption::Plaintext>::
-          fromNameOrThrow(common::LAST_TOUCH_1D);
+  auto lastClick1D = AttributionRule<common::PUBLISHER>::fromNameOrThrow(
+      common::LAST_CLICK_1D);
+  auto lastTouch1D = AttributionRule<common::PUBLISHER>::fromNameOrThrow(
+      common::LAST_TOUCH_1D);
   auto thresholdsLastClick1D = game.privatelyShareThresholds(
       touchpoints, privateTouchpoints, *lastClick1D, 2);
   auto thresholdsLastTouch1D = game.privatelyShareThresholds(
@@ -223,16 +221,10 @@ TEST(AttributionGameTest, TestAttributionReformattedOutputLogicPlaintextBatch) {
   std::vector<std::vector<int>> convValuesLastTouch1D{
       {20, 20}, {40, 40}, {60, 60}};
 
-  auto lastClick1D = AttributionRule<
-      common::PUBLISHER,
-
-      common::InputEncryption::Plaintext>::
-      fromNameOrThrow(common::LAST_CLICK_1D);
-  auto lastTouch1D = AttributionRule<
-      common::PUBLISHER,
-
-      common::InputEncryption::Plaintext>::
-      fromNameOrThrow(common::LAST_TOUCH_1D);
+  auto lastClick1D = AttributionRule<common::PUBLISHER>::fromNameOrThrow(
+      common::LAST_CLICK_1D);
+  auto lastTouch1D = AttributionRule<common::PUBLISHER>::fromNameOrThrow(
+      common::LAST_TOUCH_1D);
   auto thresholdsLastClick1D = game.privatelyShareThresholds(
       touchpoints, privateTouchpoints, *lastClick1D, 2);
   auto thresholdsLastTouch1D = game.privatelyShareThresholds(


### PR DESCRIPTION
Summary:
In this stack of diff, we will gradually remove `inputEncyption` variable in the template as this should be a run time parameter.

This time we take a bottom-up approach to gradually propagate the changes upwards.

This diff changes the attribution input metrics

Differential Revision:
D43259139

Privacy Context Container: L416713

