### PR TITLE
Adding KIA deployment script

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -60,11 +60,24 @@ COPY pceValidator.sh /terraform_deployment
 RUN chmod +x /terraform_deployment/pceValidator.sh
 COPY aws_terraform_template /terraform_deployment/terraform_scripts
 COPY data_ingestion /terraform_deployment/terraform_scripts/data_ingestion
+COPY key_injection_agent /terraform_deployment/terraform_scripts/key_injection_agent
 COPY semi_automated_data_ingestion /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
 COPY config.yml /terraform_deployment/config
 COPY cli.py /terraform_deployment
 RUN mkdir -p /terraform_deployment/fbpcs/infra/cloud_bridge
 COPY deployment_helper /terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper
+
+###################################################################
+# Install cryptography and prerequisite libraries. Needed for KIA.
+##################################################################
+
+RUN pip3 install \
+    --platform manylinux2010_x86_64 \
+    --implementation cp \
+    --python 3.9 \
+    --only-binary=:all: --upgrade \
+    --target awsbundle \
+    cryptography -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -40,6 +40,7 @@ image-build: $(SERVER_JAR) external_deps
 	# Cleanup copied resources
 	@echo "\nCleaning up dependencies..."
 	$(RM) -r aws_terraform_template
+	$(RM) -r kia_source_code
 	$(RM) config.yml
 	@echo "Done"
 
@@ -50,6 +51,7 @@ image-run: image-build
 clean:
 	server/gradlew -p server clean
 	$(RM) -r aws_terraform_template
+	$(RM) -r kia_source_code
 	$(RM) config.yml
 
 distclean: clean
@@ -57,8 +59,18 @@ distclean: clean
 
 
 # Dockerfile will not accept these resources as links, so they need to be copied in
-external_deps: config.yml aws_terraform_template
+external_deps: kia_source_code config.yml aws_terraform_template
 	@echo "Dependencies Copied\n"
+
+kia_source_code:
+	mkdir -p key_injection_agent/kia_source_code
+	mkdir -p key_injection_agent/kia_source_code/private_computation
+	mkdir -p key_injection_agent/kia_source_code/private_computation/tee_lift
+	chmod +x key_injection_agent/kia_source_code
+	cp -r ../../../private_computation/tee_lift/key_injection_agent/kia_runner.py key_injection_agent/kia_source_code/
+	cp -r ../../../private_computation/tee_lift/key_injection_agent key_injection_agent/kia_source_code/private_computation/tee_lift
+	cp -r ../../../private_computation/tee_lift/pc_crypto key_injection_agent/kia_source_code/private_computation/tee_lift
+	cp -r ../../../private_computation/tee_lift/utils key_injection_agent/kia_source_code/private_computation/tee_lift
 
 config.yml:
 	cp ../../private_computation_cli/config.yml .

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
@@ -1,0 +1,110 @@
+provider "aws" {
+  profile = "default"
+  region  = var.region
+}
+
+provider "archive" {}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+data "archive_file" "zip_lambda" {
+  type        = "zip"
+  source_dir = "kia_source_code"
+  output_path = "kia.zip"
+}
+
+resource "aws_s3_bucket_object" "upload_lambda" {
+  bucket = var.kia_lambda_s3_bucket
+  key    = var.kia_lambda_s3_key
+  source = "kia.zip"
+}
+
+locals {
+  kia_lambda_log_group       = "/aws/lambda/${var.kia_lambda_function_name}-${var.tag_postfix}"
+  kia_lambda_stream_name = "kia-lambda-log-stream"
+}
+
+resource "aws_cloudwatch_log_group" "kia-lambda-log-group" {
+  name = local.kia_lambda_log_group
+}
+
+resource "aws_cloudwatch_log_stream" "kia-lambda-log-stream" {
+  name           = local.kia_lambda_stream_name
+  log_group_name = aws_cloudwatch_log_group.kia-lambda-log-group.name
+}
+
+resource "aws_iam_role_policy" "kia_lambda_s3_access_policy" {
+  name = "kia_lambda_s3_access_policy"
+  role = aws_iam_role.kia_lambda_iam.name
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowLambdaAccessToS3",
+      "Effect": "Allow",
+      "Action": [
+         "s3:*"
+      ],
+      "Resource":[
+        "arn:aws:s3:::${var.kia_lambda_input_bucket}",
+        "arn:aws:s3:::${var.kia_lambda_input_bucket}/*"
+      ]
+    },
+    {
+      "Sid": "AllowLambdaAccessToKMSKey",
+      "Effect": "Allow",
+      "Action": [
+         "kms:CreateKey",
+         "kms:CreateAlias",
+         "kms:GenerateDataKey",
+         "kms:TagResource"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+resource "aws_iam_role" "kia_lambda_iam" {
+  name = "kia_lambda-iam${var.tag_postfix}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "kia_lambda" {
+  function_name    = var.kia_lambda_function_name
+  role             = aws_iam_role.kia_lambda_iam.arn
+  handler          = "kia_runner.lambda_handler"
+  runtime          = "python3.9"
+  s3_bucket        = var.kia_lambda_s3_bucket
+  s3_key           = var.kia_lambda_s3_key
+  publish          = true
+  environment {
+    variables = {
+      DEBUG = "false"
+    }
+  }
+}

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/variable.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/variable.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  description = "region of the aws resources"
+  default     = "us-west-2"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}
+
+variable "aws_account_id" {
+  description = "your aws account id, that's used to read encrypted S3 files"
+  default     = ""
+}
+
+variable "kia_lambda_function_name" {
+  description = "Name of the KIA lambda"
+  default     = ""
+}
+
+variable "kia_lambda_s3_bucket" {
+  description = "S3 bucket where source code zip file for KIA is stored."
+  default     = ""
+}
+
+variable "kia_lambda_input_bucket" {
+  description = "S3 bucket where input data for KIA is stored."
+  default     = ""
+}
+
+variable "kia_lambda_s3_key" {
+  description = "S3 key for source code zip file for KIA."
+  default     = ""
+}


### PR DESCRIPTION
Summary:
# Context
KIA Deployment is a python library that we need to deploy as an AWS lambda on advertiser side as part of cloud bridge. Thus adding deployment scripts for the same here.

# Details
Refer to kia deployment document - https://docs.google.com/document/d/1veMIk6idEHlMZZjRXS0NxhwWNdHlVApxQvQB3ZiMvb0/edit?usp=sharing, for detailed steps to deploy KIA from local machine. But tl;dr, we need to follow the fbpcs/infra/cloud_bridge deployment process and https://www.internalfb.com/code/fbsource/fbcode/fbpcs/infra/cloud_bridge/README.md with some modifications to get the KIA code in the docker directory.

# Next diff
Will add a flag to only Run KIA cmds when a tee specific flag is enabled.

Differential Revision: D46244452

