### PR TITLE
Add required dependencies in onedocker image

### DIFF
--- a/docker/emp_games/Dockerfile.ubuntu
+++ b/docker/emp_games/Dockerfile.ubuntu
@@ -36,7 +36,9 @@ FROM ubuntu:${os_release} as prod
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    libboost-context1.71.0 \
     libboost-regex1.71.0 \
+    libevent-2.1-7 \
     libcurl4 \
     libdouble-conversion3 \
     libgflags2.2 \

--- a/docker/onedocker/prod/Dockerfile.ubuntu
+++ b/docker/onedocker/prod/Dockerfile.ubuntu
@@ -25,7 +25,9 @@ RUN apt-get update && apt-get install -y \
   python3.8 \
   python3-pip \
   ca-certificates \
+  libboost-context1.71.0 \
   libboost-regex1.71.0 \
+  libevent-2.1-7 \
   libcurl4 \
   libdouble-conversion3 \
   libgflags2.2 \

--- a/docker/onedocker/test/Dockerfile.ubuntu
+++ b/docker/onedocker/test/Dockerfile.ubuntu
@@ -24,7 +24,9 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     python3-pip \
     # emp_games and data_processing dependencies
     ca-certificates \
+    libboost-context1.71.0 \
     libboost-regex1.71.0 \
+    libevent-2.1-7 \
     libcurl4 \
     libdouble-conversion3 \
     libgflags2.2 \


### PR DESCRIPTION
Summary: A previous change added a folly::Future  dependency in emp_games.  This requires a few runtime libs causing GH action failures (https://github.com/facebookresearch/fbpcs/actions/runs/4186989515/jobs/7256580450).  This change adds them to the onedocker & emp_games images.

Differential Revision: D43337593

