### PR TITLE
Adding PCS feature gate for publisher pc pre validation

### DIFF
--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -28,6 +28,7 @@ class PCSFeature(Enum):
         "pid_filter_low_quality_identifier_thresh166"
     )
     CREATE_DUPLICATE_INSTANCES = "create_duplicate_instances"
+    PUBLISHER_PC_PRE_VALIDATION = "publisher_pc_pre_validation"
     UNKNOWN = "unknown"
 
     @classmethod


### PR DESCRIPTION
Summary:
This diff stack is intended to enable PC PRE-VALIDATION on publisher.

This diff defines a PCS feature gate for publisher side pre-validation. It will act as a kill switch in case something goes wrong.

Differential Revision: D43578507

