### PR TITLE
update udp encryption API to take in customized indexes in fbpcs

### DIFF
--- a/.github/workflows/build_fbpcs_images.yml
+++ b/.github/workflows/build_fbpcs_images.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  FBPCF_VERSION: 2.1.141  # Please also update line 25 (FBPCF_VERSION) in .github/workflows/docker-publish.yml
+  FBPCF_VERSION: 2.1.143  # Please also update line 25 (FBPCF_VERSION) in .github/workflows/docker-publish.yml
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
   PL_CONTAINER_NAME: e2e_pl_container
   PA_CONTAINER_NAME: e2e_pa_container
   TIME_RANGE: 24 hours
-  FBPCF_VERSION: 2.1.141  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
+  FBPCF_VERSION: 2.1.143  # Please also update line 8 in .github/workflows/build_fbpcs_images.yml
   PID_VERSION: 0.0.9
 
 jobs:

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.cpp
@@ -36,9 +36,7 @@ void UdpEncryptor::processDataInBuffer() {
                                  data = std::move(bufferForMyData_),
                                  indexes = std::move(indexesForMyData_),
                                  p = std::move(promise)]() mutable {
-      // comment out 2nd parameter for now as the
-      // underlying change hasn't been done yet.
-      udpEncryption_->processMyData(*data /*, *indexes*/);
+      udpEncryption_->processMyData(*data, *indexes);
       p.setValue(folly::Unit());
     });
     myDataProcessingFutures_.push_back(std::move(future));

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
@@ -9,7 +9,10 @@
 #include "fbpcf/mpc_std_lib/unified_data_process/data_processor/test/UdpEncryptionMock.h"
 
 #include <gtest/gtest.h>
+#include <functional>
 #include <memory>
+#include <optional>
+#include "folly/Random.h"
 
 using namespace ::testing;
 namespace unified_data_process {
@@ -42,17 +45,27 @@ TEST(UdpEncryptorTestWithMock, testProcessingMyData) {
 
   std::vector<std::vector<std::vector<unsigned char>>> testData;
   std::vector<std::vector<std::vector<unsigned char>>> testData1;
+  std::vector<std::vector<uint64_t>> index;
+  std::vector<std::vector<uint64_t>> index1;
+  uint64_t randomIndex = 0;
   for (size_t i = 0; i < totalRow; i += chunkSize) {
     testData.push_back(std::vector<std::vector<unsigned char>>());
     testData.back().reserve(std::min(chunkSize, totalRow - i));
+    index.push_back(std::vector<uint64_t>());
+    index.back().reserve(std::min(chunkSize, totalRow - i));
+
     for (size_t j = 0; (j < chunkSize) && (j + i < totalRow); j++) {
-      testData.back().push_back(
-          std::vector<unsigned char>(width, (i + j) & 0xFF));
+      uint8_t randomChar = folly::Random::rand32(0, 0xff);
+      randomIndex +=
+          folly::Random::rand32(); // make sure random index is always unique
+      testData.back().push_back(std::vector<unsigned char>(width, randomChar));
+      index.back().push_back(randomIndex);
       if ((i + j) % sampleSize == 0) {
         testData1.push_back(std::vector<std::vector<unsigned char>>());
+        index1.push_back(std::vector<uint64_t>());
       }
-      testData1.back().push_back(
-          std::vector<unsigned char>(width, (i + j) & 0xFF));
+      testData1.back().push_back(std::vector<unsigned char>(width, randomChar));
+      index1.back().push_back(randomIndex);
     }
   }
 
@@ -61,7 +74,7 @@ TEST(UdpEncryptorTestWithMock, testProcessingMyData) {
 
   EXPECT_CALL(*mock, prepareToProcessMyData(width)).Times(1);
   for (size_t i = 0; i < testData.size(); i++) {
-    EXPECT_CALL(*mock, processMyData(testData.at(i))).Times(1);
+    EXPECT_CALL(*mock, processMyData(testData.at(i), index.at(i))).Times(1);
   }
   EXPECT_CALL(*mock, getExpandedKey()).Times(1);
 
@@ -69,14 +82,12 @@ TEST(UdpEncryptorTestWithMock, testProcessingMyData) {
   for (size_t i = 0; i < testData1.size() / 2; i++) {
     for (size_t j = 0; j < testData1.at(i).size(); j++) {
       encryptor.pushOneLineFromMe(
-          std::move(testData1.at(i).at(j)), 0 /* temporary placeholder */);
+          std::move(testData1.at(i).at(j)), index1.at(i).at(j));
     }
   }
   for (size_t i = testData1.size() / 2; i < testData1.size(); i++) {
-    auto size = testData1.at(i).size();
     encryptor.pushLinesFromMe(
-        std::move(testData1.at(i)),
-        std::vector<uint64_t>(size) /* temporary placeholder */);
+        std::move(testData1.at(i)), std::move(index1.at(i)));
   }
   encryptor.getExpandedKey();
 }
@@ -92,18 +103,29 @@ TEST(UdpEncryptorTestWithMock, testProcessingBothSidesData) {
 
   std::vector<std::vector<std::vector<unsigned char>>> testData;
   std::vector<std::vector<std::vector<unsigned char>>> testData1;
-
+  std::vector<std::vector<uint64_t>> index;
+  std::vector<std::vector<uint64_t>> index1;
+  uint64_t randomIndex = 0;
   for (size_t i = 0; i < myTotalRow; i += chunkSize) {
     testData.push_back(std::vector<std::vector<unsigned char>>());
     testData.back().reserve(std::min(chunkSize, myTotalRow - i));
-    for (size_t j = 0; j < chunkSize && j + i < myTotalRow; j++) {
+    index.push_back(std::vector<uint64_t>());
+    index.back().reserve(std::min(chunkSize, myTotalRow - i));
+
+    for (size_t j = 0; (j < chunkSize) && (j + i < myTotalRow); j++) {
+      uint8_t randomChar = folly::Random::rand32(0, 0xff);
+      randomIndex +=
+          folly::Random::rand32(); // make sure random index is always unique
       testData.back().push_back(
-          std::vector<unsigned char>(myWidth, (i + j) & 0xFF));
+          std::vector<unsigned char>(myWidth, randomChar));
+      index.back().push_back(randomIndex);
       if ((i + j) % sampleSize == 0) {
         testData1.push_back(std::vector<std::vector<unsigned char>>());
+        index1.push_back(std::vector<uint64_t>());
       }
       testData1.back().push_back(
-          std::vector<unsigned char>(myWidth, (i + j) & 0xFF));
+          std::vector<unsigned char>(myWidth, randomChar));
+      index1.back().push_back(randomIndex);
     }
   }
 
@@ -112,7 +134,7 @@ TEST(UdpEncryptorTestWithMock, testProcessingBothSidesData) {
 
   EXPECT_CALL(*mock, prepareToProcessMyData(myWidth)).Times(1);
   for (size_t i = 0; i < testData.size(); i++) {
-    EXPECT_CALL(*mock, processMyData(testData.at(i))).Times(1);
+    EXPECT_CALL(*mock, processMyData(testData.at(i), index.at(i))).Times(1);
   }
   EXPECT_CALL(*mock, getExpandedKey()).Times(1);
 
@@ -130,14 +152,12 @@ TEST(UdpEncryptorTestWithMock, testProcessingBothSidesData) {
   for (size_t i = 0; i < testData1.size() / 2; i++) {
     for (size_t j = 0; j < testData1.at(i).size(); j++) {
       encryptor.pushOneLineFromMe(
-          std::move(testData1.at(i).at(j)), 0 /* temporary placeholder */);
+          std::move(testData1.at(i).at(j)), index1.at(i).at(j));
     }
   }
   for (size_t i = testData1.size() / 2; i < testData1.size(); i++) {
-    auto size = testData1.at(i).size();
     encryptor.pushLinesFromMe(
-        std::move(testData1.at(i)),
-        std::vector<uint64_t>(size) /* temporary placeholder */);
+        std::move(testData1.at(i)), std::move(index1.at(i)));
   }
   encryptor.getExpandedKey();
   encryptor.getEncryptionResults();


### PR DESCRIPTION
Summary:
We will use 3 diffs to change the udp encryption API to support customized indexes.

This diff makes the change in fbpcs, which complete the change.
In next diff, we will clean up the temporary APIs in fbpcf.

Reviewed By: robotal

Differential Revision:
D44264568

Privacy Context Container: L416713

