### PR TITLE
fix the error when deploy mpc

### DIFF
--- a/fbpcs/infra/cloud_bridge/Dockerfile
+++ b/fbpcs/infra/cloud_bridge/Dockerfile
@@ -20,9 +20,11 @@ RUN pip install \
     awscli
 
 # Note: the dataclasses backport can be removed once Python 3 is upgraded to 3.7
+# Note: pin the s3transfer==0.8.0 to fix the error "is_s3express_bucket"
 RUN pip3 install \
     boto3 \
-    dataclasses
+    dataclasses \
+    s3transfer==0.10.0
 
 ##########################################
 # Install fbpcp modules


### PR DESCRIPTION
Summary:
Error: putting S3 Bucket Notification Configuration: InvalidArgument: The ARN cannot be null or empty

Turns out for MPC deployment, it's expecting the "var.ingestion_input_data_validation_lambda_arn" in https://www.internalfb.com/code/fbsource/[af6a46ce537f7e813de3d15e6d99a485fa4e4bbd]/fbcode/fbpcs/infra/cloud_bridge/s3_bucket_notification/main.tf. While the deploy.sh doesn't pass it in because it only exists in the tee-pl.

The solution is to also deploy what is needed. This won't affect anyone since we won't have any new users to MPC.

Differential Revision: D53145774


