### PR TITLE
Fix the error "ImportError: cannot import name 'is_s3express_bucket' from 'botocore.utils'"

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -20,9 +20,11 @@ RUN pip install \
     awscli
 
 # Note: the dataclasses backport can be removed once Python 3 is upgraded to 3.7
+# Note: pin the s3transfer==0.8.0 to fix the error "is_s3express_bucket"
 RUN pip3 install \
     boto3 \
-    dataclasses
+    dataclasses \
+    s3transfer==0.10.0
 
 ##########################################
 # Install fbpcp modules


### PR DESCRIPTION
Summary:
When QA testing the pc infra deployment, they got:
https://pxl.cl/4f8g1

It happend at https://www.internalfb.com/code/fbsource/[2b54d293a02bed7a60ff1d16502c3e0cfaa02d54]/fbcode/fbpcs/infra/cloud_bridge/util.sh?lines=169, which is this command:
```
aws ec2 describe-regions --region us-west-1 --query "Regions[].{Name:RegionName}" --output text
```

I login to the pod and could reproduce it:
https://pxl.cl/4f8gV

After seach on the internet, turns out it's version mismatch. Source: https://repost.aws/it/questions/QU2l9P6ZEhSkSL0lFQonOHfQ/a-lambda-failed-to-start-with-the-error-cannot-import-name-is-s3express-bucket-from-botocore-utils

The rootcause is is_s3express_bucket is added after s3transfer==0.8.0

Reviewed By: ztlbells, chennyc

Differential Revision: D53145762


