### PR TITLE
Add Athena Query logging infra deploy and undeploy support in PC installation toolkit

### DIFF
--- a/fbpcs/infra/cloud_bridge/advertiser_infra_logging/athena_logging/log_to_cloudwatch.tf
+++ b/fbpcs/infra/cloud_bridge/advertiser_infra_logging/athena_logging/log_to_cloudwatch.tf
@@ -1,0 +1,186 @@
+provider "aws" {
+  region = var.region
+}
+
+provider "archive" {}
+
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+## create a cloudwatch log group name to capture Athena operations usage
+locals {
+  athena_cloudwatch_log_group = "/aws/athena/${var.installation_tag}"
+}
+
+## Get the existing resource for S3 logging bucket
+data "aws_s3_bucket" "s3_logging_bucket" {
+  bucket = var.s3_logging_bucket_name
+}
+
+## Get the advertiser infra common kinesis Log Stream
+data "aws_kinesis_stream" "logs_kinesis_stream" {
+  name = var.kinesis_log_stream_name
+}
+
+## Create a cloudwatch athena log group
+resource "aws_cloudwatch_log_group" "cloudtrail_athena_logs" {
+  name              = local.athena_cloudwatch_log_group
+  retention_in_days = 7
+}
+
+### Setup athena cloudtrail iam role and policies to write to cloudwatch log group
+resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
+  name = "${var.installation_tag}-athena-ct-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "cloudtrail_cloudwatch_write_policy" {
+  name = "${var.installation_tag}-athena-ct-policy"
+  role = aws_iam_role.cloudtrail_cloudwatch_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {   
+            "Sid": "AWSCloudTrailCreateLogs",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],  
+            "Resource": [
+                "${aws_cloudwatch_log_group.cloudtrail_athena_logs.arn}:*"
+            ]   
+        }  
+    ]   
+}
+EOF
+}
+
+
+### Setup athena logging for cloudtrail to cloudwatch log group
+resource "aws_cloudtrail" "cloudtrail_athena_cloudwatch_logging" {
+  name                       = "${var.installation_tag}-athena-trail"
+  s3_bucket_name             = var.s3_logging_bucket_name
+  s3_key_prefix              = "athena_logs"
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_cloudwatch_role.arn
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudtrail_athena_logs.arn}:*"
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+  }
+}
+
+## Create IAM Role for CloudWatch to publish logs to Kinesis
+resource "aws_iam_role" "cloudwatch_kinesis_role" {
+  name = "${var.installation_tag}-athena-cw-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+## Create IAM Policy for CloudWatch to publish athena logs to the advertiser infra common Kinesis stream
+resource "aws_iam_role_policy" "cloudwatch_kinesis_write_policy" {
+  name = "${var.installation_tag}-athena-cw-policy"
+  role = aws_iam_role.cloudwatch_kinesis_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudwatchKinesisWriteLogs",
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:PutRecord"
+            ],
+            "Resource": [
+                "${data.aws_kinesis_stream.logs_kinesis_stream.arn}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+## Find all VPCs in the account that belongs to TEE-PL infra
+data "aws_vpcs" "all_vpcs" {
+  tags = {
+    Application = "Private Computation Infrastructure"
+  }
+}
+
+## Get details of all TEE-PL VPCs
+data "aws_vpc" "filtered_vpc" {
+  for_each = toset(data.aws_vpcs.all_vpcs.ids)
+  id       = each.key
+}
+
+## Find all eks clusters in the account
+data "aws_eks_clusters" "all_clusters" {}
+
+## Get details of all the eks clusters in the account
+data "aws_eks_cluster" "filtered_cluster" {
+  for_each = toset(data.aws_eks_clusters.all_clusters.names)
+  name     = each.key
+}
+
+## Extract the names of all TEE-PL VPCs
+locals {
+  vpc_name_list = [for vpc_name, params in data.aws_vpc.filtered_vpc : split("/", params.tags["Name"])[0]]
+}
+
+## Create a list of TEE-PL EKS cluster names
+locals {
+  tee_pl_eks_cluster_name_list = [for cluster_name, params in data.aws_eks_cluster.filtered_cluster : cluster_name if contains(local.vpc_name_list, params.tags["MainStack"])]
+}
+
+## Create the filter regex of TEE-PL EKS cluster names
+locals {
+  tee_pl_eks_cluster_name_regex = join("|", local.tee_pl_eks_cluster_name_list)
+}
+
+## Push athena cloudwatch log group to Kinesis stream
+resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_to_kinesis_subscription" {
+  name            = "${var.installation_tag}-athena-log-filter"
+  log_group_name  = aws_cloudwatch_log_group.cloudtrail_athena_logs.name
+  filter_pattern  = "{($.eventSource = \"athena.amazonaws.com\") && ($.userIdentity.sessionContext.sessionIssuer.userName = %^eksctl-.*${local.tee_pl_eks_cluster_name_regex}.*%)}"
+  destination_arn = data.aws_kinesis_stream.logs_kinesis_stream.arn
+  role_arn        = aws_iam_role.cloudwatch_kinesis_role.arn
+}

--- a/fbpcs/infra/cloud_bridge/advertiser_infra_logging/athena_logging/variable.tf
+++ b/fbpcs/infra/cloud_bridge/advertiser_infra_logging/athena_logging/variable.tf
@@ -1,0 +1,22 @@
+variable "region" {
+  description = "region of the advertiser aws resources"
+  default     = "us-west-2"
+}
+
+variable "installation_tag" {
+  type        = string
+  description = "Name of the TEE-PL advertiser infra installation tag"
+  default     = "default-installation-tag"
+}
+
+variable "s3_logging_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket where all logs generated from TEE-PL advertiser side KMS cloudtrail logs will be stored"
+  default     = "s3-log-bucket-advertiser"
+}
+
+variable "kinesis_log_stream_name" {
+  type        = string
+  description = "Name of the kinesys stream where various cloudwatch log groups (s3, Lambda, KMS etc.) in TEE-PL advertiser infra would push logs"
+  default     = "kinesis-log-stream-advertiser"
+}

--- a/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh
+++ b/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh
@@ -90,6 +90,26 @@ undeploy_aws_resources() {
         -var "query_results_key_path=$query_results_key_path"
     echo "########################Deletion completed########################"
 
+    echo "######################## Deleting Advertiser Side Athena Logging Infrastructure ######################"
+    log_streaming_data "starting to delete Advertiser side Athena logging infra"
+
+    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/athena_logging
+
+    terraform init -reconfigure \
+        -backend-config "bucket=$s3_bucket_config" \
+        -backend-config "region=$region" \
+        -backend-config "key=tfstate/athena_logging_infra_$tag_postfix.tfstate"
+
+    terraform destroy \
+        -auto-approve \
+        -var "region=$region" \
+        -var "s3_logging_bucket_name=$s3_logging_bucket" \
+        -var "kinesis_log_stream_name=$kinesis_stream_name" \
+        -var "installation_tag=athena$tag_postfix"
+
+    echo "######################## Cleaned up Advertiser Side Athena Logging Infrastructure ######################"
+    log_streaming_data "Cleaned up Advertiser side Athena logging infra"
+
     echo "######################## Deleting Advertiser Side KMS Logging Infrastructure ######################"
     log_streaming_data "starting to delete Advertiser side KMS logging infra"
 
@@ -583,6 +603,26 @@ deploy_aws_resources() {
 
     echo "######################## Deployed Advertiser Side KMS Logging Infrastructure ######################"
     log_streaming_data "finished deploying Advertiser side KMS logging infra"
+
+    echo "######################## Deploy Advertiser Side Athena Logging Infrastructure ######################"
+    log_streaming_data "starting to deploy Advertiser side Athena logging infra"
+
+    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/athena_logging
+
+    terraform init -reconfigure \
+        -backend-config "bucket=$s3_bucket_config" \
+        -backend-config "region=$region" \
+        -backend-config "key=tfstate/athena_logging_infra_$tag_postfix.tfstate"
+
+    terraform apply \
+        -auto-approve \
+        -var "region=$region" \
+        -var "s3_logging_bucket_name=$s3_logging_bucket" \
+        -var "kinesis_log_stream_name=$kinesis_stream_name" \
+        -var "installation_tag=athena$tag_postfix"
+
+    echo "######################## Deployed Advertiser Side Athena Logging Infrastructure ######################"
+    log_streaming_data "finished deploying Advertiser side Athena logging infra"
 
     echo "########################Finished AWS Infrastructure Deployment########################"
     log_streaming_data "finished deploying resources..."


### PR DESCRIPTION
Summary:
This diff is adds support for deploying and destroying the complete advertiser side Athena query logging infrastructure as part of PC deployment toolkit

 {F1109703139}

Reviewed By: ramesc

Differential Revision:
D49858577

Privacy Context Container: L1199492

