### PR TITLE
Add Boost serialization libaries to the OneDocker Images

### DIFF
--- a/docker/onedocker/prod/Dockerfile.ubuntu
+++ b/docker/onedocker/prod/Dockerfile.ubuntu
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y \
   ca-certificates \
   libboost-context1.71.0 \
   libboost-regex1.71.0 \
+  libboost-serialization1.71.0\
   libevent-2.1-7 \
   libcurl4 \
   libdouble-conversion3 \

--- a/docker/onedocker/test/Dockerfile.ubuntu
+++ b/docker/onedocker/test/Dockerfile.ubuntu
@@ -26,6 +26,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libboost-context1.71.0 \
     libboost-regex1.71.0 \
+    libboost-serialization1.71.0\
     libevent-2.1-7 \
     libcurl4 \
     libdouble-conversion3 \


### PR DESCRIPTION
Summary:
## Context:
This change requires the boost serialization libraries in the OneDocker images: D43752781

## This Diff:
See title

Reviewed By: RuiyuZhu

Differential Revision: D44300096

