### PR TITLE
Hot fix to prevent automatic creation of data ingestion lambda log group

### DIFF
--- a/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/main.tf
@@ -164,6 +164,15 @@ resource "aws_iam_role_policy_attachment" "lambda_kinesis_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
 }
 
+## Create log group explicitly
+locals {
+  data_ingestion_lambda_log_group = "/aws/lambda/${var.data_ingestion_lambda_name}"
+}
+
+resource "aws_cloudwatch_log_group" "data-ingestion-log-group" {
+  name = local.data_ingestion_lambda_log_group
+}
+
 resource "aws_lambda_function" "lambda_processor" {
   s3_bucket     = var.data_processing_lambda_s3_bucket
   s3_key        = var.data_processing_lambda_s3_key

--- a/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh
+++ b/fbpcs/infra/cloud_bridge/deploy_pc_infra.sh
@@ -167,7 +167,7 @@ undeploy_aws_resources() {
 
     log_streaming_data "starting to destroy Advertiser side lambda logging infra"
 
-    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/lambda_logging_new_log_group
+    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/lambda_logging_existing_log_group
 
     terraform init -reconfigure \
         -backend-config "bucket=$s3_bucket_config" \
@@ -179,8 +179,6 @@ undeploy_aws_resources() {
         -var "region=$region" \
         -var "lambda_name=$data_ingestion_lambda_name" \
         -var "kinesis_log_stream_name=$kinesis_stream_name"
-
-    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/lambda_logging_existing_log_group
 
     terraform init -reconfigure \
         -backend-config "bucket=$s3_bucket_config" \
@@ -543,7 +541,7 @@ deploy_aws_resources() {
 
     log_streaming_data "starting to deploy Advertiser side lambda logging infra"
 
-    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/lambda_logging_new_log_group/
+    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/lambda_logging_existing_log_group
 
     terraform init -reconfigure \
         -backend-config "bucket=$s3_bucket_config" \
@@ -555,8 +553,6 @@ deploy_aws_resources() {
         -var "region=$region" \
         -var "lambda_name=$data_ingestion_lambda_name" \
         -var "kinesis_log_stream_name=$kinesis_stream_name"
-
-    cd /terraform_deployment/terraform_scripts/advertiser_infra_logging/lambda_logging_existing_log_group
 
     terraform init -reconfigure \
         -backend-config "bucket=$s3_bucket_config" \

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/lambda.tf
@@ -32,6 +32,15 @@ resource "aws_iam_role" "lambda_iam" {
 EOF
 }
 
+## Create log group explicitly
+locals {
+  semi_data_ingestion_lambda_log_group = "/aws/lambda/manual-upload-trigger${var.tag_postfix}"
+}
+
+resource "aws_cloudwatch_log_group" "semi-data-ingestion-lambda-log-group" {
+  name = local.semi_data_ingestion_lambda_log_group
+}
+
 resource "aws_lambda_function" "lambda_trigger" {
   s3_bucket     = var.app_data_input_bucket_id
   s3_key        = "${var.data_upload_key_path}/${var.lambda_trigger_s3_key}"


### PR DESCRIPTION
Summary:
Data ingestion lambda cloudwatch log group is automatically created after lambda creation even if there is no explicit creation of the log group.

This might happen if the lambda is somehow triggered after its creation.

However subsequent infra creation steps assume the log-group is not present and tries to create it. This operation fails as the log group might have been automatically created by AWS

This diff explicitly creates the logs groups for data ingestion lambdas.

Reviewed By: ajinkya-ghonge

Differential Revision: D50751325


