### PR TITLE
Remove unused variables in fbit/itstorage/data_crawler/thread/ThreadedCrawler.cpp

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineFileCombinerTest.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineFileCombinerTest.cpp
@@ -58,7 +58,6 @@ class AttributionIdSpineFileCombinerTest : public testing::Test {
     std::string spineIdContentPath =
         "/tmp/AttributionIdSpineFileCombinerTestSpineIdContent" +
         std::to_string(randStart);
-    constexpr size_t kBufferedReaderChunkSize = 4096;
     data_processing::test_utils::writeVecToFile(dataContent, dataContentPath);
     data_processing::test_utils::writeVecToFile(
         spineIdContent, spineIdContentPath);

--- a/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineFileCombinerTest.cpp
+++ b/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineFileCombinerTest.cpp
@@ -58,7 +58,6 @@ class PrivateIdDfcaIdSpineFileCombinerTest : public testing::Test {
     std::string spineIdContentPath =
         "/tmp/PrivateIdDfcaIdSpineFileCombinerTestSpineIdContent" +
         std::to_string(randStart);
-    constexpr size_t kBufferedReaderChunkSize = 4096;
     data_processing::test_utils::writeVecToFile(dataContent, dataContentPath);
     data_processing::test_utils::writeVecToFile(
         spineIdContent, spineIdContentPath);

--- a/fbpcs/emp_games/dotproduct/DotproductGame_impl.h
+++ b/fbpcs/emp_games/dotproduct/DotproductGame_impl.h
@@ -53,7 +53,6 @@ std::vector<double> DotproductGame<schedulerId>::computeDotProduct(
   XLOG(INFO, "Performed the OR for all labels");
 
   constexpr uint64_t divisor = static_cast<uint64_t>(1e9);
-  constexpr double tolerance = 1e-7;
 
   auto prgFactory = std::make_unique<fbpcf::engine::util::AesPrgFactory>();
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D56022415


