### PR TITLE
Adding feature flag check for publisher pc pre validation

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -32,15 +32,24 @@ CONVERSION_METADATA_FIELD = "conversion_metadata"
 VALUE_FIELD = "value"
 EVENT_TIMESTAMP_FIELD = "event_timestamp"
 TIMESTAMP = "timestamp"
+OPPORTUNITY_TIMESTAMP = "opportunity_timestamp"
+AD_ID = "ad_id"
+IS_CLICK = "is_click"
+
 
 PA_FIELDS: List[str] = [
     CONVERSION_VALUE_FIELD,
     CONVERSION_TIMESTAMP_FIELD,
     CONVERSION_METADATA_FIELD,
 ]
+PA_PUBLISHER_FIELDS: List[str] = [AD_ID, TIMESTAMP, IS_CLICK]
 PL_FIELDS: List[str] = [
     VALUE_FIELD,
     EVENT_TIMESTAMP_FIELD,
+]
+PL_PUBLISHER_FIELDS: List[str] = [
+    ID_FIELD_PREFIX,
+    OPPORTUNITY_TIMESTAMP,
 ]
 PRIVATE_ID_DFCA_FIELDS: List[str] = ["partner_user_id"]
 REQUIRED_FIELDS: List[str] = [

--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -39,7 +39,9 @@ from fbpcs.pc_pre_validation.constants import (
     INPUT_DATA_VALIDATOR_NAME,
     INTEGER_MAX_VALUE,
     PA_FIELDS,
+    PA_PUBLISHER_FIELDS,
     PL_FIELDS,
+    PL_PUBLISHER_FIELDS,
     PRIVATE_ID_DFCA_FIELDS,
     STREAMING_DURATION_LIMIT_IN_SECONDS,
     TIMESTAMP,
@@ -331,9 +333,19 @@ class InputDataValidator(Validator):
         match_pa_fields = len(set(PA_FIELDS).intersection(set(header_row))) == len(
             PA_FIELDS
         )
+
+        match_pa_publisher_fields = len(
+            set(PA_PUBLISHER_FIELDS).intersection(set(header_row))
+        ) == len(PA_PUBLISHER_FIELDS)
+
         match_pl_fields = len(set(PL_FIELDS).intersection(set(header_row))) == len(
             PL_FIELDS
         )
+
+        match_pl_publisher_fields = len(
+            set(PL_PUBLISHER_FIELDS).intersection(set(header_row))
+        ) == len(PL_PUBLISHER_FIELDS)
+
         match_private_id_dfca_fields = len(
             set(PRIVATE_ID_DFCA_FIELDS).intersection(set(header_row))
         ) == len(PRIVATE_ID_DFCA_FIELDS)
@@ -343,9 +355,16 @@ class InputDataValidator(Validator):
                 f"Failed to parse the header row. The header row fields must have columns with prefix {ID_FIELD_PREFIX}"
             )
 
-        if not (match_pa_fields or match_pl_fields or match_private_id_dfca_fields):
+        if not (
+            match_pa_fields
+            or match_pl_fields
+            or match_private_id_dfca_fields
+            or match_pl_publisher_fields
+            or match_pa_publisher_fields
+        ):
             raise InputDataValidationException(
-                f"Failed to parse the header row. The header row fields must have either: {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS}"
+                f"Failed to parse the header row. The header row fields must have either: \
+                {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS} or: {PL_PUBLISHER_FIELDS} or {PA_PUBLISHER_FIELDS}"
             )
 
     def _validate_line_ending(self, line: str) -> None:

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -21,7 +21,9 @@ Usage:
         [--start-timestamp=<start-timestamp>]
         [--end-timestamp=<end-timestamp>]
         [--binary-version=<binary-version>]
+        [--private-computation-role=<private-computation-role>]
         [--pre-validation-file-stream=<pre-validation-file-stream>]
+        [--publisher-pc-pre-validation=<publisher-pc-pre-validation>]
 """
 
 
@@ -46,6 +48,9 @@ END_TIMESTAMP = "--end-timestamp"
 BINARY_VERSION = "--binary-version"
 PRE_VALIDATION_FILE_STREAM_FLAG = "--pre-validation-file-stream"
 PRE_VALIDATION_FILE_STREAM_ENABLED = "enabled"
+PUBLISHER_PC_PRE_VALIDATION_FLAG = "--publisher-pc-pre-validation"
+PUBLISHER_PC_PRE_VALIDATION_ENABLED = "enabled"
+PRIVATE_COMPUTATION_ROLE = "--private-computation-role"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -63,6 +68,8 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(END_TIMESTAMP): optional_string,
             Optional(BINARY_VERSION): optional_string,
             Optional(PRE_VALIDATION_FILE_STREAM_FLAG): optional_string,
+            Optional(PUBLISHER_PC_PRE_VALIDATION_FLAG): optional_string,
+            Optional(PRIVATE_COMPUTATION_ROLE): optional_string,
         }
     )
     arguments = s.validate(docopt(__doc__, argv))
@@ -70,6 +77,10 @@ def main(argv: OptionalType[List[str]] = None) -> None:
     print("Parsed pc_pre_validation_cli arguments")
     stream_file = (
         arguments[PRE_VALIDATION_FILE_STREAM_FLAG] == PRE_VALIDATION_FILE_STREAM_ENABLED
+    )
+    publisher_pc_pre_validation = (
+        arguments[PUBLISHER_PC_PRE_VALIDATION_FLAG]
+        == PUBLISHER_PC_PRE_VALIDATION_ENABLED
     )
 
     validators = [
@@ -80,6 +91,8 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 cloud_provider=arguments[CLOUD_PROVIDER],
                 region=arguments[REGION],
                 stream_file=stream_file,
+                publisher_pc_pre_validation=publisher_pc_pre_validation,
+                private_computation_role=arguments[PRIVATE_COMPUTATION_ROLE],
                 start_timestamp=arguments[START_TIMESTAMP],
                 end_timestamp=arguments[END_TIMESTAMP],
                 access_key_id=arguments[ACCESS_KEY_ID],

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -19,15 +19,16 @@ from fbpcs.pc_pre_validation.constants import (
     INPUT_DATA_TMP_FILE_PATH,
     INPUT_DATA_VALIDATOR_NAME,
     PA_FIELDS,
-    PA_PUBLISHER_FIELDS,
     PL_FIELDS,
-    PL_PUBLISHER_FIELDS,
     PRIVATE_ID_DFCA_FIELDS,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.pc_pre_validation.input_data_validator import InputDataValidator
 from fbpcs.pc_pre_validation.validation_report import ValidationReport
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
 
 # Name the file randomly in order to avoid failures when the tests run concurrently
 TEST_FILENAME = f"test-input-data-validation-{random.randint(0, 1000000)}.csv"
@@ -39,6 +40,8 @@ TEST_INPUT_FILE_PATH = (
 )
 TEST_REGION = "us-west-2"
 TEST_STREAM_FILE = False
+TEST_PUBLISHER_PC_PRE_VALIDATION = False
+TEST_PRIVATE_COMPUTATION_ROLE: PrivateComputationRole = PrivateComputationRole.PARTNER
 TEST_TIMESTAMP: float = time.time()
 TEST_TEMP_FILEPATH = f"{INPUT_DATA_TMP_FILE_PATH}/{TEST_FILENAME}-{TEST_TIMESTAMP}"
 
@@ -77,12 +80,14 @@ class TestInputDataValidator(TestCase):
         self.storage_service_mock.__init__(return_value=constructed_storage_service)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH,
-            TEST_CLOUD_PROVIDER,
-            TEST_REGION,
-            TEST_STREAM_FILE,
-            access_key_id,
-            access_key_data,
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
+            access_key_id=access_key_id,
+            access_key_data=access_key_data,
         )
 
         self.storage_service_mock.assert_called_with(
@@ -105,7 +110,12 @@ class TestInputDataValidator(TestCase):
         self.storage_service_mock.copy.side_effect = Exception(exception_message)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -134,6 +144,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=True,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -153,6 +165,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=True,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -178,7 +192,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -206,7 +225,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -234,7 +258,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -271,7 +300,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -308,7 +342,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -336,7 +375,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -369,7 +413,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -403,7 +452,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -437,7 +491,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -476,7 +535,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -486,8 +550,7 @@ class TestInputDataValidator(TestCase):
     def test_run_validations_errors_when_pa_pl_data_fields_not_found(
         self, time_mock: Mock
     ) -> None:
-        exception_message = f"Failed to parse the header row. The header row fields must have either: \
-                {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS} or: {PL_PUBLISHER_FIELDS} or {PA_PUBLISHER_FIELDS}"
+        exception_message = f"Failed to parse {TEST_PRIVATE_COMPUTATION_ROLE} the header row. The header row fields must have either: {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS}"
         time_mock.time.return_value = TEST_TIMESTAMP
         lines = [
             b"id_,header,row\n",
@@ -505,7 +568,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -533,7 +601,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -553,7 +626,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -581,7 +659,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -626,7 +709,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -670,7 +758,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -715,7 +808,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -745,7 +843,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -791,7 +894,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
         self.assertEqual(report, expected_report)
@@ -815,7 +923,12 @@ class TestInputDataValidator(TestCase):
         count_empty_field_mock.side_effect = Exception(expected_exception_message)
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -848,7 +961,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -874,7 +992,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, TEST_CLOUD_PROVIDER, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -901,7 +1024,12 @@ class TestInputDataValidator(TestCase):
         )
 
         validator = InputDataValidator(
-            TEST_INPUT_FILE_PATH, cloud_provider, TEST_REGION, TEST_STREAM_FILE
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
 
@@ -916,6 +1044,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1650000000",
             end_timestamp="1640000000",
         )
@@ -930,6 +1060,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="bad-timestamp",
             end_timestamp="",
         )
@@ -972,6 +1104,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )
@@ -1015,6 +1149,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )
@@ -1053,6 +1189,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )
@@ -1091,6 +1229,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
         )
@@ -1120,6 +1260,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=True,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
         report = validator.validate()
@@ -1167,6 +1309,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=True,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
         report = validator.validate()
@@ -1211,6 +1355,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=True,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
         report = validator.validate()
@@ -1254,6 +1400,8 @@ class TestInputDataValidator(TestCase):
             cloud_provider=TEST_CLOUD_PROVIDER,
             region=TEST_REGION,
             stream_file=True,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
         report = validator.validate()

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -19,7 +19,9 @@ from fbpcs.pc_pre_validation.constants import (
     INPUT_DATA_TMP_FILE_PATH,
     INPUT_DATA_VALIDATOR_NAME,
     PA_FIELDS,
+    PA_PUBLISHER_FIELDS,
     PL_FIELDS,
+    PL_PUBLISHER_FIELDS,
     PRIVATE_ID_DFCA_FIELDS,
 )
 from fbpcs.pc_pre_validation.enums import ValidationResult
@@ -484,7 +486,8 @@ class TestInputDataValidator(TestCase):
     def test_run_validations_errors_when_pa_pl_data_fields_not_found(
         self, time_mock: Mock
     ) -> None:
-        exception_message = f"Failed to parse the header row. The header row fields must have either: {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS}"
+        exception_message = f"Failed to parse the header row. The header row fields must have either: \
+                {PL_FIELDS} or: {PA_FIELDS} or: {PRIVATE_ID_DFCA_FIELDS} or: {PL_PUBLISHER_FIELDS} or {PA_PUBLISHER_FIELDS}"
         time_mock.time.return_value = TEST_TIMESTAMP
         lines = [
             b"id_,header,row\n",

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -11,6 +11,9 @@ from unittest.mock import Mock, patch
 from fbpcs.pc_pre_validation import pc_pre_validation_cli as validation_cli
 from fbpcs.pc_pre_validation.enums import ValidationResult
 from fbpcs.private_computation.entity.cloud_provider import CloudProvider
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
 
 
 class TestPCPreValidationCLI(TestCase):
@@ -45,6 +48,8 @@ class TestPCPreValidationCLI(TestCase):
             cloud_provider=expected_cloud_provider,
             region=expected_region,
             stream_file=False,
+            publisher_pc_pre_validation=False,
+            private_computation_role=None,
             start_timestamp=None,
             end_timestamp=None,
             access_key_id=None,
@@ -83,6 +88,9 @@ class TestPCPreValidationCLI(TestCase):
         expected_access_key_id = "access_key_id2"
         expected_access_key_data = "access_key_data3"
         expected_binary_version = "binary_version"
+        expected_pc_computation_role: PrivateComputationRole = (
+            PrivateComputationRole.PARTNER.name
+        )
         argv = [
             f"--input-file-path={expected_input_file_path}",
             f"--cloud-provider={cloud_provider_str}",
@@ -92,7 +100,9 @@ class TestPCPreValidationCLI(TestCase):
             f"--access-key-id={expected_access_key_id}",
             f"--access-key-data={expected_access_key_data}",
             f"--binary-version={expected_binary_version}",
+            f"--private-computation-role={expected_pc_computation_role}",
             "--pre-validation-file-stream=enabled",
+            "--publisher-pc-pre-validation=enabled",
         ]
 
         validation_cli.main(argv)
@@ -102,6 +112,8 @@ class TestPCPreValidationCLI(TestCase):
             cloud_provider=expected_cloud_provider,
             region=expected_region,
             stream_file=True,
+            publisher_pc_pre_validation=True,
+            private_computation_role=PrivateComputationRole.PARTNER.name,
             start_timestamp=expected_start_timestamp,
             end_timestamp=expected_end_timestamp,
             access_key_id=expected_access_key_id,

--- a/fbpcs/private_computation/entity/pc_validator_config.py
+++ b/fbpcs/private_computation/entity/pc_validator_config.py
@@ -17,6 +17,7 @@ from dataclasses_json import dataclass_json
 class PCValidatorConfig:
     region: str
     pc_pre_validator_enabled: bool = True
+    pc_pre_validator_publisher_enabled: bool = False
 
     def __str__(self) -> str:
         # pyre-ignore

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -206,7 +206,23 @@ class PCPreValidationStageService(PrivateComputationStageService):
     def _should_run_pre_validation(
         self, pc_instance: PrivateComputationInstance
     ) -> bool:
-        return (
-            self._pc_validator_config.pc_pre_validator_enabled
-            and pc_instance.infra_config.role == PrivateComputationRole.PARTNER
+        if (
+            pc_instance.infra_config.role == PrivateComputationRole.PARTNER
+            and self._pc_validator_config.pc_pre_validator_enabled
+        ):
+            self._logger.info(
+                f"PC pre validation is enabled for private computation role: {PrivateComputationRole.PARTNER}"
+            )
+            return True
+        elif (
+            pc_instance.infra_config.role == PrivateComputationRole.PUBLISHER
+            and self._pc_validator_config.pc_pre_validator_publisher_enabled
+        ):
+            self._logger.info(
+                f"PC pre validation is enabled for private computation role: {PrivateComputationRole.PUBLISHER}"
+            )
+            return True
+        self._logger.info(
+            f"PC pre validation is disbled for private computation role: {pc_instance.infra_config.role}. Skipping pre-validation check."
         )
+        return False

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -116,11 +116,16 @@ class PCPreValidationStageService(PrivateComputationStageService):
         pre_validation_file_stream_flag = pc_instance.has_feature(
             PCSFeature.PRE_VALIDATION_FILE_STREAM
         )
+        publisher_pc_pre_validation_flag = pc_instance.has_feature(
+            PCSFeature.PUBLISHER_PC_PRE_VALIDATION
+        )
         cmd_args = get_cmd_args(
             input_path=pc_instance.product_config.common.input_path,
             region=region,
             binary_config=binary_config,
             pre_validation_file_stream_flag=pre_validation_file_stream_flag,
+            publisher_pc_pre_validation_flag=publisher_pc_pre_validation_flag,
+            private_computation_role=pc_instance.infra_config.role,
             input_path_start_ts=pc_instance.product_config.common.input_path_start_ts,
             input_path_end_ts=pc_instance.product_config.common.input_path_end_ts,
         )
@@ -216,6 +221,7 @@ class PCPreValidationStageService(PrivateComputationStageService):
             return True
         elif (
             pc_instance.infra_config.role == PrivateComputationRole.PUBLISHER
+            and pc_instance.has_feature(PCSFeature.PUBLISHER_PC_PRE_VALIDATION)
             and self._pc_validator_config.pc_pre_validator_publisher_enabled
         ):
             self._logger.info(

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -12,6 +12,9 @@ from typing import Any, Dict, List
 
 from fbpcp.entity.container_instance import ContainerInstanceStatus
 from fbpcs.onedocker_binary_names import OneDockerBinaryNames
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
 from fbpcs.private_computation.service.pc_pre_validation_stage_service import (
     PRE_VALIDATION_CHECKS_TIMEOUT,
 )
@@ -41,12 +44,18 @@ class PreValidateService:
         binary_config = pc_service.onedocker_binary_config_map[binary_name]
         env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
 
+        """
+        [BE] T147526958 pass private computation role from cli.
+        Since this service runs on partner PCE, we are hardcoding PrivateComputationRole to PARTNER in the code below.
+        """
         cmd_args = [
             get_cmd_args(
                 input_path=input_path,
                 region=region,
                 binary_config=binary_config,
                 pre_validation_file_stream_flag=True,
+                publisher_pc_pre_validation_flag=True,
+                private_computation_role=PrivateComputationRole.PARTNER,
                 input_path_start_ts=None,
                 input_path_end_ts=None,
             )

--- a/fbpcs/private_computation/service/pre_validation_util.py
+++ b/fbpcs/private_computation/service/pre_validation_util.py
@@ -9,6 +9,9 @@
 from typing import Optional
 
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
+from fbpcs.private_computation.entity.private_computation_instance import (
+    PrivateComputationRole,
+)
 
 
 def get_cmd_args(
@@ -16,8 +19,10 @@ def get_cmd_args(
     region: str,
     binary_config: OneDockerBinaryConfig,
     pre_validation_file_stream_flag: bool,
+    publisher_pc_pre_validation_flag: bool,
     input_path_start_ts: Optional[str],
     input_path_end_ts: Optional[str],
+    private_computation_role: Optional[PrivateComputationRole] = None,
 ) -> str:
     args = [
         f"--input-file-path={input_path}",
@@ -25,6 +30,7 @@ def get_cmd_args(
         f"--region={region}",
         # pc_pre_validation assumes all other binaries runs on the same version tag as its own
         f"--binary-version={binary_config.binary_version}",
+        f"--private-computation-role={private_computation_role}",
     ]
 
     if input_path_start_ts and input_path_end_ts:
@@ -37,5 +43,8 @@ def get_cmd_args(
 
     if pre_validation_file_stream_flag:
         args.append("--pre-validation-file-stream=enabled")
+
+    if publisher_pc_pre_validation_flag:
+        args.append("--publisher-pc-pre-validation=enabled")
 
     return " ".join(args)

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -209,9 +209,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             pc_instance, NullCertificateProvider(), NullCertificateProvider(), "", ""
         )
         status = stage_service.get_status(pc_instance)
-
         mock_onedocker_svc.start_container.assert_not_called()
-        mock_get_pc_status_from_stage_state.assert_not_called()
         self.assertEqual(status, expected_status)
 
     @patch(

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -125,6 +125,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 "--cloud-provider=AWS",
                 f"--region={region}",
                 "--binary-version=latest",
+                f"--private-computation-role={PrivateComputationRole.PARTNER}",
             ]
         )
         pc_validator_config = PCValidatorConfig(
@@ -314,7 +315,10 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
     ) -> None:
         pc_instance = PrivateComputationInstance(
             infra_config=self._get_infra_config(
-                {PCSFeature.PRE_VALIDATION_FILE_STREAM}
+                {
+                    PCSFeature.PRE_VALIDATION_FILE_STREAM,
+                    PCSFeature.PUBLISHER_PC_PRE_VALIDATION,
+                }
             ),
             product_config=self._product_config,
         )
@@ -330,7 +334,9 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 "--cloud-provider=AWS",
                 f"--region={region}",
                 "--binary-version=latest",
+                f"--private-computation-role={PrivateComputationRole.PARTNER}",
                 "--pre-validation-file-stream=enabled",
+                "--publisher-pc-pre-validation=enabled",
             ]
         )
         pc_validator_config = PCValidatorConfig(


### PR DESCRIPTION
Summary:
Right now PC Pre Validator checks for file path on partner side but publisher side is no op.

This diff addresses 2 issues
1. adds feature flag for publisher side pre-validation changes
2. use private computation role for input data validation.

What to expect next in this diff stack:
1. Publisher file data checks. Right now we only validate the header row
2. Considering this diff is already >300 lines of code adding unittests in the follow up diffs

Differential Revision: D43706378

