### PR TITLE
Update PCS to prevent TLS configuration on unsupported game types

### DIFF
--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -52,6 +52,11 @@ class PrivateComputationGameType(Enum):
     ANONYMIZER = "ANONYMIZER"
 
 
+TLS_SUPPORTED_GAME_TYPES: Set[PrivateComputationGameType] = {
+    PrivateComputationGameType.LIFT
+}
+
+
 UnionedPCInstance = Union[PostProcessingInstance, StageStateInstance]
 
 
@@ -193,6 +198,14 @@ class InfraConfig(DataClassJsonMixin, DataclassMutabilityMixin):
 
         return PrivateComputationBaseStageFlow.cls_name_to_cls(
             self._stage_flow_cls_name
+        )
+
+    @property
+    def is_tls_enabled(self) -> bool:
+        """Returns true if the TLS feature is enabled; otherwise, false."""
+        return (
+            PCSFeature.PCF_TLS in self.pcs_features
+            and self.game_type in TLS_SUPPORTED_GAME_TYPES
         )
 
     def is_stage_flow_completed(self) -> bool:

--- a/fbpcs/private_computation/service/private_computation.py
+++ b/fbpcs/private_computation/service/private_computation.py
@@ -653,7 +653,7 @@ class PrivateComputationService:
     ) -> CertificateProvider:
         if (
             pc_instance.infra_config.role == PrivateComputationRole.PUBLISHER
-            and pc_instance.has_feature(PCSFeature.PCF_TLS)
+            and pc_instance.infra_config.is_tls_enabled
         ):
             return PCInstanceServerCertificateProvider(pc_instance)
         else:
@@ -664,7 +664,7 @@ class PrivateComputationService:
     ) -> PrivateKeyReferenceProvider:
         if (
             pc_instance.infra_config.role == PrivateComputationRole.PUBLISHER
-            and pc_instance.has_feature(PCSFeature.PCF_TLS)
+            and pc_instance.infra_config.is_tls_enabled
             and pc_instance.infra_config.server_key_ref
             and pc_instance.infra_config.pce_config
         ):
@@ -681,13 +681,13 @@ class PrivateComputationService:
     ) -> CertificateProvider:
         if (
             pc_instance.infra_config.role == PrivateComputationRole.PUBLISHER
-            and pc_instance.has_feature(PCSFeature.PCF_TLS)
+            and pc_instance.infra_config.is_tls_enabled
         ):
             return PCInstanceCaCertificateProvider(pc_instance)
         if (
             pc_instance.infra_config.role == PrivateComputationRole.PARTNER
             and ca_certificate
-            and pc_instance.has_feature(PCSFeature.PCF_TLS)
+            and pc_instance.infra_config.is_tls_enabled
         ):
             return BasicCaCertificateProvider(ca_certificate)
         return NullCertificateProvider()
@@ -715,7 +715,7 @@ class PrivateComputationService:
         )
 
         # TODO: T136265785 refactor the tls input validation logic into a TLS config class
-        enable_tls = pc_instance.has_feature(PCSFeature.PCF_TLS)
+        enable_tls = pc_instance.infra_config.is_tls_enabled
         if enable_tls:
             self._validate_tls_data(
                 pc_instance, stage, server_hostnames, ca_certificate

--- a/fbpcs/private_computation/test/entity/test_infra_config.py
+++ b/fbpcs/private_computation/test/entity/test_infra_config.py
@@ -13,6 +13,7 @@ from fbpcs.private_computation.entity.infra_config import (
     PrivateComputationRole,
     StatusUpdate,
 )
+from fbpcs.private_computation.entity.pcs_feature import PCSFeature
 from fbpcs.private_computation.entity.private_computation_instance import (
     PrivateComputationInstanceStatus,
 )
@@ -24,6 +25,56 @@ class TestInfraConfig(unittest.TestCase):
 
     def test_is_stage_flow_completed(self) -> None:
         pass
+
+    def test_is_tls_enabled_when_flag_missing(self):
+        # Arrange
+        config = self._create_config(PrivateComputationGameType.LIFT, set())
+
+        # Act
+        is_tls_enabled = config.is_tls_enabled
+
+        # Assert
+        self.assertFalse(is_tls_enabled)
+
+    def test_is_tls_enabled_when_not_supported(self):
+        # Arrange
+        config = self._create_config(
+            PrivateComputationGameType.ATTRIBUTION, {PCSFeature.PCF_TLS}
+        )
+
+        # Act
+        is_tls_enabled = config.is_tls_enabled
+
+        # Assert
+        self.assertFalse(is_tls_enabled)
+
+    @patch("fbpcs.private_computation.entity.infra_config.InfraConfig")
+    def test_is_tls_enabled_when_supported_and_flag_present(self, mock_infra_config):
+        # Arrange
+        config = self._create_config(
+            PrivateComputationGameType.LIFT, {PCSFeature.PCF_TLS}
+        )
+
+        # Act
+        is_tls_enabled = config.is_tls_enabled
+
+        # Assert
+        self.assertTrue(is_tls_enabled)
+
+    def _create_config(self, game_type, pcs_features):
+        return InfraConfig(
+            instance_id="test-instance-id",
+            role=PrivateComputationRole.PARTNER,
+            status=PrivateComputationInstanceStatus.CREATED,
+            status_update_ts=1,
+            instances=[],
+            game_type=game_type,
+            num_pid_containers=1,
+            num_mpc_containers=1,
+            num_files_per_mpc_container=1,
+            status_updates=[],
+            pcs_features=pcs_features,
+        )
 
 
 class TestInfraConfigFreeFunctions(unittest.TestCase):

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -889,12 +889,13 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
         joint_stage = PrivateComputationStageFlow.COMPUTE
         non_joint_stage = PrivateComputationStageFlow.POST_PROCESSING_HANDLERS
 
-        def _run_sub_test(cert, hostnames, stage):
+        def _run_sub_test(cert, hostnames, stage, game_type):
             stage_svc = AsyncMock(spec=self._get_dummy_stage_svc())
             pl_instance = self.create_sample_instance(
                 status=stage.previous_stage.completed_status,
                 role=PrivateComputationRole.PARTNER,
                 pcs_features={PCSFeature.PCF_TLS},
+                game_type=game_type,
             )
             self.private_computation_service.instance_repository.read = MagicMock(
                 return_value=pl_instance
@@ -911,15 +912,21 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
         # Act & Assert
         with self.assertRaises(ValueError):
-            _run_sub_test(None, None, joint_stage)
+            _run_sub_test(None, None, joint_stage, PrivateComputationGameType.LIFT)
 
         with self.assertRaises(ValueError):
-            _run_sub_test(valid_cert, None, joint_stage)
+            _run_sub_test(
+                valid_cert, None, joint_stage, PrivateComputationGameType.LIFT
+            )
 
         with self.assertRaises(ValueError):
-            _run_sub_test(None, valid_hostnames, joint_stage)
+            _run_sub_test(
+                None, valid_hostnames, joint_stage, PrivateComputationGameType.LIFT
+            )
 
-        _run_sub_test(None, None, non_joint_stage)
+        _run_sub_test(None, None, non_joint_stage, PrivateComputationGameType.LIFT)
+
+        _run_sub_test(None, None, joint_stage, PrivateComputationGameType.ATTRIBUTION)
 
     def test_run_stage_partner_tls(
         self,


### PR DESCRIPTION
Summary:
This change updates PCS to only configure TLS and to expect TLS configuration when the game type supports it.

During testing, we had found that TLS was configured even when running Attribution, which does not fully support TLS at this time.

Reviewed By: joe1234wu

Differential Revision: D45193775

