### PR TITLE
Remove unused-variable in fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp

### DIFF
--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -181,7 +181,6 @@ class CalculatorAppTestFixture
 
     auto [communicationAgentFactory0, communicationAgentFactory1] =
         fbpcf::engine::communication::getSocketAgentFactoryPair(tlsInfo);
-    int epoch = 1546300800;
 
     auto future0 = std::async(
         runUDPInputProcessorWithScheduler<0>,


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D64279152


