### PR TITLE
upgrade urllib3 version in fbpcs

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -3,7 +3,7 @@ botocore==1.21.65
 cython==0.29.30 # required by thriftpy2 setup
 dataclasses-json==0.5.2 # fbpcp requires this version, so we must as well
 docopt>=0.6.2
-fbpcp~=0.6 # depending on: boto3, botocore
+fbpcp~=0.6.1 # depending on: boto3, botocore
 marshmallow==3.5.1
 networkx>=2.6.3
 requests>=2.26.0
@@ -13,6 +13,6 @@ thriftpy2==0.4.14
 pytz>=2022.1
 thrift>=0.16.0 # logging_service client requires this
 tqdm==4.55.1 # fbpcp requires this version, so we must as well
-urllib3==1.26.7 # fbpcp requires this version, so we must as well
+urllib3==1.26.17 # fbpcp requires this version, so we must as well
 fastapi==0.93.0 # required by smart agent setup
 uvicorn==0.20.0 # required by smart agent setup


### PR DESCRIPTION
Summary:
# Context
 T165465798

## Reference on security vulnerability in a package dependency
https://github.com/urllib3/urllib3/security/advisories/GHSA-v845-jxx5-vc9f
https://github.com/urllib3/urllib3/commit/01220354d389cd05474713f8c982d05c9b17aafb
https://github.com/urllib3/urllib3/commit/644124ecd0b6e417c527191f866daa05a5a2056d
https://github.com/advisories/GHSA-v845-jxx5-vc9f

# What
fix security vulnerability in a package dependency defined in the repository, facebookresearch/fbpcp and fbpcs

Reviewed By: danbunnell, Kewen12

Differential Revision: D49924173

