### PR TITLE
Fix shadowed variable in fbpcs/emp_games/lift/metadata_compaction/test/MetadataCompactorGameTest.cpp

### DIFF
--- a/fbpcs/emp_games/lift/metadata_compaction/test/MetadataCompactorGameTest.cpp
+++ b/fbpcs/emp_games/lift/metadata_compaction/test/MetadataCompactorGameTest.cpp
@@ -52,8 +52,8 @@ class MetadataCompactorGameTestFixture : public ::testing::TestWithParam<bool> {
     auto future1 = std::async(
         createCompactorGame<1>, 1, GetParam(), std::move(factories[1]));
 
-    auto compactorGame0 = future0.get();
-    auto compactorGame1 = future1.get();
+    auto compactorGame0_2 = future0.get();
+    auto compactorGame1_2 = future1.get();
   }
 };
 


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: chennyc

Differential Revision: D52582915


