### PR TITLE
Adding partner pre-validation gk changes in pc pre-validation stage service

### DIFF
--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -79,6 +79,7 @@ class InputDataValidator(Validator):
         region: str,
         stream_file: bool,
         publisher_pc_pre_validation: bool,
+        partner_pc_pre_validation: bool,
         private_computation_role: PrivateComputationRole,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
@@ -93,6 +94,7 @@ class InputDataValidator(Validator):
         self._num_id_columns = 0
         self._stream_file = stream_file
         self._publisher_pc_pre_validation = publisher_pc_pre_validation
+        self._partner_pc_pre_validation = partner_pc_pre_validation
         self._private_computation_role: PrivateComputationRole = (
             private_computation_role
         )
@@ -526,6 +528,7 @@ class InputDataValidator(Validator):
 
         run_partner_pre_validation_check = (
             self._private_computation_role is PrivateComputationRole.PARTNER
+            and self._partner_pc_pre_validation
         )
         if not match_id_fields:
             raise InputDataValidationException(

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -24,6 +24,7 @@ Usage:
         [--private-computation-role=<private-computation-role>]
         [--pre-validation-file-stream=<pre-validation-file-stream>]
         [--publisher-pc-pre-validation=<publisher-pc-pre-validation>]
+        [--partner-pc-pre-validation=<partner-pc-pre-validation>]
 """
 
 
@@ -51,6 +52,8 @@ PRE_VALIDATION_FILE_STREAM_ENABLED = "enabled"
 PUBLISHER_PC_PRE_VALIDATION_FLAG = "--publisher-pc-pre-validation"
 PUBLISHER_PC_PRE_VALIDATION_ENABLED = "enabled"
 PRIVATE_COMPUTATION_ROLE = "--private-computation-role"
+PARTNER_PC_PRE_VALIDATION_FLAG = "--partner-pc-pre-validation"
+PARTNER_PC_PRE_VALIDATION_ENABLED = "enabled"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -69,6 +72,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(BINARY_VERSION): optional_string,
             Optional(PRE_VALIDATION_FILE_STREAM_FLAG): optional_string,
             Optional(PUBLISHER_PC_PRE_VALIDATION_FLAG): optional_string,
+            Optional(PARTNER_PC_PRE_VALIDATION_FLAG): optional_string,
             Optional(PRIVATE_COMPUTATION_ROLE): optional_string,
         }
     )
@@ -82,6 +86,9 @@ def main(argv: OptionalType[List[str]] = None) -> None:
         arguments[PUBLISHER_PC_PRE_VALIDATION_FLAG]
         == PUBLISHER_PC_PRE_VALIDATION_ENABLED
     )
+    partner_pc_pre_validation = (
+        arguments[PARTNER_PC_PRE_VALIDATION_FLAG] == PARTNER_PC_PRE_VALIDATION_ENABLED
+    )
 
     validators = [
         cast(
@@ -92,6 +99,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 region=arguments[REGION],
                 stream_file=stream_file,
                 publisher_pc_pre_validation=publisher_pc_pre_validation,
+                partner_pc_pre_validation=partner_pc_pre_validation,
                 private_computation_role=arguments[PRIVATE_COMPUTATION_ROLE],
                 start_timestamp=arguments[START_TIMESTAMP],
                 end_timestamp=arguments[END_TIMESTAMP],

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -43,6 +43,7 @@ TEST_INPUT_FILE_PATH = (
 TEST_REGION = "us-west-2"
 TEST_STREAM_FILE = False
 TEST_PUBLISHER_PC_PRE_VALIDATION = False
+TEST_PARTNER_PC_PRE_VALIDATION = True
 TEST_PRIVATE_COMPUTATION_ROLE: PrivateComputationRole = PrivateComputationRole.PARTNER
 TEST_TIMESTAMP: float = time.time()
 TEST_TEMP_FILEPATH = f"{INPUT_DATA_TMP_FILE_PATH}/{TEST_FILENAME}-{TEST_TIMESTAMP}"
@@ -88,6 +89,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             access_key_id=access_key_id,
             access_key_data=access_key_data,
@@ -118,6 +120,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -148,6 +151,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -169,6 +173,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -203,6 +208,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -242,6 +248,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -281,6 +288,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -410,6 +418,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -448,6 +457,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -487,6 +497,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -525,6 +536,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -568,6 +580,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -601,6 +614,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -634,6 +648,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -659,6 +674,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -691,6 +707,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -724,6 +741,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=publisher_role,
         )
         report = validator.validate()
@@ -757,6 +775,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=publisher_pc_pre_validation,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=publisher_role,
         )
         report = validator.validate()
@@ -789,6 +808,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -839,6 +859,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -888,6 +909,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -938,6 +960,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -973,6 +996,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1024,6 +1048,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1053,6 +1078,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1091,6 +1117,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1122,6 +1149,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1153,6 +1181,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1169,6 +1198,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1650000000",
             end_timestamp="1640000000",
@@ -1187,6 +1217,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="test",
             end_timestamp=end_timestamp,
@@ -1206,6 +1237,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp=start_timestamp,
             end_timestamp="test",
@@ -1252,6 +1284,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1297,6 +1330,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1337,6 +1371,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1377,6 +1412,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1459,6 +1495,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
@@ -1502,6 +1539,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
@@ -1668,6 +1706,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1701,6 +1740,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1737,6 +1777,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1670000000",
             end_timestamp="1650000000",
@@ -1776,6 +1817,7 @@ class TestInputDataValidator(TestCase):
             region=TEST_REGION,
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="test1",
             end_timestamp="test2",

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -49,6 +49,7 @@ class TestPCPreValidationCLI(TestCase):
             region=expected_region,
             stream_file=False,
             publisher_pc_pre_validation=False,
+            partner_pc_pre_validation=False,
             private_computation_role=None,
             start_timestamp=None,
             end_timestamp=None,
@@ -103,6 +104,7 @@ class TestPCPreValidationCLI(TestCase):
             f"--private-computation-role={expected_pc_computation_role}",
             "--pre-validation-file-stream=enabled",
             "--publisher-pc-pre-validation=enabled",
+            "--partner-pc-pre-validation=enabled",
         ]
 
         validation_cli.main(argv)
@@ -113,6 +115,7 @@ class TestPCPreValidationCLI(TestCase):
             region=expected_region,
             stream_file=True,
             publisher_pc_pre_validation=True,
+            partner_pc_pre_validation=True,
             private_computation_role=PrivateComputationRole.PARTNER.name,
             start_timestamp=expected_start_timestamp,
             end_timestamp=expected_end_timestamp,

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -122,12 +122,16 @@ class PCPreValidationStageService(PrivateComputationStageService):
         publisher_pc_pre_validation_flag = pc_instance.has_feature(
             PCSFeature.PUBLISHER_PC_PRE_VALIDATION
         )
+        partner_pc_pre_validation_flag = pc_instance.has_feature(
+            PCSFeature.PARTNER_PC_PRE_VALIDATION
+        )
         cmd_args = get_cmd_args(
             input_path=pc_instance.product_config.common.input_path,
             region=region,
             binary_config=binary_config,
             pre_validation_file_stream_flag=pre_validation_file_stream_flag,
             publisher_pc_pre_validation_flag=publisher_pc_pre_validation_flag,
+            partner_pc_pre_validation_flag=partner_pc_pre_validation_flag,
             private_computation_role=pc_instance.infra_config.role,
             input_path_start_ts=pc_instance.product_config.common.input_path_start_ts,
             input_path_end_ts=pc_instance.product_config.common.input_path_end_ts,
@@ -220,6 +224,7 @@ class PCPreValidationStageService(PrivateComputationStageService):
     ) -> bool:
         if (
             pc_instance.infra_config.role == PrivateComputationRole.PARTNER
+            and pc_instance.has_feature(PCSFeature.PARTNER_PC_PRE_VALIDATION)
             and self._pc_validator_config.pc_pre_validator_enabled
         ):
             self._logger.info(

--- a/fbpcs/private_computation/service/pre_validate_service.py
+++ b/fbpcs/private_computation/service/pre_validate_service.py
@@ -56,6 +56,7 @@ class PreValidateService:
                 binary_config=binary_config,
                 pre_validation_file_stream_flag=True,
                 publisher_pc_pre_validation_flag=True,
+                partner_pc_pre_validation_flag=True,
                 private_computation_role=PrivateComputationRole.PARTNER,
                 input_path_start_ts=None,
                 input_path_end_ts=None,

--- a/fbpcs/private_computation/service/pre_validation_util.py
+++ b/fbpcs/private_computation/service/pre_validation_util.py
@@ -20,6 +20,7 @@ def get_cmd_args(
     binary_config: OneDockerBinaryConfig,
     pre_validation_file_stream_flag: bool,
     publisher_pc_pre_validation_flag: bool,
+    partner_pc_pre_validation_flag: bool,
     input_path_start_ts: Optional[str],
     input_path_end_ts: Optional[str],
     private_computation_role: Optional[PrivateComputationRole] = None,
@@ -46,5 +47,8 @@ def get_cmd_args(
 
     if publisher_pc_pre_validation_flag:
         args.append("--publisher-pc-pre-validation=enabled")
+
+    if partner_pc_pre_validation_flag:
+        args.append("--partner-pc-pre-validation=enabled")
 
     return " ".join(args)

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -121,6 +121,13 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         self, mock_stage_state_instance, mock_run_binary_base_service_start_containers
     ) -> None:
         pc_instance = self._pc_instance
+        infra_config: InfraConfig = self._get_infra_config(
+            private_computation_role=PrivateComputationRole.PARTNER,
+            pcs_features={
+                PCSFeature.PARTNER_PC_PRE_VALIDATION,
+            },
+        )
+        pc_instance.infra_config = infra_config
         mock_container_instance = MagicMock()
         mock_onedocker_svc = MagicMock()
         mock_run_binary_base_service_start_containers.return_value = [
@@ -134,6 +141,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 f"--region={region}",
                 "--binary-version=latest",
                 f"--private-computation-role={PrivateComputationRole.PARTNER}",
+                "--partner-pc-pre-validation=enabled",
             ]
         )
         pc_validator_config = PCValidatorConfig(
@@ -184,6 +192,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             pcs_features={
                 PCSFeature.PRE_VALIDATION_FILE_STREAM,
                 PCSFeature.PUBLISHER_PC_PRE_VALIDATION,
+                PCSFeature.PARTNER_PC_PRE_VALIDATION,
             },
         )
         pc_instance.infra_config = infra_config
@@ -202,6 +211,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 f"--private-computation-role={PrivateComputationRole.PUBLISHER}",
                 "--pre-validation-file-stream=enabled",
                 "--publisher-pc-pre-validation=enabled",
+                "--partner-pc-pre-validation=enabled",
             ]
         )
         pc_validator_config = PCValidatorConfig(
@@ -357,6 +367,13 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         self, mock_run_binary_base_service_start_containers
     ) -> None:
         pc_instance = self._pc_instance
+        infra_config: InfraConfig = self._get_infra_config(
+            private_computation_role=PrivateComputationRole.PARTNER,
+            pcs_features={
+                PCSFeature.PARTNER_PC_PRE_VALIDATION,
+            },
+        )
+        pc_instance.infra_config = infra_config
         mock_onedocker_svc = MagicMock()
         exception_message = "Unexpected exception.."
         mock_run_binary_base_service_start_containers.side_effect = [
@@ -386,6 +403,13 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         self, mock_get_pc_status_from_stage_state
     ) -> None:
         pc_instance = self._pc_instance
+        infra_config: InfraConfig = self._get_infra_config(
+            private_computation_role=PrivateComputationRole.PARTNER,
+            pcs_features={
+                PCSFeature.PARTNER_PC_PRE_VALIDATION,
+            },
+        )
+        pc_instance.infra_config = infra_config
         task_id = "test-task-id-123"
         cluster_name = "test-cluster-name"
         account_id = "1234567890"
@@ -435,6 +459,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 {
                     PCSFeature.PRE_VALIDATION_FILE_STREAM,
                     PCSFeature.PUBLISHER_PC_PRE_VALIDATION,
+                    PCSFeature.PARTNER_PC_PRE_VALIDATION,
                 }
             ),
             product_config=self._product_config,
@@ -454,6 +479,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 f"--private-computation-role={PrivateComputationRole.PARTNER}",
                 "--pre-validation-file-stream=enabled",
                 "--publisher-pc-pre-validation=enabled",
+                "--partner-pc-pre-validation=enabled",
             ]
         )
         pc_validator_config = PCValidatorConfig(
@@ -591,7 +617,9 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
         mock_onedocker_svc = MagicMock()
         infra_config: InfraConfig = self._get_infra_config(
             private_computation_role=PrivateComputationRole.PARTNER,
-            pcs_features={},
+            pcs_features={
+                PCSFeature.PARTNER_PC_PRE_VALIDATION,
+            },
         )
         pc_instance.infra_config = infra_config
         with self.subTest("pc_pre_validator_enabled"):


### PR DESCRIPTION
Summary:
Adding feature gate for partner PC pre-validation, which is similar to publisher pre-validation.

**What to expect in this diff stack**
Adding feature flag for partner pre-validation - D44544518
Adding GK for the feature - D44545441
sitevar changes for the feature flag - D44546399
Integrate feature flag in the pre_validation stage

**Why**
Adding feature gate so that partner pre-validation can be turned off from GK if we run into any issue

Differential Revision: D44555039

