### PR TITLE
add a new cli parameter for tee data validation

### DIFF
--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -80,6 +80,7 @@ class InputDataValidator(Validator):
         stream_file: bool,
         publisher_pc_pre_validation: bool,
         partner_pc_pre_validation: bool,
+        enable_for_tee: bool,
         private_computation_role: PrivateComputationRole,
         access_key_id: Optional[str] = None,
         access_key_data: Optional[str] = None,
@@ -95,6 +96,7 @@ class InputDataValidator(Validator):
         self._stream_file = stream_file
         self._publisher_pc_pre_validation = publisher_pc_pre_validation
         self._partner_pc_pre_validation = partner_pc_pre_validation
+        self._enable_for_tee = enable_for_tee
         self._private_computation_role: PrivateComputationRole = (
             private_computation_role
         )

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -25,6 +25,7 @@ Usage:
         [--pre-validation-file-stream=<pre-validation-file-stream>]
         [--publisher-pc-pre-validation=<publisher-pc-pre-validation>]
         [--partner-pc-pre-validation=<partner-pc-pre-validation>]
+        [--enable-for-tee=<enable-for-tee>]
 """
 
 
@@ -54,6 +55,8 @@ PUBLISHER_PC_PRE_VALIDATION_ENABLED = "enabled"
 PRIVATE_COMPUTATION_ROLE = "--private-computation-role"
 PARTNER_PC_PRE_VALIDATION_FLAG = "--partner-pc-pre-validation"
 PARTNER_PC_PRE_VALIDATION_ENABLED = "enabled"
+ENABLE_FOR_TEE_FLAG = "--enable-for-tee"
+ENABLE_FOR_TEE_ENABLED = "enabled"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -73,6 +76,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(PRE_VALIDATION_FILE_STREAM_FLAG): optional_string,
             Optional(PUBLISHER_PC_PRE_VALIDATION_FLAG): optional_string,
             Optional(PARTNER_PC_PRE_VALIDATION_FLAG): optional_string,
+            Optional(ENABLE_FOR_TEE_FLAG): optional_string,
             Optional(PRIVATE_COMPUTATION_ROLE): optional_string,
         }
     )
@@ -89,6 +93,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
     partner_pc_pre_validation = (
         arguments[PARTNER_PC_PRE_VALIDATION_FLAG] == PARTNER_PC_PRE_VALIDATION_ENABLED
     )
+    enable_for_tee = arguments[ENABLE_FOR_TEE_FLAG] == ENABLE_FOR_TEE_ENABLED
 
     validators = [
         cast(
@@ -100,6 +105,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 stream_file=stream_file,
                 publisher_pc_pre_validation=publisher_pc_pre_validation,
                 partner_pc_pre_validation=partner_pc_pre_validation,
+                enable_for_tee=enable_for_tee,
                 private_computation_role=arguments[PRIVATE_COMPUTATION_ROLE],
                 start_timestamp=arguments[START_TIMESTAMP],
                 end_timestamp=arguments[END_TIMESTAMP],

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -44,6 +44,7 @@ TEST_REGION = "us-west-2"
 TEST_STREAM_FILE = False
 TEST_PUBLISHER_PC_PRE_VALIDATION = False
 TEST_PARTNER_PC_PRE_VALIDATION = True
+TEST_ENABLE_FOR_TEE = False
 TEST_PRIVATE_COMPUTATION_ROLE: PrivateComputationRole = PrivateComputationRole.PARTNER
 TEST_TIMESTAMP: float = time.time()
 TEST_TEMP_FILEPATH = f"{INPUT_DATA_TMP_FILE_PATH}/{TEST_FILENAME}-{TEST_TIMESTAMP}"
@@ -90,6 +91,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             access_key_id=access_key_id,
             access_key_data=access_key_data,
@@ -121,6 +123,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -152,6 +155,7 @@ class TestInputDataValidator(TestCase):
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -174,6 +178,7 @@ class TestInputDataValidator(TestCase):
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -209,6 +214,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -249,6 +255,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -289,6 +296,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -419,6 +427,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -458,6 +467,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -498,6 +508,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -537,6 +548,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -581,6 +593,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -615,6 +628,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -649,6 +663,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -675,6 +690,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -708,6 +724,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -742,6 +759,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=publisher_role,
         )
         report = validator.validate()
@@ -776,6 +794,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=publisher_pc_pre_validation,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=publisher_role,
         )
         report = validator.validate()
@@ -809,6 +828,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -860,6 +880,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -910,6 +931,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -961,6 +983,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -997,6 +1020,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1049,6 +1073,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1079,6 +1104,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1118,6 +1144,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1150,6 +1177,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1182,6 +1210,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1199,6 +1228,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1650000000",
             end_timestamp="1640000000",
@@ -1218,6 +1248,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="test",
             end_timestamp=end_timestamp,
@@ -1238,6 +1269,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp=start_timestamp,
             end_timestamp="test",
@@ -1285,6 +1317,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1331,6 +1364,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1372,6 +1406,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1413,6 +1448,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1640000000",
             end_timestamp="1650000000",
@@ -1496,6 +1532,7 @@ class TestInputDataValidator(TestCase):
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
@@ -1540,6 +1577,7 @@ class TestInputDataValidator(TestCase):
             stream_file=True,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
 
@@ -1707,6 +1745,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1741,6 +1780,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
         )
         report = validator.validate()
@@ -1778,6 +1818,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="1670000000",
             end_timestamp="1650000000",
@@ -1818,6 +1859,7 @@ class TestInputDataValidator(TestCase):
             stream_file=TEST_STREAM_FILE,
             publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
             partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=TEST_ENABLE_FOR_TEE,
             private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
             start_timestamp="test1",
             end_timestamp="test2",

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -50,6 +50,7 @@ class TestPCPreValidationCLI(TestCase):
             stream_file=False,
             publisher_pc_pre_validation=False,
             partner_pc_pre_validation=False,
+            enable_for_tee=False,
             private_computation_role=None,
             start_timestamp=None,
             end_timestamp=None,
@@ -105,6 +106,7 @@ class TestPCPreValidationCLI(TestCase):
             "--pre-validation-file-stream=enabled",
             "--publisher-pc-pre-validation=enabled",
             "--partner-pc-pre-validation=enabled",
+            "--enable-for-tee=enabled",
         ]
 
         validation_cli.main(argv)
@@ -116,6 +118,7 @@ class TestPCPreValidationCLI(TestCase):
             stream_file=True,
             publisher_pc_pre_validation=True,
             partner_pc_pre_validation=True,
+            enable_for_tee=True,
             private_computation_role=PrivateComputationRole.PARTNER.name,
             start_timestamp=expected_start_timestamp,
             end_timestamp=expected_end_timestamp,


### PR DESCRIPTION
Summary:
In this diff, we add a new parameter `enable-for-tee` to enable/disable TEE data validation.

1. We add an optional parameter `--enable-for-tee` in `pc_pre_validation_cli.py` to capture whether this feature is enabled.
2. We add this parameter in`input_data_validator.py` to enable TEE data validation.

Next diff:
We will add the logic when TEE data validation is enabled in the next diff.

Reviewed By: wenhaizhu

Differential Revision: D46197596

