### PR TITLE
make fbpcs/emp_games compatible with buck2

### DIFF
--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
@@ -19,7 +19,7 @@
 #include <folly/test/JsonTestUtil.h>
 
 #include <fbpcf/io/api/FileIOWrappers.h>
-
+#include <fbpcs/emp_games/common/TestUtil.h>
 namespace measurement::private_attribution {
 
 class AggMetricsTest : public ::testing::Test {
@@ -27,7 +27,8 @@ class AggMetricsTest : public ::testing::Test {
   void SetUp() override {
     // Get full path of current source file
     std::string filePath = __FILE__;
-    baseDir_ = filePath.substr(0, filePath.rfind("/")) + "/test/";
+    baseDir_ =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__) + "test/";
   }
 
   std::string baseDir_;

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidationTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidationTest.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fbpcs/emp_games/common/TestUtil.h>
 #include "ShardAggregatorValidation.h"
 
 namespace measurement::private_attribution {
@@ -26,8 +27,8 @@ class ShardAggregatorValidationTest : public ::testing::Test {
   void SetUp() override {
     // Get full path of current source file
     std::string filePath = __FILE__;
-    baseDir_ = filePath.substr(0, filePath.rfind("/")) +
-        "/test/shard_validation_test/";
+    baseDir_ = private_measurement::test_util::getBaseDirFromPath(__FILE__) +
+        "test/shard_validation_test/";
   }
 
   std::string baseDir_;

--- a/fbpcs/emp_games/pcf2_shard_combiner/AggMetricsTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/AggMetricsTest.cpp
@@ -21,7 +21,8 @@ class AggMetricsTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::string filePath = __FILE__;
-    baseDir_ = filePath.substr(0, filePath.rfind("/")) + "/test/";
+    baseDir_ =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__) + "test/";
   }
   std::string baseDir_;
 };

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
@@ -23,6 +23,7 @@
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 
+#include <fbpcs/emp_games/common/TestUtil.h>
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerApp.h"
@@ -180,7 +181,8 @@ class ShardCombinerAppTestFixture
  protected:
   void SetUp() override {
     std::string filePath = __FILE__;
-    baseDir_ = filePath.substr(0, filePath.rfind("/")) + "/test/";
+    baseDir_ =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__) + "test/";
     tempDir_ = std::filesystem::temp_directory_path();
 
     tlsDir_ = fbpcf::engine::communication::setUpTlsFiles();

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGameTest.cpp
@@ -17,7 +17,7 @@
 #include <fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h>
 #include <fbpcf/engine/communication/test/AgentFactoryCreationHelper.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
-
+#include <fbpcs/emp_games/common/TestUtil.h>
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/test/TestUtils.h"
 #include "fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h"
@@ -238,7 +238,8 @@ class ShardCombinerGameTestFixture
  protected:
   void SetUp() override {
     std::string filePath = __FILE__;
-    baseDir_ = filePath.substr(0, filePath.rfind("/")) + "/test/";
+    baseDir_ =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__) + "test/";
   }
 
   std::string baseDir_;

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardValidatorTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardValidatorTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <fbpcf/exception/exceptions.h>
+#include <fbpcs/emp_games/common/TestUtil.h>
 #include <fbpcs/emp_games/pcf2_shard_combiner/AggMetrics.h>
 #include <fbpcs/emp_games/pcf2_shard_combiner/ShardValidator.h>
 #include <fbpcs/emp_games/pcf2_shard_combiner/ShardValidator_impl.h>
@@ -19,8 +20,8 @@ class ShardValidatorTest : public ::testing::Test {
   void SetUp() override {
     // Get full path of current source file
     std::string filePath = __FILE__;
-    baseDir_ = filePath.substr(0, filePath.rfind("/")) +
-        "/test/shard_validation_test/";
+    baseDir_ = private_measurement::test_util::getBaseDirFromPath(__FILE__) +
+        "test/shard_validation_test/";
   }
   std::string baseDir_;
   static constexpr int schedulerId = 0;

--- a/fbpcs/emp_games/private_id_dfca_aggregator/test/PrivateIdDfcaAggregatorTest.cpp
+++ b/fbpcs/emp_games/private_id_dfca_aggregator/test/PrivateIdDfcaAggregatorTest.cpp
@@ -23,6 +23,7 @@
 #include <fbpcf/engine/communication/test/SocketInTestHelper.h>
 #include <fbpcf/engine/communication/test/TlsCommunicationUtils.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
+#include <fbpcs/emp_games/common/TestUtil.h>
 
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/private_id_dfca_aggregator/PrivateIdDfcaAggregatorApp.h"
@@ -33,7 +34,9 @@ class PrivateIdDfcaAggregatorAppTestFixture
  protected:
   void SetUp() override {
     std::string filePath = __FILE__;
-    epxectedResultsDir_ = filePath.substr(0, filePath.rfind("/")) + "/outputs/";
+    epxectedResultsDir_ =
+        private_measurement::test_util::getBaseDirFromPath(__FILE__) +
+        "outputs/";
     tempDir_ = std::filesystem::temp_directory_path();
 
     tlsDir_ = fbpcf::engine::communication::setUpTlsFiles();


### PR DESCRIPTION
Summary:
In this diff, we update the unit tests to make them compatible with buck2.

These tests will fail under buck2 because of the way how they retireve the path test files behavor different when using buck1 and buck2. We updated them with 'getBaseDirFromPath' under `private_measurement::test_util` to retireve the path of base directory.

We also changed `fbcode/contbuild/configs/fbpcs_pca` to make the CI test run to use buck2 as default. This could potentially solve the test coverage issue under `fbpcs/emp_games`.

more context about test coverage issue:
https://docs.google.com/document/d/13lTezlaQTTZtn6dy7s3tNQs0wyaSfc96ikEXnzM8UNA/edit#heading=h.76ujvfwojh5

Reviewed By: musebc

Differential Revision: D46850021

