### PR TITLE
Make `prepareMpcInput` return types more readable

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame.h
@@ -21,6 +21,16 @@
 namespace pcf2_attribution {
 
 template <int schedulerId>
+struct MpcInputs {
+  std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>
+      secTimeStamps_;
+  std::vector<PrivateTouchpoint<schedulerId>> touchPoints_;
+  std::vector<PrivateConversion<schedulerId>> conversions_;
+  std::vector<std::shared_ptr<const AttributionRule<schedulerId>>> attrRules_;
+  std::vector<int64_t> ids_;
+};
+
+template <int schedulerId>
 class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
  public:
   explicit AttributionGame(
@@ -33,16 +43,9 @@ class AttributionGame : public fbpcf::frontend::MpcGame<schedulerId> {
       common::InputEncryption inputEncryption);
 
   using PrivateTouchpointT = PrivateTouchpoint<schedulerId>;
-
   using PrivateConversionT = PrivateConversion<schedulerId>;
 
-  std::tuple<
-      std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>,
-      std::vector<PrivateTouchpointT>,
-      std::vector<PrivateConversionT>,
-      std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>,
-      std::vector<int64_t>>
-  prepareMpcInputs(
+  MpcInputs<schedulerId> prepareMpcInputs(
       const int myRole,
       const AttributionInputMetrics& inputData,
       common::InputEncryption inputEncryption);

--- a/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionGame_impl.h
@@ -357,13 +357,7 @@ AttributionOutputMetrics AttributionGame<schedulerId>::computeAttributions(
 }
 
 template <int schedulerId>
-std::tuple<
-    std::vector<std::vector<std::vector<SecTimestamp<schedulerId>>>>,
-    std::vector<typename AttributionGame<schedulerId>::PrivateTouchpointT>,
-    std::vector<typename AttributionGame<schedulerId>::PrivateConversionT>,
-    std::vector<std::shared_ptr<const AttributionRule<schedulerId>>>,
-    std::vector<int64_t>>
-AttributionGame<schedulerId>::prepareMpcInputs(
+MpcInputs<schedulerId> AttributionGame<schedulerId>::prepareMpcInputs(
     const int myRole,
     const AttributionInputMetrics& inputData,
     common::InputEncryption inputEncryption) {


### PR DESCRIPTION
Summary: As title.

Differential Revision:
D43329747

Privacy Context Container: L416713

