### PR TITLE
Add permission to KIA policy to assume other IAM roles

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -83,8 +83,10 @@ RUN pip3 install \
     --target awsbundle \
     cryptography -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 
-RUN pip install pyqldb -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip3 install pyqldb -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 RUN pip3 install pyion2json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip3 install dataclasses-json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip3 install injector -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 # #########################################
 # Spring Boot
 # #########################################

--- a/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
@@ -83,6 +83,14 @@ resource "aws_iam_role_policy" "kia_lambda_access_policy" {
          "logs:PutLogEvents"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowToAssumeRole",
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Summary:
# Context
We need to validate the PCR measurements send to KIA from Coordinator. For this we will leverage the immutable AWS QLDB query.
In this stack, we will add changes for the same in - Key Injection Agent, KIA Deployment script and Cloudbridge backend.

# Changes in the stack
1. Add qldb iam role as input to KIA.
2. Add measurement validation logic in KIA.
3. Integrate measurement validation logic handler in KIA runner.
4. Add query source measurement validation logic.
5. Add logic to assume specific QLDB read IAM role in the measurement validation handler.
6. Add qldb related fields to KIA input.
7. Make changes to KIA deployment script.
8. Make changes to Cloudbridge backend to send qldb fields to KIA.

# Changes in the diff
During encrytion agent testing, got a permission issue as KIA needs access to assume the other role. Thus in this diff adding the required access to KIA.

Differential Revision: D49420564

