### PR TITLE
Fix a typo in interface type name - using the right name for fbpcs

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h
@@ -21,7 +21,7 @@ class UdpEncryptor {
       fbpcf::mpc_std_lib::unified_data_process::data_processor::IUdpEncryption;
 
  public:
-  using EncryptionResuts = UdpEncryption::EncryptionResuts;
+  using EncryptionResuts = UdpEncryption::EncryptionResults;
 
   UdpEncryptor(std::unique_ptr<UdpEncryption> udpEncryption, size_t chunkSize)
       : udpEncryption_(std::move(udpEncryption)),

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptionMock.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptionMock.h
@@ -35,7 +35,7 @@ class UdpEncryptionMock final
 
   MOCK_METHOD(void, processPeerData, (size_t));
 
-  MOCK_METHOD(EncryptionResuts, getProcessedData, ());
+  MOCK_METHOD(EncryptionResults, getProcessedData, ());
 };
 
 } // namespace unified_data_process


### PR DESCRIPTION
Summary: Update the typename in fbpcs repo

Differential Revision:
D44136536

Privacy Context Container: L416713

