### PR TITLE
Copying advertiser_infra_logging in docker file

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -67,6 +67,7 @@ COPY config.yml /terraform_deployment/config
 COPY cli.py /terraform_deployment
 RUN mkdir -p /terraform_deployment/fbpcs/infra/cloud_bridge
 COPY deployment_helper /terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper
+COPY advertiser_infra_logging /terraform_deployment/terraform_scripts/advertiser_infra_logging
 
 ###################################################################
 # Install cryptography and prerequisite libraries. Needed for KIA.


### PR DESCRIPTION
Summary: Adding advertiser infra folder in docker file

Reviewed By: anthonyzhang25, somnathfb

Differential Revision: D48881088


