### PR TITLE
Update Shard stage service to support container permissions overrides

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -177,6 +177,7 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
     ca_certificate: Optional[str] = immutable_field(default=None)
     server_key_ref: Optional[str] = immutable_field(default=None)
     server_domain: Optional[str] = immutable_field(default=None)
+    container_permission_id: Optional[str] = immutable_field(default=None)
 
     num_secure_random_shards: int = 1
     num_udp_containers: int = 1

--- a/fbpcs/private_computation/service/aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/service/aggregate_shards_stage_service.py
@@ -37,6 +37,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
@@ -131,6 +132,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
             env_vars = generate_env_vars_dict(
                 repository_path=binary_config.repository_path,
             )
+        container_permission = gen_container_permission(pc_instance)
 
         container_instances = await self._mpc_service.start_containers(
             cmd_args_list=cmd_args_list,
@@ -142,6 +144,7 @@ class AggregateShardsStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
             env_vars_list=env_vars_list,
+            permission=container_permission,
         )
         server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,

--- a/fbpcs/private_computation/service/compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/service/compute_metrics_stage_service.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
@@ -181,6 +182,8 @@ class ComputeMetricsStageService(PrivateComputationStageService):
                 repository_path=binary_config.repository_path,
             )
 
+        container_permission = gen_container_permission(pc_instance)
+
         container_instances = await self._mpc_service.start_containers(
             cmd_args_list=cmd_args_list,
             onedocker_svc=self._mpc_service.onedocker_svc,
@@ -194,6 +197,7 @@ class ComputeMetricsStageService(PrivateComputationStageService):
             opa_workflow_path=TLS_OPA_WORKFLOW_PATH
             if pc_instance.has_feature(PCSFeature.PCF_TLS)
             else None,
+            permission=container_permission,
         )
         server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,

--- a/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/service/pc_pre_validation_stage_service.py
@@ -38,6 +38,7 @@ from fbpcs.private_computation.service.run_binary_base_service import (
     RunBinaryBaseService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
 )
@@ -135,6 +136,8 @@ class PCPreValidationStageService(PrivateComputationStageService):
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )
+        container_permission = gen_container_permission(pc_instance)
+
         container_instances = await RunBinaryBaseService().start_containers(
             cmd_args_list=[cmd_args],
             onedocker_svc=self._onedocker_svc,
@@ -145,6 +148,7 @@ class PCPreValidationStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
             container_type=ContainerType.LARGE,
+            permission=container_permission,
         )
 
         stage_state = StageStateInstance(

--- a/fbpcs/private_computation/service/pcf2_base_stage_service.py
+++ b/fbpcs/private_computation/service/pcf2_base_stage_service.py
@@ -41,6 +41,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
 )
 
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
@@ -173,7 +174,7 @@ class PCF2BaseStageService(PrivateComputationStageService):
             env_vars = generate_env_vars_dict(
                 repository_path=binary_config.repository_path,
             )
-
+        container_permission = gen_container_permission(pc_instance)
         container_instances = await self._mpc_service.start_containers(
             cmd_args_list=cmd_args_list,
             onedocker_svc=self._mpc_service.onedocker_svc,
@@ -187,6 +188,7 @@ class PCF2BaseStageService(PrivateComputationStageService):
             opa_workflow_path=TLS_OPA_WORKFLOW_PATH
             if pc_instance.has_feature(PCSFeature.PCF_TLS)
             else None,
+            permission=container_permission,
         )
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,

--- a/fbpcs/private_computation/service/pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/service/pid_prepare_stage_service.py
@@ -37,6 +37,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
     stop_stage_service,
@@ -174,6 +175,7 @@ class PIDPrepareStageService(PrivateComputationStageService):
             # Use large FARGATE container for SNMK
             logging.info("Setting pid prepare stage container to LARGE")
             container_type = ContainerType.LARGE
+        container_permission = gen_container_permission(pc_instance)
 
         return await pid_prepare_binary_service.start_containers(
             cmd_args_list=args_list,
@@ -185,6 +187,7 @@ class PIDPrepareStageService(PrivateComputationStageService):
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
             container_type=container_type,
+            permission=container_permission,
         )
 
     def stop_service(

--- a/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/service/pid_run_protocol_stage_service.py
@@ -47,6 +47,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
@@ -237,6 +238,7 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
             # Use large FARGATE container for SNMK
             logging.info("Setting pid run protocol stage container to LARGE")
             container_type = ContainerType.LARGE
+        container_permission = gen_container_permission(pc_instance)
 
         return await pid_run_protocol_binary_service.start_containers(
             cmd_args_list=args_list,
@@ -251,6 +253,7 @@ class PIDRunProtocolStageService(PrivateComputationStageService):
             opa_workflow_path=TLS_OPA_WORKFLOW_PATH
             if pc_instance.has_feature(PCSFeature.PCF_TLS)
             else None,
+            permission=container_permission,
         )
 
     @classmethod

--- a/fbpcs/private_computation/service/pid_shard_stage_service.py
+++ b/fbpcs/private_computation/service/pid_shard_stage_service.py
@@ -32,6 +32,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
     stop_stage_service,
@@ -153,6 +154,8 @@ class PIDShardStageService(PrivateComputationStageService):
         should_wait_spin_up: bool = (
             pc_instance.infra_config.role is PrivateComputationRole.PARTNER
         )
+        container_permission = gen_container_permission(pc_instance)
+
         return await sharding_binary_service.start_containers(
             cmd_args_list=[args],
             onedocker_svc=self._onedocker_svc,
@@ -162,6 +165,7 @@ class PIDShardStageService(PrivateComputationStageService):
             env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
+            permission=container_permission,
         )
 
     def stop_service(

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -204,6 +204,7 @@ class PrivateComputationService:
         ca_certificate: Optional[str] = None,
         server_domain: Optional[str] = None,
         server_key_secret_ref: Optional[str] = None,
+        container_permission_id: Optional[str] = None,
     ) -> PrivateComputationInstance:
         self.logger.info(f"Creating instance: {instance_id}")
         self.metric_svc.bump_entity_key(PCSERVICE_ENTITY_NAME, "create_instance")
@@ -261,6 +262,7 @@ class PrivateComputationService:
             ca_certificate=ca_certificate,
             server_key_ref=server_key_secret_ref,
             server_domain=server_domain,
+            container_permission_id=container_permission_id,
         )
         multikey_enabled = True
         if pid_configs and "multikey_enabled" in pid_configs.keys():

--- a/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/service/private_id_dfca_aggregate_stage_service.py
@@ -30,6 +30,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
@@ -136,6 +137,7 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
             ca_certificate_provider=ca_certificate_provider,
             ca_certificate_path=ca_certificate_path,
         )
+        container_permission = gen_container_permission(pc_instance)
 
         container_instances = await self._mpc_service.start_containers(
             cmd_args_list=cmd_args_list,
@@ -146,6 +148,7 @@ class PrivateIdDfcaAggregateStageService(PrivateComputationStageService):
             env_vars=env_vars,
             wait_for_containers_to_start_up=should_wait_spin_up,
             existing_containers=pc_instance.get_existing_containers_for_retry(),
+            permission=container_permission,
         )
         server_uris = gen_tls_server_hostnames_for_publisher(
             server_domain=pc_instance.infra_config.server_domain,

--- a/fbpcs/private_computation/service/run_binary_base_service.py
+++ b/fbpcs/private_computation/service/run_binary_base_service.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional
 from fbpcp.entity.certificate_request import CertificateRequest
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcp.error.pcp import ThrottlingError
 from fbpcp.service.onedocker import OneDockerService
@@ -38,6 +39,7 @@ class RunBinaryBaseService:
         certificate_request: Optional[CertificateRequest] = None,
         env_vars_list: Optional[List[Dict[str, str]]] = None,
         opa_workflow_path: Optional[str] = None,
+        permission: Optional[ContainerPermissionConfig] = None,
     ) -> List[ContainerInstance]:
         logger = logging.getLogger(__name__)
 
@@ -62,6 +64,7 @@ class RunBinaryBaseService:
                 container_type=container_type,
                 certificate_request=certificate_request,
                 opa_workflow_path=opa_workflow_path,
+                permission=permission,
             )
 
             pending_containers = self.get_pending_containers(

--- a/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
+++ b/fbpcs/private_computation/service/secure_random_sharder_stage_service.py
@@ -44,6 +44,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     gen_tls_server_hostnames_for_publisher,
     generate_env_vars_dict,
     generate_env_vars_dicts_list,
@@ -190,6 +191,7 @@ class SecureRandomShardStageService(PrivateComputationStageService):
             env_vars = generate_env_vars_dict(
                 repository_path=binary_config.repository_path,
             )
+        container_permission = gen_container_permission(pc_instance)
 
         container_instances = await self._mpc_service.start_containers(
             cmd_args_list=cmd_args_list,
@@ -202,6 +204,7 @@ class SecureRandomShardStageService(PrivateComputationStageService):
             existing_containers=pc_instance.get_existing_containers_for_retry(),
             env_vars_list=env_vars_list,
             opa_workflow_path=TLS_OPA_WORKFLOW_PATH if enable_tls else None,
+            permission=container_permission,
         )
         stage_state = StageStateInstance(
             pc_instance.infra_config.instance_id,

--- a/fbpcs/private_computation/service/shard_stage_service.py
+++ b/fbpcs/private_computation/service/shard_stage_service.py
@@ -30,6 +30,7 @@ from fbpcs.private_computation.service.private_computation_stage_service import 
     PrivateComputationStageService,
 )
 from fbpcs.private_computation.service.utils import (
+    gen_container_permission,
     generate_env_vars_dict,
     get_pc_status_from_stage_state,
 )
@@ -183,6 +184,8 @@ class ShardStageService(PrivateComputationStageService):
 
         binary_name = sharder.get_binary_name(ShardType.ROUND_ROBIN)
         env_vars = generate_env_vars_dict(repository_path=binary_config.repository_path)
+        container_permission = gen_container_permission(private_computation_instance)
+
         return await sharder.start_containers(
             cmd_args_list=args_list,
             onedocker_svc=onedocker_svc,
@@ -193,4 +196,5 @@ class ShardStageService(PrivateComputationStageService):
             env_vars=env_vars,
             wait_for_containers_to_start_up=wait_for_containers_to_start_up,
             existing_containers=private_computation_instance.get_existing_containers_for_retry(),
+            permission=container_permission,
         )

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -11,6 +11,8 @@ import asyncio
 import re
 from typing import Dict, List, Optional
 
+from fbpcp.entity.container_permission import ContainerPermissionConfig
+
 from fbpcp.service.onedocker import OneDockerService
 from fbpcp.service.storage import StorageService
 from fbpcs.common.entity.stage_state_instance import StageStateInstanceStatus
@@ -329,3 +331,19 @@ def gen_tls_server_hostnames_for_publisher(
         return None
     else:
         return [f"node{i}.{server_domain}" for i in range(num_containers)]
+
+
+def gen_container_permission(
+    pc_instance: PrivateComputationInstance,
+) -> Optional[ContainerPermissionConfig]:
+    """Returns a container permission configuration, when specified by the PC Instance,
+    which can be used to override the default permissions during container start
+
+    Arguments:
+        pc_instance: The PC instance for which containers are being started
+    """
+    container_permission_id = pc_instance.infra_config.container_permission_id
+    if container_permission_id is not None:
+        return ContainerPermissionConfig(container_permission_id)
+
+    return None

--- a/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_aggregate_shards_stage_service.py
@@ -11,6 +11,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.infra.certificate.private_key import StaticPrivateKeyReferenceProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -63,6 +64,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
         self.stage_svc = AggregateShardsStageService(
             onedocker_binary_config_map, self.mock_mpc_svc
         )
+        self.container_permission_id = "test-container-permission"
 
     async def test_aggregate_shards(self) -> None:
         containers = [
@@ -103,6 +105,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             wait_for_containers_to_start_up=True,
             existing_containers=None,
             env_vars_list=None,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
         self.assertEqual(
             containers,
@@ -235,6 +238,7 @@ class TestAggregateShardsStageService(IsolatedAsyncioTestCase):
             run_id=self.run_id,
             pcs_features=pcs_features if pcs_features else {PCSFeature.PCS_DUMMY},
             log_cost_bucket="test_log_cost_bucket",
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_compute_metrics_stage_service.py
@@ -12,6 +12,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.infra.certificate.private_key import StaticPrivateKeyReferenceProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -64,6 +65,7 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
         self.stage_svc = ComputeMetricsStageService(
             onedocker_binary_config_map, self.mock_mpc_svc
         )
+        self.container_permission_id = "test-container-permission"
 
     async def test_compute_metrics(self) -> None:
         containers = [
@@ -116,6 +118,7 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
                     wait_for_containers_to_start_up=True,
                     existing_containers=None,
                     opa_workflow_path=None,
+                    permission=ContainerPermissionConfig(self.container_permission_id),
                 )
                 self.assertEqual(
                     containers,
@@ -297,6 +300,7 @@ class TestComputeMetricsStageService(IsolatedAsyncioTestCase):
             status_updates=[],
             pcs_features=pcs_features,
             run_id=self.run_id,
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pc_pre_validation_stage_service.py
@@ -10,6 +10,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcp.entity.container_type import ContainerType
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
@@ -62,10 +63,12 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=1,
             pcs_features=pcs_features if pcs_features else {PCSFeature.UNKNOWN},
             status_updates=[],
+            container_permission_id=self.container_permission_id,
         )
 
     def setUp(self) -> None:
         # create partner PrivateComputationInstance
+        self.container_permission_id = "test-container-permission"
         self._infra_config: InfraConfig = self._get_infra_config()
         self._common: CommonProductConfig = CommonProductConfig(
             input_path="https://a-test-bucket.s3.us-west-2.amazonaws.com/lift/test/input_data1.csv",
@@ -85,6 +88,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
                 repository_path="test_path/",
             )
         )
+
         # create publisher PrivateComputationInstance
         infra_config_publisher: InfraConfig = InfraConfig(
             instance_id="123",
@@ -97,6 +101,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=1,
             num_files_per_mpc_container=1,
             status_updates=[],
+            container_permission_id=self.container_permission_id,
         )
         common_publisher: CommonProductConfig = CommonProductConfig(
             input_path="https://a-test-bucket.s3.us-west-2.amazonaws.com/lift/test/input_data1.csv",
@@ -154,6 +159,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             wait_for_containers_to_start_up=True,
             existing_containers=None,
             container_type=ContainerType.LARGE,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
 
         mock_stage_state_instance.assert_called_with(
@@ -222,6 +228,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             wait_for_containers_to_start_up=False,
             existing_containers=None,
             container_type=ContainerType.LARGE,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
 
         mock_stage_state_instance.assert_called_with(
@@ -472,6 +479,7 @@ class TestPCPreValidationStageService(IsolatedAsyncioTestCase):
             wait_for_containers_to_start_up=True,
             existing_containers=None,
             container_type=ContainerType.LARGE,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
 
         mock_stage_state_instance.assert_called_with(

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -11,6 +11,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -56,6 +57,7 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             onedocker_binary_config_map,
             self.mock_mpc_svc,
         )
+        self.container_permission_id = "test-container-permission"
 
     async def test_run_async_with_udp(self) -> None:
         containers = [
@@ -97,6 +99,7 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             existing_containers=None,
             env_vars_list=None,
             opa_workflow_path=None,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
         self.assertEqual(
             containers,
@@ -166,6 +169,7 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
             status_updates=[],
             pcs_features={PCSFeature.PRIVATE_LIFT_UNIFIED_DATA_PROCESS},
             log_cost_bucket="test_log_cost_bucket",
+            container_permission_id=self.container_permission_id,
         )
 
         common: CommonProductConfig = CommonProductConfig(

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_stage_service.py
@@ -12,6 +12,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.infra.certificate.private_key import StaticPrivateKeyReferenceProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -71,6 +72,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             onedocker_binary_config_map,
             self.mock_mpc_svc,
         )
+        self.container_permission_id = "test-container-permission"
 
     async def test_compute_metrics(self) -> None:
         containers = [
@@ -79,9 +81,8 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             )
         ]
         self.mock_mpc_svc.start_containers.return_value = containers
-
         private_computation_instance = self._create_pc_instance(
-            pcs_features={PCSFeature.PCF_TLS}
+            pcs_features={PCSFeature.PCF_TLS},
         )
         binary_name = "private_lift/pcf2_lift"
         num_containers = private_computation_instance.infra_config.num_mpc_containers
@@ -115,6 +116,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             wait_for_containers_to_start_up=True,
             existing_containers=None,
             opa_workflow_path=TLS_OPA_WORKFLOW_PATH,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
         self.assertEqual(
             containers,
@@ -331,6 +333,7 @@ class TestPCF2LiftStageService(IsolatedAsyncioTestCase):
             run_id=self.run_id,
             log_cost_bucket="test_log_cost_bucket",
             pcs_features=pcs_features,
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -124,6 +124,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_prepare_stage_service.py
@@ -10,6 +10,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -57,6 +58,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
         self.output_path = "out"
         self.pc_instance_id = "test_instance_123"
         self.container_timeout = 86400
+        self.container_permission_id = "test-container-permission"
 
     async def test_pid_prepare_stage_service(self) -> None:
         async def _run_sub_test(
@@ -124,7 +126,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
-                permission=None,
+                permission=ContainerPermissionConfig(self.container_permission_id),
             )
             # test the return value is as expected
             self.assertEqual(
@@ -185,6 +187,7 @@ class TestPIDPrepareStageService(IsolatedAsyncioTestCase):
             num_files_per_mpc_container=test_num_containers,
             status_updates=[],
             run_id=run_id,
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.input_path,

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -141,6 +141,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(
@@ -310,6 +311,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=TLS_OPA_WORKFLOW_PATH,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_run_protocol_stage_service.py
@@ -11,6 +11,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 
 from fbpcs.data_processing.service.pid_run_protocol_binary_service import (
@@ -71,6 +72,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
         self.pc_instance_id = "test_instance_123"
         self.port = 15200
         self.use_row_numbers = True
+        self.container_permission_id = "test-container-permission"
 
     async def test_pid_run_protocol_stage(self) -> None:
         async def _run_sub_test(
@@ -141,7 +143,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
-                permission=None,
+                permission=ContainerPermissionConfig(self.container_permission_id),
             )
             # test the return value is as expected
             self.assertEqual(
@@ -311,7 +313,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=TLS_OPA_WORKFLOW_PATH,
-                permission=None,
+                permission=ContainerPermissionConfig(self.container_permission_id),
             )
             # test the return value is as expected
             self.assertEqual(
@@ -373,6 +375,7 @@ class TestPIDRunProtocolStageService(IsolatedAsyncioTestCase):
             run_id=run_id,
             server_domain=server_domain,
             pcs_features=set() if not use_tls else {PCSFeature.PCF_TLS},
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.input_path,

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -10,6 +10,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.common.entity.stage_state_instance import StageStateInstance
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
@@ -60,6 +61,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
         self.pc_instance_id = "test_instance_123"
         self.container_timeout = 789
         self.test_hmac_key = "CoXbp7BOEvAN9L1CB2DAORHHr3hB7wE7tpxMYm07tc0="
+        self.container_permission_id = "test-container-permission"
 
     async def test_pid_shard_stage_service(self) -> None:
         async def _run_sub_test(
@@ -108,7 +110,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
-                permission=None,
+                permission=ContainerPermissionConfig(self.container_permission_id),
             )
             # test the return value is as expected
             self.assertEqual(
@@ -162,6 +164,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
             num_mpc_containers=test_num_containers,
             num_files_per_mpc_container=test_num_containers,
             status_updates=[],
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path=self.input_path,

--- a/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pid_shard_stage_service.py
@@ -108,6 +108,7 @@ class TestPIDShardStageService(IsolatedAsyncioTestCase):
                 container_type=None,
                 certificate_request=None,
                 opa_workflow_path=None,
+                permission=None,
             )
             # test the return value is as expected
             self.assertEqual(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -321,6 +321,8 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     delta=1,
                 )
 
+                self.assertIsNone(args.infra_config.container_permission_id)
+
                 if pcs_features is not None:
                     if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value in pcs_features:
                         self.assertTrue(

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -193,6 +193,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         expected_ca_certificate = "test ca certificate"
         expected_server_domain = "example.com"
         expected_server_key_secret_ref = "test_secret_id"
+        expected_container_permission_id = "test container permission id"
 
         for (
             test_game_type,
@@ -203,6 +204,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             ca_certificate,
             server_domain,
             server_key_secret_ref,
+            container_permission_id,
         ) in (
             (
                 self._get_subtest_args(
@@ -252,6 +254,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     ca_certificate=expected_ca_certificate,
                     server_domain=expected_server_domain,
                     server_key_secret_ref=expected_server_key_secret_ref,
+                    container_permission_id=expected_container_permission_id,
                 )
             ),
             # test PCSFeature.PCF_TLS for lift with partner
@@ -291,6 +294,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     ca_certificate=ca_certificate,
                     server_domain=server_domain,
                     server_key_secret_ref=server_key_secret_ref,
+                    container_permission_id=container_permission_id,
                 )
                 # check instance_repository.create is called with the correct arguments
                 # pyre-fixme[16]: Callable `create` has no attribute `assert_called`.
@@ -320,8 +324,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     # pyre-ignore
                     delta=1,
                 )
-
-                self.assertIsNone(args.infra_config.container_permission_id)
 
                 if pcs_features is not None:
                     if PCSFeature.PRIVATE_ATTRIBUTION_MR_PID.value in pcs_features:
@@ -381,6 +383,10 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                         args.infra_config.server_key_ref,
                         expected_server_key_secret_ref,
                     )
+                    self.assertEqual(
+                        args.infra_config.container_permission_id,
+                        expected_container_permission_id,
+                    )
 
                 if (
                     pcs_features is not None
@@ -401,6 +407,10 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
                     )
                     self.assertEqual(
                         args.infra_config.server_key_ref,
+                        None,
+                    )
+                    self.assertEqual(
+                        args.infra_config.container_permission_id,
                         None,
                     )
 
@@ -1438,11 +1448,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         ca_certificate: Optional[str] = None,
         server_domain: Optional[str] = None,
         server_key_secret_ref: Optional[str] = None,
+        container_permission_id: Optional[str] = None,
     ) -> Tuple[
         PrivateComputationGameType,
         int,
         Optional[List[str]],
         PrivateComputationRole,
+        Optional[str],
         Optional[str],
         Optional[str],
         Optional[str],
@@ -1457,6 +1469,7 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
             ca_certificate,
             server_domain,
             server_key_secret_ref,
+            container_permission_id,
         )
 
 

--- a/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_private_id_dfca_aggregate_stage_service.py
@@ -9,6 +9,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
 from fbpcs.onedocker_binary_config import OneDockerBinaryConfig
 from fbpcs.private_computation.entity.infra_config import (
@@ -50,6 +51,7 @@ class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
         self.stage_svc = PrivateIdDfcaAggregateStageService(
             onedocker_binary_config_map, self.mock_mpc_svc
         )
+        self.container_permission_id = "test-container-permission"
 
     async def test_private_id_dfca_aggregate(self) -> None:
         containers = [
@@ -89,6 +91,7 @@ class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
             env_vars={"ONEDOCKER_REPOSITORY_PATH": "test_path/"},
             wait_for_containers_to_start_up=True,
             existing_containers=None,
+            permission=ContainerPermissionConfig(self.container_permission_id),
         )
         self.assertEqual(
             containers,
@@ -116,6 +119,7 @@ class TestPrivateIdDfcaAggregateStageService(IsolatedAsyncioTestCase):
             status_updates=[],
             run_id=self.run_id,
             pcs_features={PCSFeature.PCS_DUMMY},
+            container_permission_id=self.container_permission_id,
         )
         common: CommonProductConfig = CommonProductConfig(
             input_path="456",

--- a/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
@@ -13,6 +13,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
 
 from fbpcp.entity.container_instance import ContainerInstance, ContainerInstanceStatus
+from fbpcp.entity.container_permission import ContainerPermissionConfig
 
 from fbpcp.service.storage import StorageService
 from fbpcs.infra.certificate.null_certificate_provider import NullCertificateProvider
@@ -122,6 +123,7 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
             onedocker_binary_config_map,
             self.mock_mpc_svc,
         )
+        self.container_permission_id = "test-container-permission"
 
     async def test_run_async_with_udp(self) -> None:
         containers = [
@@ -165,6 +167,7 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
                 existing_containers=None,
                 env_vars_list=None,
                 opa_workflow_path=None,
+                permission=ContainerPermissionConfig(self.container_permission_id),
             )
             self.assertEqual(
                 containers,
@@ -409,6 +412,7 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
             status_updates=[],
             log_cost_bucket="test_log_cost_bucket",
             pcs_features=pcs_features if pcs_features else set(),
+            container_permission_id=self.container_permission_id,
         )
 
         common: CommonProductConfig = CommonProductConfig(


### PR DESCRIPTION
Summary:
This change updates the Shard stage service to support overriding permissions at container start time. Container permissions will only be overridden when configured at the time of study instance (run) creation.

For more information, refer to: D44466415

Reviewed By: gitfish77

Differential Revision: D44468435

