### PR TITLE
Back out "Add concurrent download in Shard Aggregator"

### DIFF
--- a/fbpcs/emp_games/attribution/Constants.h
+++ b/fbpcs/emp_games/attribution/Constants.h
@@ -18,6 +18,4 @@ const int64_t PUBLISHER = emp::ALICE;
 const int64_t PARTNER = emp::BOB;
 
 const int64_t INVALID_TP_ID = -1;
-const unsigned long MAX_IO_THREADS = 20;
-
 } // namespace measurement::private_attribution


### PR DESCRIPTION
Summary: The change introduced dependency on a couple of runtime libraries - which cannot be added currently.

Reviewed By: musebc

Differential Revision: D43369718

