### PR TITLE
Remove unused variables in fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp
@@ -156,10 +156,6 @@ GroupedLiftMetrics LiftCalculator::compute(
     }
 
     if (opportunity && opportunityTimestamp > 0) {
-      uint64_t value_subsum = 0;
-      uint64_t convCount = 0;
-      bool converted = false;
-      bool countedMatchAlready = false;
       if (testFlag) {
         updateTestMetrics(
             groupedLiftMetrics,

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationGame_impl.h
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationGame_impl.h
@@ -208,11 +208,6 @@ AggregationOutputMetrics AggregationGame<schedulerId>::computeAggregations(
 
   const int8_t indicatorSumWidth = adIdWidth;
   bool isPublisher = (myRole == common::PUBLISHER);
-  auto oramRole = isPublisher
-      ? fbpcf::mpc_std_lib::oram::IWriteOnlyOram<
-            fbpcf::mpc_std_lib::util::AggregationValue>::Alice
-      : fbpcf::mpc_std_lib::oram::IWriteOnlyOram<
-            fbpcf::mpc_std_lib::util::AggregationValue>::Bob;
 
   PrivateAggregationMetrics<schedulerId> aggregationMetrics{
       aggregationFormats,
@@ -294,11 +289,6 @@ AggregationGame<schedulerId>::computeAggregationsReformatted(
 
   const int64_t indicatorSumWidth = adIdWidth;
   bool isPublisher = (myRole == common::PUBLISHER);
-  auto oramRole = isPublisher
-      ? fbpcf::mpc_std_lib::oram::IWriteOnlyOram<
-            fbpcf::mpc_std_lib::util::AggregationValue>::Alice
-      : fbpcf::mpc_std_lib::oram::IWriteOnlyOram<
-            fbpcf::mpc_std_lib::util::AggregationValue>::Bob;
 
   PrivateAggregationMetrics<schedulerId> aggregationMetrics{
       aggregationFormats,


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D56022428


