### PR TITLE
Update playbook URL in OCR token validation rules

### DIFF
--- a/fbpcs/pl_coordinator/token_validation_rules.py
+++ b/fbpcs/pl_coordinator/token_validation_rules.py
@@ -23,8 +23,7 @@ class TokenRuleException(RuntimeError):
 
 """
 required token scopes defined here:
-https://github.com/facebookresearch/fbpcs/blob/main/docs/PCS_Partner_Playbook_UI.pdf
-(see Step 3: generating 60 days access token)
+https://developers.facebook.com/docs/private-computation/setup-guide/step-2
 """
 REQUIRED_TOKEN_SCOPES = {
     "ads_management",


### PR DESCRIPTION
Summary:
See T147552929 - We are migrating open sourced docs from github to dev docs: https://developers.facebook.com/docs/private-computation.

This diff updates the hyperlink in PL one-command runner token validator to get this change reflected.

Differential Revision: D43932789

