### PR TITLE
Fix minor grammar error and link LICENSE file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PCS (Private Computation Solutions)
-Private Computation Solutions provides multiple solutions that leverage various Privacy Enhancing Technologies (e.g., multi-party computation, differential privacy) used across Measurement and Signals. The existing solutions includes Private Lift and Private Attribution, which allow calculations of Lift and Attribution metrics without revealing opportunity or conversion data on an individual level through 2PC.
+Private Computation Solutions provides multiple solutions that leverage various Privacy Enhancing Technologies (e.g., multi-party computation, differential privacy) used across Measurement and Signals. The existing solutions include Private Lift and Private Attribution, which allow calculations of Lift and Attribution metrics without revealing opportunity or conversion data on an individual level through 2PC.
 
 ## AWS Infra Set-up
 * [Instruction](fbpcs/infra/cloud_bridge/README.md)
@@ -9,4 +9,4 @@ Private Computation Solutions provides multiple solutions that leverage various 
 * [Emp games (including Lift and Attribution)](fbpcs/emp_games/README.md)
 
 ## License
-PCS is [MIT](LICENSE) licensed, as found in the LICENSE file.
+PCS is [MIT](LICENSE) licensed, as found in the [LICENSE](LICENSE) file.


### PR DESCRIPTION
Noticed a minor grammatical error and also linked the LICENSE file.