### PR TITLE
Attach glue pass roles directly onto the glue_service_role

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/glue.tf
@@ -53,6 +53,62 @@ resource "aws_iam_role_policy" "s3_policy" {
 EOF
 }
 
+resource "aws_iam_role_policy" "pass_glue_service_role" {
+  name   = "pass-glue-service-role${var.tag_postfix}"
+  role   = aws_iam_role.glue_service_role.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:iam::*:role/AWSGlueServiceRole*",
+      "Condition": {
+        "StringLike": {
+          "iam:PassedToService": [
+            "glue.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:iam::*:role/AWSGlueServiceNotebookRole*",
+      "Condition": {
+        "StringLike": {
+          "iam:PassedToService": [
+            "ec2.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::*:role/service-role/AWSGlueServiceRole*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "iam:PassedToService": [
+            "glue.amazonaws.com"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_glue_crawler" "mpc_events_crawler" {
   database_name = aws_glue_catalog_database.mpc_database.name
   name          = "mpc-events-crawler${var.tag_postfix}"


### PR DESCRIPTION
Summary:
There is an issue with deployment where the iam:PassRole from the
AWSGlueConsoleFullAccess policy isn't propagating into the glue_service_role.
To resolve, attach the 3 required roles according to the Glue docs:
https://docs.aws.amazon.com/glue/latest/dg/attach-policy-iam-user.html

Differential Revision: D44379301

