### PR TITLE
Update Stage State instances updates call to batch call

### DIFF
--- a/fbpcs/common/service/retry_handler.py
+++ b/fbpcs/common/service/retry_handler.py
@@ -8,6 +8,7 @@
 
 import asyncio
 import logging
+import time
 from enum import auto, Enum
 from types import TracebackType
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Type, TypeVar, Union
@@ -46,7 +47,7 @@ class RetryHandler:
 
     Synchronous function usage:
     with RetryHandler(MyException, max_attempts=3) as retry_handler:
-        await retry_handler.execute_sync(blocking_func_we_want_to_retry, arg1, arg2, arg3=999)
+        retry_handler.execute_sync(blocking_func_we_want_to_retry, arg1, arg2, arg3=999)
     """
 
     def __init__(
@@ -114,7 +115,7 @@ class RetryHandler:
         self.logger.error("Out of retry attempts. Raising last error.")
         raise saved_err
 
-    async def execute_sync(
+    def execute_sync(
         self, f: Callable[..., T], *args: Any, **kwargs: Dict[str, Any]
     ) -> T:
         """
@@ -129,7 +130,7 @@ class RetryHandler:
                 self.logger.warning(
                     f"Caught exception during attempt [{attempt} / {self.max_attempts}]"
                 )
-                await asyncio.sleep(self._get_backoff_time(attempt))
+                time.sleep(self._get_backoff_time(attempt))
                 saved_err = e
             except BaseException as e:
                 self.logger.warning(

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -440,7 +440,7 @@ async def _run_study_async_helper(
         backoff_type=BackoffType.CONSTANT,
         max_attempts=10,
     ) as retry_handler:
-        end_state_study_data = await retry_handler.execute_sync(
+        end_state_study_data = retry_handler.execute_sync(
             _get_study_data, study_id, client
         )
 

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -1096,9 +1096,9 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             ContainerInstance(instance_id="id", status=ContainerInstanceStatus.STARTED)
         ]
         # pyre-ignore
-        self.onedocker_service.container_svc.get_instance.return_value = (
+        self.onedocker_service.container_svc.get_instances.return_value = [
             ContainerInstance(instance_id="id", status=ContainerInstanceStatus.FAILED)
-        )
+        ]
         state_instance = StageStateInstance(
             instance_id=self.test_private_computation_id,
             stage_name="AGGREGATE",


### PR DESCRIPTION
Summary:
## Why
In update Stage State instance, we were using single `get_container` for each container.
It might cause too many requests to be throttled.

## What
switching to `get_containers` method which is batch call already.
Refactor the update_status to fit the batch call mode.

Differential Revision: D44189473

