### PR TITLE
Remove unused exception parameter from fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp

### DIFF
--- a/fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp
+++ b/fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp
@@ -57,7 +57,7 @@ void aggregateLiftNonIdColumns(
       try {
         int32_t val = std::stoi(dRow[col]);
         columnValues[col].push_back(val);
-      } catch (std::exception& err) {
+      } catch (std::exception&) {
         XLOG(FATAL)
             << "Error: Exception caught during casting string to int.\n"
             << "\tFor PL, non-id columns has to be int to aggregate in case of duplicates.";


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dmm-fb

Differential Revision: D52957687


