### PR TITLE
Remove unused variables in fbmeshd/rnl/tests/NetlinkSocketTest.cpp

### DIFF
--- a/fbpcs/emp_games/dotproduct/DotproductApp.h
+++ b/fbpcs/emp_games/dotproduct/DotproductApp.h
@@ -109,7 +109,7 @@ class DotproductApp {
     std::vector<std::vector<bool>> allLabels;
     auto lineNo = 0;
 
-    bool success = private_measurement::csv::readCsv(
+    private_measurement::csv::readCsv(
         inputPath,
         [&](const std::vector<std::string>& header,
             const std::vector<std::string>& parts) {


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D57344008


