### PR TITLE
facebook-unused-include-check in fbcode/fbpcs/data_processing

### DIFF
--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombiner.cpp
@@ -20,12 +20,8 @@
 
 #include <fbpcs/performance_tools/CostEstimation.h>
 #include "fbpcf/io/api/BufferedReader.h"
-#include "fbpcf/io/api/FileIOWrappers.h"
-#include "fbpcf/io/api/FileReader.h"
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h"
-#include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerUtil.h"
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineFileCombiner.h"
-#include "fbpcs/data_processing/common/FilepathHelpers.h"
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);

--- a/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineFileCombinerTest.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineFileCombinerTest.cpp
@@ -7,12 +7,9 @@
 
 #include "AttributionIdSpineFileCombiner.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <folly/Random.h>

--- a/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombiner.cpp
@@ -9,15 +9,8 @@
 
 #include <boost/algorithm/string.hpp>
 #include <folly/Random.h>
-#include <folly/String.h>
 #include <folly/logging/xlog.h>
-#include <re2/re2.h>
-#include <iomanip>
 #include <istream>
-#include <stdexcept>
-#include <unordered_map>
-
-#include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
 
 namespace pid::combiner {
 MrPidAttributionIdCombiner::MrPidAttributionIdCombiner()

--- a/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombinerTest.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombinerTest.cpp
@@ -8,11 +8,8 @@
 #include "fbpcs/data_processing/attribution_id_combiner/MrPidAttributionIdCombiner.h"
 
 #include <folly/Random.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h"

--- a/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombiner.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombiner.cpp
@@ -7,13 +7,9 @@
 
 #include "fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombiner.h"
 
-#include <folly/String.h>
 #include <folly/logging/xlog.h>
 #include <re2/re2.h>
-#include <iomanip>
 #include <istream>
-#include <stdexcept>
-#include <unordered_map>
 
 #include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
 

--- a/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombinerTest.cpp
+++ b/fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombinerTest.cpp
@@ -8,14 +8,10 @@
 #include "fbpcs/data_processing/attribution_id_combiner/PidAttributionIdCombiner.h"
 
 #include <folly/Random.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
-#include "fbpcf/io/api/FileIOWrappers.h"
 #include "fbpcs/data_processing/attribution_id_combiner/AttributionIdSpineCombinerOptions.h"
 #include "fbpcs/data_processing/test_utils/FileIOTestUtils.h"
 

--- a/fbpcs/data_processing/lift_id_combiner/LiftStrategy.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/LiftStrategy.cpp
@@ -15,7 +15,6 @@
 #include "fbpcs/data_processing/id_combiner/DataPreparationHelpers.h"
 #include "fbpcs/data_processing/id_combiner/DataValidation.h"
 #include "fbpcs/data_processing/id_combiner/GroupBy.h"
-#include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
 #include "fbpcs/data_processing/id_combiner/SortIds.h"
 #include "fbpcs/data_processing/id_combiner/SortIntegralValues.h"
 #include "fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h"

--- a/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombiner.cpp
@@ -11,8 +11,6 @@
 #include <folly/Random.h>
 #include <folly/String.h>
 #include <folly/logging/xlog.h>
-#include <re2/re2.h>
-#include <iomanip>
 #include <istream>
 #include <ostream>
 #include <stdexcept>
@@ -22,9 +20,7 @@
 #include <vector>
 
 #include "fbpcf/io/api/BufferedReader.h"
-#include "fbpcf/io/api/FileIOWrappers.h"
 #include "fbpcf/io/api/FileReader.h"
-#include "fbpcs/data_processing/common/FilepathHelpers.h"
 #include "fbpcs/data_processing/id_combiner/DataPreparationHelpers.h"
 #include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
 #include "fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h"

--- a/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombinerTest.cpp
@@ -8,11 +8,9 @@
 #include "fbpcs/data_processing/lift_id_combiner/MrPidLiftIdCombiner.h"
 
 #include <folly/Random.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
 #include "fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h"

--- a/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombiner.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombiner.cpp
@@ -8,23 +8,16 @@
 #include "fbpcs/data_processing/lift_id_combiner/PidLiftIdCombiner.h"
 
 #include <boost/algorithm/string.hpp>
-#include <folly/String.h>
 #include <folly/logging/xlog.h>
-#include <re2/re2.h>
 #include <iomanip>
 #include <istream>
 #include <ostream>
-#include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "fbpcf/io/api/BufferedReader.h"
 #include "fbpcf/io/api/FileReader.h"
-#include "fbpcs/data_processing/common/FilepathHelpers.h"
-#include "fbpcs/data_processing/id_combiner/DataPreparationHelpers.h"
 #include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
-#include "fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h"
 
 namespace pid::combiner {
 PidLiftIdCombiner::PidLiftIdCombiner(

--- a/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/PidLiftIdCombinerTest.cpp
@@ -8,11 +8,9 @@
 #include "fbpcs/data_processing/lift_id_combiner/PidLiftIdCombiner.h"
 
 #include <folly/Random.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
 #include "fbpcs/data_processing/lift_id_combiner/LiftIdSpineCombinerOptions.h"

--- a/fbpcs/data_processing/lift_id_combiner/test/LiftIdSpineFileCombinerTest.cpp
+++ b/fbpcs/data_processing/lift_id_combiner/test/LiftIdSpineFileCombinerTest.cpp
@@ -12,7 +12,6 @@
 #include <fstream>
 #include "fbpcs/data_processing/test_utils/FileIOTestUtils.h"
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 using namespace ::pid::combiner;

--- a/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
+++ b/fbpcs/data_processing/pid_preparer/UnionPIDDataPreparer.cpp
@@ -11,11 +11,9 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/fbpcs/data_processing/private_id_dfca_id_combiner/MrPidPrivateIdDfcaIdCombiner.cpp
+++ b/fbpcs/data_processing/private_id_dfca_id_combiner/MrPidPrivateIdDfcaIdCombiner.cpp
@@ -9,15 +9,8 @@
 
 #include <boost/algorithm/string.hpp>
 #include <folly/Random.h>
-#include <folly/String.h>
 #include <folly/logging/xlog.h>
-#include <re2/re2.h>
-#include <iomanip>
 #include <istream>
-#include <stdexcept>
-#include <unordered_map>
-
-#include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
 
 namespace pid::combiner {
 MrPidPrivateIdDfcaIdCombiner::MrPidPrivateIdDfcaIdCombiner()

--- a/fbpcs/data_processing/private_id_dfca_id_combiner/PidPrivateIdDfcaIdCombiner.cpp
+++ b/fbpcs/data_processing/private_id_dfca_id_combiner/PidPrivateIdDfcaIdCombiner.cpp
@@ -7,13 +7,9 @@
 
 #include "fbpcs/data_processing/private_id_dfca_id_combiner/PidPrivateIdDfcaIdCombiner.h"
 
-#include <folly/String.h>
 #include <folly/logging/xlog.h>
 #include <re2/re2.h>
-#include <iomanip>
 #include <istream>
-#include <stdexcept>
-#include <unordered_map>
 
 #include "fbpcs/data_processing/id_combiner/IdSwapMultiKey.h"
 

--- a/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineCombiner.cpp
+++ b/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineCombiner.cpp
@@ -20,9 +20,6 @@
 
 #include <fbpcs/performance_tools/CostEstimation.h>
 #include "fbpcf/io/api/BufferedReader.h"
-#include "fbpcf/io/api/FileIOWrappers.h"
-#include "fbpcf/io/api/FileReader.h"
-#include "fbpcs/data_processing/common/FilepathHelpers.h"
 #include "fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineCombinerOptions.h"
 #include "fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineFileCombiner.h"
 

--- a/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineFileCombinerTest.cpp
+++ b/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineFileCombinerTest.cpp
@@ -7,12 +7,9 @@
 
 #include "fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaIdSpineFileCombiner.h"
 
-#include <chrono>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <folly/Random.h>

--- a/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaStrategy.cpp
+++ b/fbpcs/data_processing/private_id_dfca_id_combiner/PrivateIdDfcaStrategy.cpp
@@ -13,10 +13,8 @@
 #include <boost/algorithm/string.hpp>
 #include "fbpcf/io/api/FileIOWrappers.h"
 #include "fbpcs/data_processing/common/FilepathHelpers.h"
-#include "fbpcs/data_processing/id_combiner/AddPaddingToCols.h"
 #include "fbpcs/data_processing/id_combiner/DataPreparationHelpers.h"
 #include "fbpcs/data_processing/id_combiner/DataValidation.h"
-#include "fbpcs/data_processing/id_combiner/GroupBy.h"
 #include "fbpcs/data_processing/id_combiner/SortIds.h"
 
 namespace pid::combiner {

--- a/fbpcs/data_processing/sharding/GenericSharder.cpp
+++ b/fbpcs/data_processing/sharding/GenericSharder.cpp
@@ -14,7 +14,6 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -31,7 +30,6 @@
 
 #include <folly/DynamicConverter.h>
 #include <folly/json.h>
-#include "fbpcs/data_processing/common/FilepathHelpers.h"
 #include "fbpcs/data_processing/common/Logging.h"
 #include "folly/String.h"
 

--- a/fbpcs/data_processing/sharding/HashBasedSharder.cpp
+++ b/fbpcs/data_processing/sharding/HashBasedSharder.cpp
@@ -7,14 +7,8 @@
 
 #include "fbpcs/data_processing/sharding/HashBasedSharder.h"
 
-#include <arpa/inet.h>
-
-#include <algorithm>
 #include <filesystem>
-#include <fstream>
 #include <memory>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/fbpcs/data_processing/sharding/Sharding.cpp
+++ b/fbpcs/data_processing/sharding/Sharding.cpp
@@ -9,16 +9,12 @@
 
 #include <folly/String.h>
 #include <folly/logging/xlog.h>
-#include <xmmintrin.h>
 
 #include "fbpcs/data_processing/sharding/HashBasedSharder.h"
 #include "fbpcs/data_processing/sharding/RoundRobinBasedSharder.h"
 
 #include "fbpcf/engine/util/AesPrgFactory.h"
-#include "fbpcf/engine/util/util.h"
 #include "fbpcf/mpc_std_lib/util/secureSamplePublicSeed.h"
-#include "fbpcs/data_processing/common/FilepathHelpers.h"
-#include "fbpcs/data_processing/common/Logging.h"
 #include "fbpcs/data_processing/sharding/SecureRandomSharder.h"
 
 namespace data_processing::sharder {


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.fbpcs.data_processing.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.fbpcs.data_processing
Autodiff bookmark: ad.uif.fbcode.fbpcs.data_processing

Differential Revision: D65957914


