### PR TITLE
Add feature gate enum in pcs

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -27,6 +27,7 @@ class PCSFeature(Enum):
     PID_FILTER_LOW_QUALITY_IDENTIFIER_THRESH166 = (
         "pid_filter_low_quality_identifier_thresh166"
     )
+    CREATE_DUPLICATE_INSTANCES = "create_duplicate_instances"
     UNKNOWN = "unknown"
 
     @classmethod


### PR DESCRIPTION
Summary:
## Why
In T145509298, Amazon wanted to have duplicated instances run on same objective. We had hotfix to support this usage case.
To have feature gating control by meta side to allow other adverisers can also use this new feature.

## What
- Add `CREATE_DUPLICATE_INSTANCES` feature flag in PCS

Reviewed By: gitfish77

Differential Revision: D43245966

