### PR TITLE
switch to use shared pointer for InputProcessor in PL

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Aggregator.h
@@ -39,14 +39,14 @@ class Aggregator {
  public:
   Aggregator(
       int myRole,
-      std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor,
+      std::shared_ptr<IInputProcessor<schedulerId>> inputProcessor,
       std::unique_ptr<Attributor<schedulerId>> attributor,
       int32_t numConversionsPerUser,
       std::shared_ptr<
           fbpcf::engine::communication::IPartyCommunicationAgentFactory>
           communicationAgentFactory)
       : myRole_{myRole},
-        inputProcessor_{std::move(inputProcessor)},
+        inputProcessor_{inputProcessor},
         attributor_{std::move(attributor)},
         communicationAgentFactory_{communicationAgentFactory} {
     initOram();
@@ -135,7 +135,7 @@ class Aggregator {
       bool testOnly) const;
 
   int32_t myRole_;
-  std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor_;
+  std::shared_ptr<IInputProcessor<schedulerId>> inputProcessor_;
   std::unique_ptr<Attributor<schedulerId>> attributor_;
   OutputMetricsData metrics_;
 

--- a/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/Attributor.h
@@ -19,8 +19,8 @@ class Attributor {
  public:
   Attributor(
       int myRole,
-      std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor)
-      : myRole_{myRole}, inputProcessor_{std::move(inputProcessor)} {
+      std::shared_ptr<IInputProcessor<schedulerId>> inputProcessor)
+      : myRole_{myRole}, inputProcessor_{inputProcessor} {
     calculateEvents();
     calculateNumConvSquaredAndValueSquaredAndConverters();
     calculateMatch();
@@ -81,7 +81,7 @@ class Attributor {
   void calculateValues();
 
   int32_t myRole_;
-  std::unique_ptr<IInputProcessor<schedulerId>> inputProcessor_;
+  std::shared_ptr<IInputProcessor<schedulerId>> inputProcessor_;
 
   std::vector<SecBit<schedulerId>> events_;
   SecBit<schedulerId> converters_;

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -16,6 +16,7 @@ class PCSFeature(Enum):
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
     PC_COORDINATED_RETRY = "private_computation_coordinated_retry"
     PRIVATE_LIFT_UNIFIED_DATA_PROCESS = "private_lift_unified_data_process"
+    PCS_PRIVATE_LIFT_DECOUPLED_UDP = "pcs_private_lift_decoupled_udp"
     PRIVATE_ATTRIBUTION_MR_PID = "private_attribution_with_mr_pid"
     SHARD_COMBINER_PCF2_RELEASE = "shard_combiner_pcf2_release"
     NUM_MPC_CONTAINER_MUTATION = "num_mpc_container_mutation"


### PR DESCRIPTION
Summary: See title. Instead of using unique pointers for both Attributor and Aggregator app (which incurs a full copy of the input processor), we use shared pointers.

Differential Revision: D44149781

