### PR TITLE
Handle retry of hung containers.

### DIFF
--- a/fbpcs/bolt/exceptions.py
+++ b/fbpcs/bolt/exceptions.py
@@ -11,7 +11,13 @@ class StageFailedException(ValueError):
 
 
 class StageTimeoutException(RuntimeError):
-    pass
+    def __init__(
+        self,
+        msg: str,
+        stage_cancelled: bool = False,
+    ) -> None:
+        super().__init__(msg)
+        self.stage_cancelled = stage_cancelled
 
 
 class WaitValidStatusTimeout(RuntimeError):


### PR DESCRIPTION
Summary:
Context: During retry, currently we don’t restart running containers.  We had a run failure where a container was hung indefinitely.  All the retries skipped it & the run eventually failed.

When a non-joint stage fails due to timeout, it could be because the containers are hung or because they are still running (Our timeouts are not tuned correctly for all stages & this is possible).  We will kill all containers that have been executing for 2 times the stage timeout.  This provides some buffer for containers which are still running beyond the stage timeout to make progress & finish while killing hung containers.

https://docs.google.com/document/d/1yu3MurSDqlObdhV6URJLCs5QZXLVl0v7LpHHj0Je1xc

Differential Revision: D44654318

