### PR TITLE
Convert directory fbcode/fbpcs to use the Ruff Formatter

### DIFF
--- a/fbpcs/bolt/read_config.py
+++ b/fbpcs/bolt/read_config.py
@@ -23,11 +23,12 @@ from fbpcs.private_computation_cli.private_computation_service_wrapper import (
 from fbpcs.utils.config_yaml.config_yaml_dict import ConfigYamlDict
 
 
-def parse_bolt_config(config: Dict[str, Any], logger: logging.Logger) -> Tuple[
+def parse_bolt_config(
+    config: Dict[str, Any], logger: logging.Logger
+) -> Tuple[
     BoltRunner[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs],
     List[BoltJob[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]],
 ]:
-
     # create runner
     runner_config = config["runner"]
     runner = create_bolt_runner(runner_config=runner_config, logger=logger)
@@ -79,7 +80,7 @@ def create_bolt_runner(
 
 
 def create_job_list(
-    job_config_list: Dict[str, Any]
+    job_config_list: Dict[str, Any],
 ) -> List[BoltJob[BoltPCSCreateInstanceArgs, BoltPCSCreateInstanceArgs]]:
     bolt_job_list = []
     for job_name, job_config in job_config_list.items():

--- a/fbpcs/common/service/graphapi_trace_logging_service.py
+++ b/fbpcs/common/service/graphapi_trace_logging_service.py
@@ -88,12 +88,12 @@ class GraphApiTraceLoggingService(TraceLoggingService):
                     continue
 
                 aggregate_msg["component"] += f"{AGGREGATE_DELIMITER}{msg['component']}"
-                aggregate_msg[
-                    "checkpoint_name"
-                ] += f"{AGGREGATE_DELIMITER}{msg['checkpoint_name']}"
-                aggregate_msg[
-                    "checkpoint_data"
-                ] += f"{AGGREGATE_DELIMITER}{msg['checkpoint_data']}"
+                aggregate_msg["checkpoint_name"] += (
+                    f"{AGGREGATE_DELIMITER}{msg['checkpoint_name']}"
+                )
+                aggregate_msg["checkpoint_data"] += (
+                    f"{AGGREGATE_DELIMITER}{msg['checkpoint_data']}"
+                )
 
             if aggregate_msg:
                 self._post_request(params=aggregate_msg)
@@ -106,7 +106,6 @@ class GraphApiTraceLoggingService(TraceLoggingService):
         status: CheckpointStatus,
         checkpoint_data: Optional[Dict[str, str]] = None,
     ) -> None:
-
         checkpoint_data = checkpoint_data or {}
         component = checkpoint_data.pop("component", DEFAULT_COMPONENT_NAME)
         scrubbed_checkpoint_data = {}

--- a/fbpcs/common/service/test/test_trace_logging_registry.py
+++ b/fbpcs/common/service/test/test_trace_logging_registry.py
@@ -12,7 +12,6 @@ from fbpcs.common.service.trace_logging_registry import RegistryFactory
 
 
 class DummyRegistry(RegistryFactory[str]):
-
     _REGISTRY: Dict[str, str] = {}
 
     @classmethod

--- a/fbpcs/common/tests/entity/test_comprehensive_hooks_and_mutability.py
+++ b/fbpcs/common/tests/entity/test_comprehensive_hooks_and_mutability.py
@@ -310,7 +310,6 @@ class TestUpdateOtherFieldHook(unittest.TestCase):
                     setattr(intance_base_obj, test_field, change_vals)
 
     def _init_event_hook(self) -> None:
-
         ##########################
         # update hooks: initialize name when id is initialized, they are both immutable
         #               initialize org when user is initialized, they are both immutable
@@ -356,7 +355,6 @@ class TestUpdateOtherFieldHook(unittest.TestCase):
             )
 
     def _update_event_hook(self) -> None:
-
         ##########################
         # update hooks: update output_path and storage when input_path is changed
         ##########################
@@ -423,7 +421,6 @@ class TestUpdateOtherFieldHook(unittest.TestCase):
         self.assertEqual(self.obj_1.highest_pressure, 70)
 
     def _delete_event_hook(self) -> None:
-
         ##########################
         # frozen hooks: frozen location when region is deleted
         ##########################

--- a/fbpcs/common/tests/test_stage_state_instance.py
+++ b/fbpcs/common/tests/test_stage_state_instance.py
@@ -58,7 +58,6 @@ class TestStageStateInstance(unittest.TestCase):
                 "Subtest with container_stoppable: {container_stoppable}",
                 container_stoppable=container_stoppable,
             ):
-
                 mock_onedocker_svc.reset_mock()
                 if container_stoppable:
                     mock_onedocker_svc.stop_containers = MagicMock(

--- a/fbpcs/data_processing/service/pid_run_protocol_binary_service.py
+++ b/fbpcs/data_processing/service/pid_run_protocol_binary_service.py
@@ -45,7 +45,6 @@ class PIDRunProtocolBinaryService(RunBinaryBaseService):
         metric_path: Optional[str] = None,
         run_id: Optional[str] = None,
     ) -> str:
-
         cmd_ls = []
 
         if server_endpoint:

--- a/fbpcs/infra/cloud_bridge/bulk_onborading/bulk_pixel_onboarding.py
+++ b/fbpcs/infra/cloud_bridge/bulk_onborading/bulk_pixel_onboarding.py
@@ -13,7 +13,6 @@ from requests import Response
 
 
 def get_access_token(hostname: str, client_id: str, client_secret: str) -> str:
-
     url = f"https://{hostname}/clients/token"
 
     payload = f"client_id={client_id}&client_secret={client_secret}&grant_type=client_credentials"

--- a/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
+++ b/fbpcs/infra/cloud_bridge/data_ingestion/data_transformation_lambda.py
@@ -58,7 +58,6 @@ def lambda_handler(
     output = []
     ##### NOTE: this script assume the schema is correct, no missing items
     for record in event["records"]:
-
         row = {}
         recordId = record["recordId"]
         row["recordId"] = recordId

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/aws_deployment_helper.py
@@ -19,7 +19,6 @@ from fbpcs.infra.cloud_bridge.deployment_helper.aws.policy_params import PolicyP
 
 
 class AwsDeploymentHelper:
-
     # policy_arn is fixed string. So defining it as a macro.
     POLICY_ARN = "arn:aws:iam::{}:policy/{}"
     IAM_POLICIES_DIRECTORY = "iam_policies"
@@ -282,7 +281,6 @@ class AwsDeploymentHelper:
     def read_json_file(
         self, file_name: str, policy_params: PolicyParams, read_mode: str = "r"
     ) -> Dict[str, Any]:
-
         # this can be replaced with a json file which is written in deploy.sh
         interpolation_data = {
             "REGION": self.region,
@@ -326,7 +324,6 @@ class AwsDeploymentHelper:
         return json_data
 
     def create_user_workflow(self, user_name: str) -> None:
-
         self.log.info(
             f"""Cli to create user is triggered. Following actions will be performed
         1. User {user_name} will be created

--- a/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
+++ b/fbpcs/infra/cloud_bridge/deployment_helper/aws/test/test_aws_deployment_helper.py
@@ -271,7 +271,6 @@ class TestAwsDeploymentHelper(unittest.TestCase):
             self.aws_deployment_helper.iam.list_users.assert_called_once()
 
     def test_create_access_key(self) -> None:
-
         self.aws_deployment_helper.iam.create_access_key.return_value = {
             "AccessKey": {"AccessKeyId": 1, "SecretAccessKey": 2}
         }

--- a/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/template/lambda_trigger.py
+++ b/fbpcs/infra/cloud_bridge/semi_automated_data_ingestion/template/lambda_trigger.py
@@ -23,7 +23,6 @@ glueJobName = "TO_BE_UPDATED_DURING_DEPLOYMENT"
 
 # Define Lambda function
 def lambda_handler(event, context):
-
     ### should be one single upload (it should be larger than 1 by default)
     if len(event["Records"]) >= 2:
         logger.info("multiple csv uploaded. please upload only one csv at a time")

--- a/fbpcs/infra/logging_service/download_logs/cloud/aws_cloud.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud/aws_cloud.py
@@ -49,7 +49,6 @@ class AwsCloud(CloudBaseClass):
         logger_name: Optional[str] = None,
         s3_bucket_name: Optional[str] = None,
     ) -> None:
-
         aws_access_key_id = aws_access_key_id or os.environ.get("AWS_ACCESS_KEY_ID")
         aws_secret_access_key = aws_secret_access_key or os.environ.get(
             "AWS_SECRET_ACCESS_KEY"

--- a/fbpcs/infra/logging_service/download_logs/cloud/test/test_aws_cloud.py
+++ b/fbpcs/infra/logging_service/download_logs/cloud/test/test_aws_cloud.py
@@ -291,7 +291,6 @@ class TestAwsCloud(unittest.TestCase):
             )
 
     def test_get_kinesis_firehose_streams(self) -> None:
-
         kinesis_firehose_stream_name = "test_stream"
         mock_return = {"stream_name": kinesis_firehose_stream_name}
         self.aws_container_logs.kinesis_client.describe_delivery_stream.return_value = (
@@ -377,9 +376,7 @@ class TestAwsCloud(unittest.TestCase):
             mock_streams = []
             mock_response = {"logStreams": mock_streams}
             self.aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
-            self.aws_container_logs.cloudwatch_client.describe_log_streams.return_value = (
-                mock_response
-            )
+            self.aws_container_logs.cloudwatch_client.describe_log_streams.return_value = mock_response
             expected = ""
             self.assertEqual(
                 expected,
@@ -391,9 +388,7 @@ class TestAwsCloud(unittest.TestCase):
         with self.subTest("EmptyResponse"):
             mock_response = {}
             self.aws_container_logs.cloudwatch_client.describe_log_streams.reset_mock()
-            self.aws_container_logs.cloudwatch_client.describe_log_streams.return_value = (
-                mock_response
-            )
+            self.aws_container_logs.cloudwatch_client.describe_log_streams.return_value = mock_response
             expected = ""
             self.assertEqual(
                 expected,

--- a/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
+++ b/fbpcs/infra/logging_service/download_logs/test/test_download_logs.py
@@ -90,11 +90,11 @@ class TestDownloadLogs(unittest.TestCase):
                 self.aws_container_logs.cloudwatch_client.describe_log_groups.reset_mock(
                     side_effect=True
                 )
-                getattr(self.aws_container_logs.s3_client, s3_endpoint).side_effect = (
-                    ClientError(
-                        error_response={"Error": {"Code": error_code}},
-                        operation_name=s3_endpoint,
-                    )
+                getattr(
+                    self.aws_container_logs.s3_client, s3_endpoint
+                ).side_effect = ClientError(
+                    error_response={"Error": {"Code": error_code}},
+                    operation_name=s3_endpoint,
                 )
                 with self.assertRaisesRegex(Exception, exc_regex):
                     self.aws_container_logs.upload_logs_to_s3_from_cloudwatch(

--- a/fbpcs/infra/logging_service/download_logs/utils/test/test_utils.py
+++ b/fbpcs/infra/logging_service/download_logs/utils/test/test_utils.py
@@ -17,7 +17,6 @@ class TestUtils(unittest.TestCase):
         self.utils = Utils()
 
     def test_create_file(self) -> None:
-
         fake_file_path = "fake/file/path"
         content_list = ["This is test string"]
         with patch(

--- a/fbpcs/infra/logging_service/log_analyzer/log_analyzer.py
+++ b/fbpcs/infra/logging_service/log_analyzer/log_analyzer.py
@@ -207,7 +207,6 @@ class LogDigest:
         log_line: str,
         parsing_state: Optional[ParsingState],
     ) -> Optional[ParsingState]:
-
         if line_num == 1:
             context = self._parse_line_context(log_line)
             self.run_study.first_log = log_line

--- a/fbpcs/infra/restore_run_state/restore_state.py
+++ b/fbpcs/infra/restore_run_state/restore_state.py
@@ -79,7 +79,6 @@ class RestoreRunState:
         self.logger.info(f"Downloaded run state to {dest_folder}")
 
     def _copy_files(self, run_data_path: str, dest_folder: str) -> None:
-
         # DataPath is like s3://fb-pc-data-nov07test1-vwxz/query-results/fbpcs_instances_638479584559395_1/
         splits = self._split_path(run_data_path)
         if splits is None:

--- a/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
+++ b/fbpcs/pc_pre_validation/pc_pre_validation_cli.py
@@ -29,7 +29,6 @@ Usage:
         [--tee-local-file-path=<local-file-path>]
 """
 
-
 from typing import cast, List, Optional as OptionalType
 
 from docopt import docopt

--- a/fbpcs/pl_coordinator/pl_study_runner.py
+++ b/fbpcs/pl_coordinator/pl_study_runner.py
@@ -159,7 +159,6 @@ async def run_study_async(
     bolt_hooks: Optional[Dict[BoltHookKey, List[BoltHook[BoltHookArgs]]]] = None,
     stage_timeout_override: Optional[int] = None,
 ) -> BoltSummary:
-
     # Create a GraphApiTraceLoggingService specific for this study_id
     client: BoltGraphAPIClient[BoltPLGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
         config=config,
@@ -367,7 +366,6 @@ async def _validate_access_to_instance(
     instance_id: str,
     run_id: str,
 ) -> None:
-
     tries = 0
     while tries < CREATE_INSTANCE_TRIES:
         tries += 1
@@ -834,14 +832,14 @@ async def _create_new_instances(
         for objective_id in cell_obj_instances[cell_id]:
             # Create new instance for cell_obj pairs which has no valid instance.
             if "instance_id" not in cell_obj_instances[cell_id][objective_id]:
-                cell_obj_instances[cell_id][objective_id]["instance_id"] = (
-                    await _create_instance_retry(
-                        client, study_id, cell_id, objective_id, run_id, logger
-                    )
-                )
                 cell_obj_instances[cell_id][objective_id][
-                    STATUS
-                ] = PrivateComputationInstanceStatus.CREATED.value
+                    "instance_id"
+                ] = await _create_instance_retry(
+                    client, study_id, cell_id, objective_id, run_id, logger
+                )
+                cell_obj_instances[cell_id][objective_id][STATUS] = (
+                    PrivateComputationInstanceStatus.CREATED.value
+                )
 
             instance_id = cell_obj_instances[cell_id][objective_id]["instance_id"]
             is_pl_timestamp_validation_enabled = await client.has_feature(
@@ -902,7 +900,7 @@ async def _create_instance_retry(
 
 @bolt_checkpoint(dump_return_val=True, component=LOG_COMPONENT)
 def _instance_to_input_path(
-    cell_obj_instance: Dict[str, Dict[str, Dict[str, Any]]]
+    cell_obj_instance: Dict[str, Dict[str, Dict[str, Any]]],
 ) -> Dict[str, Dict[str, str]]:
     instance_input_path = {}
     for cell_id in cell_obj_instance:

--- a/fbpcs/private_computation/entity/infra_config.py
+++ b/fbpcs/private_computation/entity/infra_config.py
@@ -14,7 +14,6 @@ from dataclasses_json import config, dataclass_json, DataClassJsonMixin
 
 # this import statument can avoid circular import
 if TYPE_CHECKING:
-
     from fbpcs.private_computation.stage_flows.private_computation_base_stage_flow import (
         PrivateComputationBaseStageFlow,
     )

--- a/fbpcs/private_computation/entity/pc_infra_config.py
+++ b/fbpcs/private_computation/entity/pc_infra_config.py
@@ -61,9 +61,9 @@ class PrivateComputationInfraConfig:
                 # can handle more than 1 override
                 for dep_key, dep_value in overrides.items():
                     if dep_key in yml_config["private_computation"]["dependency"]:
-                        yml_config["private_computation"]["dependency"][
-                            dep_key
-                        ] = dep_value
+                        yml_config["private_computation"]["dependency"][dep_key] = (
+                            dep_value
+                        )
 
                     elif dep_key in yml_config["mpc"]["dependency"]:
                         yml_config["mpc"]["dependency"][dep_key] = dep_value

--- a/fbpcs/private_computation/entity/pc_infra_config_data.py
+++ b/fbpcs/private_computation/entity/pc_infra_config_data.py
@@ -17,7 +17,6 @@ class PrivateComputationInfraConfigData:
 
 
 class PrivateComputationInfraConfigInfo(Enum):
-
     CONTAINER_SERVICE = PrivateComputationInfraConfigData(
         "fbpcp.service.container_aws.AWSContainerService",
         {"region", "cluster", "subnets"},

--- a/fbpcs/private_computation/entity/pcs_feature.py
+++ b/fbpcs/private_computation/entity/pcs_feature.py
@@ -11,7 +11,6 @@ from enum import Enum
 
 
 class PCSFeature(Enum):
-
     PCS_DUMMY = "pcs_dummy_feature"
     PRIVATE_LIFT_PCF2_RELEASE = "private_lift_pcf2_release"
     PC_COORDINATED_RETRY = "private_computation_coordinated_retry"

--- a/fbpcs/private_computation/pc_attribution_runner.py
+++ b/fbpcs/private_computation/pc_attribution_runner.py
@@ -161,7 +161,6 @@ async def run_attribution_async(
     bolt_hooks: Optional[Dict[BoltHookKey, List[BoltHook[BoltHookArgs]]]] = None,
     stage_timeout_override: Optional[int] = None,
 ) -> BoltSummary:
-
     ## Step 1: Validation. Function arguments and  for private attribution run.
     # obtain the values in the dataset info vector.
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
@@ -251,7 +250,6 @@ async def _run_attribution_async_helper(
     bolt_hooks: Optional[Dict[BoltHookKey, List[BoltHook[BoltHookArgs]]]],
     stage_timeout_override: Optional[int],
 ) -> BoltSummary:
-
     try:
         datasets_info = _get_attribution_dataset_info(client, dataset_id, logger)
     except GraphAPIGenericException as err:
@@ -605,7 +603,6 @@ def get_runnable_timestamps(
     graphapi_version: Optional[str] = None,
     graphapi_domain: Optional[str] = None,
 ) -> Iterable[str]:
-
     client: BoltGraphAPIClient[BoltPAGraphAPICreateInstanceArgs] = BoltGraphAPIClient(
         config=config,
         logger=logger,

--- a/fbpcs/private_computation/service/utils.py
+++ b/fbpcs/private_computation/service/utils.py
@@ -98,7 +98,6 @@ def transform_file_path(file_path: str, aws_region: Optional[str] = None) -> str
         rf"https://[sS]3\.{region_regex_pattern}+\.amazonaws\.com/{bucket_name_regex_pattern}+/{key_pattern}+",
         file_path,
     ):
-
         # Extract Bucket, Key, and Region
         key_name_search = re.search(
             rf"https://[sS]3\.{region_regex_pattern}+\.amazonaws\.com/{bucket_name_regex_pattern}+/",
@@ -131,9 +130,7 @@ def transform_file_path(file_path: str, aws_region: Optional[str] = None) -> str
 
     # Check if it matches the s3 style access format, s3://bucket-name/key-name
     if re.search(rf"[sS]3://{bucket_name_regex_pattern}+/{key_pattern}+", file_path):
-
         if aws_region is not None:
-
             # Extract Bucket, Key
             bucket_name_search = re.search(r"[sS]3://", file_path)
             key_name_search = re.search(
@@ -144,7 +141,6 @@ def transform_file_path(file_path: str, aws_region: Optional[str] = None) -> str
 
             # Check for not None rather than extracting on search, to keep pyre happy
             if key_name_search and bucket_name_search:
-
                 bucket = file_path[
                     bucket_name_search.span()[1] : key_name_search.span()[1] - 1
                 ]
@@ -289,7 +285,6 @@ def generate_env_vars_dicts_list(
     server_hostnames: Optional[List[str]] = None,
     server_private_key_ref_provider: Optional[PrivateKeyReferenceProvider] = None,
 ) -> List[Dict[str, str]]:
-
     _validate_env_vars_length(
         num_containers=num_containers,
         server_ip_addresses=server_ip_addresses,

--- a/fbpcs/private_computation/test/entity/generate_instance_json.py
+++ b/fbpcs/private_computation/test/entity/generate_instance_json.py
@@ -153,9 +153,9 @@ def main() -> None:
             json_output = json.dumps(instance_dict)
         elif path == LIFT_PC_PATH:
             instance_dict = json.loads(json_output)
-            instance_dict["infra_config"][
-                "invalid_parameter_to_exclude"
-            ] = "This instance value should be excluded."
+            instance_dict["infra_config"]["invalid_parameter_to_exclude"] = (
+                "This instance value should be excluded."
+            )
             instance_dict["infra_config"]["instances"][0][
                 "invalid_parameter_to_exclude"
             ] = "This instance value should be excluded."

--- a/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_id_spine_combiner_stage_service.py
@@ -58,7 +58,6 @@ class TestIdSpineCombinerStageService(IsolatedAsyncioTestCase):
         self.container_permission_id = "test-container-permission"
 
     async def test_id_spine_combiner(self) -> None:
-
         for test_run_id, test_log_cost_bucket in (
             (None, "test-log-bucket"),
             ("2621fda2-0eca-11ed-861d-0242ac120002", "test-log-bucket"),

--- a/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_pcf2_lift_metadata_compaction_stage_service.py
@@ -154,7 +154,6 @@ class TestPCF2LiftMetadataCompactionStageService(IsolatedAsyncioTestCase):
         )
 
     def _create_pc_instance(self) -> PrivateComputationInstance:
-
         infra_config: InfraConfig = InfraConfig(
             instance_id="test_instance_123",
             role=PrivateComputationRole.PARTNER,

--- a/fbpcs/private_computation/test/service/test_private_computation.py
+++ b/fbpcs/private_computation/test/service/test_private_computation.py
@@ -1486,7 +1486,6 @@ class TestPrivateComputationService(unittest.IsolatedAsyncioTestCase):
 
 class TestTransformFilePath(unittest.TestCase):
     def test_virtual_hosted_format(self) -> None:
-
         test_cases = [
             "https://bucket-name.s3.Region.amazonaws.com/key-name",
             "https://fbpcs-github-e2e.s3.us-west-2.amazonaws.com/lift/results/partner_expected_result.json",
@@ -1504,7 +1503,6 @@ class TestTransformFilePath(unittest.TestCase):
             self.assertEqual(transform_file_path(x), y)
 
     def test_s3_format(self) -> None:
-
         test_cases = [
             "S3://bucket-name/key-name",
             "s3://bucket-name/key-name",
@@ -1522,7 +1520,6 @@ class TestTransformFilePath(unittest.TestCase):
             self.assertEqual(transform_file_path(x, "Region"), y)
 
     def test_path_format(self) -> None:
-
         test_cases = [
             "https://s3.Region.amazonaws.com/bucket-name/key-name",
             "https://s3.us-west-2.amazonaws.com/fbpcs-github-e2e/lift/results/partner_expected_result.json",
@@ -1538,7 +1535,6 @@ class TestTransformFilePath(unittest.TestCase):
             self.assertEqual(transform_file_path(x), y)
 
     def test_bad_inputs(self) -> None:
-
         test_cases = [
             "",
             "www.facebook.com",

--- a/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
+++ b/fbpcs/private_computation/test/service/test_secure_random_sharding_stage_service.py
@@ -397,7 +397,6 @@ class TestSecureRandomShardingStageService(IsolatedAsyncioTestCase):
     def _create_pc_instance(
         self, pcs_features: Optional[Set[PCSFeature]] = None
     ) -> PrivateComputationInstance:
-
         infra_config: InfraConfig = InfraConfig(
             instance_id="test_instance_123",
             role=PrivateComputationRole.PARTNER,

--- a/fbpcs/private_computation_cli/private_computation_cli.py
+++ b/fbpcs/private_computation_cli/private_computation_cli.py
@@ -542,7 +542,6 @@ def _get_trace_logging_service(
     client: BoltGraphAPIClient,
     study_id_or_dataset_id: Optional[str],
 ) -> Optional[TraceLoggingService]:
-
     if study_id_or_dataset_id is None:
         return None
 

--- a/fbpcs/private_computation_cli/private_computation_service_wrapper.py
+++ b/fbpcs/private_computation_cli/private_computation_service_wrapper.py
@@ -162,7 +162,6 @@ def run_next(
     logger: logging.Logger,
     server_ips: Optional[List[str]] = None,
 ) -> None:
-
     pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
@@ -189,7 +188,6 @@ def run_stage(
     server_ips: Optional[List[str]] = None,
     dry_run: bool = False,
 ) -> None:
-
     pc_service = build_private_computation_service(
         config["private_computation"],
         config["mpc"],
@@ -361,7 +359,7 @@ def get_tier(config: Dict[str, Any]) -> PCSTier:
 
 
 def _try_build_log_retriever(
-    log_retriever_config: Dict[str, Any]
+    log_retriever_config: Dict[str, Any],
 ) -> Optional[LogRetriever]:
     if log_retriever_config:
         return reflect.get_instance(log_retriever_config, LogRetriever)
@@ -507,19 +505,19 @@ def build_private_computation_service(
 
 
 def _build_onedocker_service_cfg(
-    onedocker_service_config: Dict[str, Any]
+    onedocker_service_config: Dict[str, Any],
 ) -> OneDockerServiceConfig:
     return OneDockerServiceConfig(**onedocker_service_config["constructor"])
 
 
 def _build_onedocker_binary_cfg(
-    onedocker_binary_config: Dict[str, Any]
+    onedocker_binary_config: Dict[str, Any],
 ) -> OneDockerBinaryConfig:
     return OneDockerBinaryConfig(**onedocker_binary_config["constructor"])
 
 
 def _build_onedocker_binary_cfg_map(
-    onedocker_binary_configs: Dict[str, Dict[str, Any]]
+    onedocker_binary_configs: Dict[str, Dict[str, Any]],
 ) -> DefaultDict[str, OneDockerBinaryConfig]:
     onedocker_binary_cfg_map = defaultdict(
         lambda: _build_onedocker_binary_cfg(onedocker_binary_configs["default"])

--- a/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
+++ b/fbpcs/private_computation_cli/tests/test_pl_study_runner.py
@@ -223,7 +223,6 @@ class TestPlStudyRunner(TestCase):
 
     @patch("time.time", new=MagicMock(return_value=1665458111.3078792))
     def test_get_runnable_objectives(self) -> None:
-
         study_data = {
             "type": "LIFT",
             "start_time": "2022-10-03T07:00:00+0000",
@@ -483,9 +482,9 @@ class TestPlStudyRunner(TestCase):
         with self.subTest("invalid_objective_id"):
             try:
                 print(invalid_study_data_dict)
-                invalid_study_data_dict["objectives"]["data"][0][
-                    "id"
-                ] = "invalid_objective_id"
+                invalid_study_data_dict["objectives"]["data"][0]["id"] = (
+                    "invalid_objective_id"
+                )
                 self.response_mock.text = json.dumps(invalid_study_data_dict)
                 self.client_mock.get_study_data.return_value = self.response_mock
                 self._validate_error(

--- a/fbpcs/scripts/gen_fake_data.py
+++ b/fbpcs/scripts/gen_fake_data.py
@@ -74,7 +74,6 @@ def _get_md5_hash_of_int(i: int) -> str:
 def _gen_adjusted_purchase_rate(
     is_test: bool, purchase_rate: float, incrementality_rate: float
 ) -> float:
-
     if is_test:
         adj_purchase_rate = purchase_rate + (incrementality_rate / 2.0)
         if adj_purchase_rate > 1.0:
@@ -190,7 +189,6 @@ def _generate_line(
 
 
 def _make_input_csv(args: Dict[str, Any]) -> None:
-
     if args.get("<input_path>") is None:
         header_line = args.get("--from_header").split(",")
         header = [InputColumn.from_str(s) for s in header_line]

--- a/fbpcs/scripts/tests/test_gen_config.py
+++ b/fbpcs/scripts/tests/test_gen_config.py
@@ -14,7 +14,6 @@ from fbpcs.scripts import gen_config
 
 class TestGenConfig(unittest.TestCase):
     def test_prompt(self) -> None:
-
         # Test if Valid replacement exists and --accept_all passed - we use existing
         res = gen_config.prompt("key", replacements={"key": "baz"}, accept_all=True)
         self.assertEqual(res, "baz")


### PR DESCRIPTION
Summary:
Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files

Reviewed By: amyreese

Differential Revision: D66247885
