### PR TITLE
Fix shadowed variable in fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGameTest.cpp

### DIFF
--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerGameTest.cpp
@@ -255,13 +255,13 @@ TEST_P(ShardCombinerGameTestFixture, TestAggLogic) {
   std::string publisherFileName = "input_publisher.json";
   std::string expectedOutFileNamePrefix = "expected_out_shards_";
   auto testFn = [&](int32_t numShards,
-                    bool usingBatch,
-                    common::SchedulerType schedulerType) {
+                    bool usingBatch_2,
+                    common::SchedulerType schedulerType_2) {
     std::string expectedOutFileName =
         folly::sformat("{}{}.json", expectedOutFileNamePrefix, numShards);
-    if (usingBatch) {
+    if (usingBatch_2) {
       runTestWithParams<true>(
-          schedulerType,
+          schedulerType_2,
           baseDir_ + "combiner_logic_test/",
           partnerFileName,
           publisherFileName,
@@ -269,7 +269,7 @@ TEST_P(ShardCombinerGameTestFixture, TestAggLogic) {
           expectedOutFileName);
     } else {
       runTestWithParams<false>(
-          schedulerType,
+          schedulerType_2,
           baseDir_ + "combiner_logic_test/",
           partnerFileName,
           publisherFileName,


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D52958938


