### PR TITLE
logic to pass Clean up agent IAM role to KIA during deployment

### DIFF
--- a/fbpcs/infra/cloud_bridge/clean_up_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/clean_up_agent/main.tf
@@ -66,7 +66,10 @@ resource "aws_iam_role_policy" "clean_up_agent_lambda_access_policy" {
         {
             "Sid": "AllowLambdaAccessToModifyS3BucketPolicy",
             "Effect": "Allow",
-            "Action": "s3:PutBucketPolicy",
+            "Action": [
+              "s3:GetBucketAcl",
+              "s3:PutBucketPolicy"
+            ],
             "Resource": "arn:aws:s3:::${var.clean_up_agent_lambda_input_bucket}"
         },
         {
@@ -74,6 +77,7 @@ resource "aws_iam_role_policy" "clean_up_agent_lambda_access_policy" {
             "Effect": "Allow",
             "Action": [
                 "kms:DescribeKey",
+                "kms:GetKeyPolicy",
                 "kms:ScheduleKeyDeletion"
             ],
             "Resource": "*",

--- a/fbpcs/infra/cloud_bridge/clean_up_agent/output.tf
+++ b/fbpcs/infra/cloud_bridge/clean_up_agent/output.tf
@@ -1,0 +1,4 @@
+output "clean_up_agent_lambda_iam_role_arn" {
+  value       = aws_iam_role.clean_up_agent_lambda_iam.arn
+  description = "Clean up agent lambda IAM role ARN."
+}

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
@@ -121,7 +121,8 @@ resource "aws_lambda_function" "kia_lambda" {
   publish          = true
   environment {
     variables = {
-      DEBUG = "false"
+      DEBUG = "false",
+      clean_up_agent_lambda_iam_role = var.clean_up_agent_lambda_iam_role
     }
   }
 

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/variable.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/variable.tf
@@ -32,3 +32,8 @@ variable "kia_lambda_s3_key" {
   description = "S3 key for source code zip file for KIA."
   default     = ""
 }
+
+variable "clean_up_agent_lambda_iam_role" {
+  description = "IAM Role arn of the clean up agent lambda."
+  default     = ""
+}


### PR DESCRIPTION
Summary:
# Context
We need to give KMS key policy grants to IAM role associated with clean up agent lambda, so that it can schedule deletion of the key. In the previous diff, we added logic for the same in KIA where the KMS key is created.
In this diff, adding terraform and bash code so that they role received as output from clean up agent deployment can be send to KIA lambda as an environment variable.

Differential Revision: D48448470

