### PR TITLE
PCE deployment in CB: deployment service received the new parameter of publisher PCE instance ID and passed to deploy.sh

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -15,6 +15,7 @@ usage() {
         [ -a, --account_id | Your AWS account ID]
         [ -p, --publisher_account_id | Publisher's AWS account ID]
         [ -v, --publisher_vpc_id | Publisher's VPC Id]
+        [ -e, --publisher_pce_instance_id | Publisher's PCE instance Id (i.e. a UUID without dash signs)]
         [ -s, --config_storage_bucket | optional. S3 bucket name for storing configs: tfstate/lambda function]
         [ -d, --data_storage_bucket | optional. S3 bucket name for storing lambda processed results]
         [ -b, --build_semi_automated_data_pipeline | optional. whether to build semi automated (manual upload) data pipeline ]"
@@ -43,6 +44,7 @@ while [ $# -gt 0 ]; do
         -a|--account_id) aws_account_id="$2" ;;
         -p|--publisher_account_id) publisher_aws_account_id="$2" ;;
         -v|--publisher_vpc_id) publisher_vpc_id="$2" ;;
+        -e|--publisher_pce_instance_id) publisher_pce_instance_id="$2" ;;
         -s|--config_storage_bucket) s3_bucket_for_storage="$2" ;;
         -d|--data_storage_bucket) s3_bucket_data_pipeline="$2" ;;
         -b|--build_semi_automated_data_pipeline) build_semi_automated_data_pipeline=true second_shift_flag=false ;;

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentParams.java
@@ -28,6 +28,7 @@ public class DeploymentParams {
   public String awsSecretAccessKey;
   public String awsSessionToken;
   public String publisherPCEId;
+  public String publisherPCEInstanceId;
   private final Logger logger = LoggerFactory.getLogger(DeploymentParams.class);
 
   enum LogLevel {
@@ -180,6 +181,8 @@ public class DeploymentParams {
             .append(", Tag: ")
             .append(", publisherPCEId: ")
             .append(publisherPCEId)
+            .append(", publisherPCEInstanceId: ")
+            .append(publisherPCEInstanceId)
             .append(tag)
             .append(", Enable Semi-Automated Data Ingestion: ")
             .append(String.valueOf(enableSemiAutomatedDataIngestion));

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -112,6 +112,10 @@ public class DeploymentRunner extends Thread {
       deployCommand.add("-d");
       deployCommand.add(deployment.dataStorage);
     }
+    if (!StringUtils.isBlank(deployment.publisherPCEInstanceId)) {
+      deployCommand.add("-e");
+      deployCommand.add(deployment.publisherPCEInstanceId);
+    }
     if (deployment.enableSemiAutomatedDataIngestion) {
       deployCommand.add("-b");
     }


### PR DESCRIPTION
Summary:
**What**
In the partner PCE deployment service, the new parameter of publisher PCE is extracted. Then the parameter is passed to the deploy.sh script as a command line parameter.

Publisher PCE Instance ID is a UUID assigned by the Meta PCE Service, like "510d2d50b15742c0ac63b346de16a0b4".

**Why**
Partner side will deploy MR-PID resources with length 4 random string as postfix (same as PCE resources) and it knows the Publisher S3 bucket name format: mrpid-publisher-${publisher_pce_instance_id}.
Further change will be made in deploy.sh to create the partner EMR resources based o the publisher PCE Instance ID.

Differential Revision: D43720635

