### PR TITLE
Remove unused-but-set variables in fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp +1

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.cpp
@@ -63,8 +63,6 @@ GroupedLiftMetrics LiftCalculator::compute(
     bool useAdvancedLift) const {
   uint64_t opportunity = 0;
   uint64_t numImpressions = 0;
-  uint64_t numClicks = 0;
-  uint64_t totalSpend = 0;
   uint64_t testFlag = 0;
   uint64_t opportunityTimestamp = 0;
   uint8_t breakdownId = 0;
@@ -111,7 +109,6 @@ GroupedLiftMetrics LiftCalculator::compute(
 
     std::tie(parsedVal, parseStatus) =
         parseUint64OrDie("num_clicks", partsPublisher, colNameToIndex);
-    numClicks = parseStatus ? parsedVal : 0;
 
     std::tie(parsedVal, parseStatus) =
         parseUint64OrDie("num_impressions", partsPublisher, colNameToIndex);
@@ -119,7 +116,6 @@ GroupedLiftMetrics LiftCalculator::compute(
 
     std::tie(parsedVal, parseStatus) =
         parseUint64OrDie("total_spend", partsPublisher, colNameToIndex);
-    totalSpend = parseStatus ? parsedVal : 0;
 
     std::tie(parsedVal, parseStatus) =
         parseUint64OrDie("breakdown_id", partsPublisher, colNameToIndex);


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. I've gone through each of these by hand, but mistakes may have slipped through. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D56887378


