### PR TITLE
Update MR-PID deployment readme to specify the stable version of Infra deployment

### DIFF
--- a/fbpcs/infra/mr_pid/partner/README.md
+++ b/fbpcs/infra/mr_pid/partner/README.md
@@ -10,7 +10,9 @@ Install docker
 1. Download the `infra` directory
   * run the following command:
 ```
-git clone https://github.com/facebookresearch/fbpcs.git
+git clone https://github.com/facebookresearch/fbpcs.git mrpid-infra
+cd mrpid-infra
+git checkout 3d263fd21f631ec531d039f93f449095002d493d
 ```
 2. Change to `mr_pid/partner` directory
   * run the following command

--- a/fbpcs/infra/mr_pid/publisher/README.md
+++ b/fbpcs/infra/mr_pid/publisher/README.md
@@ -10,7 +10,9 @@ Install docker
 1. Download the `infra` directory
   * run the following command:
 ```
-git clone https://github.com/facebookresearch/fbpcs.git
+git clone https://github.com/facebookresearch/fbpcs.git mrpid-infra
+cd mrpid-infra
+git checkout 3d263fd21f631ec531d039f93f449095002d493d
 ```
 2. Change to `mr_pid/publisher` directory
   * run the following command


### PR DESCRIPTION
Summary: Use the stable version which we used during pilot running instead of PCE integration version.

Reviewed By: Pradeepnitw

Differential Revision: D44805717

