### PR TITLE
increase the glue cralwer deployment timeout to 1200

### DIFF
--- a/fbpcs/infra/cloud_bridge/deploy.sh
+++ b/fbpcs/infra/cloud_bridge/deploy.sh
@@ -327,7 +327,7 @@ deploy_aws_resources() {
     echo "######################## Initializing terraform working directory completed ########################"
     echo "######################## Deploy Data Ingestion Terraform scripts started ########################"
     set +e
-    local data_ingestion_time_out=600
+    local data_ingestion_time_out=1200
     SECONDS=0
     while [ $SECONDS -lt $data_ingestion_time_out ]
     do


### PR DESCRIPTION
Summary: We recently noticed that the data infra deployment would take more than 10 mins (firehose took 10+ mins) and this causes it exceeds the timeout time and failed immediately. Increasing the timeout to 20mins to give it enough time on retry.

Reviewed By: joe1234wu

Differential Revision: D47418149

