### PR TITLE
Remove unused exception parameter from fbpcs/data_processing/id_combiner/DataValidation.cpp

### DIFF
--- a/fbpcs/data_processing/id_combiner/DataValidation.cpp
+++ b/fbpcs/data_processing/id_combiner/DataValidation.cpp
@@ -60,7 +60,7 @@ void validateCsvData(std::istream& dataFile) {
     for (auto& v : rowVec) {
       try {
         folly::to<std::uint64_t>(v);
-      } catch (std::exception& e) {
+      } catch (std::exception&) {
         XLOG(FATAL) << v << " failed to parse to int";
       }
     }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: yanglu-fb

Differential Revision: D52957709


