### PR TITLE
Remove unused variables in fboss/agent/state/Interface.cpp

### DIFF
--- a/fbpcs/data_processing/sharding/GenericSharder.cpp
+++ b/fbpcs/data_processing/sharding/GenericSharder.cpp
@@ -65,15 +65,6 @@ void strReplaceNullColumnWithEmpty(std::string& str) {
 static const std::string kIdColumnPrefix = "id_";
 static const std::string numIds = "num_ids";
 
-/*
-  The chunk size for writing to cloud storage (currently
-  only AWS S3) must be greater than 5 MB, per the AWS
-  documentation. Otherwise multipart upload will fail.
-
-  The number below is 5 MB in bytes.
-*/
-static const uint64_t kBufferedWriterChunkSize = 5'242'880;
-
 std::vector<std::string> GenericSharder::genOutputPaths(
     const std::string& outputBasePath,
     std::size_t startIndex,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/fbpcf/pull/536

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: peygar

Differential Revision: D55099975


