### PR TITLE
enhanced print_log_urls cli-endpoint allow partner can retreive all stages or failed only cw logs

### DIFF
--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -21,7 +21,7 @@ Usage:
     pc-cli cancel_current_stage <instance_id> --config=<config_file> [options]
     pc-cli print_instance <instance_id> --config=<config_file> [options]
     pc-cli print_current_status <instance_id> --config=<config_file> [options]
-    pc-cli print_log_urls <instance_id> --config=<config_file> [options]
+    pc-cli print_log_urls <instance_id> --config=<config_file> [--all_stages --failed_only] [options]
     pc-cli get_attribution_dataset_info --dataset_id=<dataset_id> --config=<config_file> [options]
     pc-cli run_attribution --config=<config_file> --dataset_id=<dataset_id> --input_path=<input_path> --timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold> [--run_id=<run_id> --graphapi_version=<graphapi_version> --graphapi_domain=<graphapi_domain> --stage_timeout_override_seconds=<stage_timeout_override_seconds>] [options]
     pc-cli pre_validate --config=<config_file> [--dataset_id=<dataset_id>] --input_path=<input_path> [--timestamp=<timestamp> --attribution_rule=<attribution_rule> --aggregation_type=<aggregation_type> --concurrency=<concurrency> --num_files_per_mpc_container=<num_files_per_mpc_container> --k_anonymity_threshold=<k_anonymity_threshold>] [options]
@@ -193,6 +193,8 @@ def main(argv: Optional[List[str]] = None) -> None:
             "print_instance": bool,
             "print_current_status": bool,
             "print_log_urls": bool,
+            "--all_stages": bool,
+            "--failed_only": bool,
             "get_attribution_dataset_info": bool,
             "bolt_e2e": bool,
             "secret_scrubber": bool,
@@ -467,6 +469,8 @@ def main(argv: Optional[List[str]] = None) -> None:
             config=config,
             instance_id=instance_id,
             logger=logger,
+            all_stages=arguments["--all_stages"],
+            failed_only=arguments["--failed_only"],
         )
     elif arguments["get_attribution_dataset_info"]:
         print(

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -311,7 +311,11 @@ def print_current_status(
 
 
 def print_log_urls(
-    config: Dict[str, Any], instance_id: str, logger: logging.Logger
+    config: Dict[str, Any],
+    instance_id: str,
+    logger: logging.Logger,
+    all_stages: bool = False,
+    failed_only: bool = False,
 ) -> None:
     """
     To print the log urls with id instance_id.
@@ -324,11 +328,14 @@ def print_log_urls(
         config.get("post_processing_handlers", {}),
         config.get("pid_post_processing_handlers", {}),
     )
-    log_urls = pc_service.get_log_urls(instance_id)
+    log_urls = pc_service.get_log_urls(
+        instance_or_id=instance_id, all_stages=all_stages, failed_only=failed_only
+    )
     if not log_urls:
         logger.warning(f"Unable to get log container urls for instance {instance_id}")
         return
 
+    print("========= print log urls =========")
     for stage, log_url in log_urls.items():
         print(f"[{stage}]: {log_url}")
 


### PR DESCRIPTION
Summary:
## Why
In recent sev S321509, as a sev follow up task, we want to provide a better way that advertiser can locate the failed cw logs.
The previous ask of the task is to add the runbook, But I think to enhanced our existing `print_log_urls` cli-endpoint would be easier for partner to locate.

## What
- In current `print_log_urls`, it's only print the recently run stage cw logs.
- adding two optional argument for print_log_urls. `--all_stages` and `--failed_only`
 - `--all_stages` would iterate all stages from instance config
 - `--failed_only` would only return failed containers logs. for easier locate the problematic log we're more concerning

Differential Revision: D43931705

