### PR TITLE
Speed up data pre validation with multiprocessing

### DIFF
--- a/fbpcs/pc_pre_validation/constants.py
+++ b/fbpcs/pc_pre_validation/constants.py
@@ -24,6 +24,14 @@ TIMESTAMP_OUT_OF_RANGE_MAX_THRESHOLD = 0.15
 # 15 minutes
 STREAMING_DURATION_LIMIT_IN_SECONDS: int = 15 * 60
 
+# use a LARGE container with 16 vCPUs
+# This is the max number of concurrent processes that can run concurrently
+MAX_PARALLELISM: int = 16
+
+# 10 MB
+# Smallest chunk size before another worker is added
+MIN_CHUNK_SIZE: int = 10 * 1024 * 1024
+
 ID_FIELD_PREFIX = "id_"
 COHORT_ID_FIELD = "cohort_id"
 CONVERSION_VALUE_FIELD = "conversion_value"

--- a/fbpcs/pc_pre_validation/exceptions.py
+++ b/fbpcs/pc_pre_validation/exceptions.py
@@ -8,3 +8,7 @@
 
 class InputDataValidationException(Exception):
     pass
+
+
+class TimeoutException(Exception):
+    pass

--- a/fbpcs/pc_pre_validation/input_data_validation_issues.py
+++ b/fbpcs/pc_pre_validation/input_data_validation_issues.py
@@ -5,6 +5,9 @@
 
 # pyre-strict
 
+
+from __future__ import annotations
+
 from collections import Counter
 from typing import Any, Dict, Optional
 
@@ -198,3 +201,16 @@ class InputDataValidationIssues:
             fields_counts[field].update(counts)
         else:
             fields_counts[field] = counts
+
+    def merge(self, other: InputDataValidationIssues) -> None:
+        """
+        Merge all the counters into this instance.
+        """
+        self.empty_counter = self.empty_counter + other.empty_counter
+        self.format_error_counter = (
+            self.format_error_counter + other.format_error_counter
+        )
+        self.range_error_counter = self.range_error_counter + other.range_error_counter
+        self.cohort_id_aggregates = (
+            self.cohort_id_aggregates + other.cohort_id_aggregates
+        )

--- a/fbpcs/pc_pre_validation/tests/input_data_validation_issues_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validation_issues_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from unittest import TestCase
+
+from fbpcs.pc_pre_validation.input_data_validation_issues import (
+    InputDataValidationIssues,
+)
+
+
+class InputDataValidationIssuesTest(TestCase):
+    def test_merge(self) -> None:
+        issues = self._create_item()
+        issues2 = self._create_item()
+
+        issues2.count_empty_field("field2")
+        issues2.count_format_error_field("field2")
+        issues2.count_format_out_of_range_field("field2")
+        issues2.update_cohort_aggregate(2, 1)
+        issues.merge(issues2)
+
+        self.assertEqual(dict(issues.empty_counter), {"field1": 2, "field2": 1})
+        self.assertEqual(dict(issues.format_error_counter), {"field1": 2, "field2": 1})
+        self.assertEqual(dict(issues.range_error_counter), {"field1": 2, "field2": 1})
+        self.assertEqual(dict(issues.cohort_id_aggregates), {1: 2, 2: 1})
+
+    def _create_item(self) -> InputDataValidationIssues:
+        issues = InputDataValidationIssues()
+        issues.empty_counter["field1"] += 1
+        issues.format_error_counter["field1"] += 1
+        issues.range_error_counter["field1"] += 1
+        issues.cohort_id_aggregates[1] += 1
+
+        return issues


### PR DESCRIPTION
Summary:
tldr;
* Speed up data pre validation by processing lines in parallel.
* Increased speed 16x (94%) for 10m lines and ~20x (95%) for 100m lines

## Why

The current pre validation program can process ~77 million lines of data in 15 mins (which is the timeout set for this stage). We want to speed up this process so that we can validate larger files and finish faster.

# How
Currently, it runs on one thread on one processor. It processes each line one at a time. Using the `multiprocessing` library, we can process the input data on multiple cores in parallel. This diff adds that capability.

## Steps
Streaming case
* Pick number of parallel workers based on size of file
* Each worker calculates a range of the file to process
* Each worker downloads and processes that range
* Once all workers complete, combine the validation results for them

Local Download case
* Split up the input file into `n` local shards suffixed from 0 to 'n'.
* Kick off n processes to consume each shard
* Process shards in parallel and calculate validation results for each shard
* Once all shards complete, combine the validation results for them

Reviewed By: marksliva

Differential Revision: D43998724

