### PR TITLE
change int32_t to uint64_t for ids in UDP in fbpcs

### DIFF
--- a/.github/workflows/build_fbpcs_images.yml
+++ b/.github/workflows/build_fbpcs_images.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  FBPCF_VERSION: 2.1.139  # Please also update line 25 (FBPCF_VERSION) in .github/workflows/docker-publish.yml
+  FBPCF_VERSION: 2.1.141  # Please also update line 25 (FBPCF_VERSION) in .github/workflows/docker-publish.yml
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.139  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
+  FBPCF_VERSION: 2.1.141  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
   PID_VERSION: 0.0.8
 
 jobs:

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.cpp
@@ -81,7 +81,7 @@ void UdpEncryptor::pushLinesFromMe(
 void UdpEncryptor::setPeerConfig(
     size_t totalNumberOfPeerRows,
     size_t peerDataWidth,
-    const std::vector<int32_t>& indexes) {
+    const std::vector<uint64_t>& indexes) {
   udpEncryption_->prepareToProcessPeerData(peerDataWidth, indexes);
   size_t numberOfProcessedRow = 0;
   peerDataProcessingFutures_.reserve(totalNumberOfPeerRows / chunkSize_ + 1);

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h
@@ -45,7 +45,7 @@ class UdpEncryptor {
   void setPeerConfig(
       size_t totalNumberOfPeerRows,
       size_t peerDataWidth,
-      const std::vector<int32_t>& indexes);
+      const std::vector<uint64_t>& indexes);
 
   EncryptionResuts getEncryptionResults();
 

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.h
@@ -26,7 +26,7 @@ class UdpEncryptorApp {
       const std::string& expandedKeyFile);
 
  private:
-  static std::vector<int32_t> readIndexFile(const std::string& fileName);
+  static std::vector<uint64_t> readIndexFile(const std::string& fileName);
 
   static std::vector<std::vector<unsigned char>> readDataFile(
       const std::string& fileName);

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorAppTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorAppTest.cpp
@@ -44,10 +44,10 @@ std::vector<std::vector<unsigned char>> generateRandomDataForTest(
   return rst;
 }
 
-std::vector<int32_t> generateRandomIndex(
+std::vector<uint64_t> generateRandomIndex(
     size_t count,
     size_t intersectionSize) {
-  std::vector<int32_t> rst(intersectionSize);
+  std::vector<uint64_t> rst(intersectionSize);
   std::map<int32_t, int32_t> swaps;
   for (size_t i = 0; i < intersectionSize; i++) {
     auto target = folly::Random::secureRand32(i, count);
@@ -75,7 +75,7 @@ void writeDataToFile(
 
 void writeIndexToFile(
     const std::string& file,
-    const std::vector<int32_t>& indexes) {
+    const std::vector<uint64_t>& indexes) {
   auto writer = std::make_unique<fbpcf::io::BufferedWriter>(
       std::make_unique<fbpcf::io::FileWriter>(file));
   std::string header("dummy header");
@@ -103,11 +103,11 @@ void distributeDataToFiles(
 
 void distributeIndexesToFiles(
     const std::vector<std::string>& files,
-    const std::vector<int32_t>& indexes) {
+    const std::vector<uint64_t>& indexes) {
   for (size_t i = 0; i < files.size(); i++) {
     writeIndexToFile(
         files.at(i),
-        std::vector<int32_t>(
+        std::vector<uint64_t>(
             indexes.begin() + i * indexes.size() / files.size(),
             indexes.begin() + (i + 1) * indexes.size() / files.size()));
   }

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
@@ -18,7 +18,7 @@ TEST(UdpEncryptorTestWithMock, testProcessingPeerData) {
   int chunkSize = 500;
   int totalRow = 1200;
   size_t dataWidth = 32;
-  std::vector<int32_t> indexes{3, 31, 6, 12, 5};
+  std::vector<uint64_t> indexes{3, 31, 6, 12, 5};
   auto mock = std::make_unique<fbpcf::mpc_std_lib::unified_data_process::
                                    data_processor::UdpEncryptionMock>();
 
@@ -84,7 +84,7 @@ TEST(UdpEncryptorTestWithMock, testProcessingBothSidesData) {
   size_t peerTotalRow = 1500;
   size_t myWidth = 32;
   size_t peerWidth = 35;
-  std::vector<int32_t> indexes{3, 31, 6, 12, 5};
+  std::vector<uint64_t> indexes{3, 31, 6, 12, 5};
 
   std::vector<std::vector<std::vector<unsigned char>>> testData;
   std::vector<std::vector<std::vector<unsigned char>>> testData1;

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGame_impl.h
@@ -33,16 +33,22 @@ UdpProcessGame<schedulerId>::playDataProcessor(
   auto dataProcessor = dataProcessorFactory_->create();
   typename UdpProcessGame<schedulerId>::SecString publisherShares;
   typename UdpProcessGame<schedulerId>::SecString advertiserShares;
+
+  std::vector<uint64_t> uint64Index(indexes.size());
+  for (size_t i = 0; i < indexes.size(); i++) {
+    uint64Index.at(i) = indexes.at(i);
+  }
+
   if (myId_ == common::PUBLISHER) {
     XLOG(INFO) << "Start to process my data...";
     publisherShares = dataProcessor->processMyData(metaData, intersectionSize);
     XLOG(INFO) << "Start to process peer's data...";
-    advertiserShares =
-        dataProcessor->processPeersData(peersDataSize, indexes, peersDataWidth);
+    advertiserShares = dataProcessor->processPeersData(
+        peersDataSize, uint64Index, peersDataWidth);
   } else {
     XLOG(INFO) << "Start to process peer's data...";
-    publisherShares =
-        dataProcessor->processPeersData(peersDataSize, indexes, peersDataWidth);
+    publisherShares = dataProcessor->processPeersData(
+        peersDataSize, uint64Index, peersDataWidth);
     XLOG(INFO) << "Start to process my data...";
     advertiserShares = dataProcessor->processMyData(metaData, intersectionSize);
   }

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/CompactionBasedInputProcessor_impl.h
@@ -121,20 +121,25 @@ CompactionBasedInputProcessor<schedulerId>::compactData(
   SecString publisherDataShares;
   SecString partnerDataShares;
 
+  std::vector<uint64_t> uint64Index(intersectionMap.size());
+  for (size_t i = 0; i < intersectionMap.size(); i++) {
+    uint64Index.at(i) = intersectionMap.at(i);
+  }
+
   if (myRole_ == common::PUBLISHER) {
     XLOG(INFO) << "Begin processing my data (publisher)";
     publisherDataShares =
-        dataProcessor_->processMyData(plaintextData, intersectionMap.size());
+        dataProcessor_->processMyData(plaintextData, uint64Index.size());
     XLOG(INFO) << "Begin processing peers data (partner)";
     partnerDataShares = dataProcessor_->processPeersData(
-        partnerRows, intersectionMap, partnerSerializer->getRowSizeBytes());
+        partnerRows, uint64Index, partnerSerializer->getRowSizeBytes());
   } else if (myRole_ == common::PARTNER) {
     XLOG(INFO) << "Begin processing peers data (publisher)";
     publisherDataShares = dataProcessor_->processPeersData(
-        publisherRows, intersectionMap, publisherSerializer->getRowSizeBytes());
+        publisherRows, uint64Index, publisherSerializer->getRowSizeBytes());
     XLOG(INFO) << "Begin processing my data (partner)";
     partnerDataShares =
-        dataProcessor_->processMyData(plaintextData, intersectionMap.size());
+        dataProcessor_->processMyData(plaintextData, uint64Index.size());
   }
 
   auto expectedIntersectionSize = std::transform_reduce(


### PR DESCRIPTION
Summary:
As title.

We used to int32_t for index in UDP to save cost (b/c it is used in adapter).
Now as we integrating with i-PID, adapter is no longer need but the index could be larger, we change it to use uint64_t.
In this diff we make the change in fbpcs repo. In the next few diffs we will remove the temporary APIs in fbpcf.

Reviewed By: adshastri

Differential Revision:
D44247961

Privacy Context Container: L416713

