### PR TITLE
Fix shadowed variable in fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp

### DIFF
--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.cpp
@@ -113,16 +113,16 @@ constructAdObjectFormatThresholdChecker(int64_t threshold) {
     for (const auto& [rule, metricsMap] : metrics->getAsMap()) {
       for (const auto& [aggregationName, aggregationData] :
            metricsMap->getAsMap()) {
-        for (const auto& [id, metrics] : aggregationData->getAsMap()) {
+        for (const auto& [id, metrics_2] : aggregationData->getAsMap()) {
           auto condition =
-              metrics->getAtKey("convs")->getEmpIntValue() >= kAnonymityLevel;
-          metrics->getAtKey("sales")->setEmpIntValue(emp::If(
+              metrics_2->getAtKey("convs")->getEmpIntValue() >= kAnonymityLevel;
+          metrics_2->getAtKey("sales")->setEmpIntValue(emp::If(
               condition,
-              metrics->getAtKey("sales")->getEmpIntValue(),
+              metrics_2->getAtKey("sales")->getEmpIntValue(),
               hiddenMetric));
-          metrics->getAtKey("convs")->setEmpIntValue(emp::If(
+          metrics_2->getAtKey("convs")->setEmpIntValue(emp::If(
               condition,
-              metrics->getAtKey("convs")->getEmpIntValue(),
+              metrics_2->getAtKey("convs")->getEmpIntValue(),
               hiddenMetric));
         }
       }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D52582794


