### PR TITLE
Update TLS installer plugin to disable DEBUG logging

### DIFF
--- a/docker/onedocker/prod/plugins/tls_cert_installer.py
+++ b/docker/onedocker/prod/plugins/tls_cert_installer.py
@@ -52,7 +52,7 @@ def main() -> None:
     logger = logging.getLogger()
     streamHandler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(levelname)s:%(filename)s:%(message)s")
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
     streamHandler.setFormatter(formatter)
     logger.addHandler(streamHandler)
 


### PR DESCRIPTION
Summary: This change updates the TLS plugin to only log at the INFO level, instead of DEBUG. We previously found unwanted, low-level logs being written during testing.

Differential Revision: D45249702

