### PR TITLE
logic for processing peer's data

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h"
+
+#include "folly/executors/CPUThreadPoolExecutor.h"
+#include "folly/experimental/coro/BlockingWait.h"
+#include "folly/experimental/coro/Collect.h"
+
+namespace unified_data_process {
+
+// load a line that is to be processed later.
+void UdpEncryptor::pushOneLineFromMe(
+    std::vector<unsigned char>&& /*serializedLine*/) {
+  throw std::runtime_error("not implemented");
+}
+
+folly::coro::Task<void> UdpEncryptor::processPeerDataCoro(
+    size_t numberOfPeerRowsInBatch) {
+  udpEncryption_->processPeerData(numberOfPeerRowsInBatch);
+  co_return;
+}
+
+// set the config for peer's data.
+void UdpEncryptor::setPeerConfig(
+    size_t totalNumberOfPeerRows,
+    size_t peerDataWidth,
+    const std::vector<int32_t>& indexes) {
+  udpEncryption_->prepareToProcessPeerData(peerDataWidth, indexes);
+  size_t numberOfProcessedRow = 0;
+  peerDataProcessingTasks_.reserve(totalNumberOfPeerRows / chunkSize_ + 1);
+
+  while (numberOfProcessedRow < totalNumberOfPeerRows) {
+    peerDataProcessingTasks_.push_back(
+        processPeerDataCoro(
+            std::min(chunkSize_, totalNumberOfPeerRows - numberOfProcessedRow))
+            .scheduleOn(peerProcessExecutor_.get())
+            .start());
+    numberOfProcessedRow += chunkSize_;
+  }
+}
+
+UdpEncryptor::EncryptionResuts UdpEncryptor::getEncryptionResults() {
+  folly::coro::blockingWait(
+      folly::coro::collectAllRange(std::move(peerDataProcessingTasks_)));
+
+  auto [ciphertexts, nonces, indexes] = udpEncryption_->getProcessedData();
+  return EncryptionResuts{ciphertexts, nonces, indexes};
+}
+
+std::vector<__m128i> UdpEncryptor::getExpandedKey() const {
+  throw std::runtime_error("not implemented");
+}
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/experimental/coro/Task.h>
+#include <memory>
+#include <thread>
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h"
+#include "folly/futures/Future.h"
+
+namespace unified_data_process {
+
+class UdpEncryptor {
+  using UdpEncryption =
+      fbpcf::mpc_std_lib::unified_data_process::data_processor::IUdpEncryption;
+
+ public:
+  using EncryptionResuts = UdpEncryption::EncryptionResuts;
+
+  UdpEncryptor(std::unique_ptr<UdpEncryption> udpEncryption, size_t chunkSize)
+      : udpEncryption_(std::move(udpEncryption)),
+        udpThreadForMySelf_(nullptr),
+        chunkSize_(chunkSize),
+        peerProcessExecutor_(
+            std::make_shared<folly::CPUThreadPoolExecutor>(1)) {}
+
+  // load a line that is to be processed later.
+  void pushOneLineFromMe(std::vector<unsigned char>&& serializedLine);
+
+  // set the config for peer's data.
+  void setPeerConfig(
+      size_t totalNumberOfPeerRows,
+      size_t peerDataWidth,
+      const std::vector<int32_t>& indexes);
+
+  EncryptionResuts getEncryptionResults();
+
+  std::vector<__m128i> getExpandedKey() const;
+
+ private:
+  folly::coro::Task<void> processPeerDataCoro(size_t numberOfPeerRowsInBatch);
+
+  std::unique_ptr<UdpEncryption> udpEncryption_;
+
+  std::unique_ptr<std::thread> udpThreadForMySelf_;
+  size_t chunkSize_;
+
+  std::shared_ptr<folly::CPUThreadPoolExecutor> peerProcessExecutor_;
+  std::vector<folly::SemiFuture<folly::Unit>> peerDataProcessingTasks_;
+};
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptionMock.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptionMock.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "fbpcf/mpc_std_lib/unified_data_process/data_processor/IUdpEncryption.h"
+
+namespace unified_data_process {
+
+using namespace ::testing;
+
+class UdpEncryptionMock final
+    : public fbpcf::mpc_std_lib::unified_data_process::data_processor::
+          IUdpEncryption {
+ public:
+  MOCK_METHOD(void, prepareToProcessMyData, (size_t));
+
+  MOCK_METHOD(
+      void,
+      processMyData,
+      (const std::vector<std::vector<unsigned char>>&));
+
+  MOCK_METHOD(std::vector<__m128i>, getExpandedKey, ());
+
+  MOCK_METHOD(
+      void,
+      prepareToProcessPeerData,
+      (size_t, const std::vector<int32_t>&));
+
+  MOCK_METHOD(void, processPeerData, (size_t));
+
+  MOCK_METHOD(EncryptionResuts, getProcessedData, ());
+};
+
+} // namespace unified_data_process

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h"
+#include "fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptionMock.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace ::testing;
+namespace unified_data_process {
+
+TEST(UdpEncryptorTest, testProcessingPeerData) {
+  int chunkSize = 500;
+  int totalRow = 1200;
+  size_t dataWidth = 32;
+  std::vector<int32_t> indexes{3, 31, 6, 12, 5};
+  auto mock = std::make_unique<unified_data_process::UdpEncryptionMock>();
+
+  EXPECT_CALL(*mock, prepareToProcessPeerData(dataWidth, indexes)).Times(1);
+  EXPECT_CALL(*mock, processPeerData(chunkSize)).Times(totalRow / chunkSize);
+  if (totalRow % chunkSize != 0) {
+    EXPECT_CALL(*mock, processPeerData(totalRow % chunkSize)).Times(1);
+  }
+  EXPECT_CALL(*mock, getProcessedData()).Times(1);
+
+  UdpEncryptor encryptor(std::move(mock), chunkSize);
+  encryptor.setPeerConfig(totalRow, dataWidth, indexes);
+  encryptor.getEncryptionResults();
+}
+
+} // namespace unified_data_process


### PR DESCRIPTION
Summary:
Implement a UDP encryptor object. This object is mostly a wrap layer to handle multi-threading for UDP encryption object (e.g. one thread to read data, one thread to process data in the background).

This diff adds the code for processing peer's data. Next diff is going to add code for processing this party's data

Reviewed By: mdas7

Differential Revision:
D43576520

Privacy Context Container: L416713

