### PR TITLE
Restrict cloudwatch logs logging bucket objects retention to 30 days

### DIFF
--- a/fbpcs/infra/cloud_bridge/advertiser_infra_logging/base_logging_infra/s3_logging_bucket.tf
+++ b/fbpcs/infra/cloud_bridge/advertiser_infra_logging/base_logging_infra/s3_logging_bucket.tf
@@ -38,3 +38,17 @@ resource "aws_s3_bucket_policy" "s3_logging_bucket_policy" {
 }
 POLICY
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "logging_bucket_config" {
+  bucket = aws_s3_bucket.s3_logging_bucket.id
+
+  rule {
+    id = "${var.s3_logging_bucket_name}-logging-bucket"
+
+    expiration {
+      days = 30
+    }
+
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
Summary:
Lifecycle rules on S3 buckets allow to specify actions such as transitioning to different storage tier, deleting objects after expiration, and specifying rule prefixes to subsets of objects in the bucket.

Currently, the S3 logging bucket holding telemetry of advertiser's AWS logs for TEE-PL infra retains log objects for ever whereas the cloudwatch logs groups hold it for 7 days.

This diff changes the object retention period for S3 logging bucket to 30 days to maintain hierarchical storage retention period for advertiser AWS service logs.

Reviewed By: ramesc

Differential Revision: D49677147


