### PR TITLE
Validate access to existing PL instance before we kickoff a run.

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -160,6 +160,23 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
         self._check_err(r, msg)
 
     @bolt_checkpoint()
+    async def update_run_id(
+        self,
+        instance_id: str,
+        run_id: str,
+    ) -> None:
+        """Update the run_id of the instance.
+
+        Args:
+            - instance_id: The study instance identifier
+            - run_id: The run_id to store in the instance
+        """
+        params = self.params.copy()
+        params["run_id"] = run_id
+        r = requests.post(f"{self.graphapi_url}/{instance_id}", params=params)
+        self._check_err(r, "updating run_id")
+
+    @bolt_checkpoint()
     async def cancel_current_stage(
         self,
         instance_id: str,
@@ -293,7 +310,7 @@ class BoltGraphAPIClient(BoltClient[BoltGraphAPICreateInstanceArgs]):
         if r.status_code != 200:
             err_msg = f"Error {msg}: {r.content}"
             self.logger.error(err_msg)
-            raise GraphAPIGenericException(err_msg)
+            raise GraphAPIGenericException(msg=err_msg, status_code=r.status_code)
 
     @bolt_checkpoint(dump_params=True, include=["adspixels_id"])
     def get_adspixels(self, adspixels_id: str, fields: List[str]) -> requests.Response:

--- a/fbpcs/pl_coordinator/exceptions.py
+++ b/fbpcs/pl_coordinator/exceptions.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import sys
 from enum import Enum
+from typing import Optional
 
 from fbpcs.pl_coordinator.constants import FBPCS_GRAPH_API_TOKEN
 
@@ -76,6 +77,7 @@ class OneCommandRunnerExitCode(Enum):
     ERROR_READ_STUDY = 80
     ERROR_CREATE_PL_INSTANCE = 81
     ERROR_READ_PL_INSTANCE = 82
+    ERROR_UPDATE_PL_INSTANCE = 83
 
     # PA validation specific error
     ERROR_READ_DATASET = 90
@@ -145,7 +147,13 @@ class PCInstanceCalculationException(OneCommandRunnerBaseException, RuntimeError
 
 
 class GraphAPIGenericException(RuntimeError):
-    pass
+    def __init__(
+        self,
+        msg: str,
+        status_code: Optional[int] = None,
+    ) -> None:
+        super().__init__(msg)
+        self.status_code = status_code
 
 
 class GraphAPITokenNotFound(OneCommandRunnerBaseException, GraphAPIGenericException):


### PR DESCRIPTION
Summary: From the client side, in pl_study_runner.py::_run_prep(), we either create new instances or reuse existing valid instances.  For the second case, make a post to /<instance_id> graphAPI endpoint with the run_id of the existing instance. If the call fails with a permission related error, raise as PCStudyValidationException

Differential Revision: D45473988

