### PR TITLE
use the correct env_var_list when retrying

### DIFF
--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -55,7 +55,9 @@ class RunBinaryBaseService:
                 version=binary_version,
                 cmd_args_list=[cmd_args_list[i] for i in containers_to_start],
                 timeout=timeout,
-                env_vars=env_vars_list if env_vars_list else env_vars,
+                env_vars=[env_vars_list[i] for i in containers_to_start]
+                if env_vars_list
+                else env_vars,
                 container_type=container_type,
                 certificate_request=certificate_request,
             )


### PR DESCRIPTION
Summary:
Similar to `cmd_args_list` in line 56, we need to only select the items `env_var_list` that corresponds to the containers for retry. Without this change, when containers fail, we would get the following output from EP
```
ERROR:fbpcs.bolt.bolt_runner:[partner_tls_e2e_instance_630] Error: type: <class 'measurement.private_measurement.private_computation_service.private_computation.types.InternalServerErrorT'>, message: Error during runNext
INFO:root:File "/data/users/yigezhu/fbsource/buck-out/v2/gen/fbcode/5697cef6ea8bc955/measurement/private_measurement/private_computation_service/__private_computation_service__/private_computation_service#link-tree/fbpcp/service/onedocker.py", line 156, in start_containers
INFO:fbpcs.bolt.bolt_runner:[partner_tls_e2e_instance_630] Retrying stage PrivateComputationPCF2LiftStageFlow.PCF2_LIFT, Retries left: 1.
INFO:root:raise ValueError(
INFO:root:ValueError: Length of env_vars 5 not equal to the length of cmd_args_list 3.
INFO:fbpcs.common.service.trace_logging_service:{"operation": "write_checkpoint", "run_id": "3bfa5a57-239a-44ef-b1bd-9da0c2c6f43a-fbpcs-default", "instance_id": "publisher_tls_e2e_instance_630", "checkpoint_name": "JOB_IS_FINISHED", "status": "STARTED", "checkpoint_data": "{\"component\": \"BoltRunner\"}"}
INFO:fbpcs.common.service.trace_logging_service:{"operation": "write_checkpoint", "run_id": "3bfa5a57-239a-44ef-b1bd-9da0c2c6f43a-fbpcs-default", "instance_id": "partner_tls_e2e_instance_630", "checkpoint_name": "UPDATE_INSTANCE", "status": "STARTED", "checkpoint_data": "{\"component\": \"BoltPCSClient\"}"}
INFO:fbpcs.private_computation.service.private_computation:Not updating partner_tls_e2e_instance_630: status is PrivateComputationInstanceStatus.PCF2_LIFT_FAILED
```
This is because `self.get_containers_to_start` return an int smaller than len(cmd_args_list) during retry

Differential Revision: D43575250

