### PR TITLE
fix wrong depoyment script name in CB docker file

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -52,8 +52,8 @@ RUN terraform --version
 RUN mkdir -p /terraform_deployment/config
 COPY deploy.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/deploy.sh
-COPY deploy_tee.sh /terraform_deployment
-RUN chmod +x /terraform_deployment/deploy_tee.sh
+COPY deploy_pc_infra.sh /terraform_deployment
+RUN chmod +x /terraform_deployment/deploy_pc_infra.sh
 COPY util.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/util.sh
 COPY pceValidator.sh /terraform_deployment


### PR DESCRIPTION
Summary: While building PC on CB via skaffold we hit an error complaining that deploy_tee.sh didn't exist. This diff fixes that.

Differential Revision: D45999834

