### PR TITLE
Update the Production and Test OneDocker images to use the same pip_requrements.txt file.

### DIFF
--- a/docker/onedocker/prod/pip_requirements.txt
+++ b/docker/onedocker/prod/pip_requirements.txt
@@ -1,4 +1,4 @@
-fbpcp == 0.3.4
+fbpcp == 0.4.0
 jmespath ~= 0.10
 s3transfer ~= 0.3
 parameterized ~= 0.7

--- a/docker/onedocker/test/Dockerfile.ubuntu
+++ b/docker/onedocker/test/Dockerfile.ubuntu
@@ -66,13 +66,10 @@ RUN chown -R pcs:pcs /tmp/fbpcs-temp/fbpcs/
 # Switch to pcs user
 USER pcs
 
-# installing fbpcp (onedocker)
-RUN python3.8 -m pip install 'git+https://github.com/facebookresearch/fbpcp.git'
-
 # installing pip requirements
 RUN mkdir -p /home/pcs/src/
 WORKDIR /home/pcs/src
-COPY fbpcs/pip_requirements.txt /home/pcs/src/.
+COPY docker/onedocker/prod/pip_requirements.txt /home/pcs/src/.
 RUN python3.8 -m pip install --user -r pip_requirements.txt
 
 # Build and copy the pc_pre_validation_cli & smart_agent binary


### PR DESCRIPTION
Summary:
## Context
Previously we were installing FBPCP directly from the Github source code in the test OneDocker file. This causes issues because yet unreleased features could be included in the bundle and cause releases to be blocked when they shouldn't be.

## This Diff
* Updates both OneDocker Dockerfiles to use a shared pip_requirements.txt file to ensure we are testing with the same versions
* Updates the FBPCP dependency for both to be the latest (0.4.0)

Reviewed By: ajitfb

Differential Revision: D44026408

