### PR TITLE
Adding run_id and pcs_features to game args.

### DIFF
--- a/fbpcs/private_computation/repository/private_computation_game.py
+++ b/fbpcs/private_computation/repository/private_computation_game.py
@@ -163,6 +163,8 @@ PRIVATE_COMPUTATION_GAME_CONFIG: Dict[str, GameNamesValue] = {
             OneDockerArgument(name="ca_cert_path", required=False),
             OneDockerArgument(name="server_cert_path", required=False),
             OneDockerArgument(name="private_key_path", required=False),
+            OneDockerArgument(name="run_id", required=False),
+            OneDockerArgument(name="pc_feature_flags", required=False),
         ],
     },
     GameNames.DECOUPLED_ATTRIBUTION.value: {


### PR DESCRIPTION
Summary: As the title, adding run_id and pcs_features to the game args for Shard Combiner. Missed this change in D42445672

Differential Revision:
D43664261

Privacy Context Container: L416713

