### PR TITLE
Upgrade PCP to get Container Service permission support

### DIFF
--- a/fbpcs/common/service/pcs_container_service.py
+++ b/fbpcs/common/service/pcs_container_service.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Union
 
 from fbpcp.entity.cluster_instance import Cluster
 from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import PcpError
 from fbpcp.service.container import ContainerService
@@ -48,12 +49,14 @@ class PCSContainerService(ContainerService):
         cmd: str,
         env_vars: Optional[Dict[str, str]] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> ContainerInstance:
         instance = self.inner_container_service.create_instance(
             container_definition=container_definition,
             cmd=cmd,
             env_vars=env_vars,
             container_type=container_type,
+            permission=permission,
         )
         log_url = None
         if self.log_retriever:
@@ -67,6 +70,7 @@ class PCSContainerService(ContainerService):
         cmds: List[str],
         env_vars: Optional[Union[Dict[str, str], List[Dict[str, str]]]] = None,
         container_type: Optional[ContainerType] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> List[ContainerInstance]:
         """
         Args:
@@ -78,6 +82,7 @@ class PCSContainerService(ContainerService):
             is the same as the length of the cmds list, such that each item corresponds
             to one instance.
             container_type: The type of container to create.
+            permission: A configuration which describes the container permissions
         Returns:
             A list of ContainerInstances.
         """
@@ -92,6 +97,7 @@ class PCSContainerService(ContainerService):
                 cmd=cmds[i],
                 env_vars=env_vars[i] if type(env_vars) is list else env_vars,
                 container_type=container_type,
+                permission=permission,
             )
             for i in range(len(cmds))
         ]

--- a/fbpcs/common/service/test/test_pcs_container_service.py
+++ b/fbpcs/common/service/test/test_pcs_container_service.py
@@ -10,6 +10,7 @@ from unittest.mock import call, MagicMock, patch
 
 from fbpcp.entity.cloud_provider import CloudProvider
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType, ContainerTypeConfig
 from fbpcp.gateway.ecs import ECSGateway
 from fbpcp.service.container_aws import AWSContainerService
@@ -37,6 +38,7 @@ TEST_CMD_1 = "test_1"
 TEST_CMD_2 = "test_2"
 TEST_CLOUD_PROVIDER = CloudProvider.AWS
 TEST_CONTAINER_TYPE = ContainerType.MEDIUM
+TEST_CONTAINER_PERMISSION = ContainerPermissionConfig("test-role-id")
 
 
 class TestPcsContainerService(unittest.TestCase):
@@ -109,12 +111,14 @@ class TestPcsContainerService(unittest.TestCase):
                 cmd=TEST_CMD_1,
                 env_vars=TEST_ENV_VARS,
                 container_type=TEST_CONTAINER_TYPE,
+                permission=TEST_CONTAINER_PERMISSION,
             ),
             call(
                 container_definition=f"{TEST_TASK_DEFNITION}#{TEST_CONTAINER_DEFNITION}",
                 cmd=TEST_CMD_2,
                 env_vars=TEST_ENV_VARS_2,
                 container_type=TEST_CONTAINER_TYPE,
+                permission=TEST_CONTAINER_PERMISSION,
             ),
         ]
 
@@ -126,6 +130,7 @@ class TestPcsContainerService(unittest.TestCase):
             cmds=cmd_list,
             env_vars=[TEST_ENV_VARS, TEST_ENV_VARS_2],
             container_type=TEST_CONTAINER_TYPE,
+            permission=TEST_CONTAINER_PERMISSION,
         )
 
         # Assert

--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -3,7 +3,7 @@ botocore==1.21.65
 cython==0.29.30 # required by thriftpy2 setup
 dataclasses-json==0.5.2 # fbpcp requires this version, so we must as well
 docopt>=0.6.2
-fbpcp~=0.5 # depending on: boto3, botocore
+fbpcp~=0.6 # depending on: boto3, botocore
 marshmallow==3.5.1
 networkx>=2.6.3
 requests>=2.26.0


### PR DESCRIPTION
Summary:
This change upgrades the FBPCS dependency on FBPCP package to a new version. This version contains added support for configuring the permissions of a container when starting new instances.

A PCS subtype of the ContainerService is also updated to reflect the interface changes.

Reviewed By: joe1234wu, marksliva, gitfish77

Differential Revision: D44433879

