### PR TITLE
Changes based on testing.

### DIFF
--- a/fbpcs/infra/cloud_bridge/clean_up_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/clean_up_agent/main.tf
@@ -67,8 +67,8 @@ resource "aws_iam_role_policy" "clean_up_agent_lambda_access_policy" {
             "Sid": "AllowLambdaAccessToModifyS3BucketPolicy",
             "Effect": "Allow",
             "Action": [
-              "s3:GetBucketAcl",
-              "s3:PutBucketPolicy"
+                "s3:GetBucketPolicy",
+                "s3:PutBucketPolicy"
             ],
             "Resource": "arn:aws:s3:::${var.clean_up_agent_lambda_input_bucket}"
         },

--- a/fbpcs/infra/cloud_bridge/clean_up_agent/output.tf
+++ b/fbpcs/infra/cloud_bridge/clean_up_agent/output.tf
@@ -1,0 +1,4 @@
+output "clean_up_agent_lambda_iam_role_arn" {
+  value       = aws_iam_role.clean_up_agent_lambda_iam.arn
+  description = "Clean up agent lambda IAM role ARN."
+}

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
@@ -121,7 +121,8 @@ resource "aws_lambda_function" "kia_lambda" {
   publish          = true
   environment {
     variables = {
-      DEBUG = "false"
+      DEBUG = "false",
+      clean_up_agent_lambda_iam_role = var.clean_up_agent_lambda_iam_role
     }
   }
 

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/variable.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/variable.tf
@@ -32,3 +32,8 @@ variable "kia_lambda_s3_key" {
   description = "S3 key for source code zip file for KIA."
   default     = ""
 }
+
+variable "clean_up_agent_lambda_iam_role" {
+  description = "IAM Role arn of the clean up agent lambda."
+  default     = ""
+}


### PR DESCRIPTION
Summary:
# Context
Did a few rounds of testing on the CB clean up lambda and discovered some issues.
Issue 1 - clean up lambda giving input validation error as it did not get enclave_iam_profie field in input.
Fix - In KIA lambda, I was uploading the field with name - enclave_iam_role, so changed it to enclave_iam_profile.
Issue 2 - I was not able to remove the S3 bucket policy using the lambda.
Fix - The logic was trying to remove the ACL grants associated with the bucket, which are different than the policy associated with the bucket. Thus, changed the logic to remove the IAM role from the policy statement.

Differential Revision:
D48471432

Privacy Context Container: L416713

