### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/coordinator-publish.yml
+++ b/.github/workflows/coordinator-publish.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Set output
         id: vars
-        run: echo ::set-output name=ref::${GITHUB_REF##*/}
+        run: echo "ref=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Tag docker image
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter