### PR TITLE
Adding github tests for PCF2 shard combiner.

### DIFF
--- a/fbpcs/tests/github/bolt_config.yml
+++ b/fbpcs/tests/github/bolt_config.yml
@@ -76,6 +76,30 @@ jobs:
       num_pid_containers: 2
       pcs_features: [private_lift_pcf2_release]
       concurrency: 4
+  lift_pcf2_shard_combiner:
+    # publisher player args
+    publisher:
+      # required args #
+      input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/publisher_e2e_input.csv
+      # optional args #
+      output_dir: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/outputs
+      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/publisher_expected_result_pcf2.json
+    # partner player args
+    partner:
+      # required args #
+      input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/inputs/partner_e2e_input.csv
+      # optional args #
+      output_dir: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/outputs
+      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result_pcf2.json
+    # args shared by both publisher and partner
+    shared:
+      # required args #
+      game_type: lift
+      # optional args #
+      num_mpc_containers: 2
+      num_pid_containers: 2
+      pcs_features: [private_lift_pcf2_release,shard_combiner_pcf2_release]
+      concurrency: 4
   lift_udp:
     # publisher player args
     publisher:
@@ -126,3 +150,31 @@ jobs:
       num_files_per_mpc_container: 1
       attribution_rule: last_touch_1d
       aggregation_type: measurement
+  attribution_pcf2_shard_combiner:
+    # publisher player args
+    publisher:
+      # required args #
+      input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/publisher_e2e_input.csv
+      # optional args #
+      output_dir: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/outputs
+      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/publisher_expected_result.json
+    # partner player args
+    partner:
+      # required args #
+      input_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/inputs/partner_e2e_input.csv
+      # optional args #
+      output_dir: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/outputs
+      expected_result_path: https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/attribution/results/partner_expected_result.json
+
+    # args shared by both publisher and partner
+    shared:
+      # required args #
+      game_type: attribution
+      # optional args #
+      num_mpc_containers: 1
+      num_pid_containers: 1
+      concurrency: 1
+      num_files_per_mpc_container: 1
+      attribution_rule: last_touch_1d
+      aggregation_type: measurement
+      pcs_features: [shard_combiner_pcf2_release]


### PR DESCRIPTION
Summary: As part of rollout of PCF 2 Shard combiner, adding github tests for the same.

Differential Revision:
D43649694

Privacy Context Container: L416713

