### PR TITLE
Polish logstream content

### DIFF
--- a/fbpcs/infra/cloud_bridge/util.sh
+++ b/fbpcs/infra/cloud_bridge/util.sh
@@ -100,7 +100,8 @@ cleanup_generated_resources() {
 
 log_streaming_data() {
     local text=$1
-    echo "$(date +"%M:%S") -> $text" >> "$TF_LOG_STREAMING"
+    TIMESTAMP_FORMAT=$(date +"%Y-%m-%d %H:%M:%S (%Z)")
+    echo "[${TIMESTAMP_FORMAT}] -> $text" >> "$TF_LOG_STREAMING"
 }
 
 log_resource_output() {


### PR DESCRIPTION
Summary:
The timestamp in each deployment/installation log might be confusing:
```
30:18 -> starting to deploy resources...
30:18 -> validating inputs...
30:28 -> creating s3 config bucket, if it does not exist
30:41 -> creating s3 data bucket, if it does not exist
30:58 -> configuring data ingestion pipeline...
34:48 -> configuring semi-automated data ingestion pipeline from CAPI-G to s3
35:53 -> starting to deploy key injection agent.
36:44 -> deployed key injection agent.
36:44 -> finished deploying resources...
36:44 -> deploying resources policies...
....
```
Actually, in the first line`30:18 -> starting to deploy resources...`,  `30:18 ` stands for 9(H):**30(M):18(S)** PM.

Put up a quick change to make those logs more readable.

Differential Revision: D46925556

