### PR TITLE
Additional grants given as per end to end test

### DIFF
--- a/fbpcs/infra/cloud_bridge/clean_up_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/clean_up_agent/main.tf
@@ -66,7 +66,10 @@ resource "aws_iam_role_policy" "clean_up_agent_lambda_access_policy" {
         {
             "Sid": "AllowLambdaAccessToModifyS3BucketPolicy",
             "Effect": "Allow",
-            "Action": "s3:PutBucketPolicy",
+            "Action": [
+              "s3:GetBucketAcl",
+              "s3:PutBucketPolicy"
+            ],
             "Resource": "arn:aws:s3:::${var.clean_up_agent_lambda_input_bucket}"
         },
         {
@@ -74,6 +77,7 @@ resource "aws_iam_role_policy" "clean_up_agent_lambda_access_policy" {
             "Effect": "Allow",
             "Action": [
                 "kms:DescribeKey",
+                "kms:GetKeyPolicy",
                 "kms:ScheduleKeyDeletion"
             ],
             "Resource": "*",


### PR DESCRIPTION
Summary:
# Context
Got some errors during end to end testing related to lambda not able to perform certain actions on other AWS resources. Thus adding the required permissions to the clean up lambda.
Also during KMS key creation in KIA, we will have to give schedule deletion permission to clean up lambda as well. (doing that in next diff)

Differential Revision: D48440526

