### PR TITLE
Deployment changes for MVA lambda function.

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -64,6 +64,7 @@ COPY aws_terraform_template /terraform_deployment/terraform_scripts
 COPY data_ingestion /terraform_deployment/terraform_scripts/data_ingestion
 COPY key_injection_agent /terraform_deployment/terraform_scripts/key_injection_agent
 COPY clean_up_agent /terraform_deployment/terraform_scripts/clean_up_agent
+COPY measurement_validation_agent /terraform_deployment/terraform_scripts/measurement_validation_agent
 COPY semi_automated_data_ingestion /terraform_deployment/terraform_scripts/semi_automated_data_ingestion
 COPY config.yml /terraform_deployment/config
 COPY cli.py /terraform_deployment
@@ -83,8 +84,11 @@ RUN pip3 install \
     --target awsbundle \
     cryptography -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 
-RUN pip install pyqldb -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
-RUN pip3 install pyion2json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip install pyqldb -t /terraform_deployment/terraform_scripts/measurement_validation_agent/mva_source_code/
+RUN pip3 install pyion2json -t /terraform_deployment/terraform_scripts/measurement_validation_agent/mva_source_code/
+RUN pip3 install dataclasses-json -t /terraform_deployment/terraform_scripts/measurement_validation_agent/mva_source_code/
+RUN pip3 install injector -t /terraform_deployment/terraform_scripts/measurement_validation_agent/mva_source_code/
+
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -82,6 +82,9 @@ RUN pip3 install \
     --only-binary=:all: --upgrade \
     --target awsbundle \
     cryptography -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+
+RUN pip install pyqldb -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip3 install pyion2json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -41,6 +41,7 @@ image-build: $(SERVER_JAR) external_deps
 	@echo "\nCleaning up dependencies..."
 	$(RM) -r aws_terraform_template
 	$(RM) -r key_injection_agent/kia_source_code
+	$(RM) -r measurement_validation_agent/mva_source_code
 	$(RM) -r clean_up_agent/clean_up_agent_source_code
 	$(RM) config.yml
 	@echo "Done"
@@ -61,7 +62,7 @@ distclean: clean
 
 
 # Dockerfile will not accept these resources as links, so they need to be copied in
-external_deps: kia_source_code clean_up_agent_source_code config.yml aws_terraform_template
+external_deps: mva_source_code kia_source_code clean_up_agent_source_code config.yml aws_terraform_template
 	@echo "Dependencies Copied\n"
 
 kia_source_code:
@@ -83,6 +84,25 @@ kia_source_code:
 	cp -r ../../../smart/private_computation/audit_log_service/srcs/repository key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
 	cp -r ../../../smart/private_computation/audit_log_service/srcs/entity key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
 
+
+mva_source_code:
+	mkdir -p measurement_validation_agent/mva_source_code
+	mkdir -p measurement_validation_agent/mva_source_code/private_computation
+	mkdir -p measurement_validation_agent/mva_source_code/private_computation/tee_lift
+	mkdir -p measurement_validation_agent/mva_source_code/smart/
+	mkdir -p measurement_validation_agent/mva_source_code/smart/private_computation/
+	mkdir -p measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service
+	mkdir -p measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service/srcs
+	mkdir -p measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service/srcs/repository
+	mkdir -p measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service/srcs/entity
+	mkdir -p measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service/srcs/entity/measurement
+	chmod +x measurement_validation_agent/mva_source_code
+	cp -r ../../../private_computation/tee_lift/measurement_validation_agent/measurement_validation_runner.py measurement_validation_agent/mva_source_code/
+	cp -r ../../../private_computation/tee_lift/measurement_validation_agent measurement_validation_agent/mva_source_code/private_computation/tee_lift
+	cp -r ../../../private_computation/tee_lift/pc_crypto measurement_validation_agent/mva_source_code/private_computation/tee_lift
+	cp -r ../../../private_computation/tee_lift/utils measurement_validation_agent/mva_source_code/private_computation/tee_lift
+	cp -r ../../../smart/private_computation/audit_log_service/srcs/repository measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service/srcs
+	cp -r ../../../smart/private_computation/audit_log_service/srcs/entity measurement_validation_agent/mva_source_code/smart/private_computation/audit_log_service/srcs
 
 clean_up_agent_source_code:
 	mkdir -p clean_up_agent/clean_up_agent_source_code

--- a/fbpcs/infra/cloud_bridge/Makefile
+++ b/fbpcs/infra/cloud_bridge/Makefile
@@ -68,11 +68,21 @@ kia_source_code:
 	mkdir -p key_injection_agent/kia_source_code
 	mkdir -p key_injection_agent/kia_source_code/private_computation
 	mkdir -p key_injection_agent/kia_source_code/private_computation/tee_lift
+	mkdir -p key_injection_agent/kia_source_code/smart/
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs/repository
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs/entity
+	mkdir -p key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs/entity/measurement
 	chmod +x key_injection_agent/kia_source_code
 	cp -r ../../../private_computation/tee_lift/key_injection_agent/kia_runner.py key_injection_agent/kia_source_code/
 	cp -r ../../../private_computation/tee_lift/key_injection_agent key_injection_agent/kia_source_code/private_computation/tee_lift
 	cp -r ../../../private_computation/tee_lift/pc_crypto key_injection_agent/kia_source_code/private_computation/tee_lift
 	cp -r ../../../private_computation/tee_lift/utils key_injection_agent/kia_source_code/private_computation/tee_lift
+	cp -r ../../../smart/private_computation/audit_log_service/srcs/repository key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
+	cp -r ../../../smart/private_computation/audit_log_service/srcs/entity key_injection_agent/kia_source_code/smart/private_computation/audit_log_service/srcs
+
 
 clean_up_agent_source_code:
 	mkdir -p clean_up_agent/clean_up_agent_source_code

--- a/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh
+++ b/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh
@@ -394,6 +394,30 @@ deploy_aws_resources() {
         semi_automated_glue_job_arn=$(terraform output semi_automated_glue_job_arn | tr -d '"')
     fi
 
+    echo "######################## Deploying Measurment verification Agent Agent AWS Lambda"
+    cd /terraform_deployment/terraform_scripts/measurement_validation_agent
+
+    log_streaming_data "starting to deploy Measurement verification agent."
+
+    terraform init -reconfigure \
+        -backend-config "bucket=$s3_bucket_config" \
+        -backend-config "region=$region" \
+        -backend-config "key=tfstate/measurement_verification_agent_$tag_postfix.tfstate"
+
+    terraform apply \
+        -auto-approve \
+        -var "region=$region" \
+        -var "tag_postfix=$tag_postfix" \
+        -var "aws_account_id=$aws_account_id" \
+        -var "measurement_validation_agent_lambda_function_name=$measurement_validation_agent_lambda_function_name" \
+        -var "measurement_validation_agent_lambda_input_bucket=$s3_bucket_data" \
+        -var "measurement_validation_agent_lambda_source_bucket=$s3_bucket_config" \
+        -var "measurement_validation_agent_lambda_s3_key=mva_source.zip"
+
+    log_streaming_data "deployed measurement verification agent."
+
+    echo "######################## Deployed Measurement Verification Agent AWS Lambda"
+
     echo "######################## Deploying Clean Up Agent Agent AWS Lambda"
     cd /terraform_deployment/terraform_scripts/clean_up_agent
 
@@ -584,6 +608,7 @@ query_results_key_path="query-results"
 data_ingestion_lambda_name="cb-data-ingestion-stream-processor${tag_postfix}"
 kia_lambda_function_name="cb-kia${tag_postfix}"
 clean_up_agent_lambda_function_name="cb-clean-up-agent${tag_postfix}"
+measurement_validation_agent_lambda_function_name="measurement_validation_agent${tag_postfix}"
 fb_pc_iam_policy="/terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy_no_compute.json"
 fb_pc_data_bucket_policy="/terraform_deployment/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_data_bucket_policy.json"
 data_bucket_policy_name="fb-pc-data-bucket-policy${tag_postfix}"

--- a/fbpcs/infra/cloud_bridge/measurement_validation_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/measurement_validation_agent/main.tf
@@ -1,0 +1,102 @@
+provider "aws" {
+  profile = "default"
+  region  = var.region
+}
+
+provider "archive" {}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+data "archive_file" "zip_lambda" {
+  type        = "zip"
+  source_dir = "mva_source_code"
+  output_path = "mva_source.zip"
+}
+
+resource "aws_s3_bucket_object" "upload_lambda" {
+  bucket = var.measurement_validation_agent_lambda_source_bucket
+  key    = var.measurement_validation_agent_lambda_s3_key
+  source = "mva_source.zip"
+}
+
+locals {
+  measurement_validation_agent_lambda_log_group       = "/aws/lambda/${var.measurement_validation_agent_lambda_function_name}"
+  measurement_validation_agent_lambda_stream_name     = "measurement-validation-agent-lambda-log-stream"
+}
+
+resource "aws_cloudwatch_log_group" "measurement-validation-agent-lambda-log-group" {
+  name = local.measurement_validation_agent_lambda_log_group
+}
+
+resource "aws_cloudwatch_log_stream" "measurement-validation-agent-lambda-log-stream" {
+  name           = local.measurement_validation_agent_lambda_stream_name
+  log_group_name = aws_cloudwatch_log_group.measurement-validation-agent-lambda-log-group.name
+}
+
+resource "aws_iam_role_policy" "measurement_validation_agent_access_policy" {
+  name = "measurement_validation_agent_lambda_access_policy"
+  role = aws_iam_role.measurement_validation_agent_lambda_iam.name
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowToAssumeRole",
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "measurement_validation_agent_lambda_iam" {
+  name = "measurement_validation_agent_lambda-iam${var.tag_postfix}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "measurement_validation_agent_lambda" {
+  function_name    = var.measurement_validation_agent_lambda_function_name
+  role             = aws_iam_role.measurement_validation_agent_lambda_iam.arn
+  handler          = "measurement_validation_runner.lambda_handler"
+  runtime          = "python3.9"
+  s3_bucket        = var.measurement_validation_agent_lambda_source_bucket
+  s3_key           = var.measurement_validation_agent_lambda_s3_key
+  memory_size      = 500
+  timeout          = 900
+  publish          = true
+  environment {
+    variables = {
+      DEBUG = "false",
+      encrypted_file_bucket = var.measurement_validation_agent_lambda_input_bucket
+    }
+  }
+
+  depends_on = [aws_s3_bucket_object.upload_lambda]
+}

--- a/fbpcs/infra/cloud_bridge/measurement_validation_agent/output.tf
+++ b/fbpcs/infra/cloud_bridge/measurement_validation_agent/output.tf
@@ -1,0 +1,4 @@
+output "measurement_validation_agent_lambda_name" {
+  value       = aws_lambda_function.measurement_validation_agent_lambda.function_name
+  description = "Measurement validation agent lambda function name."
+}

--- a/fbpcs/infra/cloud_bridge/measurement_validation_agent/variable.tf
+++ b/fbpcs/infra/cloud_bridge/measurement_validation_agent/variable.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  description = "region of the aws resources"
+  default     = "us-west-2"
+}
+
+variable "tag_postfix" {
+  description = "the postfix to append after a resource name or tag"
+  default     = ""
+}
+
+variable "aws_account_id" {
+  description = "your aws account id, that's used to read encrypted S3 files"
+  default     = ""
+}
+
+variable "measurement_validation_agent_lambda_function_name" {
+  description = "Name of the Measurement validation Agent lambda"
+  default     = ""
+}
+
+variable "measurement_validation_agent_lambda_source_bucket" {
+  description = "S3 bucket where source code zip file for Measurement validation Agent is stored."
+  default     = ""
+}
+
+variable "measurement_validation_agent_lambda_input_bucket" {
+  description = "S3 bucket where input data for Measurement validation Agent is stored."
+  default     = ""
+}
+
+variable "measurement_validation_agent_lambda_s3_key" {
+  description = "S3 key for source code zip file for Measurement validation Agent."
+  default     = ""
+}


### PR DESCRIPTION
Summary:
# Context
As part of KIA - ALS integration. I added logic required for PCR measurement validation to KIA lambda function. As part of this integration, the Lambda function needs to temporarily assume a different IAM role to query the Meta AWS deployed QLDB, validate the measurements and then assume it's original IAM role. While the KIA-ALS integration worked fine, the function was not able to assume it's original role post that. Based on further investigation I see hopping back and forth between IAM roles is not supported right now in AWS Lambda function. In order to solve this issue, I am moving the measurement validation logic to a new lambda that will be invoked from KIA.
Thus, KIA will now invoke this new lambda with the PCRs and QLDB parameters. The new Measurement Validation Agent, will assume the role provided, validate the measurements and return back Success/Failure status back to KIA. Based on the Successful measurement validation then, KIA will proceed with the encryption and on Faillure will terminate the process with a Failed status.

# Changes in the stack
1. Add a new QLDB repo handler : This handler will create the ALS QLDB repository.
2. Add a Measurement validation handler : This handler will hold logic to validate the measurements.
3. Add Measurement validation Runner : Entry point of the lambda function, this will validate the input and call the handlers.
4. Add Deployment changes for the new lambda : Changes need to deploy the new lambda as part of CB AWS infra.
5. Invoke Lambda from KIA :  Add changes required to invoke the MVA lambda from KIA.
6.  Add deployment changes for KIA : As part of this, we will need to pass the MVA lambda function name to KIA, add changes to deployment script for that.
7. Remove Measurement validation code from KIA : Now that the measurement validation logic is moved to a new lambda function, remove it from KIA.
8. Changes to undeploy MVA lambda : Add changes to undeploy MVA lambda when CB is uninstalled.
9. Add changes to CB API to pass QLDB parameters to KIA.
10. Add changes to Coordinator to pass QLDB parameters to CB.

# Changes in this diff
Add Deployment changes for the new lambda : Changes need to deploy the new lambda as part of CB AWS infra.

Differential Revision: D49374679

