### PR TITLE
Add logging for number of id columns

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.h
+++ b/fbpcs/data_processing/sharding/GenericSharder.h
@@ -132,14 +132,14 @@ class GenericSharder {
     std::stringstream ss;
     ss << shard;
     std::string key = ss.str();
-    rowsInShard[key]++;
+    pid_shard_info[key]++;
   }
 
   int getRowsForShard(std::size_t shard) {
     std::stringstream ss;
     ss << shard;
     std::string key = ss.str();
-    return rowsInShard[key];
+    return pid_shard_info[key];
   }
 
   /**
@@ -175,17 +175,17 @@ class GenericSharder {
   /**
    * Log number of rows in each shard to a json file
    */
-  void logShardDistribution();
+  void logShardInfo();
 
   /**
    * Return the json string that contains the number of rows in each shard
    */
-  std::string getShardDistributionJson();
+  std::string getShardInfoJson();
 
  private:
   std::string inputPath_;
   std::vector<std::string> outputPaths_;
   int32_t logEveryN_;
-  std::unordered_map<std::string, int> rowsInShard;
+  std::unordered_map<std::string, int> pid_shard_info;
 };
 } // namespace data_processing::sharder

--- a/fbpcs/data_processing/sharding/test/GenericSharderTest.cpp
+++ b/fbpcs/data_processing/sharding/test/GenericSharderTest.cpp
@@ -37,7 +37,7 @@ class GenericSharderTest final : public GenericSharder {
       const std::vector<int32_t>& /* unused */) final {
     linesCalledWith_.push_back(line);
     // shardLine is overwritten here so we should mannually call the
-    // logRowsToShard to make changes to rowsInShard.
+    // logRowsToShard to make changes to pid_shard_info.
     std::size_t s = {0};
     logRowsToShard(s);
   }
@@ -147,7 +147,7 @@ TEST(GenericSharderTest, TestShardLine) {
   EXPECT_EQ(actual.linesCalledWith_, expected);
 }
 
-TEST(GenericSharderTest, TestGetShardDistributionJson) {
+TEST(GenericSharderTest, TestGetShardInfoJson) {
   // This test is just ensuring that the json file is correctly written
   auto randStart = folly::Random::secureRand64();
   std::string inputPath =
@@ -170,12 +170,12 @@ TEST(GenericSharderTest, TestGetShardDistributionJson) {
   // There are 2 output paths, so there will be two shards.
   // Since there are 4 rows in the input file, the shardLine() is called for 4
   // times. logRowsToShard(0) is also called for 4 times. Thus, the first pair
-  // in json should be "0":4. As rowsInShard[1] is never specified, it should be
-  // a default 0, thus the second pair should be "1":0.
+  // in json should be "0":4. As pid_shard_info[1] is never specified, it should
+  // be a default 0, thus the second pair should be "1":0.
   std::string expected{
-      "{\n  \"0\": 4,\n  \"1\": 0\n}",
+      "{\n  \"0\": 4,\n  \"1\": 0,\n  \"num_ids\": 1\n}",
   };
-  EXPECT_EQ(actual.getShardDistributionJson(), expected);
+  EXPECT_EQ(actual.getShardInfoJson(), expected);
 }
 
 } // namespace data_processing::sharder


### PR DESCRIPTION
Summary:
## Why
The purpose is to log how many multi-key the advertisers are using.
In PID SHARD stage, we have "rowsInShard" to log the number of rows of each shard. And now we need to log the number of columns of the file. So we rename "rowsInShard" to be more generic "pid_shard_info".
## What
 read the file header to calculate the number of columns;

Reviewed By: yuyashiraki

Differential Revision: D43066928

