### PR TITLE
Fix shadowed variable in fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.cpp

### DIFF
--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.cpp
@@ -184,8 +184,8 @@ void UdpEncryptorApp::processMyData(
   auto data = folly::collectAll(std::move(futures)).get();
   for (auto& datum : data) {
     datum.throwUnlessValue();
-    auto& [index, data] = datum.value();
-    encryptor_->pushLinesFromMe(std::move(data), std::move(index));
+    auto& [index, data_2] = datum.value();
+    encryptor_->pushLinesFromMe(std::move(data_2), std::move(index));
   }
   return;
 }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: haochenuw

Differential Revision: D52958941


