### PR TITLE
Upgrading fast api version

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -14,5 +14,5 @@ pytz>=2022.1
 thrift>=0.16.0 # logging_service client requires this
 tqdm==4.55.1 # fbpcp requires this version, so we must as well
 urllib3==1.26.18 # fbpcp requires this version, so we must as well
-fastapi==0.93.0 # required by smart agent setup
+fastapi==0.109.1 # required by smart agent setup
 uvicorn==0.20.0 # required by smart agent setup


### PR DESCRIPTION
Summary:
# Context
As PC oncall, received an alert that github has detected security vulnerability in fast api dependency.

# Changes
In this diff, upgrading fast api version to one recommended by github.

Differential Revision: D53487969


