### PR TITLE
HE Aggregation Game

### DIFF
--- a/fbpcs/emp_games/he_aggregation/HEAggGame.cpp
+++ b/fbpcs/emp_games/he_aggregation/HEAggGame.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fbpcs/emp_games/he_aggregation/HEAggGame.h"
+#include <cstdint>
+#include "fbpcf/engine/util/AesPrgFactory.h"
+#include "fbpcf/mpc_std_lib/oram/DifferenceCalculatorFactory.h"
+#include "fbpcf/mpc_std_lib/oram/LinearOramFactory.h"
+#include "fbpcf/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h"
+#include "fbpcf/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h"
+#include "fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h"
+#include "fbpcs/emp_games/he_aggregation/AttributionAdditiveSSResult.h"
+#include "fbpcs/emp_games/he_aggregation/HEAggOptions.h"
+
+#include "folly/logging/xlog.h"
+
+#include "privacy_infra/elgamal/ElGamal.h"
+
+namespace pcf2_he {
+
+std::vector<uint8_t> encryptAttrResult(
+    heschme::PublicKey& pk,
+    const AggregationInputMetrics& input,
+    int maxTouchpoints,
+    int maxConversions) {
+  std::vector<std::vector<std::vector<AttributionAdditiveSSResult>>>
+      secretShareAttributionArrays = input.getAttributionSecretShares();
+  std::vector<uint8_t> ciphertextArray;
+  for (const auto& secretShareAttributionArray : secretShareAttributionArrays) {
+    for (const auto& paddedSecretAttribution : secretShareAttributionArray) {
+      // Each touchpoint has is_attr ss for each conversion. We add all
+      // is_attr ss for the same touchpoint in plaintext before HE encryption
+      for (int i = 0; i < maxTouchpoints; i++) {
+        int partnerAttrResult = 0;
+        for (int j = i; j < maxConversions * maxTouchpoints;
+             j += maxTouchpoints) {
+          partnerAttrResult += paddedSecretAttribution[j].isAttributed;
+        }
+        std::vector<uint8_t> c = pk.encrypt(partnerAttrResult).toBytes();
+        ciphertextArray.insert(ciphertextArray.end(), c.begin(), c.end());
+      }
+    }
+  }
+  return ciphertextArray;
+}
+std::vector<uint64_t> decryptAggCiphertext(
+    heschme::PrivateKey& sk,
+    const std::vector<uint8_t>& aggregatedCiphertexts,
+    int numGroups,
+    int ciphertextSize) {
+  std::vector<uint64_t> decryptedArray;
+
+  // Initialize pointers to the ciphertext
+  int ciphertextStart = 0;
+  int ciphertextEnd = ciphertextStart + ciphertextSize;
+
+  for (int j = 0; j < numGroups; j++) {
+    // initialize the ciphertext based on the pointers' location
+    const std::vector<uint8_t> c(
+        aggregatedCiphertexts.begin() + ciphertextStart,
+        aggregatedCiphertexts.begin() + ciphertextEnd);
+    heschme::Ciphertext aggregatedCiphertext =
+        heschme::Ciphertext::fromBytes(c);
+
+    // Decrypt ciphertext
+    uint64_t decrypted = sk.decrypt(aggregatedCiphertext);
+    decryptedArray.push_back(std::move(decrypted));
+
+    // advance the ciphertext pointers
+    ciphertextStart += ciphertextSize;
+    ciphertextEnd += ciphertextSize;
+  }
+  return decryptedArray;
+}
+
+std::unordered_map<uint64_t, heschme::Ciphertext> aggregateCiphertexts(
+    const std::vector<uint8_t>& ciphertextArray,
+    const AggregationInputMetrics& input,
+    int maxTouchpoints,
+    int maxConversions,
+    int ciphertextSize) {
+  std::unordered_map<uint64_t, heschme::Ciphertext> adIdToAggregate;
+
+  auto& touchpointMetadataArrays = input.getTouchpointMetadata();
+  auto& secretShareAttributionArrays = input.getAttributionSecretShares();
+
+  int ciphertextStart = 0;
+  int ciphertextEnd = ciphertextStart + ciphertextSize;
+  for (int i = 0; i < touchpointMetadataArrays.size(); i++) {
+    // get publisher side secret share for the first attr r
+    auto& paddedSecretAttribution = secretShareAttributionArrays[0][i];
+    auto& touchpointMetadataArray = touchpointMetadataArrays[i];
+
+    for (int j = 0; j < touchpointMetadataArray.size(); j++) {
+      // Each touchpoint has is_attr for each conversion. Add all is_attr for
+      // the same touchpoint in plaintext
+      uint64_t pubAttrResult = 0;
+      for (int k = 0; k < maxConversions * maxTouchpoints;
+           k += maxTouchpoints) {
+        pubAttrResult += paddedSecretAttribution[k].isAttributed;
+      }
+
+      // initialize the ciphertext from received bytes
+      std::vector<uint8_t> c(
+          ciphertextArray.begin() + ciphertextStart,
+          ciphertextArray.begin() + ciphertextEnd);
+      heschme::Ciphertext partnerAttrValue = heschme::Ciphertext::fromBytes(c);
+
+      // combine publisher and partner conv values in HE
+      heschme::Ciphertext attrVal = heschme::Ciphertext::add_with_plaintext(
+          partnerAttrValue, pubAttrResult);
+
+      // find the adId to aggregate against
+      int adId = touchpointMetadataArray[j].originalAdId;
+
+      // add ciphertext to the adId bucket
+      if (adIdToAggregate.find(adId) != adIdToAggregate.end()) {
+        heschme::Ciphertext currentSum = adIdToAggregate[adId];
+        adIdToAggregate[adId] =
+            heschme::Ciphertext::add_with_ciphertext(currentSum, attrVal);
+      } else {
+        adIdToAggregate[adId] = attrVal;
+      }
+
+      // advance the ciphertext pointers
+      ciphertextStart += ciphertextSize;
+      ciphertextEnd += ciphertextSize;
+    }
+  }
+  return adIdToAggregate;
+}
+
+std::unordered_map<uint64_t, uint64_t> HEAggGame::computeAggregations(
+    const int myRole,
+    const AggregationInputMetrics& inputData) {
+  XLOG(INFO, "Running private aggregation");
+
+  std::vector<int64_t> ids = inputData.getIds();
+  uint32_t numIds = ids.size();
+  XLOGF(INFO, "Have {} ids", numIds);
+
+  const int ciphertextSize = FLAGS_ciphertext_size;
+  const int maxTouchpoints = FLAGS_max_num_touchpoints;
+  const int maxConversions = FLAGS_max_num_conversions;
+
+  // final output is (breakdown_id, aggregate)
+  std::unordered_map<uint64_t, uint64_t> out;
+
+  if (myRole == common::PARTNER) {
+    // 0) Generate private key, public key and decryption table
+    auto sk = heschme::PrivateKey::generate();
+    auto pk = sk.toPublicKey();
+
+    heschme::initializeElGamalDecryptionTable(FLAGS_decryption_table_size);
+
+    // 1) Encrypt the attr values
+    XLOG(INFO, "Encrypting partner conv values...");
+    std::vector<uint8_t> ciphertextArray =
+        encryptAttrResult(pk, inputData, maxTouchpoints, maxConversions);
+    XLOGF(INFO, "Ciphertext array size  = {}", ciphertextArray.size());
+
+    // 2) Send the ciphertext
+    auto communicationAgent = communicationAgentFactory_->create(
+        common::PUBLISHER, "he_aggregator_partner");
+    communicationAgent->sendT(ciphertextArray);
+
+    // 7) Receive number of groups and aggregated ciphertext
+    // Receive num of groups
+    XLOG(INFO, "Waiting to receive number of groups ... ");
+    int msgSize = 1;
+    std::vector<uint8_t> receivedNumGroups =
+        communicationAgent->receive(msgSize);
+
+    if (receivedNumGroups.size() == 0) {
+      XLOG(ERR, "Received an empty array, cannot read number of groups");
+      std::exit(1);
+    };
+    int numGroups = receivedNumGroups[0];
+    XLOGF(INFO, "Received number of groups  = {}", numGroups);
+
+    // Receive aggregated ciphertext
+    XLOG(INFO, "Waiting to receive aggregated ciphertext ... ");
+    msgSize = numGroups * ciphertextSize;
+    std::vector<uint8_t> aggregatedCiphertexts =
+        communicationAgent->receive(msgSize);
+    XLOGF(INFO, "Received array size  = {}", aggregatedCiphertexts.size());
+
+    // 8) Decrypt the aggregated ciphertext
+    // Initialize a vector for decrypted plaintext
+    std::vector<uint64_t> decryptedArray = decryptAggCiphertext(
+        sk, aggregatedCiphertexts, numGroups, ciphertextSize);
+
+    // 9) Send final decrypted result to publisher
+    communicationAgent->sendT(decryptedArray);
+
+  } else if (myRole == common::PUBLISHER) {
+    // 3) Receive ciphertext from partner
+    XLOG(INFO, "Starting to receive ciphertext...");
+    int msgSize = numIds * maxTouchpoints * ciphertextSize;
+    auto communicationAgent = communicationAgentFactory_->create(
+        common::PARTNER, "he_aggregator_publisher");
+    std::vector<uint8_t> ciphertextArray = communicationAgent->receive(msgSize);
+    XLOGF(INFO, "Received array size  = {}", ciphertextArray.size());
+
+    // 4) Aggregate ciphertext based on ad id
+    XLOG(INFO, "Aggregating conv values...");
+    std::unordered_map<uint64_t, heschme::Ciphertext> adIdToAggregate =
+        aggregateCiphertexts(
+            ciphertextArray,
+            inputData,
+            maxTouchpoints,
+            maxConversions,
+            ciphertextSize);
+
+    // 5) Add noise to each ad_id bucket
+    // Initialize noise generator and to be less than the size of the decryption
+    // table
+    std::random_device rd;
+    std::mt19937_64 e(rd());
+    std::uniform_int_distribution<int> randomInt(
+        0, FLAGS_decryption_table_size - 1);
+    std::vector<int> noiseVector;
+    uint8_t numGroups = 0;
+    std::vector<uint8_t> aggregatedCiphertexts;
+    for (auto i = adIdToAggregate.begin(); i != adIdToAggregate.end(); i++) {
+      // add noise
+      int noise = randomInt(e);
+      std::vector<uint8_t> c =
+          heschme::Ciphertext::add_with_plaintext((i->second), noise).toBytes();
+      aggregatedCiphertexts.insert(
+          aggregatedCiphertexts.end(), c.begin(), c.end());
+
+      // Keep track of the added noise
+      noiseVector.push_back(std::move(noise));
+      numGroups += 1;
+    }
+
+    // 6) Send the aggregated ciphertext to Partner
+    std::vector<uint8_t> numGroupsArr{numGroups};
+    communicationAgent->sendT(numGroupsArr);
+    communicationAgent->sendT(aggregatedCiphertexts);
+
+    // 10) Receive final result (Decrypted plaintext)
+    XLOGF(INFO, "number of groups = {}", numGroups);
+    msgSize = numGroups;
+
+    auto receivedPlainTextArray =
+        communicationAgent->receiveT<uint64_t>(msgSize);
+    XLOGF(
+        INFO,
+        "Received receivedPlainTextArray size  = {}",
+        receivedPlainTextArray.size());
+
+    // 11) Remove the noise and generate output
+    // Sanity checks
+    if (noiseVector.size() != numGroups &&
+        receivedPlainTextArray.size() != numGroups) {
+      XLOG(
+          ERR,
+          "Noise vector and plaintext array has to be equal to the number of groups");
+      std::exit(1);
+    }
+
+    int index = 0;
+    for (auto i = adIdToAggregate.begin(); i != adIdToAggregate.end(); i++) {
+      // Join the adId with the plaintext and noise
+      int plainTextAgg = receivedPlainTextArray[index];
+      int addedNoise = noiseVector[index];
+      out[i->first] = plainTextAgg - addedNoise;
+      XLOGF(
+          INFO,
+          "Index= {}, Adid = {}, Aggregate  = {}",
+          index,
+          i->first,
+          plainTextAgg - addedNoise);
+      ++index;
+    }
+  }
+
+  return out;
+}
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/HEAggGame.h
+++ b/fbpcs/emp_games/he_aggregation/HEAggGame.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "folly/logging/xlog.h"
+
+#include "fbpcf/engine/communication/IPartyCommunicationAgent.h"
+#include "fbpcf/engine/communication/IPartyCommunicationAgentFactory.h"
+#include "fbpcf/frontend/mpcGame.h"
+#include "fbpcs/emp_games/common/Constants.h"
+#include "fbpcs/emp_games/common/Util.h"
+#include "fbpcs/emp_games/he_aggregation/AggregationInputMetrics.h"
+#include "fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h"
+#include "fbpcs/emp_games/pcf2_aggregation/TouchpointMetadata.h"
+
+#include "privacy_infra/elgamal/ElGamal.h"
+
+namespace heschme = facebook::privacy_infra::elgamal;
+
+namespace pcf2_he {
+
+class HEAggGame {
+ public:
+  explicit HEAggGame(
+      std::shared_ptr<
+          fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+          communicationAgentFactory)
+      : communicationAgentFactory_(communicationAgentFactory) {}
+
+  std::unordered_map<uint64_t, uint64_t> computeAggregations(
+      const int myRole,
+      const AggregationInputMetrics& inputData);
+
+ private:
+  std::shared_ptr<fbpcf::engine::communication::IPartyCommunicationAgentFactory>
+      communicationAgentFactory_;
+};
+
+} // namespace pcf2_he

--- a/fbpcs/emp_games/he_aggregation/HEAggOptions.cpp
+++ b/fbpcs/emp_games/he_aggregation/HEAggOptions.cpp
@@ -63,3 +63,6 @@ DEFINE_int32(
 DEFINE_int32(max_num_touchpoints, 4, "Maximum touchpoints per user");
 DEFINE_int32(max_num_conversions, 4, "Maximum conversions per user");
 DEFINE_bool(use_new_output_format, false, "New Format of Attribution output");
+DEFINE_int32(ciphertext_size, 64, "Size of HE ciphertext");
+DEFINE_int32(plaintext_size, 8, "Size of plaintext");
+DEFINE_int32(decryption_table_size, 2000000, "Size of the Decryption Table");

--- a/fbpcs/emp_games/he_aggregation/HEAggOptions.h
+++ b/fbpcs/emp_games/he_aggregation/HEAggOptions.h
@@ -30,3 +30,6 @@ DECLARE_int32(input_encryption);
 DECLARE_int32(max_num_touchpoints);
 DECLARE_int32(max_num_conversions);
 DECLARE_bool(use_new_output_format);
+DECLARE_int32(ciphertext_size);
+DECLARE_int32(plaintext_size);
+DECLARE_int32(decryption_table_size);


### PR DESCRIPTION
Summary:
This diff has the main logic of the HEAggGame. The game works as follow:

```
Partner                                                      Publisher
0) Generate Encryption & decryption keys
1) Encrypt the attr ciphertext
2) Send the ciphertext to publisher

                                                              3) Receive ciphertext
                                                              4) Aggregate ciphertext based on ad id
                                                              5) Add noise to each ad_id bucket
                                                              6) Send the aggregated ciphertext to Partner

7) Receive aggregated ciphertext from publisher
8) Decrypt the aggregated ciphertext
9) Send the aggregated plaintext

                                                              10) Receive aggregated plaintext
                                                              11) Remove the noise and write output
```

The file named "HEAggGame_impl.h" has a function "computeAggregations", this is the entry point to the logic described above and you can map each step with the corresponding code based on the number next to it.

Changes added after accept:

1) Removing the inheritance from MpcGame<schedulerId>
2) Using const& function parameters for non-trivial data types (e.g., std::string, std::vector, AggregationInputMetrics, ..etc)

Differential Revision:
D43972061

Privacy Context Container: L1173372

