### PR TITLE
Bump GRAPHAPI_DEFAULT_VERSION to v17.0

### DIFF
--- a/fbpcs/pl_coordinator/bolt_graphapi_client.py
+++ b/fbpcs/pl_coordinator/bolt_graphapi_client.py
@@ -31,7 +31,7 @@ from fbpcs.utils.config_yaml.exceptions import ConfigYamlBaseException
 
 GRAPHAPI_HTTPS = "https://"
 GRAPHAPI_DEFAULT_DOMAIN = "graph.facebook.com"
-GRAPHAPI_DEFAULT_VERSION = "v15.0"
+GRAPHAPI_DEFAULT_VERSION = "v17.0"
 
 GRAPHAPI_INSTANCE_STATUSES: Dict[str, PrivateComputationInstanceStatus] = {
     **{status.value: status for status in PrivateComputationInstanceStatus},


### PR DESCRIPTION
Summary:
We call ads apis (categorized as marketing apis) in MPC PL study one-command runner, which still uses v15.0 deprecated on Sept 20th, 2023:
```
2023-09-21 14:37:55,490Z ERROR t:MainThread n:__main__ ! Error getting study data: b'{"error":{"message":"(#2635) You are calling a deprecated version of the Ads API. Please update to the latest version: v17.0.","type":"OAuthException","code":2635,"fbtrace_id":"A7mDKs8IkqiVETMe3QHusOW"}}'
```

This diff bumps the default version to v17.0 (recommended, valid until May 14, 2024), similar to  D41862704.

Reviewed By: wuman

Differential Revision: D49525182


