### PR TITLE
Write test for Utils copy_file and remove ')' from SameFileError message

### DIFF
--- a/fbpcs/infra/logging_service/download_logs/utils/utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/utils.py
@@ -198,7 +198,7 @@ class Utils:
             file_path = shutil.copy2(src=source, dst=destination)
         except shutil.SameFileError as err:
             raise shutil.SameFileError(
-                f"{source} and {destination} represents same file)"
+                f"{source} and {destination} represents same file"
             ) from err
         except PermissionError as err:
             raise PermissionError("Permission denied") from err


### PR DESCRIPTION
Summary: Write a unit test for Utils copy_file function and edit an existing error message

Differential Revision: D52892160


