### PR TITLE
Fix shadowed variable in fbpcs/emp_games/common/SecretSharing.hpp

### DIFF
--- a/fbpcs/emp_games/common/SecretSharing.hpp
+++ b/fbpcs/emp_games/common/SecretSharing.hpp
@@ -151,7 +151,7 @@ const std::vector<std::vector<O>> privatelyShareArraysFrom(
 
       // Perform the padding
       std::vector<T> paddedVec(vec.begin(), vec.end());
-      for (size_t i = 0; i < paddedLength - arrayLength; i++) {
+      for (size_t i_2_2 = 0; i_2_2 < paddedLength - arrayLength; i_2_2++) {
         const T paddingCopy = paddingValue;
         paddedVec.push_back(paddingCopy);
       }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D52582799


