### PR TITLE
Update the id_ column validation

### DIFF
--- a/fbpcs/pc_pre_validation/input_data_validator.py
+++ b/fbpcs/pc_pre_validation/input_data_validator.py
@@ -610,6 +610,9 @@ class InputDataValidator(Validator):
 
         if value.strip() == "":
             validation_issues.count_empty_field(field)
+        elif self._enable_for_tee and field == ID_FIELD_PREFIX:
+            if not self._is_valid_list(value, VALIDATION_REGEXES[ID_FIELD_PREFIX]):
+                validation_issues.count_format_error_field(field)
         elif field in VALIDATION_REGEXES and not VALIDATION_REGEXES[field].match(value):
             validation_issues.count_format_error_field(field)
         elif field.endswith(TIMESTAMP):
@@ -738,3 +741,22 @@ class InputDataValidator(Validator):
                 validation_issues.set_value_field_name(field_name)
                 # The header row should have either 'value' or 'conversion_value'
                 break
+
+    def _is_valid_list(self, str_list: str, valid_regex: Pattern[str]) -> bool:
+        # Check that the string starts with "[" and ends with "]"
+        if not (str_list.startswith("[") and str_list.endswith("]")):
+            return False
+
+        # Remove the brackets and split the string by commas
+        inner_strs = str_list[1:-1].split(",")
+
+        # Strip whitespace and validate each string with the provided regex pattern
+        for inner_str in inner_strs:
+            inner_str = inner_str.strip()
+
+            # Check if the string matches the regex
+            if not valid_regex.match(inner_str):
+                return False
+
+        # If we made it this far, the input is a valid list of strings matching the pattern
+        return True

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -26,6 +26,7 @@ Usage:
         [--publisher-pc-pre-validation=<publisher-pc-pre-validation>]
         [--partner-pc-pre-validation=<partner-pc-pre-validation>]
         [--enable-for-tee=<enable-for-tee>]
+        [--tee-local-file-path=<local-file-path>]
 """
 
 
@@ -57,6 +58,7 @@ PARTNER_PC_PRE_VALIDATION_FLAG = "--partner-pc-pre-validation"
 PARTNER_PC_PRE_VALIDATION_ENABLED = "enabled"
 ENABLE_FOR_TEE_FLAG = "--enable-for-tee"
 ENABLE_FOR_TEE_ENABLED = "enabled"
+TEE_LOCAL_FILE_PATH = "--tee-local-file-path"
 
 
 def main(argv: OptionalType[List[str]] = None) -> None:
@@ -77,6 +79,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
             Optional(PUBLISHER_PC_PRE_VALIDATION_FLAG): optional_string,
             Optional(PARTNER_PC_PRE_VALIDATION_FLAG): optional_string,
             Optional(ENABLE_FOR_TEE_FLAG): optional_string,
+            Optional(TEE_LOCAL_FILE_PATH): optional_string,
             Optional(PRIVATE_COMPUTATION_ROLE): optional_string,
         }
     )
@@ -111,6 +114,7 @@ def main(argv: OptionalType[List[str]] = None) -> None:
                 end_timestamp=arguments[END_TIMESTAMP],
                 access_key_id=arguments[ACCESS_KEY_ID],
                 access_key_data=arguments[ACCESS_KEY_DATA],
+                tee_local_file_path=arguments[TEE_LOCAL_FILE_PATH],
             ),
         ),
         cast(

--- a/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
+++ b/fbpcs/pc_pre_validation/tests/input_data_validator_test.py
@@ -222,7 +222,7 @@ class TestInputDataValidator(TestCase):
         ]
         lines.extend(
             [
-                b"abcd/1234+WXYZ=,100,1645157987\n",
+                b'"[abcd/1234+WXYZ=]",100,1645157987\n',
             ]
             * 10000
         )
@@ -234,6 +234,45 @@ class TestInputDataValidator(TestCase):
             message=f"File: {TEST_TEMP_FILEPATH} completed validation successfully",
             details={
                 "rows_processed_count": 10000,
+            },
+        )
+
+        validator = InputDataValidator(
+            input_file_path=TEST_INPUT_FILE_PATH,
+            cloud_provider=TEST_CLOUD_PROVIDER,
+            region=TEST_REGION,
+            stream_file=TEST_STREAM_FILE,
+            publisher_pc_pre_validation=TEST_PUBLISHER_PC_PRE_VALIDATION,
+            partner_pc_pre_validation=TEST_PARTNER_PC_PRE_VALIDATION,
+            enable_for_tee=True,
+            private_computation_role=TEST_PRIVATE_COMPUTATION_ROLE,
+            tee_local_file_path=TEST_TEMP_FILEPATH,
+        )
+        report = validator.validate()
+
+        self.assertEqual(report, expected_report)
+
+    @patch("fbpcs.pc_pre_validation.input_data_validator.time")
+    def test_run_validations_fail_for_bad_id_format_local_file_path(
+        self, time_mock: Mock
+    ) -> None:
+        # test run validation for TEE local file with invalid ud format
+        time_mock.time.return_value = TEST_TIMESTAMP
+        lines = [
+            b"id_,value,event_timestamp\n",
+            b'"[abcd/1234+WXYZ=,abcd/1234+WXYZ=]",100,1645157987\n',
+            b'"[abcd/1234+_XYZ=,abcd/1234+WXYZ=,abcd/1234+WXYZ=]",24,1641233881\n',  # bad id format
+            b'"abcd/1234+WXYZ=,abcd/1234+WXYZ=",100,1645157987\n',  # bad id format
+        ]
+
+        self.write_lines_to_file(lines)
+        expected_report = ValidationReport(
+            validation_result=ValidationResult.FAILED,
+            validator_name=INPUT_DATA_VALIDATOR_NAME,
+            message=f"File: {TEST_TEMP_FILEPATH} failed validation, with errors on 'id_'.",
+            details={
+                "rows_processed_count": 3,
+                "validation_errors": {"id_": {"bad_format_count": 2}},
             },
         )
 

--- a/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
+++ b/fbpcs/pc_pre_validation/tests/pc_pre_validation_cli_test.py
@@ -56,6 +56,7 @@ class TestPCPreValidationCLI(TestCase):
             end_timestamp=None,
             access_key_id=None,
             access_key_data=None,
+            tee_local_file_path=None,
         )
         binary_file_validator_mock.assert_called_with(
             region=expected_region,
@@ -93,6 +94,7 @@ class TestPCPreValidationCLI(TestCase):
         expected_pc_computation_role: PrivateComputationRole = (
             PrivateComputationRole.PARTNER.name
         )
+        expected_tee_local_file_path = "/tmp/local_file_path"
         argv = [
             f"--input-file-path={expected_input_file_path}",
             f"--cloud-provider={cloud_provider_str}",
@@ -107,6 +109,7 @@ class TestPCPreValidationCLI(TestCase):
             "--publisher-pc-pre-validation=enabled",
             "--partner-pc-pre-validation=enabled",
             "--enable-for-tee=enabled",
+            f"--tee-local-file-path={expected_tee_local_file_path}",
         ]
 
         validation_cli.main(argv)
@@ -124,6 +127,7 @@ class TestPCPreValidationCLI(TestCase):
             end_timestamp=expected_end_timestamp,
             access_key_id=expected_access_key_id,
             access_key_data=expected_access_key_data,
+            tee_local_file_path=expected_tee_local_file_path,
         )
         binary_file_validator_mock.assert_called_with(
             region=expected_region,


### PR DESCRIPTION
Summary:
In this diff, we update the id_column validation. The new `id_column` will be an array of ids instead of a single string.

For example:
 - Previous: `base64string`
 - Now: `"[base64string,base64string,base64string]"`

We implement a new method that intakes a `str` and a `Pattern`. This method will check if the `str` starts and ends with `[]`. Then, it splits it into multiple inner str and validate each one individually.

During validation, the new id validation logic will be used only if the TEE is enabled (`_enable_for_tee = True`) and the field is `id_`.

Reviewed By: joe1234wu

Differential Revision: D46406492

