### PR TITLE
Fix shadowed variable in fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp

### DIFF
--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
@@ -111,9 +111,9 @@ class AttributionAppTest
     std::string baseDir_ =
         private_measurement::test_util::getBaseDirFromPath(__FILE__);
     std::string tempDir = std::filesystem::temp_directory_path();
-    std::string outputPathAlice_ = folly::sformat(
+    std::string outputPathAlice_2 = folly::sformat(
         "{}/output_path_alice.json_{}", tempDir, folly::Random::secureRand64());
-    std::string outputPathBob_ = folly::sformat(
+    std::string outputPathBob_2 = folly::sformat(
         "{}/output_path_bob.json_{}", tempDir, folly::Random::secureRand64());
 
     attributionRules_ = std::vector<string>{
@@ -127,8 +127,8 @@ class AttributionAppTest
       std::string filePrefix = baseDir_ + "test_correctness/" + attributionRule;
       inputFilenamesAlice_.push_back(filePrefix + ".publisher.csv");
       inputFilenamesBob_.push_back(filePrefix + ".partner.csv");
-      outputFilenamesAlice_.push_back(outputPathAlice_ + attributionRule);
-      outputFilenamesBob_.push_back(outputPathBob_ + attributionRule);
+      outputFilenamesAlice_.push_back(outputPathAlice_2 + attributionRule);
+      outputFilenamesBob_.push_back(outputPathBob_2 + attributionRule);
       expectedOutputFilenames_.push_back(filePrefix + ".json");
     }
   }


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D64398713


