### PR TITLE
Increase test timeout to 3 hours

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_E2E_TEST_ROLE_TO_ASSUME }}
           aws-region: us-west-2
-          role-duration-seconds: 5400
+          role-duration-seconds: 10800
           role-session-name: ${{ steps.aws_session_name.outputs.session_name }}
 
       - name: Clean Up Docker Images
@@ -110,7 +110,7 @@ jobs:
 
       ### Private Lift and Attribution E2E tests
       - name: End to end testing
-        timeout-minutes: 90
+        timeout-minutes: 180
         run: |
           docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e AWS_DEFAULT_REGION --rm -v "instances":"/instances" -v "$(realpath fbpcs_e2e_aws.yml):/home/pcs/pl_coordinator_env/fbpcs_e2e_aws.yml" -v "$(realpath bolt_config.yml):/home/pcs/pl_coordinator_env/bolt_config.yml" ${{ env.COORDINATOR_IMAGE }}:${{ inputs.new_tag }} python3.8 -m fbpcs.private_computation_cli.private_computation_cli bolt_e2e --bolt_config="bolt_config.yml"
         working-directory: fbpcs/tests/github/


### PR DESCRIPTION
Summary: Right now, we are seeing the Publish OneDocker tests consistently timing out. Until we can determine why, this increases the token timeout to 3 hours from 1.5 hours.

Differential Revision: D43874057

