### PR TITLE
Adding lambda get function for PC prevalidation KIA lambda check

### DIFF
--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy_no_compute.json
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/iam_policies/fb_pc_iam_policy_no_compute.json
@@ -54,7 +54,8 @@
         },
         {
             "Action": [
-                "lambda:InvokeFunction"
+                "lambda:InvokeFunction",
+                "lambda:GetFunction"
             ],
             "Effect": "Allow",
             "Resource": "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${KIA_LAMBDA_NAME}"


### PR DESCRIPTION
Summary:
Currently, our cb instance is not supporting kia_service status checking, and it'll display the error as below when we fetch the kia_service from our smart platform:
"Failed to fetch Lambda status during resource check.
Error: User: arn:aws:sts::046312032962:assumed-role/vg-onebox-111-feb2-ConversionsApiGatewayIamRole-toCtIrRgJBMz/i-0de4416bd949ed716 is not authorized to perform: lambda:GetFunction on resource: arn:aws:lambda:us-west-2:046312032962:function:cb-kia-5ujbtee-t0ug because no identity-based policy allows the lambda:GetFunction action (Service: AWSLambda; Status Code: 403; Error Code: AccessDeniedException; Request ID: 2199e72e-a5c4-4dc0-bef1-47fb848a9e04; Proxy: null)"
To resolve this issue, we can add lambda:GetFunction to the existing I AM policy.

Differential Revision: D53434002


