### PR TITLE
Add terraform code to deploy the clean up lambda.

### DIFF
--- a/fbpcs/infra/cloud_bridge/pl_clean_up_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/pl_clean_up_agent/main.tf
@@ -1,0 +1,142 @@
+provider "aws" {
+  profile = "default"
+  region  = var.region
+}
+
+provider "archive" {}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+data "archive_file" "zip_lambda" {
+  type        = "zip"
+  source_dir = "clean_up_agent_source_code"
+  output_path = "source.zip"
+}
+
+resource "aws_s3_bucket_object" "upload_lambda" {
+  bucket = var.clean_up_agent_lambda_source_bucket
+  key    = var.clean_up_agent_lambda_s3_key
+  source = "source.zip"
+}
+
+locals {
+  kia_lambda_log_group       = "/aws/lambda/${var.clean_up_agent_lambda_function_name}"
+  kia_lambda_stream_name = "clean-up-agent-lambda-log-stream"
+}
+
+resource "aws_cloudwatch_log_group" "clean-up-agent-lambda-log-group" {
+  name = local.clean_up_agent_lambda_log_group
+}
+
+resource "aws_cloudwatch_log_stream" "clean-up-agent-lambda-log-stream" {
+  name           = local.clean_up_agent_lambda_stream_name
+  log_group_name = aws_cloudwatch_log_group.clean-up-agent-lambda-log-group.name
+}
+
+resource "aws_iam_role_policy" "clean_up_agent_lambda_access_policy" {
+  name = "clean_up_agent_lambda_access_policy"
+  role = aws_iam_role.clean_up_agent_lambda_iam.name
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowLambdaAccessToS3",
+      "Effect": "Allow",
+      "Action": [
+         "s3:GetObject",
+         "s3:ListObjects"
+         "s3:DeleteObject",
+      ],
+      "Resource":[
+        "arn:aws:s3:::${var.clean_up_agent_lambda_input_bucket}",
+        "arn:aws:s3:::${var.clean_up_agent_lambda_input_bucket}/*"
+      ]
+    },
+    {
+      "Sid": "AllowLambdaAccessToModifyS3BucketPolicy",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutBucketPolicy"
+
+      ],
+      "Resource":[
+        "arn:aws:s3:::${var.clean_up_agent_lambda_input_bucket}"
+      ]
+    },
+    {
+      "Sid": "AllowLambdaAccessToKMSKey",
+      "Effect": "Allow",
+      "Action": [
+         "kms:DescribeKey",
+         "kms:ScheduleKeyDeletion"
+
+      ],
+      "Resource": "*",
+      "Condition": {
+          "StringEquals": {
+              "aws:ResourceTag/Name": "CreatedBy",
+              "aws:ResourceTag/Value": "KIALambda"
+          }
+    },
+    {
+      "Sid": "AllowLambdaAccessToCloudWatch",
+      "Effect": "Allow",
+      "Action": [
+         "logs:CreateLogGroup",
+         "logs:CreateLogStream",
+         "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "clean_up_agent_lambda_iam" {
+  name = "clean_up_agent_lambda-iam${var.tag_postfix}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "clean_up_agent_lambda" {
+  function_name    = var.clean_up_agent_lambda_function_name
+  role             = aws_iam_role.clean_up_agent_lambda_iam.arn
+  handler          = "pl_run_clean_up.lambda_handler"
+  runtime          = "python3.9"
+  s3_bucket        = var.clean_up_agent_lambda_source_bucket
+  s3_key           = var.clean_up_agent_lambda_s3_key
+  memory_size      = 500
+  timeout          = 900
+  publish          = true
+  environment {
+    variables = {
+      DEBUG = "false"
+    }
+  }
+
+  depends_on = [aws_s3_bucket_object.upload_lambda]
+}

--- a/fbpcs/infra/cloud_bridge/pl_clean_up_agent/variable.tf
+++ b/fbpcs/infra/cloud_bridge/pl_clean_up_agent/variable.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  description = "region of the aws resources"
+  default     = "us-west-2"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}
+
+variable "aws_account_id" {
+  description = "your aws account id, that's used to read encrypted S3 files"
+  default     = ""
+}
+
+variable "clean_up_agent_lambda_function_name" {
+  description = "Name of the Clean Up Agent lambda"
+  default     = ""
+}
+
+variable "clean_up_agent_lambda_source_bucket" {
+  description = "S3 bucket where source code zip file for Clean Up Agent is stored."
+  default     = ""
+}
+
+variable "clean_up_agent_lambda_input_bucket" {
+  description = "S3 bucket where input data for Clean Up Agent is stored."
+  default     = ""
+}
+
+variable "clean_up_agent_lambda_s3_key" {
+  description = "S3 key for source code zip file for Clean Up Agent."
+  default     = ""
+}


### PR DESCRIPTION
Summary:
# Context
As per the update Advertiser clean up design - https://docs.google.com/document/d/1WfcIrj9Se2imGhp99tBXmriMQphkrMcgubOZO_rTWZE/edit?usp=sharing. We will create a new clean up lambda that will be triggered every hour on the advertiser side.
In this stack, we will implement the changes need to KIA, new Clean up lambda as well as deployment changes required for Clean up lambda and cloudwatch event rule.

# Stack
1. Modify KIA to output additional fields.
2. Create structure of the new Clean up lambda.
3. Add logic to read/filter run_status.
4. Add logic to delete S3 files.
5. Add logic to schedule KMS key deletion.
6. Add logic to remove policy from S3 bucket ACL.
7. Add error handling to Clean up lambda.
8. Add terraform script for Clean Up Lambda.
9. Add deployment changes for Clean up lambda.
10. Deploy CloudWatch event rule.

# Changes in this diff
Add terraform script for Clean Up Lambda.

Differential Revision: D47960311

