### PR TITLE
Increasing timeout and memory of Lambda function.

### DIFF
--- a/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
@@ -116,10 +116,14 @@ resource "aws_lambda_function" "kia_lambda" {
   runtime          = "python3.9"
   s3_bucket        = var.kia_lambda_s3_bucket
   s3_key           = var.kia_lambda_s3_key
+  memory_size      = 3072
+  timeout          = 900
   publish          = true
   environment {
     variables = {
       DEBUG = "false"
     }
   }
+
+  depends_on = [aws_s3_bucket_object.upload_lambda]
 }


### PR DESCRIPTION
Summary: The AWS lambda needs to run at scale, thus increasing the max memory to 3 GB (we are processing at 100 MB chunks) and max time to 15 minutes.

Differential Revision: D46509113

