### PR TITLE
Fix the CB PC makefile

### DIFF
--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -40,7 +40,7 @@ image-build: $(SERVER_JAR) external_deps
 	# Cleanup copied resources
 	@echo "\nCleaning up dependencies..."
 	$(RM) -r aws_terraform_template
-	$(RM) -r kia_source_code
+	$(RM) -r key_injection_agent/kia_source_code
 	$(RM) config.yml
 	@echo "Done"
 
@@ -51,7 +51,7 @@ image-run: image-build
 clean:
 	server/gradlew -p server clean
 	$(RM) -r aws_terraform_template
-	$(RM) -r kia_source_code
+	$(RM) -r key_injection_agent/kia_source_code
 	$(RM) config.yml
 
 distclean: clean


### PR DESCRIPTION
Summary: The clean up command didn't work for the kia_source_code because it is using the wrong folder.

Reviewed By: ztlbells

Differential Revision: D46543319

