### PR TITLE
Rename breakdownGroupId

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
@@ -88,7 +88,7 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
         liftGameProcessedData_,
         cohortGroupIds_,
         controlPopulation_,
-        breakdownGroupIds_,
+        breakdownBitGroupIds_,
         testGroupIds_);
     input_processing::computeTestIndexShares(
         liftGameProcessedData_, controlPopulation_, testGroupIds_);
@@ -141,7 +141,7 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
-  SecBit<schedulerId> breakdownGroupIds_;
+  SecBit<schedulerId> breakdownBitGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
 
   LiftGameProcessedData<schedulerId> liftGameProcessedData_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
@@ -185,7 +185,7 @@ void CompactionBasedInputProcessor<schedulerId>::extractCompactedData(
       liftGameProcessedData_,
       controlPopulation_,
       cohortGroupIds_,
-      breakdownGroupIds_,
+      breakdownBitGroupIds_,
       publisherDataShares,
       partnerDataShares,
       numConversionsPerUser_);

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor.h
@@ -41,7 +41,7 @@ class InputProcessor : public IInputProcessor<schedulerId> {
         liftGameProcessedData_,
         cohortGroupIds_,
         controlPopulation_,
-        breakdownGroupIds_,
+        breakdownBitGroupIds_,
         testGroupIds_);
     input_processing::computeTestIndexShares(
         liftGameProcessedData_, controlPopulation_, testGroupIds_);
@@ -87,7 +87,7 @@ class InputProcessor : public IInputProcessor<schedulerId> {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
-  SecBit<schedulerId> breakdownGroupIds_;
+  SecBit<schedulerId> breakdownBitGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
 
   LiftGameProcessedData<schedulerId> liftGameProcessedData_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
@@ -23,7 +23,7 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
   XLOG(INFO) << "Share publisher breakdown group ids";
   std::vector<bool> booleanBreakdownGroupIds(
       inputData_.getBreakdownIds().begin(), inputData_.getBreakdownIds().end());
-  breakdownGroupIds_ = common::privatelyShareArrayWithPaddingFrom<
+  breakdownBitGroupIds_ = common::privatelyShareArrayWithPaddingFrom<
       common::PUBLISHER,
       bool,
       SecBit<schedulerId>>(

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData.h
@@ -40,15 +40,21 @@ inline const std::vector<std::string> SECRET_SHARES_HEADER = {
 
 template <int schedulerId>
 struct LiftGameProcessedData {
-  int64_t numRows;
-  uint32_t numPartnerCohorts;
-  uint32_t numPublisherBreakdowns;
-  uint32_t numGroups;
-  uint32_t numTestGroups;
-  uint8_t valueBits;
-  uint8_t valueSquaredBits;
+  int64_t numRows = 0;
+  uint32_t numPartnerCohorts = 0;
+  uint32_t numPublisherBreakdowns = 0;
+  uint32_t numGroups = 0;
+  uint32_t numBreakdownTestGroups = 0;
+  uint32_t numCohortTestGroups = 0;
+  uint32_t numTestGroups = 0;
+  uint8_t valueBits = 0;
+  uint8_t valueSquaredBits = 0;
   std::vector<std::vector<bool>> indexShares;
   std::vector<std::vector<bool>> testIndexShares;
+  std::vector<std::vector<bool>> indexBreakdownShares;
+  std::vector<std::vector<bool>> testIndexBreakdownShares;
+  std::vector<std::vector<bool>> indexCohortShares;
+  std::vector<std::vector<bool>> testIndexCohortShares;
   SecTimestamp<schedulerId> opportunityTimestamps;
   SecBit<schedulerId> isValidOpportunityTimestamp;
   std::vector<SecTimestamp<schedulerId>> purchaseTimestamps;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor.h
@@ -54,7 +54,7 @@ class PostUDPInputProcessor : public IInputProcessor<schedulerId> {
         liftGameProcessedData_,
         cohortGroupIds_,
         controlPopulation_,
-        breakdownGroupIds_,
+        breakdownBitGroupIds_,
         testGroupIds_);
     input_processing::computeTestIndexShares(
         liftGameProcessedData_, controlPopulation_, testGroupIds_);
@@ -82,7 +82,7 @@ class PostUDPInputProcessor : public IInputProcessor<schedulerId> {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
-  SecBit<schedulerId> breakdownGroupIds_;
+  SecBit<schedulerId> breakdownBitGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
 
   LiftGameProcessedData<schedulerId> liftGameProcessedData_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor_impl.h
@@ -33,7 +33,7 @@ void PostUDPInputProcessor<schedulerId>::extractCompactedData(
       liftGameProcessedData_,
       controlPopulation_,
       cohortGroupIds_,
-      breakdownGroupIds_,
+      breakdownBitGroupIds_,
       publisherDataShares,
       partnerDataShares,
       numConversionsPerUser_);


### PR DESCRIPTION
Summary: Made existing breakdownGroupId explicitly named to show that it holds booleans instead of numbers. This is important to avoid confusion because when breakdownGroupIds are added that are numbers, both of these will be side by side until the GK is fully removed after the full rollout.

Reviewed By: robotal

Differential Revision: D43881785

