### PR TITLE
Remove unused variables in fbpcs/emp_games/pcf2_shard_combiner/util/AggMetricsThresholdCheckers_impl.h (#2369)

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/util/AggMetricsThresholdCheckers_impl.h
+++ b/fbpcs/emp_games/pcf2_shard_combiner/util/AggMetricsThresholdCheckers_impl.h
@@ -157,11 +157,11 @@ checkThresholdAndUpdateMetric(
     return getGroupLiftChecker<schedulerId, usingBatch, inputEncryption>(
         threshold, sentinelVal);
   } else {
-    return [threshold, sentinelVal](
-               AggMetrics_sp<schedulerId, usingBatch, inputEncryption>) {
-      // for any other type do nothing.
-      XLOG(WARN) << "Threshold: " << threshold << " is unused";
-    };
+    return
+        [threshold](AggMetrics_sp<schedulerId, usingBatch, inputEncryption>) {
+          // for any other type do nothing.
+          XLOG(WARN) << "Threshold: " << threshold << " is unused";
+        };
   }
 }
 


### PR DESCRIPTION
Summary:

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: danzimm, ajinkya-ghonge, meyering

Differential Revision: D52849677


