### PR TITLE
Fix shadowed variable in fbpcs/data_processing/sharding/GenericSharder.cpp

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.cpp
+++ b/fbpcs/data_processing/sharding/GenericSharder.cpp
@@ -162,9 +162,9 @@ void GenericSharder::shard() {
 
   bufferedReader->close();
 
-  for (auto i = 0; i < numShards; ++i) {
-    outFiles.at(i)->close();
-    XLOG(INFO, fmt::format("Shard {} has {} rows", i, getRowsForShard(i)));
+  for (auto i_2 = 0; i_2 < numShards; ++i_2) {
+    outFiles.at(i_2)->close();
+    XLOG(INFO, fmt::format("Shard {} has {} rows", i_2, getRowsForShard(i_2)));
   }
 
   XLOG(INFO) << "All file writes successful";


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dmm-fb

Differential Revision: D52959130


