### PR TITLE
Call wait_valid_publisher_status before initiating a retry.

### DIFF
--- a/fbpcs/bolt/bolt_runner.py
+++ b/fbpcs/bolt/bolt_runner.py
@@ -587,6 +587,12 @@ class BoltRunner(Generic[T, U]):
                                 ),
                             )
 
+                            await self.wait_valid_publisher_status(
+                                instance_id=publisher_id,
+                                poll_interval=poll_interval,
+                                timeout=WAIT_VALID_STATUS_TIMEOUT,
+                            )
+
                     except Exception as e:
                         logger.error(
                             f"Unable to cancel current stage {stage.name}. Error: type: {type(e)}, message: {e}."


### PR DESCRIPTION
Summary:
# Context
In co-ordinated retry, during partner failure in joint stage, we cancel the partner and publisher stage containers in order to restart the stage.
In some instances we have noticed that even after the wait period to retry, when we poll the publisher stage, we get a FAILED sta

Differential Revision: D44152010

