### PR TITLE
Delete Smart agent from build onedocker

### DIFF
--- a/binaries_out_lists/smart_agent.txt
+++ b/binaries_out_lists/smart_agent.txt
@@ -1,1 +1,0 @@
-smart_agent_server

--- a/docker/onedocker/test/Dockerfile.ubuntu
+++ b/docker/onedocker/test/Dockerfile.ubuntu
@@ -60,7 +60,7 @@ COPY --from=private_id /opt/private-id/bin/private-id-multi-key-server /usr/loca
 # OneDocker likes to change permissions as 'pcs' in /usr/local/bin, set these to be owned by 'pcs' to prevent an error
 RUN chown pcs:pcs /usr/local/bin/*
 
-# Copy fbpcs for building the pc_pre_validation_cli & smart_agent binary later
+# Copy fbpcs for building the pc_pre_validation_cli binary later
 COPY fbpcs/ /tmp/fbpcs-temp/fbpcs/
 RUN chown -R pcs:pcs /tmp/fbpcs-temp/fbpcs/
 
@@ -73,18 +73,14 @@ WORKDIR /home/pcs/src
 COPY docker/onedocker/prod/pip_requirements.txt /home/pcs/src/.
 RUN python3.8 -m pip install --user -r pip_requirements.txt
 
-# Build and copy the pc_pre_validation_cli & smart_agent binary
+# Build and copy the pc_pre_validation_cli binary
 USER pcs
 WORKDIR /tmp/fbpcs-temp/fbpcs/pc_pre_validation/
 RUN pyinstaller pc_pre_validation_cli.py --onefile --distpath /tmp/fbpcs-temp/fbpcs/pyinstaller/dist/
-WORKDIR /tmp/fbpcs-temp/fbpcs/smart_agent/
-RUN pyinstaller server.py --onefile --name smart_agent_server --distpath /tmp/fbpcs-temp/fbpcs/pyinstaller/dist/
 
 USER root
 RUN cp /tmp/fbpcs-temp/fbpcs/pyinstaller/dist/pc_pre_validation_cli /usr/local/bin/
 RUN chown pcs:pcs /usr/local/bin/pc_pre_validation_cli
-RUN cp /tmp/fbpcs-temp/fbpcs/pyinstaller/dist/smart_agent_server /usr/local/bin/
-RUN chown pcs:pcs /usr/local/bin/smart_agent_server
 WORKDIR /
 RUN rm -rf /tmp/fbpcs-temp/fbpcs/
 USER pcs
@@ -92,7 +88,7 @@ USER pcs
 # Link all the binaries into /home/pcs/onedocker/package
 RUN mkdir -p /home/pcs/onedocker/package
 WORKDIR /usr/local/bin
-RUN for b in $(ls attribution* lift* pid* shard* private-id* decoupled* pcf2* pc_pre* secure_random* smart_agent*); do ln -s $(pwd)/$b /home/pcs/onedocker/package/$b; done
+RUN for b in $(ls attribution* lift* pid* shard* private-id* decoupled* pcf2* pc_pre* secure_random*); do ln -s $(pwd)/$b /home/pcs/onedocker/package/$b; done
 
 # Link binaries name to match with onedocker binaries name
 RUN ln -s decoupled_attribution_calculator /home/pcs/onedocker/package/decoupled_attribution

--- a/extract-docker-binaries.sh
+++ b/extract-docker-binaries.sh
@@ -9,21 +9,20 @@ set -e
 PROG_NAME=$0
 usage() {
   cat << EOF >&2
-Usage: $PROG_NAME <emp_games|data_processing|pid|validation|smart_agent> [-t TAG] [-d DOCKER_IMAGE_NAME]
+Usage: $PROG_NAME <emp_games|data_processing|pid|validation> [-t TAG] [-d DOCKER_IMAGE_NAME]
 
 package:
   emp_games - extracts the binaries from fbpcs/emp-games docker image
   data_processing - extracts the binaries from fbpcs/data-processing docker image
   pid - extracts the binaries from private-id docker image
   validation - extracts the binaries from the onedocker docker image
-  smart_agent - extracts the binaries from the onedocker docker image
 -t TAG: uses the image with the given tag (default: latest)
 -d DOCKER_IMAGE_NAME: defines the image name to extract from
 EOF
   exit 1
 }
 
-PACKAGES="emp_games data_processing pid validation smart_agent"
+PACKAGES="emp_games data_processing pid validation"
 PACKAGE=$1
 if [[ ! " $PACKAGES " =~ $PACKAGE ]]; then
    usage
@@ -53,7 +52,6 @@ if [ -z "$DOCKER_IMAGE_NAME" ]; then
     data_processing) DOCKER_IMAGE_NAME="fbpcs/data-processing";;
     pid) DOCKER_IMAGE_NAME="fbpcs/onedocker/test";;
     validation) DOCKER_IMAGE_NAME="fbpcs/onedocker/test";;
-    smart_agent) DOCKER_IMAGE_NAME="fbpcs/onedocker/test";;
   esac
 fi
 DOCKER_IMAGE_PATH="${DOCKER_IMAGE_NAME}:${TAG}"
@@ -107,9 +105,4 @@ fi
 if [ "$PACKAGE" = "validation" ]; then
 docker create -ti --name "$TEMP_CONTAINER_NAME" "${DOCKER_IMAGE_PATH}"
 docker cp "$TEMP_CONTAINER_NAME":/usr/local/bin/pc_pre_validation_cli "$SCRIPT_DIR/binaries_out/."
-fi
-
-if [ "$PACKAGE" = "smart_agent" ]; then
-docker create -ti --name "$TEMP_CONTAINER_NAME" "${DOCKER_IMAGE_PATH}"
-docker cp "$TEMP_CONTAINER_NAME":/usr/local/bin/smart_agent_server "$SCRIPT_DIR/binaries_out/."
 fi

--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -14,5 +14,3 @@ pytz>=2022.1
 thrift>=0.16.0 # logging_service client requires this
 tqdm==4.55.1 # fbpcp requires this version, so we must as well
 urllib3==1.26.18 # fbpcp requires this version, so we must as well
-fastapi==0.109.1 # required by smart agent setup
-uvicorn==0.20.0 # required by smart agent setup

--- a/promote_scripts/promote_binaries.sh
+++ b/promote_scripts/promote_binaries.sh
@@ -41,7 +41,6 @@ binary_names=(
     'data_processing/attribution_id_combiner'
     'data_processing/private_id_dfca_id_combiner'
     'validation/pc_pre_validation_cli'
-    'smart_agent/smart_agent_server'
     'udp_encryptor'
 )
 

--- a/upload-binaries-to-s3-test.sh
+++ b/upload-binaries-to-s3-test.sh
@@ -9,20 +9,19 @@ set -e
 PROG_NAME=$0
 usage() {
   cat << EOF >&2
-Usage: $PROG_NAME <emp_games|data_processing|pid|validation|smart_agent> <tag>
+Usage: $PROG_NAME <emp_games|data_processing|pid|validation> <tag>
 
 package:
   emp_games - extracts the binaries from fbpcs/emp-games docker image
   data_processing - extracts the binaries from fbpcs/data-processing docker image
   pid - extracts the binaries from private-id docker image
   validation - extracts the binaries from the onedocker docker image
-  smart_agent - extracts the binaries from the onedocker docker image
   tag: used to determine the subfolder/version in s3 for each binary
 EOF
   exit 1
 }
 
-PACKAGES="emp_games data_processing pid validation smart_agent"
+PACKAGES="emp_games data_processing pid validation"
 PACKAGE=$1
 TAG=$2
 if [[ ! " $PACKAGES " =~ $PACKAGE ]] || [[ ! " $TAG " =~ $TAG ]]; then
@@ -45,7 +44,6 @@ private_id_dfca_aggregator_package="s3://$one_docker_repo/private_id_dfca/privat
 data_processing_repo="s3://$one_docker_repo/data_processing"
 private_id_repo="s3://$one_docker_repo/pid"
 validation_repo="s3://$one_docker_repo/validation"
-smart_agent_repo="s3://$one_docker_repo/smart_agent"
 udp_encryptor_package="s3://$one_docker_repo/data_processing/unified_data_process/udp_encryptor/${TAG}/udp_encryptor"
 
 if [ "$PACKAGE" = "emp_games" ]; then
@@ -87,9 +85,4 @@ fi
 if [ "$PACKAGE" = "validation" ]; then
 cd binaries_out || exit
 aws s3 cp pc_pre_validation_cli "$validation_repo/pc_pre_validation_cli/${TAG}/pc_pre_validation_cli"
-fi
-
-if [ "$PACKAGE" = "smart_agent" ]; then
-cd binaries_out || exit
-aws s3 cp smart_agent_server "$smart_agent_repo/smart_agent_server/${TAG}/smart_agent_server"
 fi

--- a/upload_scripts/upload-binaries-using-onedocker.sh
+++ b/upload_scripts/upload-binaries-using-onedocker.sh
@@ -9,14 +9,13 @@ set -e
 PROG_NAME=$0
 usage() {
   cat << EOF >&2
-Usage: $PROG_NAME <emp_games|data_processing|pid|validation|smart_agent> <tag> -c <config>
+Usage: $PROG_NAME <emp_games|data_processing|pid|validation> <tag> -c <config>
 
 package:
   emp_games - extracts the binaries from fbpcs/emp-games docker image
   data_processing - extracts the binaries from fbpcs/data-processing docker image
   pid - extracts the binaries from private-id docker image
   validation - extracts the binaries from the onedocker docker image
-  smart_agent - extracts the binaries from the onedocker docker image
 
 tag: used to determine the subfolder/version in s3 for each binary
 
@@ -25,7 +24,7 @@ EOF
   exit 1
 }
 
-PACKAGES="emp_games data_processing pid validation smart_agent"
+PACKAGES="emp_games data_processing pid validation"
 PACKAGE=$1
 TAG=$2
 
@@ -105,11 +104,5 @@ fi
 if [ "$PACKAGE" = "validation" ]; then
 cd binaries_out || exit
 onedocker_upload validation/pc_pre_validation_cli pc_pre_validation_cli
-cd .. || exit
-fi
-
-if [ "$PACKAGE" = "smart_agent" ]; then
-cd binaries_out || exit
-onedocker_upload smart_agent/smart_agent_server smart_agent_server
 cd .. || exit
 fi


### PR DESCRIPTION
Summary:
Smart agent was't release to production but we changed to tee-pl solution.
thus this MPC solution is safe to delete and smart agent is never productionized and used in production code.


Cleaning up Smart agent from build onedocker

Differential Revision: D57077666


