### PR TITLE
Adding retrying module dependency to KIA deployment script

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -86,6 +86,7 @@ RUN pip3 install \
     cryptography -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 
 RUN pip3 install pyqldb -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
+RUN pip3 install retrying -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 RUN pip3 install pyion2json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 RUN pip3 install dataclasses-json -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/
 RUN pip3 install injector -t /terraform_deployment/terraform_scripts/key_injection_agent/kia_source_code/


### PR DESCRIPTION
Summary:
# Context
In D50562498 we added retrying logic to key generation in KIA. During development and local testing we build the project using buck, however for AWS deployment we use terraform (with docker image).
For the new dependency added here (retrying module). We also need to add the same to the Dockerfile so that it can be included in the KIA deployment.

# Changes in the diff
Added retrying module install step in Dockerfile for KIA.

Differential Revision:
D51490362

Privacy Context Container: L416713


