### PR TITLE
Reading the Aggregation Game Input

### DIFF
--- a/fbpcs/emp_games/he_aggregation/AggregationInputMetrics.cpp
+++ b/fbpcs/emp_games/he_aggregation/AggregationInputMetrics.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+
+#include <re2/re2.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fbpcf/io/api/FileIOWrappers.h>
+#include "folly/json.h"
+#include "folly/logging/xlog.h"
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+#include "fbpcs/emp_games/he_aggregation/AggregationInputMetrics.h"
+#include "fbpcs/emp_games/he_aggregation/AttributionAdditiveSSResult.h"
+#include "fbpcs/emp_games/he_aggregation/HEAggOptions.h"
+#include "fbpcs/emp_games/pcf2_aggregation/TouchpointMetadata.h"
+
+// using namespace pcf2_aggregation;
+
+namespace pcf2_he {
+
+static const std::vector<pcf2_aggregation::TouchpointMetadata>
+parseTouchpointMetadata(
+    common::InputEncryption inputEncryption,
+    const int lineNo,
+    const std::vector<std::string>& header,
+    const std::vector<std::string>& parts) {
+  std::vector<uint64_t> adIds;
+  std::vector<uint64_t> timestamps;
+  std::vector<bool> isClicks;
+  std::vector<uint64_t> campaignMetadata;
+
+  CHECK_EQ(header.size(), parts.size())
+      << "Error when reading csv file, header does not match parts.";
+
+  for (size_t i = 0; i < header.size(); ++i) {
+    std::string column = header[i];
+    std::string value = parts[i];
+    if (column == "ad_ids") {
+      adIds = common::getInnerArray<uint64_t>(value);
+    } else if (column == "timestamps") {
+      timestamps = common::getInnerArray<uint64_t>(value);
+    } else if (column == "is_click") {
+      if (inputEncryption == common::InputEncryption::Xor) {
+        // input is 64-bit secret shares
+        std::vector<uint64_t> isClickShares =
+            common::getInnerArray<uint64_t>(value);
+        for (uint64_t isClickShare : isClickShares) {
+          // suffices to read last bit
+          isClicks.push_back(isClickShare & 1);
+        }
+      } else {
+        isClicks = common::getInnerArray<bool>(value);
+      }
+    } else if (column == "campaign_metadata") {
+      campaignMetadata = common::getInnerArray<uint64_t>(value);
+    }
+  }
+
+  CHECK_EQ(adIds.size(), timestamps.size())
+      << "Ad ids and timestamps arrays are not the same length.";
+  CHECK_EQ(adIds.size(), isClicks.size())
+      << "Ad ids and is_click arrays are not the same length.";
+  CHECK_EQ(adIds.size(), campaignMetadata.size())
+      << "Ad ids and campaign_metadata arrays are not the same length.";
+  CHECK_LE(adIds.size(), FLAGS_max_num_touchpoints)
+      << "Number of touchpoints exceeds the maximum allowed value.";
+
+  std::vector<int64_t> unique_ids;
+  for (size_t i = 0; i < timestamps.size(); ++i) {
+    unique_ids.push_back(i);
+  }
+
+  const std::unordered_set<int64_t> idSet{unique_ids.begin(), unique_ids.end()};
+  CHECK_EQ(idSet.size(), timestamps.size())
+      << "Found non-unique id for line " << lineNo << ". "
+      << "This implementation currently only supports unique touchpoint ids per user.";
+
+  std::vector<pcf2_aggregation::TouchpointMetadata> tpms;
+  for (size_t i = 0; i < adIds.size(); ++i) {
+    tpms.push_back(pcf2_aggregation::TouchpointMetadata{
+        /* original adId */ adIds.at(i),
+        /* ts */ timestamps.at(i),
+        /* isClick */ isClicks.at(i) == 1,
+        /* campaignMetadata */ campaignMetadata.at(i),
+        /* compressed adId */ 0});
+  }
+
+  // Sort touchpoints so that metadata are aligned with order in attribution
+  // game. If input is encrypted, we assume that the input is already sorted.
+  if (inputEncryption != common::InputEncryption::Xor) {
+    std::sort(tpms.begin(), tpms.end());
+  }
+
+  // Add padding at the end of the input data for publisher; partner data
+  // consists only of padded data
+  for (size_t i = tpms.size(); i < FLAGS_max_num_touchpoints; ++i) {
+    tpms.push_back(pcf2_aggregation::TouchpointMetadata{0, 0, false, 0, 0});
+  }
+
+  return tpms;
+}
+
+// Secret share attribution result received by the game will be structured as
+// : {"rule1" -> {"format1" -> {"pid1" -> {results}}}} Thus here, we are
+// iterating over list of attribution results per pid per format per rule and
+// adding them to a vector of maps from pid to vector<result>. While
+// running the aggregation game, we will share this vector of vectors between
+// parties (order maintained), where each vector would represent results for
+// one rule and one format.
+static std::vector<std::vector<std::vector<AttributionAdditiveSSResult>>>
+getAttributionsArrayfromDynamic(const folly::dynamic& obj) {
+  std::vector<std::map<int64_t, std::vector<AttributionAdditiveSSResult>>>
+      attributionPidVectorMap;
+  std::vector<std::string> attributionList; // list of attribution rules
+  // For now, I am not using the rule name or formatter name in the logic as
+  // the aggregation behaviour is not affected by different attribution rules.
+  std::vector<std::vector<std::vector<AttributionAdditiveSSResult>>>
+      attributionResultsList;
+  for (const auto& [rule, formatters] : obj.items()) {
+    attributionList.push_back(rule.asString());
+    for (const auto& [formatter, resultPerPID] : formatters.items()) {
+      std::map<int64_t, std::vector<AttributionAdditiveSSResult>>
+          attributionsPerPidMap;
+      for (const auto& [pid, results] : resultPerPID.items()) {
+        std::vector<AttributionAdditiveSSResult> attributionResults;
+        for (const auto& result : results) {
+          attributionResults.push_back(
+              AttributionAdditiveSSResult::fromDynamic(result));
+        }
+        attributionsPerPidMap.emplace(
+            pid.asInt(), std::move(attributionResults));
+      }
+      attributionPidVectorMap.push_back(std::move(attributionsPerPidMap));
+    }
+
+    for (const auto& attributionsPerPidMap : attributionPidVectorMap) {
+      std::vector<std::vector<AttributionAdditiveSSResult>>
+          attributionPidVector;
+      for (const auto& attributionResults : attributionsPerPidMap) {
+        attributionPidVector.push_back(attributionResults.second);
+      }
+      attributionResultsList.push_back(std::move(attributionPidVector));
+    }
+  }
+
+  return attributionResultsList;
+}
+
+AggregationInputMetrics::AggregationInputMetrics(
+    common::InputEncryption inputEncryption,
+    std::filesystem::path inputSecretShareFilePath,
+    std::filesystem::path inputClearTextFilePath) {
+  XLOGF(
+      INFO,
+      "Reading attribution result file {}",
+      inputSecretShareFilePath.string());
+  XLOGF(
+      INFO, "Reading metadata input file {}", inputClearTextFilePath.string());
+  XLOGF(
+      INFO, "Parsing input metadata file {}", inputClearTextFilePath.string());
+
+  // Parse the input metadata file
+  int lineNo = 0;
+  bool success = private_measurement::csv::readCsv(
+      inputClearTextFilePath,
+      [&](const std::vector<std::string>& header,
+          const std::vector<std::string>& parts) {
+        ids_.push_back(lineNo);
+
+        touchpointMetadataArrays_.push_back(
+            parseTouchpointMetadata(inputEncryption, lineNo, header, parts));
+
+        lineNo++;
+      });
+
+  if (!success) {
+    XLOGF(
+        FATAL,
+        "Failed to read input metadata file {},",
+        inputClearTextFilePath.string());
+  }
+
+  XLOGF(
+      INFO,
+      "Parsing input secret share file {}",
+      inputSecretShareFilePath.string());
+  // Reading the attribution results received from private attribution game in
+  // an unordered_map.
+  auto attributionResultJson = folly::parseJson(
+      fbpcf::io::FileIOWrappers::readFile(inputSecretShareFilePath));
+
+  attributionSecretShare_ =
+      getAttributionsArrayfromDynamic(attributionResultJson);
+}
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/AggregationInputMetrics.h
+++ b/fbpcs/emp_games/he_aggregation/AggregationInputMetrics.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "fbpcs/emp_games/common/Csv.h"
+#include "fbpcs/emp_games/he_aggregation/AttributionAdditiveSSResult.h"
+#include "fbpcs/emp_games/pcf2_aggregation/TouchpointMetadata.h"
+
+// using namespace pcf2_aggregation;
+
+namespace pcf2_he {
+
+/*
+ * This class represents input data for Private Aggregation.
+ * It processes an input csv and generates the std::vectors for each column
+ */
+class AggregationInputMetrics {
+ public:
+  explicit AggregationInputMetrics(
+      common::InputEncryption inputEncryption,
+      std::filesystem::path inputSecretShareFilePath,
+      std::filesystem::path inputClearTextFilePaths);
+
+  explicit AggregationInputMetrics(
+      std::vector<int64_t> ids,
+      std::vector<std::vector<std::vector<AttributionAdditiveSSResult>>>
+          attributionSecretShare,
+      std::vector<std::vector<pcf2_aggregation::TouchpointMetadata>>
+          touchpointMetadataArrays)
+      : ids_{ids},
+        attributionSecretShare_{attributionSecretShare},
+        touchpointMetadataArrays_{touchpointMetadataArrays} {}
+
+  const std::vector<int64_t>& getIds() const {
+    return ids_;
+  }
+
+  const std::vector<std::vector<std::vector<AttributionAdditiveSSResult>>>
+  getAttributionSecretShares() const {
+    return attributionSecretShare_;
+  }
+
+  const std::vector<std::vector<pcf2_aggregation::TouchpointMetadata>>&
+  getTouchpointMetadata() const {
+    return touchpointMetadataArrays_;
+  }
+
+ private:
+  std::vector<int64_t> ids_;
+  std::vector<std::vector<std::vector<AttributionAdditiveSSResult>>>
+      attributionSecretShare_;
+  std::vector<std::vector<pcf2_aggregation::TouchpointMetadata>>
+      touchpointMetadataArrays_;
+};
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/AttributionAdditiveSSResult.h
+++ b/fbpcs/emp_games/he_aggregation/AttributionAdditiveSSResult.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+/*
+ * This struct represents Additive secret shares after attribution stage
+ */
+namespace pcf2_he {
+
+struct AttributionAdditiveSSResult {
+  const int64_t isAttributed;
+
+  static AttributionAdditiveSSResult fromDynamic(const folly::dynamic& obj) {
+    return AttributionAdditiveSSResult{obj["is_attributed"].asInt()};
+  }
+};
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/HEAggApp.h
+++ b/fbpcs/emp_games/he_aggregation/HEAggApp.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbpcf/io/api/FileIOWrappers.h>
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/scheduler/LazySchedulerFactory.h"
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+
+#include "fbpcs/emp_games/common/SchedulerStatistics.h"
+
+namespace pcf2_he {
+
+template <int MY_ROLE, int schedulerId>
+class HEAggApp {
+ public:
+  HEAggApp(
+      std::unique_ptr<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+          communicationAgentFactory,
+      std::string& secretShareFilePath,
+      std::string& inputFilePath,
+      std::string& outputFilePath,
+      std::shared_ptr<fbpcf::util::MetricCollector> metricCollector,
+      double delta,
+      double eps,
+      common::InputEncryption inputEncryption,
+      const bool addDpNoise = true)
+      : communicationAgentFactory_(std::move(communicationAgentFactory)),
+        secretShareFilePath_(secretShareFilePath),
+        inputFilePath_(inputFilePath),
+        outputFilePath_(outputFilePath),
+        delta_(delta),
+        eps_(eps),
+        schedulerStatistics_{0, 0, 0, 0, 0},
+        metricCollector_{metricCollector},
+        addDpNoise_(addDpNoise),
+        inputEncryption_(inputEncryption) {}
+
+  void run() {
+    auto scheduler = fbpcf::scheduler::getLazySchedulerFactoryWithRealEngine(
+                         MY_ROLE, *communicationAgentFactory_, metricCollector_)
+                         ->create();
+
+    XLOG(INFO) << "Start HEAgg App ";
+
+    auto gateStatistics =
+        fbpcf::scheduler::SchedulerKeeper<schedulerId>::getGateStatistics();
+    XLOGF(
+        INFO,
+        "Non-free gate count = {}, Free gate count = {}",
+        gateStatistics.first,
+        gateStatistics.second);
+
+    auto trafficStatistics =
+        fbpcf::scheduler::SchedulerKeeper<schedulerId>::getTrafficStatistics();
+    XLOGF(
+        INFO,
+        "Sent network traffic = {}, Received network traffic = {}",
+        trafficStatistics.first,
+        trafficStatistics.second);
+    fbpcf::scheduler::SchedulerKeeper<schedulerId>::deleteEngine();
+    schedulerStatistics_.nonFreeGates = gateStatistics.first;
+    schedulerStatistics_.freeGates = gateStatistics.second;
+    schedulerStatistics_.sentNetwork = trafficStatistics.first;
+    schedulerStatistics_.receivedNetwork = trafficStatistics.second;
+    schedulerStatistics_.details = metricCollector_->collectMetrics();
+  }
+
+  common::SchedulerStatistics getSchedulerStatistics() {
+    return schedulerStatistics_;
+  }
+
+ private:
+  std::unique_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+      communicationAgentFactory_;
+  std::string secretShareFilePath_;
+  std::string inputFilePath_;
+  std::string outputFilePath_;
+  int numFeatures_;
+  int labelWidth_;
+  double delta_;
+  double eps_;
+  common::SchedulerStatistics schedulerStatistics_;
+  std::shared_ptr<fbpcf::util::MetricCollector> metricCollector_;
+  bool addDpNoise_;
+  common::InputEncryption inputEncryption_;
+};
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/HEAggOptions.cpp
+++ b/fbpcs/emp_games/he_aggregation/HEAggOptions.cpp
@@ -60,3 +60,6 @@ DEFINE_int32(
     input_encryption,
     0,
     "0 for plaintext input, 1 for partner XOR encrypted input (used for Consortium MPC), 2 for both publisher and partner XOR encrypted input (used with PS3I)");
+DEFINE_int32(max_num_touchpoints, 4, "Maximum touchpoints per user");
+DEFINE_int32(max_num_conversions, 4, "Maximum conversions per user");
+DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");

--- a/fbpcs/emp_games/he_aggregation/HEAggOptions.cpp
+++ b/fbpcs/emp_games/he_aggregation/HEAggOptions.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/he_aggregation/HEAggOptions.h"
+
+#include <gflags/gflags.h>
+
+DEFINE_int32(party, 1, "1 = publisher, 2 = partner");
+DEFINE_string(server_ip, "127.0.0.1", "Server's IP address");
+DEFINE_int32(port, 5000, "Server's port");
+DEFINE_string(
+    input_base_path_secret_share,
+    "",
+    "Local or s3 base path for the secret share attribution results.");
+DEFINE_string(input_base_path, "", "Local or s3 base path for the input file");
+DEFINE_string(
+    output_base_path,
+    "",
+    "Local or s3 base path where output files are written to");
+DEFINE_double(delta, 1e-6, "DP noise parameter (delta)");
+DEFINE_double(eps, 5, "DP noise parameter (epsilon)");
+DEFINE_string(
+    run_name,
+    "",
+    "A user given run name that will be used in s3 filename");
+DEFINE_bool(
+    log_cost,
+    false,
+    "Log cost info into cloud which will be used for dashboard");
+DEFINE_bool(
+    add_dp_noise,
+    true,
+    "If true, dp noise will not be added to the output.");
+DEFINE_string(log_cost_s3_bucket, "", "s3 bucket name");
+DEFINE_string(
+    log_cost_s3_region,
+    ".s3.us-west-2.amazonaws.com/",
+    "s3 region name");
+DEFINE_bool(
+    use_tls,
+    false,
+    "Whether to use TLS when communicating with other parties.");
+DEFINE_string(
+    ca_cert_path,
+    "",
+    "Relative file path where root CA cert is stored. It will be prefixed with $HOME.");
+DEFINE_string(
+    server_cert_path,
+    "",
+    "Relative file path where server cert is stored. It will be prefixed with $HOME.");
+DEFINE_string(
+    private_key_path,
+    "",
+    "Relative file path where private key is stored. It will be prefixed with $HOME.");
+DEFINE_int32(
+    input_encryption,
+    0,
+    "0 for plaintext input, 1 for partner XOR encrypted input (used for Consortium MPC), 2 for both publisher and partner XOR encrypted input (used with PS3I)");

--- a/fbpcs/emp_games/he_aggregation/HEAggOptions.h
+++ b/fbpcs/emp_games/he_aggregation/HEAggOptions.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <gflags/gflags_declare.h>
+
+DECLARE_int32(party);
+DECLARE_string(server_ip);
+DECLARE_int32(port);
+DECLARE_string(input_base_path_secret_share);
+DECLARE_string(input_base_path);
+DECLARE_string(output_base_path);
+DECLARE_double(delta);
+DECLARE_double(eps);
+DECLARE_string(run_name);
+DECLARE_bool(log_cost);
+DECLARE_bool(add_dp_noise);
+DECLARE_string(log_cost_s3_bucket);
+DECLARE_string(log_cost_s3_region);
+DECLARE_bool(use_tls);
+DECLARE_string(ca_cert_path);
+DECLARE_string(server_cert_path);
+DECLARE_string(private_key_path);
+DECLARE_int32(input_encryption);

--- a/fbpcs/emp_games/he_aggregation/HEAggOptions.h
+++ b/fbpcs/emp_games/he_aggregation/HEAggOptions.h
@@ -27,3 +27,6 @@ DECLARE_string(ca_cert_path);
 DECLARE_string(server_cert_path);
 DECLARE_string(private_key_path);
 DECLARE_int32(input_encryption);
+DECLARE_int32(max_num_touchpoints);
+DECLARE_int32(max_num_conversions);
+DECLARE_bool(use_new_output_format);

--- a/fbpcs/emp_games/he_aggregation/MainUtil.h
+++ b/fbpcs/emp_games/he_aggregation/MainUtil.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <future>
+#include <memory>
+
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcs/emp_games/common/SchedulerStatistics.h"
+
+namespace pcf2_he {
+
+template <int PARTY>
+inline common::SchedulerStatistics startHEAggApp(
+    std::string serverIp,
+    int port,
+    fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
+        tlsInfo) {
+  std::map<
+      int,
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
+          PartyInfo>
+      partyInfos({{0, {serverIp, port}}, {1, {serverIp, port}}});
+
+  auto metricCollector =
+      std::make_shared<fbpcf::util::MetricCollector>("heagg");
+
+  auto communicationAgentFactory = std::make_unique<
+      fbpcf::engine::communication::SocketPartyCommunicationAgentFactory>(
+      PARTY, partyInfos, tlsInfo, metricCollector);
+
+  ////////////////////////
+  // Add HE Agg App Here
+  ////////////////////////
+
+  common::SchedulerStatistics schedulerStatistics;
+  return schedulerStatistics;
+}
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/MainUtil.h
+++ b/fbpcs/emp_games/he_aggregation/MainUtil.h
@@ -13,6 +13,7 @@
 
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcs/emp_games/common/SchedulerStatistics.h"
+#include "fbpcs/emp_games/he_aggregation/HEAggApp.h"
 
 namespace pcf2_he {
 
@@ -20,8 +21,15 @@ template <int PARTY>
 inline common::SchedulerStatistics startHEAggApp(
     std::string serverIp,
     int port,
+    std::string& secretShareFilePath,
+    std::string& inputFilePath,
+    std::string& outFilePath,
+    double delta,
+    double eps,
+    bool addDpNoise,
     fbpcf::engine::communication::SocketPartyCommunicationAgent::TlsInfo&
-        tlsInfo) {
+        tlsInfo,
+    common::InputEncryption inputEncryption) {
   std::map<
       int,
       fbpcf::engine::communication::SocketPartyCommunicationAgentFactory::
@@ -38,6 +46,19 @@ inline common::SchedulerStatistics startHEAggApp(
   ////////////////////////
   // Add HE Agg App Here
   ////////////////////////
+  auto app = std::make_unique<pcf2_he::HEAggApp<PARTY, PARTY>>(
+      std::move(communicationAgentFactory),
+      secretShareFilePath,
+      inputFilePath,
+      outFilePath,
+      metricCollector,
+      delta,
+      eps,
+      inputEncryption,
+      addDpNoise);
+
+  app->run();
+  return app->getSchedulerStatistics();
 
   common::SchedulerStatistics schedulerStatistics;
   return schedulerStatistics;

--- a/fbpcs/emp_games/he_aggregation/main.cpp
+++ b/fbpcs/emp_games/he_aggregation/main.cpp
@@ -50,19 +50,46 @@ int main(int argc, char* argv[]) {
       FLAGS_private_key_path,
       "");
   try {
+    common::InputEncryption inputEncryption;
+    if (FLAGS_input_encryption == 1) {
+      inputEncryption = common::InputEncryption::PartnerXor;
+    } else if (FLAGS_input_encryption == 2) {
+      inputEncryption = common::InputEncryption::Xor;
+    } else {
+      inputEncryption = common::InputEncryption::Plaintext;
+    }
+
     if (FLAGS_party == common::PUBLISHER) {
       XLOG(INFO)
           << "Starting HE Aggregation as Publisher, will wait for Partner...";
 
       schedulerStatistics = pcf2_he::startHEAggApp<common::PUBLISHER>(
-          FLAGS_server_ip, FLAGS_port, tlsInfo);
+          FLAGS_server_ip,
+          FLAGS_port,
+          FLAGS_input_base_path_secret_share,
+          FLAGS_input_base_path,
+          FLAGS_output_base_path,
+          FLAGS_delta,
+          FLAGS_eps,
+          FLAGS_add_dp_noise,
+          tlsInfo,
+          inputEncryption);
 
     } else if (FLAGS_party == common::PARTNER) {
       XLOG(INFO)
           << "Starting HE Aggregation as Partner, will wait for Publisher...";
 
       schedulerStatistics = pcf2_he::startHEAggApp<common::PARTNER>(
-          FLAGS_server_ip, FLAGS_port, tlsInfo);
+          FLAGS_server_ip,
+          FLAGS_port,
+          FLAGS_input_base_path_secret_share,
+          FLAGS_input_base_path,
+          FLAGS_output_base_path,
+          FLAGS_delta,
+          FLAGS_eps,
+          FLAGS_add_dp_noise,
+          tlsInfo,
+          inputEncryption);
 
     } else {
       XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);

--- a/fbpcs/emp_games/he_aggregation/main.cpp
+++ b/fbpcs/emp_games/he_aggregation/main.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gflags/gflags.h>
+#include <string>
+
+#include "folly/Format.h"
+#include "folly/init/Init.h"
+#include "folly/logging/xlog.h"
+
+#include <fbpcf/aws/AwsSdk.h>
+#include <fbpcs/performance_tools/CostEstimation.h>
+
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/he_aggregation/HEAggOptions.h"
+
+#include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
+#include "fbpcs/emp_games/he_aggregation/MainUtil.h"
+
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  fbpcs::performance_tools::CostEstimation cost =
+      fbpcs::performance_tools::CostEstimation(
+          "heagg", FLAGS_log_cost_s3_bucket, FLAGS_log_cost_s3_region, "pcf2");
+  cost.start();
+
+  fbpcf::AwsSdk::aquire();
+
+  FLAGS_party--; // subtract 1 because we use 0 and 1 for publisher and partner
+                 // instead of 1 and 2
+
+  XLOGF(INFO, "Party: {}", FLAGS_party);
+  XLOGF(INFO, "Server IP: {}", FLAGS_server_ip);
+  XLOGF(INFO, "Port: {}", FLAGS_port);
+  XLOGF(INFO, "Base input path: {}", FLAGS_input_base_path);
+  XLOGF(INFO, "Base output path: {}", FLAGS_output_base_path);
+
+  common::SchedulerStatistics schedulerStatistics;
+
+  auto tlsInfo = fbpcf::engine::communication::getTlsInfoFromArgs(
+      FLAGS_use_tls,
+      FLAGS_ca_cert_path,
+      FLAGS_server_cert_path,
+      FLAGS_private_key_path,
+      "");
+  try {
+    if (FLAGS_party == common::PUBLISHER) {
+      XLOG(INFO)
+          << "Starting HE Aggregation as Publisher, will wait for Partner...";
+
+      schedulerStatistics = pcf2_he::startHEAggApp<common::PUBLISHER>(
+          FLAGS_server_ip, FLAGS_port, tlsInfo);
+
+    } else if (FLAGS_party == common::PARTNER) {
+      XLOG(INFO)
+          << "Starting HE Aggregation as Partner, will wait for Publisher...";
+
+      schedulerStatistics = pcf2_he::startHEAggApp<common::PARTNER>(
+          FLAGS_server_ip, FLAGS_port, tlsInfo);
+
+    } else {
+      XLOGF(FATAL, "Invalid Party: {}", FLAGS_party);
+    }
+
+  } catch (const std::exception& e) {
+    XLOG(ERR)
+        << "Error: Exception caught in HE Aggregation run.\n \t error msg: "
+        << e.what() << "\n \t input file: " << FLAGS_input_base_path;
+    std::exit(1);
+  }
+  cost.end();
+  XLOG(INFO, cost.getEstimatedCostString());
+
+  XLOGF(
+      INFO,
+      "Non-free gate count = {}, Free gate count = {}",
+      schedulerStatistics.nonFreeGates,
+      schedulerStatistics.freeGates);
+
+  XLOGF(
+      INFO,
+      "Sent network traffic = {}, Received network traffic = {}",
+      schedulerStatistics.sentNetwork,
+      schedulerStatistics.receivedNetwork);
+
+  if (FLAGS_log_cost) {
+    bool run_name_specified = FLAGS_run_name != "";
+    auto run_name = run_name_specified ? FLAGS_run_name : "temp_run_name";
+    auto party = (FLAGS_party == common::PUBLISHER) ? "Publisher" : "Partner";
+
+    folly::dynamic extra_info = folly::dynamic::object(
+        "publisher_input_path", (FLAGS_party == common::PUBLISHER) ? FLAGS_input_base_path : "")
+        ("partner_input_basepath", (FLAGS_party == common::PARTNER) ? FLAGS_input_base_path : "")
+        ("publisher_output_basepath", (FLAGS_party == common::PUBLISHER) ? FLAGS_output_base_path : "")
+        ("partner_output_basepath", (FLAGS_party ==  common::PARTNER) ? FLAGS_output_base_path : "")
+        ("non_free_gates", schedulerStatistics.nonFreeGates)
+        ("free_gates", schedulerStatistics.freeGates)
+        ("scheduler_transmitted_network", schedulerStatistics.sentNetwork)
+        ("scheduler_received_network", schedulerStatistics.receivedNetwork)
+        ("mpc_traffic_details", schedulerStatistics.details);
+
+    folly::dynamic costDict =
+        cost.getEstimatedCostDynamic(run_name, party, extra_info);
+
+    auto objectName = run_name_specified
+        ? run_name
+        : folly::to<std::string>(
+              FLAGS_run_name, '_', costDict["timestamp"].asString());
+
+    XLOGF(INFO, "{}", cost.writeToS3(party, objectName, costDict));
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Summary:
This diff defines the input to the aggregation game which includes: (1) AttributionSecretShare (Additive secret shares) , (2) Touchpoint Array which contains the publisher side info such as id_ and ad_id (aggregation key).

The following are the main changes in the diff:

<AggregationInputMetrics.h> Defines the structure of the input to the aggregation game, it contains the AttributionSecret share result and the publisher side touchpoint array

<AggregationInputMetrics.cpp> Reads the files and parses them into the AggregationInputMetrics format.

<AttributionAdditiveSSResult.h> Similar to AttributionResult class in pcf2_aggregation but it contains an integer secret share instead of boolean XOR secret share.

<HEAggApp.h>: This calls the getInputData function which triggers the logic of reading the files into the AggregationInputMetrics format

<TARGET>: a library to reuse the Touchpoint/Conversion classes  used in pcf2_aggregation

Differential Revision:
D43932767

Privacy Context Container: L1173372

