### PR TITLE
Crypto utility for encryption & decryption

### DIFF
--- a/fbpcs/emp_games/common/Crypto.cpp
+++ b/fbpcs/emp_games/common/Crypto.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/common/Crypto.h"
+
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <stdexcept>
+
+namespace private_measurement::crypto {
+
+HybridCipher::CipherMessage HybridCipher::encrypt(
+    const std::vector<unsigned char>& plaintext,
+    folly::ssl::EvpPkeySharedPtr pubKey) {
+  // Obtain parameters for encryption
+  const size_t kBlockSize = EVP_CIPHER_block_size(kSymmetricCipher);
+  const size_t kIvLength = EVP_CIPHER_iv_length(kSymmetricCipher);
+  const size_t publickKeyLength = EVP_PKEY_size(pubKey.get());
+
+  // Create space for storing the symmetric key, iv, and output ciphertext
+  CipherMessage msg(
+      plaintext.size() + kBlockSize, // ciphertext length
+      kIvLength, // iv length
+      publickKeyLength, // session key length
+      0 // signature length
+  );
+  int32_t sessionKeyLen;
+
+  // Initialize context
+  folly::ssl::EvpCipherCtxUniquePtr ctx(EVP_CIPHER_CTX_new());
+  int32_t ciphertextLen;
+  int32_t len;
+
+  // Initialise the envelope seal operation. This operation generates
+  // a session key for the provided cipher, and then encrypts that key a number
+  // of times (one for each public key provided in the pub_key array).
+  // Here the array size is just one. This operation also
+  // generates an IV and places it in iv.
+  unsigned char* sessionKeyWrap[1] = {msg.sessionKey.data()};
+  EVP_PKEY* keyWrap[1] = {pubKey.get()};
+  checkSuccessOrThrow(
+      EVP_SealInit(
+          ctx.get(), // EVP_CIPHER_CTX * EVP_context
+          kSymmetricCipher, // const EVP_CIPHER * EVP_cipher
+          sessionKeyWrap, // unsigned char ** session_keys_loc
+          &sessionKeyLen, // int * session_key_length_loc
+          msg.iv.data(), // unsigned char * iv_loc
+          keyWrap, // EVP_PKEY ** pubkeys_loc
+          1), // int num_pubkeys
+      "EVP_SealInit");
+  msg.sessionKey.resize(sessionKeyLen);
+
+  // Provide the message to be encrypted, and obtain the encrypted output.
+  checkSuccessOrThrow(
+      EVP_SealUpdate(
+          ctx.get(), // EVP_CIPHER_CTX * EVP_context
+          msg.ciphertext.data(), // unsigned char * output_location
+          &len, // int * output_length
+          plaintext.data(), // unsigned char * input_location
+          plaintext.size()), // int input_length
+      "EVP_SealUpdate failed");
+  ciphertextLen = len;
+
+  // Finalise the encryption.
+  checkSuccessOrThrow(
+      EVP_SealFinal(ctx.get(), msg.ciphertext.data() + len, &len),
+      "EVP_SealFinal failed");
+  ciphertextLen += len;
+  msg.ciphertext.resize(ciphertextLen);
+
+  return msg;
+}
+
+std::vector<unsigned char> HybridCipher::decrypt(
+    const HybridCipher::CipherMessage& msg,
+    folly::ssl::EvpPkeySharedPtr privKey) {
+  folly::ssl::EvpCipherCtxUniquePtr ctx(EVP_CIPHER_CTX_new());
+  int len;
+  int plaintextLen;
+
+  std::vector<unsigned char> plaintext(msg.ciphertext.size());
+  // Initialise the decryption operation. The asymmetric private key is
+  // provided as privKey, whilst the encrypted session key is held in
+  // sessionKey
+  checkSuccessOrThrow(
+      EVP_OpenInit(
+          ctx.get(), // EVP_CIPHER_CTX * ctx
+          kSymmetricCipher, // const EVP_CIPHER * EVP_cipher
+          msg.sessionKey.data(), // unsigned char * session_key
+          msg.sessionKey.size(), // int session_key_length
+          msg.iv.data(), // unsigned char * iv
+          privKey.get()), // EVP_PKEY * private_key
+      "EVP_OpenInit failed.");
+
+  // Provide the message to be decrypted, and obtain the plaintext output.
+  checkSuccessOrThrow(
+      EVP_OpenUpdate(
+          ctx.get(), // EVP_CIPHER_CTX * ctx
+          plaintext.data(), // unsigned char* output
+          &len, // int * output length
+          msg.ciphertext.data(), // unsigned char * input
+          msg.ciphertext.size()), // int input length
+      "EVP_OpenUpdate failed.");
+  plaintextLen = len;
+
+  // Finalise the decryption.
+  checkSuccessOrThrow(
+      EVP_OpenFinal(ctx.get(), plaintext.data() + len, &len),
+      "EVP_OpenFinal failed");
+  plaintextLen += len;
+  plaintext.resize(plaintextLen);
+
+  return plaintext;
+}
+
+} // namespace private_measurement::crypto

--- a/fbpcs/emp_games/common/Crypto.h
+++ b/fbpcs/emp_games/common/Crypto.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <folly/ssl/OpenSSLPtrTypes.h>
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace private_measurement::crypto {
+
+class OpenSSLException : public std::runtime_error {
+ public:
+  explicit OpenSSLException(const std::string& msg, int ret)
+      : std::runtime_error(
+            fmt::format("OpenSSL exception: {}. ret={}.", msg, ret)) {}
+};
+
+inline void checkSuccessOrThrow(int ret, std::string errMsg, int succRet = 1) {
+  if (ret != succRet) {
+    throw OpenSSLException(errMsg, ret);
+  }
+}
+
+template <typename TFailureFn>
+inline void
+checkSuccessOrThrow(int ret, std::string errMsg, TFailureFn&& isFailure) {
+  static_assert(std::is_invocable_r_v<bool, TFailureFn, int>, "Type mismatch!");
+  if (isFailure(ret)) {
+    throw OpenSSLException(errMsg, ret);
+  }
+}
+
+// Wrapper for C-style OpenSSL hybrid encryption/decryption
+class HybridCipher {
+ public:
+  const EVP_CIPHER* kSymmetricCipher = EVP_aes_256_cbc();
+
+  struct CipherMessage {
+    CipherMessage(
+        size_t ciphertextLen,
+        size_t ivLen,
+        size_t sessionKeyLen,
+        size_t sigLen)
+        : ciphertext(ciphertextLen),
+          iv(ivLen), // required by some symmetric ciphers
+          sessionKey(sessionKeyLen), // used for encrypting the ciphertext
+          signature(sigLen) {}
+
+    std::vector<unsigned char> ciphertext;
+    std::vector<unsigned char> iv; // required by some symmetric ciphers
+    std::vector<unsigned char> sessionKey; // used for encrypting the ciphertext
+    std::vector<unsigned char> signature;
+
+    // TODO: Add serialization / deserialization methods
+  };
+
+  // TODO: Add message signing
+  CipherMessage encrypt(
+      const std::vector<unsigned char>& plaintext,
+      folly::ssl::EvpPkeySharedPtr pubKey);
+
+  // TODO: Add message signature verification
+  std::vector<unsigned char> decrypt(
+      const CipherMessage& cipherMsg,
+      folly::ssl::EvpPkeySharedPtr privKey);
+};
+
+} // namespace private_measurement::crypto

--- a/fbpcs/emp_games/common/test/CryptoTest.cpp
+++ b/fbpcs/emp_games/common/test/CryptoTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <climits>
+#include <functional>
+#include <random>
+#include <stdexcept>
+
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+#include <folly/ssl/OpenSSLPtrTypes.h>
+
+#include "fbpcs/emp_games/common/Crypto.h"
+
+namespace private_measurement::crypto {
+
+folly::ssl::EvpPkeyUniquePtr getRandomRSAKeyPair(size_t length) {
+  // Generate RSA keypair
+  EVP_PKEY* pkey = nullptr;
+  folly::ssl::EvpPkeyCtxUniquePtr ctx(
+      EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr));
+  checkSuccessOrThrow(
+      EVP_PKEY_keygen_init(ctx.get()), "EVP_PKEY_kegen_init failed.");
+  checkSuccessOrThrow(
+      EVP_PKEY_CTX_set_rsa_keygen_bits(ctx.get(), length),
+      "EVP_PKEY_CTX_set_rsa_keygen_bits failed.");
+  checkSuccessOrThrow(
+      EVP_PKEY_keygen(ctx.get(), &pkey), "EVP_PKEY_keygen failed.");
+  return folly::ssl::EvpPkeyUniquePtr(pkey);
+}
+
+void encryptionTestHelper(
+    const std::vector<unsigned char>& plaintext,
+    folly::ssl::EvpPkeySharedPtr keyPair1,
+    folly::ssl::EvpPkeySharedPtr keyPair2) {
+  HybridCipher cipher;
+  auto cipherMsg = cipher.encrypt(plaintext, keyPair1);
+
+  // Decrypt with the correct private key
+  auto decryptedText = cipher.decrypt(cipherMsg, keyPair1);
+  EXPECT_THAT(plaintext, testing::ContainerEq(decryptedText));
+
+  // Decrypt with a wrong private key
+  EXPECT_THROW(cipher.decrypt(cipherMsg, keyPair2), OpenSSLException);
+}
+
+using randomBytesEngine = std::independent_bits_engine<
+    std::default_random_engine,
+    CHAR_BIT,
+    unsigned char>;
+inline std::vector<unsigned char> generateRandomBytes(size_t size) {
+  randomBytesEngine rbe;
+  std::vector<unsigned char> res(size);
+  std::generate(res.begin(), res.end(), std::ref(rbe));
+  return res;
+}
+
+TEST(CryptoUtilTest, testEncryptionDecryption) {
+  const size_t keyLength = 1024;
+  folly::ssl::EvpPkeySharedPtr keyPair1 = getRandomRSAKeyPair(keyLength);
+  folly::ssl::EvpPkeySharedPtr keyPair2 = getRandomRSAKeyPair(keyLength);
+
+  // Simple string
+  const std::string inputMsg =
+      "Hello world \4\5 I'm \t \17\22 test \177 string";
+  auto inputBytes =
+      std::vector<unsigned char>(inputMsg.cbegin(), inputMsg.cend());
+  inputBytes[6] = '\0';
+  encryptionTestHelper(inputBytes, keyPair1, keyPair2);
+
+  // Empty string
+  encryptionTestHelper(std::vector<unsigned char>(), keyPair1, keyPair2);
+
+  // All zero bytes
+  encryptionTestHelper(std::vector<unsigned char>(100, 0), keyPair1, keyPair2);
+
+  // Random bytes
+  encryptionTestHelper(generateRandomBytes(2000), keyPair1, keyPair2);
+}
+
+} // namespace private_measurement::crypto


### PR DESCRIPTION
Summary:
# Why
This library will be used to encrypt / decrypt shares from ad-hoc advertisers.

# What
The diff implements a light wrapper on OpenSSL hybrid encryption/decryption functions, based on RSA (for encrypting the session key) and AES_256_CBC (for encrypting the actual data).

TODO (in subsequent diffs):
* Add signatures to cipher message (authentication).
* Add serialization / deserialization.

# Risk
Unfortunately, the API of OpenSSL libcrypto is a bit messy, and they are constantly deprecating mysterious APIs in newer versions. So we may have to come back to update the code.

We have tried to use only APIs that are not deprecated in OpenSSL 3.1.

Differential Revision: D43255201

