### PR TITLE
facebook-unused-include-check in fbcode/fbpcs/data_processing/id_combiner

### DIFF
--- a/fbpcs/data_processing/id_combiner/AddPaddingToCols.cpp
+++ b/fbpcs/data_processing/id_combiner/AddPaddingToCols.cpp
@@ -10,9 +10,7 @@
 #include <iomanip>
 #include <istream>
 #include <ostream>
-#include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <boost/algorithm/string.hpp>

--- a/fbpcs/data_processing/id_combiner/DataPreparationHelpers.cpp
+++ b/fbpcs/data_processing/id_combiner/DataPreparationHelpers.cpp
@@ -9,14 +9,11 @@
 
 #include <folly/logging/xlog.h>
 #include <cstdint>
-#include <filesystem>
-#include <iomanip>
 #include <istream>
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <re2/re2.h>

--- a/fbpcs/data_processing/id_combiner/DataValidation.cpp
+++ b/fbpcs/data_processing/id_combiner/DataValidation.cpp
@@ -11,14 +11,12 @@
 #include <istream>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
 #include <folly/Conv.h>
 #include <folly/String.h>
 #include <folly/logging/xlog.h>
-#include <re2/re2.h>
 
 #include "DataPreparationHelpers.h"
 

--- a/fbpcs/data_processing/id_combiner/GroupBy.cpp
+++ b/fbpcs/data_processing/id_combiner/GroupBy.cpp
@@ -7,8 +7,6 @@
 
 #include "GroupBy.h"
 
-#include <filesystem>
-#include <iomanip>
 #include <istream>
 #include <ostream>
 #include <stdexcept>

--- a/fbpcs/data_processing/id_combiner/IdInsert.cpp
+++ b/fbpcs/data_processing/id_combiner/IdInsert.cpp
@@ -8,9 +8,7 @@
 #include "IdInsert.h"
 #include "DataPreparationHelpers.h"
 
-#include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <istream>
 #include <ostream>
 #include <sstream>

--- a/fbpcs/data_processing/id_combiner/IdSwap.cpp
+++ b/fbpcs/data_processing/id_combiner/IdSwap.cpp
@@ -7,11 +7,8 @@
 
 #include "IdSwap.h"
 #include "DataPreparationHelpers.h"
-#include "folly/Optional.h"
 
-#include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <istream>
 #include <ostream>
 #include <sstream>

--- a/fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp
+++ b/fbpcs/data_processing/id_combiner/IdSwapMultiKey.cpp
@@ -7,13 +7,10 @@
 
 #include "IdSwapMultiKey.h"
 #include "DataPreparationHelpers.h"
-#include "folly/Optional.h"
 
 #include <algorithm>
 #include <cstdint>
-#include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <istream>
 #include <numeric>
 #include <ostream>

--- a/fbpcs/data_processing/id_combiner/SortIds.cpp
+++ b/fbpcs/data_processing/id_combiner/SortIds.cpp
@@ -7,8 +7,6 @@
 
 #include "SortIds.h"
 
-#include <filesystem>
-#include <iomanip>
 #include <istream>
 #include <ostream>
 #include <stdexcept>

--- a/fbpcs/data_processing/id_combiner/test/AddPaddingToColsTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/AddPaddingToColsTest.cpp
@@ -10,9 +10,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 using namespace ::pid::combiner;

--- a/fbpcs/data_processing/id_combiner/test/DataValidationTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/DataValidationTest.cpp
@@ -14,7 +14,6 @@
 #include <fstream>
 
 #include <folly/Conv.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 using namespace ::pid::combiner;

--- a/fbpcs/data_processing/id_combiner/test/GroupByTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/GroupByTest.cpp
@@ -7,12 +7,8 @@
 
 #include "../GroupBy.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
-#include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 class GroupByTest : public testing::Test {

--- a/fbpcs/data_processing/id_combiner/test/IdInsertTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/IdInsertTest.cpp
@@ -7,12 +7,9 @@
 
 #include "../IdInsert.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <folly/logging/xlog.h>

--- a/fbpcs/data_processing/id_combiner/test/IdSwapMultiKeyTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/IdSwapMultiKeyTest.cpp
@@ -7,13 +7,10 @@
 
 #include "../IdSwapMultiKey.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
 #include <folly/Random.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <folly/logging/xlog.h>

--- a/fbpcs/data_processing/id_combiner/test/IdSwapTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/IdSwapTest.cpp
@@ -7,12 +7,9 @@
 
 #include "../IdSwap.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <folly/logging/xlog.h>

--- a/fbpcs/data_processing/id_combiner/test/SortIdsTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/SortIdsTest.cpp
@@ -7,12 +7,8 @@
 
 #include "../SortIds.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
-#include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 class SortIdsTest : public testing::Test {

--- a/fbpcs/data_processing/id_combiner/test/SortIntegralValuesTest.cpp
+++ b/fbpcs/data_processing/id_combiner/test/SortIntegralValuesTest.cpp
@@ -10,9 +10,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 using namespace ::pid::combiner;


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.fbpcs.data_processing.id_combiner.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.fbpcs.data_processing.id_combiner
Autodiff bookmark: ad.uif.fbcode.fbpcs.data_processing.id_combiner

Reviewed By: dtolnay

Differential Revision: D65957898


