### PR TITLE
Reformatted output PCS feature

### DIFF
--- a/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_aggregation_stage_service.py
@@ -128,7 +128,9 @@ class PCF2AggregationStageService(PCF2BaseStageService):
                 "max_num_conversions": private_computation_instance.product_config.common.padding_size,
                 "log_cost": self._log_cost_to_s3,
                 "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
-                "use_new_output_format": False,
+                "use_new_output_format": private_computation_instance.has_feature(
+                    PCSFeature.PRIVATE_ATTRIBUTION_REFORMATTED_OUTPUT
+                ),
                 "run_id": private_computation_instance.infra_config.run_id,
                 **tls_args,
             }

--- a/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_attribution_stage_service.py
@@ -120,6 +120,9 @@ class PCF2AttributionStageService(PCF2BaseStageService):
                 "use_postfix": True,
                 "run_id": private_computation_instance.infra_config.run_id,
                 "log_cost_s3_bucket": private_computation_instance.infra_config.log_cost_bucket,
+                "use_new_output_format": private_computation_instance.has_feature(
+                    PCSFeature.PRIVATE_ATTRIBUTION_REFORMATTED_OUTPUT
+                ),
                 **tls_args,
             }
 


### PR DESCRIPTION
Summary: Updated the "use_new_output_format" game args to read from the PCS feature flags instead, and removed them from the default game args.

Reviewed By: joe1234wu

Differential Revision: D43757926

