### PR TITLE
Rename cohort/breakdown fields in inputdata

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor.h
@@ -88,7 +88,7 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
         liftGameProcessedData_,
         cohortGroupIds_,
         controlPopulation_,
-        breakdownGroupIds_,
+        breakdownBitGroupIds_,
         testGroupIds_);
     input_processing::computeTestIndexShares(
         liftGameProcessedData_, controlPopulation_, testGroupIds_);
@@ -141,7 +141,7 @@ class CompactionBasedInputProcessor : public IInputProcessor<schedulerId> {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
-  SecBit<schedulerId> breakdownGroupIds_;
+  SecBit<schedulerId> breakdownBitGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
 
   LiftGameProcessedData<schedulerId> liftGameProcessedData_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
@@ -185,7 +185,7 @@ void CompactionBasedInputProcessor<schedulerId>::extractCompactedData(
       liftGameProcessedData_,
       controlPopulation_,
       cohortGroupIds_,
-      breakdownGroupIds_,
+      breakdownBitGroupIds_,
       publisherDataShares,
       partnerDataShares,
       numConversionsPerUser_);

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/GlobalSharingUtils.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/GlobalSharingUtils.h
@@ -45,22 +45,31 @@ inline void shareNumGroupsStep(
     LiftGameProcessedData<schedulerId>& liftGameProcessedData) {
   // TODO: We shouldn't be using MPC for this, it should just be shared over
   // a normal network socket as part of the protocol setup
-  XLOG(INFO) << "Set up number of partner groups";
-  if (inputData.getNumGroups() >
+  XLOG(INFO) << "Set up number of breakdowns and cohorts";
+  if (inputData.getNumPartnerCohorts() >
       (1
        << (groupWidth - 1))) { // subtract one because we multiply the number of
     // groups by 2 for the test/control populations
-    XLOG(ERR) << "The input has " << inputData.getNumGroups()
-              << " groups but we only support " << (1 << groupWidth)
-              << " groups.";
+    XLOG(ERR) << "The input has " << inputData.getNumPartnerCohorts()
+              << " cohorts but we only support " << (1 << groupWidth)
+              << " cohorts.";
+    exit(1);
+  }
+  if (inputData.getNumPublisherBreakdowns() >
+      (1
+       << (groupWidth - 1))) { // subtract one because we multiply the number of
+    // groups by 2 for the test/control populations
+    XLOG(ERR) << "The input has " << inputData.getNumPublisherBreakdowns()
+              << " breakdowns but we only support " << (1 << groupWidth)
+              << " breakdowns.";
     exit(1);
   }
   liftGameProcessedData.numPartnerCohorts = common::
       shareIntFrom<schedulerId, groupWidth, common::PARTNER, common::PUBLISHER>(
-          myRole, inputData.getNumGroups());
+          myRole, inputData.getNumPartnerCohorts());
   liftGameProcessedData.numPublisherBreakdowns = common::
       shareIntFrom<schedulerId, groupWidth, common::PUBLISHER, common::PARTNER>(
-          myRole, inputData.getNumGroups());
+          myRole, inputData.getNumPublisherBreakdowns());
   if (liftGameProcessedData.numPublisherBreakdowns > 2) {
     XLOG(ERR)
         << "The input has " << liftGameProcessedData.numPublisherBreakdowns

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.cpp
@@ -176,15 +176,17 @@ void InputData::addFromCSV(
     } else if (column == "total_spend") {
       totalSpend_.push_back(parsed);
     } else if (column == "cohort_id") {
-      groupIds_.push_back(parsed);
+      partnerCohortIds_.push_back(parsed);
       // We use parsed + 1 because cohorts are zero-indexed
-      numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+      numPartnerCohorts_ =
+          std::max(numPartnerCohorts_, static_cast<uint32_t>(parsed + 1));
     } else if (column == "breakdown_id") {
       if (computePublisherBreakdowns_) {
         breakdownIds_.push_back(parsed);
 
         // We use parsed + 1 because breakdowns are zero-indexed
-        numGroups_ = std::max(numGroups_, static_cast<uint32_t>(parsed + 1));
+        numPublisherBreakdowns =
+            std::max(numPublisherBreakdowns, static_cast<uint32_t>(parsed + 1));
       }
     } else if (column == "event_timestamp") {
       // When event_timestamp column presents (in standard Converter Lift
@@ -251,7 +253,9 @@ void InputData::addFromCSV(
 std::vector<int64_t> InputData::bitmaskFor(int64_t groupId) const {
   std::vector<int64_t> res(numRows_);
   for (std::size_t i = 0; i < res.size(); ++i) {
-    res[i] = groupIds_.size() > i && groupIds_.at(i) == groupId ? 1 : 0;
+    res[i] = partnerCohortIds_.size() > i && partnerCohortIds_.at(i) == groupId
+        ? 1
+        : 0;
   }
   return res;
 }

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputData.h
@@ -95,16 +95,20 @@ class InputData {
     return purchaseValueSquaredArrays_;
   }
 
-  const std::vector<uint32_t>& getGroupIds() const {
-    return groupIds_;
+  const std::vector<uint32_t>& getPartnerCohortIds() const {
+    return partnerCohortIds_;
   }
 
   const std::vector<uint32_t>& getBreakdownIds() const {
     return breakdownIds_;
   }
 
-  int64_t getNumGroups() const {
-    return numGroups_;
+  int64_t getNumPublisherBreakdowns() const {
+    return numPublisherBreakdowns;
+  }
+
+  int64_t getNumPartnerCohorts() const {
+    return numPartnerCohorts_;
   }
 
   int64_t getNumBitsForValue() const {
@@ -171,7 +175,7 @@ class InputData {
   std::vector<uint32_t> purchaseTimestamps_;
   std::vector<int64_t> purchaseValues_;
   std::vector<int64_t> purchaseValuesSquared_;
-  std::vector<uint32_t> groupIds_;
+  std::vector<uint32_t> partnerCohortIds_;
   std::vector<uint32_t> breakdownIds_;
   std::vector<std::vector<uint32_t>> opportunityTimestampArrays_;
   std::vector<std::vector<uint32_t>> purchaseTimestampArrays_;
@@ -181,7 +185,8 @@ class InputData {
 
   int64_t totalValue_ = 0;
   int64_t totalValueSquared_ = 0;
-  uint32_t numGroups_ = 0;
+  uint32_t numPartnerCohorts_ = 0;
+  uint32_t numPublisherBreakdowns = 0;
   int32_t numConversionsPerUser_;
 
   bool firstLineParsedAlready_ = false;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor.h
@@ -41,7 +41,7 @@ class InputProcessor : public IInputProcessor<schedulerId> {
         liftGameProcessedData_,
         cohortGroupIds_,
         controlPopulation_,
-        breakdownGroupIds_,
+        breakdownBitGroupIds_,
         testGroupIds_);
     input_processing::computeTestIndexShares(
         liftGameProcessedData_, controlPopulation_, testGroupIds_);
@@ -87,7 +87,7 @@ class InputProcessor : public IInputProcessor<schedulerId> {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
-  SecBit<schedulerId> breakdownGroupIds_;
+  SecBit<schedulerId> breakdownBitGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
 
   LiftGameProcessedData<schedulerId> liftGameProcessedData_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
@@ -18,7 +18,7 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
       common::PARTNER,
       uint32_t,
       SecGroup<schedulerId>>(
-      inputData_.getGroupIds(), liftGameProcessedData_.numRows, 0);
+      inputData_.getPartnerCohortIds(), liftGameProcessedData_.numRows, 0);
 
   XLOG(INFO) << "Share publisher breakdown group ids";
   std::vector<bool> booleanBreakdownGroupIds(

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/InputProcessor_impl.h
@@ -23,7 +23,7 @@ void InputProcessor<schedulerId>::privatelyShareGroupIdsStep() {
   XLOG(INFO) << "Share publisher breakdown group ids";
   std::vector<bool> booleanBreakdownGroupIds(
       inputData_.getBreakdownIds().begin(), inputData_.getBreakdownIds().end());
-  breakdownGroupIds_ = common::privatelyShareArrayWithPaddingFrom<
+  breakdownBitGroupIds_ = common::privatelyShareArrayWithPaddingFrom<
       common::PUBLISHER,
       bool,
       SecBit<schedulerId>>(

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData.h
@@ -40,15 +40,21 @@ inline const std::vector<std::string> SECRET_SHARES_HEADER = {
 
 template <int schedulerId>
 struct LiftGameProcessedData {
-  int64_t numRows;
-  uint32_t numPartnerCohorts;
-  uint32_t numPublisherBreakdowns;
-  uint32_t numGroups;
-  uint32_t numTestGroups;
-  uint8_t valueBits;
-  uint8_t valueSquaredBits;
+  int64_t numRows = 0;
+  uint32_t numPartnerCohorts = 0;
+  uint32_t numPublisherBreakdowns = 0;
+  uint32_t numGroups = 0;
+  uint32_t numBreakdownTestGroups = 0;
+  uint32_t numCohortTestGroups = 0;
+  uint32_t numTestGroups = 0;
+  uint8_t valueBits = 0;
+  uint8_t valueSquaredBits = 0;
   std::vector<std::vector<bool>> indexShares;
   std::vector<std::vector<bool>> testIndexShares;
+  SecGroup<schedulerId> indexBreakdownShares;
+  SecGroup<schedulerId> testIndexBreakdownShares;
+  SecGroup<schedulerId> indexCohortShares;
+  SecGroup<schedulerId> testIndexCohortShares;
   SecTimestamp<schedulerId> opportunityTimestamps;
   SecBit<schedulerId> isValidOpportunityTimestamp;
   std::vector<SecTimestamp<schedulerId>> purchaseTimestamps;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor.h
@@ -54,7 +54,7 @@ class PostUDPInputProcessor : public IInputProcessor<schedulerId> {
         liftGameProcessedData_,
         cohortGroupIds_,
         controlPopulation_,
-        breakdownGroupIds_,
+        breakdownBitGroupIds_,
         testGroupIds_);
     input_processing::computeTestIndexShares(
         liftGameProcessedData_, controlPopulation_, testGroupIds_);
@@ -82,7 +82,7 @@ class PostUDPInputProcessor : public IInputProcessor<schedulerId> {
 
   SecBit<schedulerId> controlPopulation_;
   SecGroup<schedulerId> cohortGroupIds_;
-  SecBit<schedulerId> breakdownGroupIds_;
+  SecBit<schedulerId> breakdownBitGroupIds_;
   SecGroup<schedulerId> testGroupIds_;
 
   LiftGameProcessedData<schedulerId> liftGameProcessedData_;

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/PostUDPInputProcessor_impl.h
@@ -33,7 +33,7 @@ void PostUDPInputProcessor<schedulerId>::extractCompactedData(
       liftGameProcessedData_,
       controlPopulation_,
       cohortGroupIds_,
-      breakdownGroupIds_,
+      breakdownBitGroupIds_,
       publisherDataShares,
       partnerDataShares,
       numConversionsPerUser_);

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/serialization/LiftMetaDataSerializer.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/serialization/LiftMetaDataSerializer.cpp
@@ -85,8 +85,8 @@ LiftMetaDataSerializer::serializePartnerMetadata() {
       unionSize_ == std::nullopt ? inputSize : unionSize_.value();
   rst.reserve(inputSize);
 
-  auto cohortIdsPadded =
-      common::padArray<uint32_t>(inputData_.getGroupIds(), unionSize, 0);
+  auto cohortIdsPadded = common::padArray<uint32_t>(
+      inputData_.getPartnerCohortIds(), unionSize, 0);
   auto purchaseTimestampsPadded = common::padNestedArrays<uint32_t>(
       inputData_.getPurchaseTimestampArrays(),
       unionSize,

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/InputDataTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/InputDataTest.cpp
@@ -21,12 +21,14 @@ class InputDataTest : public ::testing::Test {
  protected:
   std::string aliceInputFilename_;
   std::string aliceInputFilename2_;
+  std::string aliceInputFilename3_;
   std::string bobInputFilename_;
   std::string bobInputFilename2_;
 
   void SetUp() override {
     aliceInputFilename_ = sample_input::getPublisherInput1().native();
     aliceInputFilename2_ = sample_input::getPublisherInput2().native();
+    aliceInputFilename3_ = sample_input::getPublisherInput3().native();
     bobInputFilename_ = sample_input::getPartnerInput4().native();
     bobInputFilename2_ = sample_input::getPartnerConverterInput().native();
   }
@@ -48,9 +50,11 @@ TEST_F(InputDataTest, TestInputDataPublisher) {
       53699630, 53699601, 0,        0,        0,        53699661, 53699252,
       53700031, 53699730, 53700172, 0,        0,        53699306, 53700140,
       53699240, 53699397, 53699415, 53700127, 53699760, 53699598};
+  auto resNumBreakdowns = inputData.getNumPublisherBreakdowns();
   auto resTestPopulation = inputData.getTestPopulation();
   auto resControlPopulation = inputData.getControlPopulation();
   auto resOpportunityTimestamps = inputData.getOpportunityTimestamps();
+  EXPECT_EQ(0, resNumBreakdowns);
   EXPECT_EQ(expectTestPopulation, resTestPopulation);
   EXPECT_EQ(expectControlPopulation, resControlPopulation);
   EXPECT_EQ(expectOpportunityTimestamps, resOpportunityTimestamps);
@@ -75,6 +79,34 @@ TEST_F(InputDataTest, TestInputDataPublisherOppColLast) {
   auto resTestPopulation = inputData.getTestPopulation();
   auto resControlPopulation = inputData.getControlPopulation();
   auto resOpportunityTimestamps = inputData.getOpportunityTimestamps();
+  EXPECT_EQ(expectTestPopulation, resTestPopulation);
+  EXPECT_EQ(expectControlPopulation, resControlPopulation);
+  EXPECT_EQ(expectOpportunityTimestamps, resOpportunityTimestamps);
+}
+
+TEST_F(InputDataTest, TestInputDataPublisherWithBreakdowns) {
+  InputData inputData{
+      aliceInputFilename3_,
+      InputData::LiftMPCType::Standard,
+      true,
+      1546300800,
+      4};
+  std::vector<bool> expectTestPopulation = {0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+                                            0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0,
+                                            1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0};
+  std::vector<bool> expectControlPopulation = {0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0,
+                                               1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0,
+                                               0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+  // opportunity_timestamp - epoch
+  std::vector<uint32_t> expectOpportunityTimestamps = {
+      0,   0,   0,   100, 100, 100, 100, 100, 100, 100, 100,
+      100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,
+      100, 100, 0,   100, 100, 100, 100, 100, 100, 100, 100};
+  auto resNumBreakdowns = inputData.getNumPublisherBreakdowns();
+  auto resTestPopulation = inputData.getTestPopulation();
+  auto resControlPopulation = inputData.getControlPopulation();
+  auto resOpportunityTimestamps = inputData.getOpportunityTimestamps();
+  EXPECT_EQ(2, resNumBreakdowns);
   EXPECT_EQ(expectTestPopulation, resTestPopulation);
   EXPECT_EQ(expectControlPopulation, resControlPopulation);
   EXPECT_EQ(expectOpportunityTimestamps, resOpportunityTimestamps);
@@ -122,8 +154,8 @@ TEST_F(InputDataTest, TestInputDataPartner) {
   EXPECT_EQ(expectGetPurchaseTimestampArrays, resPurchaseTimestampArrays);
   EXPECT_EQ(expectPurchaseValueArrays, resPurchaseValueArrays);
 
-  ASSERT_EQ(3, inputData.getNumGroups());
-  EXPECT_EQ(expectCohortIds, inputData.getGroupIds());
+  ASSERT_EQ(3, inputData.getNumPartnerCohorts());
+  EXPECT_EQ(expectCohortIds, inputData.getPartnerCohortIds());
 }
 
 TEST_F(InputDataTest, TestInputDataPartnerConverterLift) {
@@ -145,6 +177,7 @@ TEST_F(InputDataTest, TestInputDataPartnerConverterLift) {
   auto resPurchaseTimestamps = inputData.getPurchaseTimestampArrays();
   auto resPurchaseValues = inputData.getPurchaseValues();
   auto resPurchaseValuesSquared = inputData.getPurchaseValuesSquared();
+  ASSERT_EQ(0, inputData.getNumPartnerCohorts());
   EXPECT_EQ(expectGetPurchaseTimestamps, resPurchaseTimestamps);
   EXPECT_EQ(expectPurchaseValues, resPurchaseValues);
   EXPECT_EQ(expectPurchaseValuesSquared, resPurchaseValuesSquared);


### PR DESCRIPTION
Summary: Rename cohort/breakdown fields in `inputdata` to be clearer what they actually are. This will make reading/maintaining the code easier.

Reviewed By: ajinkya-ghonge, chennyc

Differential Revision: D43883241

