### PR TITLE
Reducing memory required from 3 GB to 2 GB

### DIFF
--- a/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
+++ b/fbpcs/infra/cloud_bridge/key_injection_agent/main.tf
@@ -124,7 +124,7 @@ resource "aws_lambda_function" "kia_lambda" {
   runtime          = "python3.9"
   s3_bucket        = var.kia_lambda_s3_bucket
   s3_key           = var.kia_lambda_s3_key
-  memory_size      = 3072
+  memory_size      = 2048
   timeout          = 900
   publish          = true
   environment {


### PR DESCRIPTION
Summary:
# Context
We are facing an issue while onboarding the first advertiser to TEE PL, where the advertiser is not able to install cloudbridge as the deployment fails on KIA lambda function creation.
Advertiser is facing a validation error.

# Root cause
We were not able to reproduce the same issue in dev or QA AWS accounts, where we were able to deploy KIA with the same deployment settings.
But, I can see that there an issue with memory limit being faced in some first time usecases in some regions -  https://stackoverflow.com/questions/70943739/aws-lambda-memorysize-value-failed-to-satisfy-constraint

# Fix
Changed the memory required from 3 GB to 2 GB. This should be good enough limit, as we do not require a lot of memory in current implementation.

Reviewed By: chennyc

Differential Revision: D50473168


