### PR TITLE
Fix vulnerability in tqdm dependency

### DIFF
--- a/fbpcs/pip_requirements.txt
+++ b/fbpcs/pip_requirements.txt
@@ -12,5 +12,5 @@ termcolor==1.1.0
 thriftpy2==0.4.14
 pytz>=2022.1
 thrift>=0.16.0 # logging_service client requires this
-tqdm==4.55.1 # fbpcp requires this version, so we must as well
+tqdm==4.66.3 # fbpcp requires this version, so we must as well
 urllib3==1.26.18 # fbpcp requires this version, so we must as well


### PR DESCRIPTION
Summary: Automated checkup noticed that this repo is using a version of tqdm with a known security vulnerability:  P1230616905. Moreover, D57063468 changes to the new version in fbpcp and comments indicate that these versions should be kept in sync.

Differential Revision: D57464049


