### PR TITLE
Reduce OneDocker runtime permissions

### DIFF
--- a/docker/onedocker/prod/Dockerfile.ubuntu
+++ b/docker/onedocker/prod/Dockerfile.ubuntu
@@ -63,4 +63,7 @@ ENV WRITE_ROUTING_SCRIPT="/home/onedocker/package/write_routing.sh"
 RUN echo "%${caAdminGroup} ALL=(ALL) NOPASSWD: ${WRITE_ROUTING_SCRIPT}" >> /etc/sudoers
 
 CMD ["/bin/bash"]
+
+# Switch to non-root user for security purposes
+USER onedocker
 WORKDIR /home/onedocker


### PR DESCRIPTION
Summary: This change updates OneDocker image runtime to use a non-root user, with limited permissions. This is necessary for security isolation.

Reviewed By: musebc

Differential Revision: D46566033

