### PR TITLE
Add Container Permissions arg to PCS lib Create Instance method

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -177,6 +177,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     ca_certificate: Optional[str] = immutable_field(default=None)
     server_key_ref: Optional[str] = immutable_field(default=None)
     server_domain: Optional[str] = immutable_field(default=None)
+    container_permission_id: Optional[str] = immutable_field(default=None)
 
     num_secure_random_shards: int = 1
     num_udp_containers: int = 1

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -204,6 +204,7 @@ class PrivateComputationService:
         ca_certificate: Optional[str] = None,
         server_domain: Optional[str] = None,
         server_key_secret_ref: Optional[str] = None,
+        container_permission_id: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
         self.metric_svc.bump_entity_key(PCSERVICE_ENTITY_NAME, "create_instance")
@@ -261,6 +262,7 @@ class PrivateComputationService:
             ca_certificate=ca_certificate,
             server_key_ref=server_key_secret_ref,
             server_domain=server_domain,
+            container_permission_id=container_permission_id,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional
 from fbpcp.entity.certificate_request import CertificateRequest
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import ThrottlingError
 from fbpcp.service.onedocker import OneDockerService
@@ -38,6 +39,7 @@ class RunBinaryBaseService:
         certificate_request: Optional[CertificateRequest] = None,
         env_vars_list: Optional[List[Dict[str, str]]] = None,
         opa_workflow_path: Optional[str] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
@@ -62,6 +64,7 @@ class RunBinaryBaseService:
                 container_type=container_type,
                 certificate_request=certificate_request,
                 opa_workflow_path=opa_workflow_path,
+                permission=permission,
             )
 
             pending_containers = self.get_pending_containers(

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -124,6 +124,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -141,6 +141,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(
@@ -310,6 +311,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=TLS_OPA_WORKFLOW_PATH,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -108,6 +108,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -321,6 +321,8 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     delta=1,
                 )
 
+                self.assertIsNone(args.infra_config.container_permission_id)
+
                 if pcs_features is not None:
                     if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value in pcs_features:
                         self.assertTrue(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -193,6 +193,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         expected_ca_certificate = "test ca certificate"
         expected_server_domain = "example.com"
         expected_server_key_secret_ref = "test_secret_id"
+        expected_container_permission_id = "test container permission id"
 
         for (
             test_game_type,
@@ -203,6 +204,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             ca_certificate,
             server_domain,
             server_key_secret_ref,
+            container_permission_id,
         ) in (
             (
                 self._get_subtest_args(
@@ -252,6 +254,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     ca_certificate=expected_ca_certificate,
                     server_domain=expected_server_domain,
                     server_key_secret_ref=expected_server_key_secret_ref,
+                    container_permission_id=expected_container_permission_id,
                 )
             ),
             # test PCSFeature.PCF_TLS for lift with partner
@@ -291,6 +294,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     ca_certificate=ca_certificate,
                     server_domain=server_domain,
                     server_key_secret_ref=server_key_secret_ref,
+                    container_permission_id=container_permission_id,
                 )
                 # check instance_repository.create is called with the correct arguments
                 # pyre-fixme[16]: Callable `create` has no attribute `assert_called`.
@@ -320,8 +324,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     # pyre-ignore
                     delta=1,
                 )
-
-                self.assertIsNone(args.infra_config.container_permission_id)
 
                 if pcs_features is not None:
                     if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value in pcs_features:
@@ -381,6 +383,10 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                         args.infra_config.server_key_ref,
                         expected_server_key_secret_ref,
                     )
+                    self.assertEqual(
+                        args.infra_config.container_permission_id,
+                        expected_container_permission_id,
+                    )
 
                 if (
                     pcs_features is not None
@@ -401,6 +407,10 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     )
                     self.assertEqual(
                         args.infra_config.server_key_ref,
+                        None,
+                    )
+                    self.assertEqual(
+                        args.infra_config.container_permission_id,
                         None,
                     )
 
@@ -1438,11 +1448,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         ca_certificate: Optional[str] = None,
         server_domain: Optional[str] = None,
         server_key_secret_ref: Optional[str] = None,
+        container_permission_id: Optional[str] = None,
     ) -> Tuple[
         PrivateComputationGameType,
         int,
         Optional[List[str]],
         PrivateComputationRole,
+        Optional[str],
         Optional[str],
         Optional[str],
         Optional[str],
@@ -1457,6 +1469,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             ca_certificate,
             server_domain,
             server_key_secret_ref,
+            container_permission_id,
         )
 
 


### PR DESCRIPTION
Summary:
This change adds an argument to the PCS lib Create Instance interface so that the caller can configure a container permission for use during the study run.

This will be used when running with the TLS feature enabled, to override default container permissions with the permissions configured and specified by the Create Instance caller.

Reviewed By: joe1234wu, gitfish77

Differential Revision: D44463793

