### PR TITLE
Add trace logging for num ID columns

### DIFF
--- a/fbpcs/private_computation/stage_flows/stage_selector.py
+++ b/fbpcs/private_computation/stage_flows/stage_selector.py
@@ -62,6 +62,7 @@ class StageSelector:
                 args.storage_svc,
                 args.onedocker_svc,
                 args.onedocker_binary_config_map,
+                args.trace_logging_svc,
             )
         elif stage_flow.name == "PID_PREPARE":
             return PIDPrepareStageService(

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -36,11 +36,15 @@ from fbpcs.private_computation.service.utils import generate_env_vars_dict
 
 
 class TestPIDShardStageService(IsolatedAsyncioTestCase):
+    @patch("fbpcs.common.service.trace_logging_service")
     @patch("fbpcp.service.storage.StorageService")
     @patch("fbpcp.service.onedocker.OneDockerService")
-    def setUp(self, mock_onedocker_svc, mock_storage_svc) -> None:
+    def setUp(
+        self, mock_onedocker_svc, mock_storage_svc, mock_trace_logging_service
+    ) -> None:
         self.mock_onedocker_svc = mock_onedocker_svc
         self.mock_storage_svc = mock_storage_svc
+        self.mock_trace_loggging_svc = mock_trace_logging_service
         self.onedocker_binary_config = OneDockerBinaryConfig(
             tmp_directory="/tmp",
             binary_version="latest",
@@ -71,6 +75,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 storage_svc=self.mock_storage_svc,
                 onedocker_svc=self.mock_onedocker_svc,
                 onedocker_binary_config_map=self.onedocker_binary_config_map,
+                trace_logging_svc=self.mock_trace_loggging_svc,
                 container_timeout=self.container_timeout,
             )
             containers = [self.create_container_instance()]


### PR DESCRIPTION
Summary:
In PID shard stage (GenericSharder.cpp), we loged the shard information to Json output (D43066928 (https://github.com/facebookresearch/fbpcs/commit/be333ab7ae1bd1cbe47f96320f8bf06305db7df1)):
(1) for the file header row, how many columns are start with prefic "id_"
(2) the number of rows for each shard.

With the [design of Centralized Trace Logging](https://docs.google.com/document/d/1mP9ctSCInz7lOlwe0XC06bfoGSnHLe5-Z_9qgjJWRe8/edit#),
We want to from advertiser-side to Meta via trace logging when running the PID Shard Stage service, if it successfully completes:
(1) number of columns that are start with prefix "id_" (PID shard stage service, );
(2) total number of rows of all the shards (PID shard stage service, ).

Reviewed By: yuyashiraki, joe1234wu, gitfish77

Differential Revision: D43171053

