### PR TITLE
Fix shadowed variable in fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/LiftGameProcessedData_impl.h
@@ -74,8 +74,8 @@ void LiftGameProcessedData<schedulerId>::writeToCSV(
       purchaseValueSquared.begin(),
       purchaseValueSquared.end(),
       std::back_inserter(purchaseValueSquaredShares),
-      [](const SecValueSquared<schedulerId>& purchaseValueSquared) {
-        return purchaseValueSquared.extractIntShare().getValue();
+      [](const SecValueSquared<schedulerId>& purchaseValueSquared_2) {
+        return purchaseValueSquared_2.extractIntShare().getValue();
       });
   std::vector<bool> testReachShares = testReach.extractBit().getValue();
 


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52582861


