### PR TITLE
add local file path for TEE data validation

### DIFF
--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -26,6 +26,7 @@ Usage:
         [--publisher-pc-pre-validation=<publisher-pc-pre-validation>]
         [--partner-pc-pre-validation=<partner-pc-pre-validation>]
         [--enable-for-tee=<enable-for-tee>]
+        [--tee-local-file-path=<local-file-path>]
 """
 
 
@@ -57,6 +58,7 @@ PARTNER_PC_PRE_VALIDATION_FLAG = "--partner-pc-pre-validation"
 PARTNER_PC_PRE_VALIDATION_ENABLED = "enabled"
 ENABLE_FOR_TEE_FLAG = "--enable-for-tee"
 ENABLE_FOR_TEE_ENABLED = "enabled"
+TEE_LOCAL_FILE_PATH = "--tee-local-file-path"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -77,6 +79,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(PUBLISHER_PC_PRE_VALIDATION_FLAG): optional_string,
             Optional(PARTNER_PC_PRE_VALIDATION_FLAG): optional_string,
             Optional(ENABLE_FOR_TEE_FLAG): optional_string,
+            Optional(TEE_LOCAL_FILE_PATH): optional_string,
             Optional(PRIVATE_COMPUTATION_ROLE): optional_string,
         }
     )
@@ -111,6 +114,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 end_timestamp=arguments[END_TIMESTAMP],
                 access_key_id=arguments[ACCESS_KEY_ID],
                 access_key_data=arguments[ACCESS_KEY_DATA],
+                tee_local_file_path=arguments[TEE_LOCAL_FILE_PATH],
             ),
         ),
         cast(

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -56,6 +56,7 @@ class TestPCPreValidationCLI(TestCase):
             end_timestamp=None,
             access_key_id=None,
             access_key_data=None,
+            tee_local_file_path=None,
         )
         binary_file_validator_mock.assert_called_with(
             region=expected_region,
@@ -93,6 +94,7 @@ class TestPCPreValidationCLI(TestCase):
         expected_pc_computation_role: PrivateComputationRole = (
             PrivateComputationRole.PARTNER.name
         )
+        expected_tee_local_file_path = "/tmp/local_file_path"
         argv = [
             f"--input-file-path={expected_input_file_path}",
             f"--cloud-provider={cloud_provider_str}",
@@ -107,6 +109,7 @@ class TestPCPreValidationCLI(TestCase):
             "--publisher-pc-pre-validation=enabled",
             "--partner-pc-pre-validation=enabled",
             "--enable-for-tee=enabled",
+            f"--tee-local-file-path={expected_tee_local_file_path}",
         ]
 
         validation_cli.main(argv)
@@ -124,6 +127,7 @@ class TestPCPreValidationCLI(TestCase):
             end_timestamp=expected_end_timestamp,
             access_key_id=expected_access_key_id,
             access_key_data=expected_access_key_data,
+            tee_local_file_path=expected_tee_local_file_path,
         )
         binary_file_validator_mock.assert_called_with(
             region=expected_region,


### PR DESCRIPTION
Summary:
In this diff, we added a new parameter to intake a local file path for TEE data validation.

1. We add a new cli parameter `--local-file-path` to capture the local file path.
2. In `__validate__` of `input_data_validator.py`, we will check if TEE data validation is enabled first. We consider   TEE data validation is enabled only if both `self._enable_for_tee` is true and `self._tee_local_file_path` is not None.
In the case that  TEE data validation is enabled, we use a local method to query file size. Then, we skip downloading part. In the end, we use local file path to generate the report.

Reviewed By: wenhaizhu

Differential Revision: D46284222

