### PR TITLE
Add ALS repository to KIA deployment script.

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -82,6 +82,9 @@ RUN pip3 install \
     --only-binary=:all: --upgrade \
     --target awsbundle \
     cryptography -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+
+RUN pip install pyqldb -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip3 install pyion2json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -68,11 +68,21 @@ kia_source_code:
 	mkdir -p key_injection_agent/kia_source_code
 	mkdir -p key_injection_agent/kia_source_code/private_computation
 	mkdir -p key_injection_agent/kia_source_code/private_computation/tee_lift
+	mkdir -p key_injection_agent/kia_source_code/smart/
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs/repository
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs/entity
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs/entity/measurement
 	chmod +x key_injection_agent/kia_source_code
 	cp -r ../../../private_computation/tee_lift/key_injection_agent/kia_runner.py key_injection_agent/kia_source_code/
 	cp -r ../../../private_computation/tee_lift/key_injection_agent key_injection_agent/kia_source_code/private_computation/tee_lift
 	cp -r ../../../private_computation/tee_lift/pc_crypto key_injection_agent/kia_source_code/private_computation/tee_lift
 	cp -r ../../../private_computation/tee_lift/utils key_injection_agent/kia_source_code/private_computation/tee_lift
+	cp -r ../../../smart/private_computation/audit_log_service/srcs/repository key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
+	cp -r ../../../smart/private_computation/audit_log_service/srcs/entity key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
+
 
 clean_up_agent_source_code:
 	mkdir -p clean_up_agent/clean_up_agent_source_code


### PR DESCRIPTION
Summary:
# Context
We need to validate the PCR measurements send to KIA from Coordinator. For this we will leverage the immutable AWS QLDB query.
In this stack, we will add changes for the same in - Key Injection Agent, KIA Deployment script and Cloudbridge backend.

# Changes in the stack
1. Add qldb iam role as input to KIA.
2. Add measurement validation logic in KIA.
3. Integrate measurement validation logic handler in KIA runner.
4. Add query source measurement validation logic.
5. Add logic to assume specific QLDB read IAM role in the measurement validation handler.
6. Add qldb related fields to KIA input.
7. Make changes to KIA deployment script.
8. Make changes to Cloudbridge backend to send qldb fields to KIA.

# Changes in the diff
Adding changes to KIA deployment script

Differential Revision:
D49209824

Privacy Context Container: L416713

