### PR TITLE
MR-PID Publisher deploy script update based on PCE integration proposal

### DIFF
--- a/fbpcs/infra/mr_pid/publisher/README.md
+++ b/fbpcs/infra/mr_pid/publisher/README.md
@@ -62,13 +62,13 @@ export TF_LOG_STREAMING=/tmp/deploymentStream.log
 
 ```
 /bin/bash mrpid_publisher_initial_deploy.sh deploy -r <> -t <> -a <> -p <> -b <optional>
-example: /bin/bash mrpid_publisher_initial_deploy.sh deploy -r us-west-2 -t your-tag-name -a 627672676272 -p 43454354533545
+example: /bin/bash mrpid_publisher_initial_deploy.sh deploy -r us-west-2 -t your-tag-name -a 627672676272 -p 510d2d50b15742c0ac63b346de16a0b4
 ```
 
  * For standard `undeploy`, run the following command
 ```
 /bin/bash mrpid_publisher_initial_deploy.sh undeploy -r <> -t <> -a <> -p <> -b <optional>
-example: /bin/bash mrpid_publisher_initial_deploy.sh undeploy -r us-west-2 -t your-tag-name -a 627672676272 -p 43454354533545
+example: /bin/bash mrpid_publisher_initial_deploy.sh undeploy -r us-west-2 -t your-tag-name -a 627672676272 -p 510d2d50b15742c0ac63b346de16a0b4
 ```
 10. wait for partner side deployment script completed, because we need to put partner side generated IAM roles into S3 bucket policy
 11. run `mrpid_publisher_final_deploy.sh`
@@ -77,14 +77,14 @@ Please use the same tag from initial script.
  * For standard `deploy`, run the following command
 
 ```
-/bin/bash mrpid_publisher_final_deploy.sh deploy -r <> -t <> -a <> -p <> -b <optional>
-example: /bin/bash mrpid_publisher_final_deploy.sh deploy -r us-west-2 -t your-tag-name -a 627672676272 -p 43454354533545
+/bin/bash mrpid_publisher_final_deploy.sh deploy -r <> -t <> -a <> -p <> -i <> -u <> -b <optional>
+example: /bin/bash mrpid_publisher_final_deploy.sh deploy -r us-west-2 -t your-tag-name -a 627672676272 -p 510d2d50b15742c0ac63b346de16a0b4 -i 43454354533545 -u nuu5
 ```
 
  * For standard `undeploy`, run the following command
 ```
-/bin/bash mrpid_publisher_final_deploy.sh undeploy -r <> -t <> -a <> -p <> -b <optional>
-example: /bin/bash mrpid_publisher_final_deploy.sh undeploy -r us-west-2 -t your-tag-name -a 627672676272 -p 43454354533545
+/bin/bash mrpid_publisher_final_deploy.sh undeploy -r <> -t <> -a <> -p <> -i <> -u <> -b <optional>
+example: /bin/bash mrpid_publisher_final_deploy.sh undeploy -r us-west-2 -t your-tag-name -a 627672676272 -p 510d2d50b15742c0ac63b346de16a0b4 -i 43454354533545 -u nuu5
 ```
 
 # Notes

--- a/fbpcs/infra/mr_pid/publisher/mrpid_publisher_initial_deploy.sh
+++ b/fbpcs/infra/mr_pid/publisher/mrpid_publisher_initial_deploy.sh
@@ -14,7 +14,7 @@ usage() {
         [ -t, --tag | A unique identifier to identify resources in this MR-PID deployment]
         [ -r, --region | MR-PID Publisher AWS region, e.g. us-west-2 ]
         [ -a, --account_id | MR-PID Publisher AWS account ID]
-        [ -p, --partner_account_id | MR-PID Partner AWS account ID]
+        [ -p, --pce_instance_id | Publisher PCE instance ID]
         [ -b, --bucket | optional. S3 bucket name for storing configs: tfstate]"
     exit 1
 }
@@ -36,7 +36,7 @@ while [ $# -gt 0 ]; do
         -t|--tag) pid_id="$2" ;;
         -r|--region) region="$2" ;;
         -a|--account_id) aws_account_id="$2" ;;
-        -p|--partner_account_id) partner_account_id="$2" ;;
+        -p|--pce_instance_id) pce_instance_id="$2" ;;
         -b|--bucket) s3_bucket_for_storage="$2" ;;
         *) usage ;;
     esac
@@ -55,13 +55,11 @@ else
 fi
 
 undeploy_aws_resources () {
-    input_validation "$region" "$pid_id" "$aws_account_id" "$partner_account_id" "$s3_bucket_for_storage"
+    input_validation "$region" "$pid_id" "$aws_account_id" "$s3_bucket_for_storage"
     echo "Start undeploying MR-PID Publisher resources..."
     echo "########################Check tfstate files########################"
     check_s3_object_exist "$s3_bucket_for_storage" "tfstate/pid$tag_postfix.tfstate" "$aws_account_id"
     echo "All tfstate files exist. Continue..."
-
-    md5hash_partner_account_id=$(echo -n $partner_account_id | md5sum | awk '{print $1}')
 
     echo "########################Delete MR-PID resources########################"
     cd /terraform_deployment/terraform_scripts_initial
@@ -73,16 +71,14 @@ undeploy_aws_resources () {
         -auto-approve \
         -var "aws_region=$region" \
         -var "pid_id=$pid_id" \
-        -var "md5hash_partner_account_id=$md5hash_partner_account_id"
+        -var "pce_instance_id=$pce_instance_id"
 }
 
 deploy_aws_resources () {
-    input_validation "$region" "$pid_id" "$aws_account_id" "$partner_account_id" "$s3_bucket_for_storage"
+    input_validation "$region" "$pid_id" "$aws_account_id" "$s3_bucket_for_storage"
     echo "########################Started MR-PID AWS Infrastructure Deployment########################"
     echo "creating s3 bucket, if it does not exist"
     validate_or_create_s3_bucket "$s3_bucket_for_storage" "$region" "$aws_account_id"
-
-    md5hash_partner_account_id=$(echo -n $partner_account_id | md5sum | awk '{print $1}')
 
     # Deploy MR-PID Publisher PID Terraform scripts
     cd /terraform_deployment/terraform_scripts_initial
@@ -94,7 +90,7 @@ deploy_aws_resources () {
         -auto-approve \
         -var "aws_region=$region" \
         -var "pid_id=$pid_id" \
-        -var "md5hash_partner_account_id=$md5hash_partner_account_id"
+        -var "pce_instance_id=$pce_instance_id"
 
     state_machine_arn=$(terraform output mrpid_publisher_sfn_arn | tr -d '"' )
     echo "Publisher side stateMachineArn: $state_machine_arn"
@@ -121,7 +117,7 @@ fi
 
 echo "MR-PID Publisher AWS region is $region."
 echo "MR-PID Publisher AWS acount ID is $aws_account_id"
-echo "MR-PID Partner AWS acount ID is $partner_account_id"
+echo "Publisher PCE instance ID is $pce_instance_id"
 echo "The S3 bucket for storing the Terraform state file is $s3_bucket_for_storage and it is in region $region"
 
 if "$undeploy"

--- a/fbpcs/infra/mr_pid/publisher/util.sh
+++ b/fbpcs/infra/mr_pid/publisher/util.sh
@@ -92,8 +92,7 @@ input_validation () {
     local region=$1
     local tag_postfix=$2
     local aws_account_id=$3
-    local partner_aws_account_id=$4
-    local s3_bucket_for_storage=$5
+    local s3_bucket_for_storage=$4
     echo "######################input validation############################"
 
     echo "validate AWS credential..."
@@ -136,7 +135,6 @@ input_validation () {
         exit 1
     fi
 
-    echo "Partner's AWS account ID is $partner_aws_account_id"
     echo "validate input: s3 buckets..."
     echo "The S3 bucket for storing Terraform state file is $s3_bucket_for_storage"
     validate_bucket_name "$s3_bucket_for_storage"

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/ec2_iam_role.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/ec2_iam_role.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role_policy" "mrpid_ec2_access_partner_s3_policy" {
+  name = "mrpid-ec2-access-partner-s3-policy-${var.pce_instance_id}"
+
+  role = aws_iam_role.mrpid_publisher_ec2_role.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::mrpid-partner-${var.partner_unique_tag}/*",
+        "arn:aws:s3:::mrpid-partner-${var.partner_unique_tag}"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/s3_bucket_policy.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/s3_bucket_policy.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket_policy" "mrpid_allow_read_access_from_partner_account" {
-  bucket = "mrpid-publisher-${var.md5hash_partner_account_id}"
+  bucket = "mrpid-publisher-${var.pce_instance_id}"
 
   policy = <<EOF
 {
@@ -15,8 +15,8 @@ resource "aws_s3_bucket_policy" "mrpid_allow_read_access_from_partner_account" {
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::mrpid-publisher-${var.md5hash_partner_account_id}/*",
-        "arn:aws:s3:::mrpid-publisher-${var.md5hash_partner_account_id}"
+        "arn:aws:s3:::mrpid-publisher-${var.pce_instance_id}/*",
+        "arn:aws:s3:::mrpid-publisher-${var.pce_instance_id}"
       ]
     },
     {
@@ -26,8 +26,8 @@ resource "aws_s3_bucket_policy" "mrpid_allow_read_access_from_partner_account" {
       },
       "Action": "s3:*",
       "Resource": [
-        "arn:aws:s3:::mrpid-publisher-${var.md5hash_partner_account_id}/*",
-        "arn:aws:s3:::mrpid-publisher-${var.md5hash_partner_account_id}"
+        "arn:aws:s3:::mrpid-publisher-${var.pce_instance_id}/*",
+        "arn:aws:s3:::mrpid-publisher-${var.pce_instance_id}"
       ],
       "Condition": {
         "Bool": {
@@ -42,8 +42,8 @@ resource "aws_s3_bucket_policy" "mrpid_allow_read_access_from_partner_account" {
       },
       "Action": "s3:*",
       "Resource": [
-        "arn:aws:s3:::mrpid-publisher-${var.md5hash_partner_account_id}/*",
-        "arn:aws:s3:::mrpid-publisher-${var.md5hash_partner_account_id}"
+        "arn:aws:s3:::mrpid-publisher-${var.pce_instance_id}/*",
+        "arn:aws:s3:::mrpid-publisher-${var.pce_instance_id}"
       ],
       "Condition": {
         "NumericLessThan": {

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/sfn.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/sfn.tf
@@ -5,10 +5,7 @@ resource "aws_sfn_state_machine" "mrpid_publisher_sfn" {
 
   type = "STANDARD"
 
-  definition = <<EOF
-  {
-  }
-  EOF
+  definition = data.template_file.publisher_sfn_definition.rendered
 
   logging_configuration {
     log_destination = "${aws_cloudwatch_log_group.mrpid_publisher_sfn_log_group.arn}:*"

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/sfn_definition.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/sfn_definition.tf
@@ -66,7 +66,7 @@ data "template_file" "publisher_sfn_definition" {
           {
             "Name": "install-cloudwatch-agent",
             "ScriptBootstrapAction": {
-              "Path": "s3://mrpid-publisher-${var.md5hash_partner_account_id}-confs/cloudwatch_agent/cloudwatch_agent_install.sh",
+              "Path": "s3://mrpid-publisher-${var.pce_instance_id}-confs/cloudwatch_agent/cloudwatch_agent_install.sh",
               "Args": []
             }
           }
@@ -106,7 +106,7 @@ data "template_file" "publisher_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=2 --class com.meta.mr.multikey.publisher.PubStageOne {} s3://mrpid-publisher-${var.md5hash_partner_account_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageOneConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageOneConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageOneYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.inputPath))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=2 --class com.meta.mr.multikey.publisher.PubStageOne {} s3://mrpid-publisher-${var.pce_instance_id}/{} {} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageOneConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageOneConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageOneYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.inputPath))"
           }
         }
       },
@@ -126,7 +126,7 @@ data "template_file" "publisher_sfn_definition" {
     "Wait_for_stage_two_ready": {
       "Type": "Task",
       "Parameters": {
-        "Bucket": "mrpid-partner-${var.md5hash_partner_account_id}",
+        "Bucket": "mrpid-partner-${var.partner_unique_tag}",
         "Key.$": "States.Format('{}/step_1_meta_enc_kc_kp/_SUCCESS', $.instanceId)"
       },
       "Resource": "arn:aws:states:::aws-sdk:s3:getObject",
@@ -162,7 +162,7 @@ data "template_file" "publisher_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=2 --class com.meta.mr.multikey.publisher.PubStageTwo {} s3://mrpid-publisher-${var.md5hash_partner_account_id}/{} {} s3://mrpid-partner-${var.md5hash_partner_account_id}/{} 2>&1 | sudo tee /mnt/var/log/spark/PubStageTwoConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageTwoConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageTwoYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.instanceId))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=2 --class com.meta.mr.multikey.publisher.PubStageTwo {} s3://mrpid-publisher-${var.pce_instance_id}/{} {} s3://mrpid-partner-${var.partner_unique_tag}/{} 2>&1 | sudo tee /mnt/var/log/spark/PubStageTwoConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageTwoConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageTwoYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.instanceId, $.outputPath, $.instanceId))"
           }
         }
       },
@@ -182,7 +182,7 @@ data "template_file" "publisher_sfn_definition" {
     "Wait_for_stage_three_ready": {
       "Type": "Task",
       "Parameters": {
-        "Bucket": "mrpid-partner-${var.md5hash_partner_account_id}",
+        "Bucket": "mrpid-partner-${var.partner_unique_tag}",
         "Key.$": "States.Format('{}/step_3_meta_all_enc_kc_kp_rc_sc_rp/_SUCCESS', $.instanceId)"
       },
       "Resource": "arn:aws:states:::aws-sdk:s3:getObject",
@@ -218,7 +218,7 @@ data "template_file" "publisher_sfn_definition" {
           "ActionOnFailure": "TERMINATE_JOB_FLOW",
           "HadoopJarStep": {
             "Jar": "command-runner.jar",
-            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=2 --class com.meta.mr.multikey.publisher.PubStageThree {} {} s3://mrpid-partner-${var.md5hash_partner_account_id}/{} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageThreeConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageThreeConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageThreeYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.outputPath, $.instanceId, $.numPidContainers))"
+            "Args.$": "States.Array('bash', '-c', States.Format('set -o pipefail;spark-submit --deploy-mode cluster --master yarn --jars {} --num-executors 10 --executor-cores 5 --executor-memory 3G --conf spark.driver.memory=10G --conf spark.sql.shuffle.partitions=10 --conf spark.yarn.maxAppAttempts=2 --class com.meta.mr.multikey.publisher.PubStageThree {} {} s3://mrpid-partner-${var.partner_unique_tag}/{} {} 2>&1 | sudo tee /mnt/var/log/spark/PubStageThreeConsole.log;exit_status=$(echo $?);applicationId=$(grep URL < /mnt/var/log/spark/PubStageThreeConsole.log | head -n 1 | cut -d / -f5);yarn logs -applicationId $applicationId | sudo tee /mnt/var/log/spark/PubStageThreeYarn.log;test $exit_status -eq 0', $.pidMrMultikeyJarPath, $.pidMrMultikeyJarPath, $.outputPath, $.instanceId, $.numPidContainers))"
           }
         }
       },

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/sfn_iam_role.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/sfn_iam_role.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_role_policy" "mrpid_sfn_access_partner_s3_policy" {
+  name = "mrpid-sfn-access-partner-s3-policy-${var.pce_instance_id}"
+
+  role = aws_iam_role.mrpid_publisher_sfn_role.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::mrpid-partner-${var.partner_unique_tag}/*",
+        "arn:aws:s3:::mrpid-partner-${var.partner_unique_tag}"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/variable.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/final_script/variable.tf
@@ -9,12 +9,17 @@ variable "pid_id" {
   description = "The identifier for marking the cloud resources in MR PID"
 }
 
+variable "pce_instance_id" {
+  type        = string
+  description = "Publisher PCE instance ID"
+}
+
 variable "partner_account_id" {
   type        = string
   description = "Partner AWS account ID"
 }
 
-variable "md5hash_partner_account_id" {
+variable "partner_unique_tag" {
   type        = string
-  description = "MD5 hashed Partner AWS account ID"
+  description = "Partner Deployment unique Tag"
 }

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/cloudwatch.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/cloudwatch.tf
@@ -1,9 +1,9 @@
 resource "aws_cloudwatch_log_group" "mrpid_publisher_sfn_log_group" {
-  name = "mrpid-publisher-sfn-log-group-${var.md5hash_partner_account_id}"
+  name = "mrpid-publisher-sfn-log-group-${var.pce_instance_id}"
   retention_in_days = 30
 }
 
 resource "aws_cloudwatch_log_group" "mrpid_publisher_ec2_log_group" {
-  name = "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}"
+  name = "mrpid-publisher-ec2-log-group-${var.pce_instance_id}"
   retention_in_days = 30
 }

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/ec2_iam_role.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/ec2_iam_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "mrpid_publisher_ec2_role" {
-  name = "mrpid-publisher-ec2-role-${var.md5hash_partner_account_id}"
+  name = "mrpid-publisher-ec2-role-${var.pce_instance_id}"
 
   assume_role_policy = <<POLICY
 {
@@ -18,7 +18,7 @@ POLICY
 }
 
 resource "aws_iam_instance_profile" "mrpid_publisher_ec2_role" {
-  name = "mrpid-publisher-ec2-role-${var.md5hash_partner_account_id}"
+  name = "mrpid-publisher-ec2-role-${var.pce_instance_id}"
   role = aws_iam_role.mrpid_publisher_ec2_role.name
 }
 
@@ -27,33 +27,8 @@ resource "aws_iam_role_policy_attachment" "mrpid_emr_ec2_role_attach" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role"
 }
 
-resource "aws_iam_role_policy" "mrpid_ec2_access_partner_s3_policy" {
-  name = "mrpid-ec2-access-partner-s3-policy-${var.md5hash_partner_account_id}"
-
-  role = aws_iam_role.mrpid_publisher_ec2_role.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::mrpid-partner-${var.md5hash_partner_account_id}/*",
-        "arn:aws:s3:::mrpid-partner-${var.md5hash_partner_account_id}"
-      ]
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_iam_role_policy" "mrpid_ec2_access_cloudwatch_logs_policy" {
-  name = "mrpid-ec2-access-cloudwatch-logs-policy-${var.md5hash_partner_account_id}"
+  name = "mrpid-ec2-access-cloudwatch-logs-policy-${var.pce_instance_id}"
 
   role = aws_iam_role.mrpid_publisher_ec2_role.id
 

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/emr_iam_role.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/emr_iam_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "mrpid_publisher_emr_role" {
-  name = "mrpid-publisher-emr-role-${var.md5hash_partner_account_id}"
+  name = "mrpid-publisher-emr-role-${var.pce_instance_id}"
 
   assume_role_policy = <<POLICY
 {

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/s3_bucket.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/s3_bucket.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "mrpid_publisher_intermediate_bucket" {
-  bucket = "mrpid-publisher-${var.md5hash_partner_account_id}"
+  bucket = "mrpid-publisher-${var.pce_instance_id}"
   force_destroy = true
 }
 
@@ -13,7 +13,7 @@ resource "aws_s3_bucket_public_access_block" "mrpid_block_public_access" {
 }
 
 resource "aws_s3_bucket" "mrpid_publisher_confs_bucket" {
-  bucket = "mrpid-publisher-${var.md5hash_partner_account_id}-confs"
+  bucket = "mrpid-publisher-${var.pce_instance_id}-confs"
   force_destroy = true
 }
 
@@ -55,37 +55,37 @@ sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /de
         "collect_list": [
           {
             "file_path": "/mnt/var/log/spark/PubStageOneConsole.log",
-            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.pce_instance_id}",
             "log_stream_name": "publisher_stage_one_console_log",
             "timezone": "UTC"
           },
           {
             "file_path": "/mnt/var/log/spark/PubStageTwoConsole.log",
-            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.pce_instance_id}",
             "log_stream_name": "publisher_stage_two_console_log",
             "timezone": "UTC"
           },
           {
             "file_path": "/mnt/var/log/spark/PubStageThreeConsole.log",
-            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.pce_instance_id}",
             "log_stream_name": "publisher_stage_three_console_log",
             "timezone": "UTC"
           },
           {
             "file_path": "/mnt/var/log/spark/PubStageOneYarn.log",
-            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.pce_instance_id}",
             "log_stream_name": "publisher_stage_one_yarn_log",
             "timezone": "UTC"
           },
           {
             "file_path": "/mnt/var/log/spark/PubStageTwoYarn.log",
-            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.pce_instance_id}",
             "log_stream_name": "publisher_stage_two_yarn_log",
             "timezone": "UTC"
           },
           {
             "file_path": "/mnt/var/log/spark/PubStageThreeYarn.log",
-            "log_group_name": "mrpid-publisher-ec2-log-group-${var.md5hash_partner_account_id}",
+            "log_group_name": "mrpid-publisher-ec2-log-group-${var.pce_instance_id}",
             "log_stream_name": "publisher_stage_three_yarn_log",
             "timezone": "UTC"
           }

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/sfn_iam_role.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/sfn_iam_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "mrpid_publisher_sfn_role" {
-  name = "mrpid-publisher-sfn-role-${var.md5hash_partner_account_id}"
+  name = "mrpid-publisher-sfn-role-${var.pce_instance_id}"
 
   assume_role_policy = <<POLICY
 {
@@ -18,7 +18,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy" "mrpid_sfn_access_cloudwatch_logs_policy" {
-  name = "mrpid-sfn-access-cloudwatch-logs-policy-${var.md5hash_partner_account_id}"
+  name = "mrpid-sfn-access-cloudwatch-logs-policy-${var.pce_instance_id}"
 
   role = aws_iam_role.mrpid_publisher_sfn_role.id
 
@@ -39,7 +39,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "mrpid_sfn_access_emr_policy" {
-  name = "mrpid-sfn-access-emr-policy-${var.md5hash_partner_account_id}"
+  name = "mrpid-sfn-access-emr-policy-${var.pce_instance_id}"
 
   role = aws_iam_role.mrpid_publisher_sfn_role.id
 
@@ -66,31 +66,6 @@ resource "aws_iam_role_policy" "mrpid_sfn_access_emr_policy" {
       "Resource": [
         "${aws_iam_role.mrpid_publisher_emr_role.arn}",
         "${aws_iam_role.mrpid_publisher_ec2_role.arn}"
-      ]
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "mrpid_sfn_access_partner_s3_policy" {
-  name = "mrpid-sfn-access-partner-s3-policy-${var.md5hash_partner_account_id}"
-
-  role = aws_iam_role.mrpid_publisher_sfn_role.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::mrpid-partner-${var.md5hash_partner_account_id}/*",
-        "arn:aws:s3:::mrpid-partner-${var.md5hash_partner_account_id}"
       ]
     }
   ]

--- a/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/variable.tf
+++ b/fbpcs/infra/pid/aws_terraform_template/publisher/initial_script/variable.tf
@@ -9,7 +9,7 @@ variable "pid_id" {
   description = "The identifier for marking the cloud resources in MR PID"
 }
 
-variable "md5hash_partner_account_id" {
+variable "pce_instance_id" {
   type        = string
-  description = "MD5 hashed Partner AWS account ID"
+  description = "Publisher PCE instance ID"
 }


### PR DESCRIPTION
Summary:
MR-PID Publisher deploy script update based on the the proposal (https://docs.google.com/document/d/1DaMZfzFc0TU4pO3HJHOuhlhWs2WUjbP98yU_E3MvmYA/edit#bookmark=id.jeeh5rn46nm7):
1. Use pce_instance_id as the Publisher aws resources postfix instead of hash of partner_account_id
2. Use partner_unique_tag as the Partner aws resoruces postfix instead of hash of partner_account_id
3. Move some resources generation sequence to final deployment based on the input parameters change

Reviewed By: Pradeepnitw

Differential Revision: D44375399

