### PR TITLE
Adding Publisher PC pre validation checks

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -32,15 +32,24 @@ CONVERSION_METADATA_FIELD = "conversion_metadata"
 VALUE_FIELD = "value"
 EVENT_TIMESTAMP_FIELD = "event_timestamp"
 TIMESTAMP = "timestamp"
+OPPORTUNITY_TIMESTAMP = "opportunity_timestamp"
+AD_ID = "ad_id"
+IS_CLICK = "is_click"
+
 
 PA_FIELDS: List[str] = [
     CONVERSION_VALUE_FIELD,
     CONVERSION_TIMESTAMP_FIELD,
     CONVERSION_METADATA_FIELD,
 ]
+PA_PUBLISHER_FIELDS: List[str] = [AD_ID, TIMESTAMP, IS_CLICK]
 PL_FIELDS: List[str] = [
     VALUE_FIELD,
     EVENT_TIMESTAMP_FIELD,
+]
+PL_PUBLISHER_FIELDS: List[str] = [
+    ID_FIELD_PREFIX,
+    OPPORTUNITY_TIMESTAMP,
 ]
 PRIVATE_ID_DFCA_FIELDS: List[str] = ["partner_user_id"]
 REQUIRED_FIELDS: List[str] = [

--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -39,7 +39,9 @@ from fbpcs.pc_pre_validation.constants import (
     INPUT_DATA_VALIDATOR_NAME,
     INTEGER_MAX_VALUE,
     PA_FIELDS,
+    PA_PUBLISHER_FIELDS,
     PL_FIELDS,
+    PL_PUBLISHER_FIELDS,
     PRIVATE_ID_DFCA_FIELDS,
     STREAMING_DURATION_LIMIT_IN_SECONDS,
     TIMESTAMP,
@@ -331,9 +333,19 @@ class InputDataValidator(Validator):
         match_pa_fields = len(set(PA_FIELDS).intersection(set(header_row))) == len(
             PA_FIELDS
         )
+
+        match_pa_publisher_fields = len(
+            set(PA_PUBLISHER_FIELDS).intersection(set(header_row))
+        ) == len(PA_PUBLISHER_FIELDS)
+
         match_pl_fields = len(set(PL_FIELDS).intersection(set(header_row))) == len(
             PL_FIELDS
         )
+
+        match_pl_publisher_fields = len(
+            set(PL_PUBLISHER_FIELDS).intersection(set(header_row))
+        ) == len(PL_PUBLISHER_FIELDS)
+
         match_private_id_dfca_fields = len(
             set(PRIVATE_ID_DFCA_FIELDS).intersection(set(header_row))
         ) == len(PRIVATE_ID_DFCA_FIELDS)
@@ -343,9 +355,16 @@ class InputDataValidator(Validator):
                 f"Failed to parse the header row. The header row fields must have columns with prefix {ID_FIELD_PREFIX}"
             )
 
-        if not (match_pa_fields or match_pl_fields or match_private_id_dfca_fields):
+        if not (
+            match_pa_fields
+            or match_pl_fields
+            or match_private_id_dfca_fields
+            or match_pl_publisher_fields
+            or match_pa_publisher_fields
+        ):
             raise InputDataValidationException(
-                f"Failed to parse the header row. The header row fields must have either: {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS}"
+                f"Failed to parse the header row. The header row fields must have either: \
+                {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS} or: {PL_PUBLISHER_FIELDS} or {PA_PUBLISHER_FIELDS}"
             )
 
     def _validate_line_ending(self, line: str) -> None:

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -19,7 +19,9 @@ from fbpcs.pc_pre_validation.constants import (
     INPUT_DATA_TMP_FILE_PATH,
     INPUT_DATA_VALIDATOR_NAME,
     PA_FIELDS,
+    PA_PUBLISHER_FIELDS,
     PL_FIELDS,
+    PL_PUBLISHER_FIELDS,
     PRIVATE_ID_DFCA_FIELDS,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
@@ -484,7 +486,8 @@ class TestInputDataValidator(TestCase):
     def test_run_validations_errors_when_pa_pl_data_fields_not_found(
         self, time_mock: Mock
     ) -> None:
-        exception_message = f"Failed to parse the header row. The header row fields must have either: {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS}"
+        exception_message = f"Failed to parse the header row. The header row fields must have either: \
+                {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS} or: {PL_PUBLISHER_FIELDS} or {PA_PUBLISHER_FIELDS}"
         time_mock.time.return_value = TEST_TIMESTAMP
         lines = [
             b"id_,header,row\n",

--- a/fbpcs/private_computation/entity/pc_validator_config.py
+++ b/fbpcs/private_computation/entity/pc_validator_config.py
@@ -17,6 +17,7 @@ from dataclasses_json import dataclass_json
 class PCValidatorConfig:
     region: str
     pc_pre_validator_enabled: bool = True
+    pc_pre_validator_publisher_enabled: bool = False
 
     def __str__(self) -> str:
         # pyre-ignore

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -206,7 +206,23 @@ class PCPreValidationStageService(PrivateComputationStageService):
     def _should_run_pre_validation(
         self, pc_instance: PrivateComputationInstance
     ) -> bool:
-        return (
-            self._pc_validator_config.pc_pre_validator_enabled
-            and pc_instance.infra_config.role == PrivateComputationRole.PARTNER
+        if (
+            pc_instance.infra_config.role == PrivateComputationRole.PARTNER
+            and self._pc_validator_config.pc_pre_validator_enabled
+        ):
+            self._logger.info(
+                f"PC pre validation is enabled for private computation role: {PrivateComputationRole.PARTNER}"
+            )
+            return True
+        elif (
+            pc_instance.infra_config.role == PrivateComputationRole.PUBLISHER
+            and self._pc_validator_config.pc_pre_validator_publisher_enabled
+        ):
+            self._logger.info(
+                f"PC pre validation is enabled for private computation role: {PrivateComputationRole.PUBLISHER}"
+            )
+            return True
+        self._logger.info(
+            f"PC pre validation is disbled for private computation role: {pc_instance.infra_config.role}. Skipping pre-validation check."
         )
+        return False

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -209,9 +209,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             pc_instance, NullCertificateProvider(), NullCertificateProvider(), "", ""
         )
         status = stage_service.get_status(pc_instance)
-
         mock_onedocker_svc.start_container.assert_not_called()
-        mock_get_pc_status_from_stage_state.assert_not_called()
         self.assertEqual(status, expected_status)
 
     @patch(


### PR DESCRIPTION
Summary:
Right now PC Pre Validator checks for file path on partner side but publisher side is no op.

This diff will enable publisher side file path checks.

What to expect next in this diff stack:
1. Add feature flag check, which will kill switch if we need to disable feature at the run time
2. Publisher file data checks. Right now we only validate the header row

Differential Revision: D42372427

