### PR TITLE
Extemd Java web server to support toolkit installation

### DIFF
--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/DeploymentRunner.java
@@ -134,8 +134,8 @@ public class DeploymentRunner extends Thread {
     }
     environmentVariables.put("TF_LOG_STREAMING", Constants.DEPLOYMENT_STREAMING_LOG_FILE);
     environmentVariables.put("TF_RESOURCE_OUTPUT", Constants.DEPLOYMENT_RESOURCE_OUTPUT_FILE);
-    if (deployment.logLevel != DeploymentParams.LogLevel.DISABLED) {
-      if (deployment.logLevel == null) deployment.logLevel = DeploymentParams.LogLevel.DEBUG;
+    if (deployment.logLevel != LogLevel.DISABLED) {
+      if (deployment.logLevel == null) deployment.logLevel = LogLevel.DEBUG;
       environmentVariables.put("TF_LOG", deployment.logLevel.getLevel());
       environmentVariables.put("TF_LOG_PATH", "/tmp/terraform.log");
     }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/InstallationException.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/InstallationException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+public class InstallationException extends RuntimeException {
+  public InstallationException(String message) {
+    super(message);
+  }
+
+  private static final long serialVersionUID = 856L;
+}

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/InstallationRunner.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/InstallationRunner.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.*;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InstallationRunner extends Thread {
+  private Logger logger = LoggerFactory.getLogger(DeployController.class);
+  private List<String> installationCommand;
+  private Map<String, String> environmentVariables;
+
+  private Runnable installationFinishedCallback;
+  private Process provisioningProcess;
+  private BufferedWriter installationLogFile;
+  private int exitValue;
+
+  public int getExitValue() {
+    return exitValue;
+  }
+
+  private Object processOutputMutex = new Object();
+  private String processOutput = new String();
+
+  public String getOutput() {
+    String output;
+    synchronized (processOutputMutex) {
+      output = processOutput;
+      processOutput = new String();
+    }
+
+    if (installationState == InstallationState.STATE_FINISHED) {
+      halt();
+    }
+
+    return output;
+  }
+
+  enum InstallationState {
+    STATE_NOT_STARTED("not started"),
+    STATE_RUNNING("running"),
+    STATE_FINISHED("finished"),
+    STATE_HALTED("halted");
+
+    private String state;
+
+    private InstallationState(String state) {
+      this.state = state;
+    }
+
+    @JsonValue
+    public String toString() {
+      return state;
+    }
+  };
+
+  private InstallationState installationState;
+
+  public InstallationState getInstallationState() {
+    return installationState;
+  }
+
+  public InstallationRunner(
+      boolean shouldInstall,
+      ToolkitInstallationParams installationParams,
+      Runnable installationFinishedCallback) {
+
+    this.installationState = InstallationState.STATE_NOT_STARTED;
+    this.installationFinishedCallback = installationFinishedCallback;
+
+    buildInstallationCommand(shouldInstall, installationParams);
+    buildEnvironmentVariables(installationParams);
+
+    try {
+      installationLogFile = new BufferedWriter(new FileWriter("/tmp/deploy.log", true));
+    } catch (IOException e) {
+      logger.error("An exception happened: ", e.getMessage());
+    }
+  }
+
+  private void buildInstallationCommand(
+      boolean shouldInstall, ToolkitInstallationParams installationParams) {
+    installationCommand = new ArrayList<String>();
+    installationCommand.add("/bin/bash");
+    installationCommand.add("/terraform_deployment/deploy_pc_infra.sh");
+    if (shouldInstall) {
+      installationCommand.add("deploy");
+    } else {
+      installationCommand.add("undeploy");
+    }
+    installationCommand.add("-r");
+    installationCommand.add(installationParams.region);
+    installationCommand.add("-a");
+    installationCommand.add(installationParams.awsAccountId);
+    installationCommand.add("-t");
+    installationCommand.add(installationParams.tag);
+    // always enable semi-automated data ingestion
+    installationCommand.add("-b");
+    logger.info("  PC toolkit installation command built: " + installationCommand);
+  }
+
+  private void buildEnvironmentVariables(ToolkitInstallationParams installationParams) {
+    environmentVariables = new HashMap<String, String>();
+    environmentVariables.put("AWS_ACCESS_KEY_ID", installationParams.awsAccessKeyId);
+    environmentVariables.put("AWS_SECRET_ACCESS_KEY", installationParams.awsSecretAccessKey);
+    if (!installationParams.awsSessionToken.isEmpty()) {
+      environmentVariables.put("AWS_SESSION_TOKEN", installationParams.awsSessionToken);
+    }
+
+    environmentVariables.put("TF_LOG_STREAMING", Constants.DEPLOYMENT_STREAMING_LOG_FILE);
+    environmentVariables.put("TF_RESOURCE_OUTPUT", Constants.DEPLOYMENT_RESOURCE_OUTPUT_FILE);
+    if (installationParams.logLevel != LogLevel.DISABLED) {
+      if (installationParams.logLevel == null) {
+        installationParams.logLevel = LogLevel.DEBUG;
+      }
+      environmentVariables.put("TF_LOG", installationParams.logLevel.getLevel());
+      environmentVariables.put("TF_LOG_PATH", "/tmp/terraform.log");
+    }
+  }
+
+  private String readOutput(BufferedReader stdout) {
+    StringBuilder sb = new StringBuilder();
+    try {
+      String s;
+      while (stdout.ready() && (s = stdout.readLine()) != null) {
+        sb.append(s);
+        sb.append('\n');
+      }
+    } catch (IOException e) {
+      logger.debug("  Problem reading installation process logs: " + e.getMessage());
+    }
+    logger.trace("  Read " + sb.length() + " chars from installation process logs");
+
+    return sb.toString();
+  }
+
+  private void logOutput(String output) {
+    synchronized (processOutputMutex) {
+      processOutput += output;
+    }
+    if (installationLogFile != null) {
+      try {
+        installationLogFile.write(output);
+        installationLogFile.flush();
+      } catch (IOException e) {
+        logger.error("Failed to log to Logger File");
+      }
+    }
+  }
+
+  private void halt() {
+    installationState = InstallationState.STATE_HALTED;
+    try {
+      installationLogFile.close();
+    } catch (IOException e) {
+      logger.error("Failed to close Logger File");
+    }
+    logger.info("  Installation finished");
+  }
+
+  public void run() {
+    installationState = InstallationState.STATE_RUNNING;
+    BufferedReader stdout = null;
+
+    try {
+      ProcessBuilder pb = new ProcessBuilder(installationCommand);
+
+      Map<String, String> env = pb.environment();
+      env.putAll(environmentVariables);
+
+      pb.redirectErrorStream(true);
+      pb.directory(new File("/terraform_deployment"));
+      provisioningProcess = pb.start();
+      logger.info("  Creating installation process");
+
+      stdout = new BufferedReader(new InputStreamReader(provisioningProcess.getInputStream()));
+
+      while (provisioningProcess.isAlive()) {
+        logOutput(readOutput(stdout));
+
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+        }
+      }
+
+      exitValue = provisioningProcess.exitValue();
+      logger.info("  Installation process exited with value: " + exitValue);
+
+    } catch (IOException e) {
+      logger.error("  Installation could not be started. Message: " + e.getMessage());
+      throw new InstallationException("Installation could not be started");
+    } finally {
+      if (stdout != null) {
+        logOutput(readOutput(stdout));
+      }
+
+      installationFinishedCallback.run();
+      installationState = InstallationState.STATE_FINISHED;
+    }
+  }
+}

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/LogLevel.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/LogLevel.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.business.cloudbridge.pl.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+enum LogLevel {
+  DISABLED("Disabled"),
+  ERROR("ERROR"),
+  WARNING("WARN"),
+  INFORMATION("INFO"),
+  DEBUG("DEBUG"),
+  TRACE("TRACE");
+
+  private final String level;
+
+  LogLevel() {
+    this.level = "DEBUG";
+  }
+
+  LogLevel(final String level) {
+    this.level = level;
+  }
+
+  public String getLevel() {
+    return this.level;
+  }
+
+  @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+  public static LogLevel getLogLevelFromName(@JsonProperty("logLevel") String level) {
+    for (LogLevel l : LogLevel.values()) {
+      if (l.getLevel().equals(level)) {
+        return l;
+      }
+    }
+    return DEBUG;
+  }
+}

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/ToolkitInstallationParams.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/ToolkitInstallationParams.java
@@ -11,22 +11,17 @@ import com.amazonaws.regions.Regions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeploymentParams {
+public class ToolkitInstallationParams {
   public String region;
-  public String accountId;
-  public String pubAccountId;
-  public String vpcId;
+  public String awsAccountId;
   public String configStorage;
   public String dataStorage;
-  public String tag;
-  public boolean enableSemiAutomatedDataIngestion;
-  public LogLevel logLevel;
-
   public String awsAccessKeyId;
   public String awsSecretAccessKey;
   public String awsSessionToken;
-  public String publisherPCEId;
-  public String publisherPCEInstanceId;
+  public String tag;
+  public LogLevel logLevel;
+
   private final Logger logger = LoggerFactory.getLogger(DeploymentParams.class);
 
   public boolean validRegion() {
@@ -35,28 +30,13 @@ public class DeploymentParams {
     } catch (IllegalArgumentException e) {
       return false;
     }
-
     return true;
   }
 
   // Amazon account identifier format can be found in
   // https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html
-  private boolean validAccountID(String id) {
-    return id != null && id.matches("^\\d{12}$");
-  }
-
-  public boolean validPubAccountID() {
-    return validAccountID(pubAccountId);
-  }
-
-  public boolean validAccountID() {
-    return validAccountID(accountId);
-  }
-
-  // Amazon VPC ID identifier format can be found in
-  // https://aws.amazon.com/about-aws/whats-new/2018/02/longer-format-resource-ids-are-now-available-in-amazon-ec2/
-  public boolean validVpcID() {
-    return vpcId != null && !vpcId.isEmpty() && vpcId.matches("^vpc-[a-z0-9]{17}$");
+  public boolean validAwsAccountID() {
+    return awsAccountId != null && awsAccountId.matches("^\\d{12}$");
   }
 
   public boolean validConfigStorage() {
@@ -99,14 +79,8 @@ public class DeploymentParams {
     if (!validRegion()) {
       logAndThrow("Invalid Region: " + region);
     }
-    if (!validAccountID()) {
-      logAndThrow("Invalid Account ID: " + accountId);
-    }
-    if (!validPubAccountID()) {
-      logAndThrow("Invalid Publisher Account ID: " + pubAccountId);
-    }
-    if (!validVpcID()) {
-      logAndThrow("Invalid VPC ID: " + vpcId);
+    if (!validAwsAccountID()) {
+      logAndThrow("Invalid AWS Account ID: " + awsAccountId);
     }
     if (!validTagPostfix()) {
       logAndThrow(
@@ -133,28 +107,32 @@ public class DeploymentParams {
         new StringBuilder()
             .append("{Region: ")
             .append(region)
-            .append(", Account ID: ")
-            .append(accountId)
-            .append(", Publisher Account ID: ")
-            .append(pubAccountId)
-            .append(", VPC ID: ")
-            .append(vpcId)
+            .append(", AWS Account ID: ")
+            .append(awsAccountId)
             .append(", Configuration Storage: ")
             .append(configStorage)
             .append(", Data Storage: ")
             .append(dataStorage)
             .append(", Tag: ")
-            .append(tag)
-            .append(", publisherPCEId: ")
-            .append(publisherPCEId)
-            .append(", publisherPCEInstanceId: ")
-            .append(publisherPCEInstanceId)
-            .append(", Enable Semi-Automated Data Ingestion: ")
-            .append(String.valueOf(enableSemiAutomatedDataIngestion));
+            .append(tag);
     if (logLevel != null) {
       sb.append(", Terraform Log Level: ").append(logLevel);
     }
     sb.append("}");
     return sb.toString();
+  }
+
+  public DeploymentParams toDeploymentParams() {
+    DeploymentParams params = new DeploymentParams();
+    params.region = region;
+    params.accountId = awsAccountId;
+    params.configStorage = configStorage;
+    params.dataStorage = dataStorage;
+    params.tag = tag;
+    params.logLevel = logLevel;
+    params.awsAccessKeyId = awsAccessKeyId;
+    params.awsSecretAccessKey = awsSecretAccessKey;
+    params.awsSessionToken = awsSessionToken;
+    return params;
   }
 }

--- a/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
+++ b/fbpcs/infra/cloud_bridge/server/src/main/java/com/facebook/business/cloudbridge/pl/server/Validator.java
@@ -199,4 +199,20 @@ public class Validator {
     // TODO S3 bucket limit validation T119080329
     return new ValidatorResult(true, "No pre validation issues found so far!");
   }
+
+  public ValidatorResult validateForInstallation(
+      ToolkitInstallationParams installationParams, boolean install) {
+    final ValidatorResult credentialsValidationResult =
+        validateCredentials(installationParams.toDeploymentParams());
+    if (!credentialsValidationResult.isSuccessful) {
+      return credentialsValidationResult;
+    }
+
+    ValidatorResult dataStorageValidationRes =
+        validateDataBucket(installationParams.toDeploymentParams());
+    if (!dataStorageValidationRes.isSuccessful) {
+      return dataStorageValidationRes;
+    }
+    return new ValidatorResult(true, "No pre validation issues found so far!");
+  }
 }

--- a/fbpcs/infra/cloud_bridge/server/src/test/java/com/facebook/business/cloudbridge/pl/server/DeploymentParamsTest.java
+++ b/fbpcs/infra/cloud_bridge/server/src/test/java/com/facebook/business/cloudbridge/pl/server/DeploymentParamsTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.facebook.business.cloudbridge.pl.server.DeploymentParams.LogLevel;
+import com.facebook.business.cloudbridge.pl.server.LogLevel;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Summary:
## Context
* Overall context: See D45981553.
* In previous diff D46447618, we added Kotlin backend impl skeleton for `installToolkit` mutation with a few TODOs:
> 1. Add MariaDB MySQL tables and implement `DBInstallationStatusManager` &  `DBInstallationStatusSqlQuery`

> 2. Extend the java web server by ultimately calling [deploy_pc_infra.sh](https://www.internalfb.com/code/fbsource/fbcode/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh) to set up cloud resources for TEE PC runs.

> 3. Update `InstallationClient` to talk to java web server properly

## This diff
Follow-up TODO #2 __Extend the java web server by ultimately calling deploy_pc_infra.sh to set up cloud resources for TEE PC runs.__:
* Added a few classes to support toolkit installation specifically:
  * InstallationException.java
  * InstallationRunner.java
  * ToolkitInstallationParams.java
* Refactor DeploymentParams.java a bit to share `LogLevel` b/w it and `ToolkitInstallationParams`
* For simplicity, we extend the webserver (DeploymentController) directly and open up new path `/v2/installation` for toolkit installation

Differential Revision: D46476558

