### PR TITLE
Bump FBPCF version to fix the EMP Games image build

### DIFF
--- a/.github/workflows/build_fbpcs_images.yml
+++ b/.github/workflows/build_fbpcs_images.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  FBPCF_VERSION: 2.1.117  # Please also update line 29 in .github/workflows/docker-publish.yml
+  FBPCF_VERSION: 2.1.132  # Please also update line 29 in .github/workflows/docker-publish.yml
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.117  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
+  FBPCF_VERSION: 2.1.132  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
   PID_VERSION: 0.0.8
 
 jobs:


### PR DESCRIPTION
Summary:
## Context. The EMP Game build is failing currently because of the following error:
```
/root/build/emp_game/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftCompactionUtils.h:19:10: fatal error: fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h: No such file or directory
   19 | #include "fbpcf/mpc_std_lib/unified_data_process/serialization/IRowStructureDefinition.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
The game has a commit that uses something new from FBPCF that isn't currently included in FBPCS.

## This commit
Bump the FBPCF version to include the new header file.

Differential Revision: D44030204

