### PR TITLE
Remove extra semi colon from fbmeshd/nl/NetlinkMessage.h

### DIFF
--- a/fbpcs/data_processing/hash_slinging_salter/test/HashSlingingSalterTest.cpp
+++ b/fbpcs/data_processing/hash_slinging_salter/test/HashSlingingSalterTest.cpp
@@ -38,4 +38,4 @@ TEST(HashSalterTest, HashSalterSameAsPythonTest) {
       private_lift::hash_slinging_salter::base64SaltedHashFromBase64Key(
           piiKey, b64Salt);
   EXPECT_EQ(b64SaltedHashFromCpp, b64SaltedHashFromPy);
-};
+}


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995028


