### PR TITLE
Consume exit code in PCSContainerInstance

### DIFF
--- a/fbpcs/common/entity/pcs_container_instance.py
+++ b/fbpcs/common/entity/pcs_container_instance.py
@@ -31,4 +31,5 @@ class PCSContainerInstance(ContainerInstance):
             log_url=log_url,
             cpu=container_instance.cpu,
             memory=container_instance.memory,
+            exit_code=container_instance.exit_code,
         )


### PR DESCRIPTION
Summary:
## Context
We've finished implementing [Granular Exit Code for OneDocker Containers](https://docs.google.com/document/d/1J58imAR4xGuMzj_nGyssHhdg4-6COc7OwOEaJo-FkKU/edit#heading=h.fdjpm1hw0y7n), which added a new entry exit_code in ContainerInstance. This is parsed from ECS response (see D43414345)
## This Commit
Expose the exit code of OneDocker containers to PCS

Differential Revision: D43859412

