### PR TITLE
facebook-unused-include-check in fbcode/fbpcs/emp_games

### DIFF
--- a/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.cpp
@@ -14,7 +14,6 @@
 #include "folly/dynamic.h"
 
 #include "fbpcs/emp_games/common/EmpOperationUtil.h"
-#include "fbpcs/emp_games/common/PrivateData.h"
 #include "fbpcs/emp_games/common/SecretSharing.h"
 
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/Aggregator.h"

--- a/fbpcs/emp_games/attribution/decoupled_aggregation/test/MainUtilTest.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_aggregation/test/MainUtilTest.cpp
@@ -10,7 +10,6 @@
 
 #include <fbpcf/mpc/EmpTestUtil.h>
 #include <string>
-#include "folly/logging/xlog.h"
 
 #include "fbpcs/emp_games/attribution/decoupled_aggregation/MainUtil.h"
 

--- a/fbpcs/emp_games/attribution/decoupled_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/test/AttributionAppTest.cpp
@@ -16,7 +16,6 @@
 #include <fbpcf/mpc/EmpGame.h>
 #include "folly/Format.h"
 #include "folly/Random.h"
-#include "folly/logging/xlog.h"
 
 #include "fbpcs/emp_games/attribution/decoupled_attribution/test/AttributionTestUtils.h"
 #include "fbpcs/emp_games/common/TestUtil.h"

--- a/fbpcs/emp_games/attribution/decoupled_attribution/test/MainUtilTest.cpp
+++ b/fbpcs/emp_games/attribution/decoupled_attribution/test/MainUtilTest.cpp
@@ -10,7 +10,6 @@
 
 #include <fbpcf/mpc/EmpTestUtil.h>
 #include <string>
-#include "folly/logging/xlog.h"
 
 #include "fbpcs/emp_games/attribution/decoupled_attribution/MainUtil.h"
 

--- a/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/AggMetricsTest.cpp
@@ -16,7 +16,6 @@
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
-#include <folly/test/JsonTestUtil.h>
 
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcs/emp_games/common/TestUtil.h>

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorGameTest.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorGameTest.cpp
@@ -15,7 +15,6 @@
 #include <folly/Random.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
-#include <folly/test/JsonTestUtil.h>
 #include <gtest/gtest.h>
 
 #include <fbpcf/io/api/FileIOWrappers.h>
@@ -23,7 +22,6 @@
 #include <fbpcf/mpc/EmpTestUtil.h>
 #include <fbpcf/mpc/QueueIO.h>
 #include "../../common/TestUtil.h"
-#include "ShardAggregatorGame.h"
 #include "fbpcs/emp_games/attribution/shard_aggregator/AggMetricsThresholdCheckers.h"
 
 namespace measurement::private_attribution {

--- a/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidation.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/ShardAggregatorValidation.cpp
@@ -7,12 +7,10 @@
 
 #include "ShardAggregatorValidation.h"
 
-#include <set>
 #include <vector>
 
 #include <fbpcf/common/FunctionalUtil.h>
 #include <folly/dynamic.h>
-#include <folly/logging/xlog.h>
 #include <stdexcept>
 
 #include "AggMetrics.h"

--- a/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
+++ b/fbpcs/emp_games/attribution/shard_aggregator/main.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <filesystem>
-#include <stdexcept>
 
 #include <gflags/gflags.h>
 
@@ -17,7 +16,6 @@
 #include <fbpcf/exception/ExceptionBase.h>
 #include <fbpcs/performance_tools/CostEstimation.h>
 #include <signal.h>
-#include "MainUtil.h"
 #include "ShardAggregatorApp.h"
 
 DEFINE_int32(party, 1, "1 = publisher, 2 = partner");

--- a/fbpcs/emp_games/common/Crypto.cpp
+++ b/fbpcs/emp_games/common/Crypto.cpp
@@ -7,10 +7,7 @@
 
 #include "fbpcs/emp_games/common/Crypto.h"
 
-#include <openssl/conf.h>
-#include <openssl/err.h>
 #include <openssl/evp.h>
-#include <stdexcept>
 
 namespace private_measurement::crypto {
 

--- a/fbpcs/emp_games/common/Csv.cpp
+++ b/fbpcs/emp_games/common/Csv.cpp
@@ -15,7 +15,6 @@
 #include "fbpcf/io/api/FileReader.h"
 #include "fbpcf/io/api/FileWriter.h"
 
-#include "Constants.h"
 #include "Csv.h"
 
 namespace private_measurement::csv {

--- a/fbpcs/emp_games/common/test/CryptoTest.cpp
+++ b/fbpcs/emp_games/common/test/CryptoTest.cpp
@@ -12,10 +12,8 @@
 #include <climits>
 #include <functional>
 #include <random>
-#include <stdexcept>
 
 #include <openssl/conf.h>
-#include <openssl/err.h>
 #include <openssl/evp.h>
 
 #include <folly/ssl/OpenSSLPtrTypes.h>

--- a/fbpcs/emp_games/compactor/main.cpp
+++ b/fbpcs/emp_games/compactor/main.cpp
@@ -8,7 +8,6 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 #include <glog/logging.h>
-#include <signal.h>
 #include <filesystem>
 #include <fstream>
 #include <sstream>

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.cpp
@@ -10,7 +10,6 @@
 #include <fbpcf/io/api/BufferedReader.h>
 #include <fbpcf/io/api/BufferedWriter.h>
 #include <fbpcf/io/api/FileReader.h>
-#include <fbpcf/io/api/FileWriter.h>
 #include <cstdint>
 #include <iterator>
 #include <string>

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/main.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/main.cpp
@@ -15,7 +15,6 @@
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcs/emp_games/common/FeatureFlagUtil.h"
 #include "fbpcs/performance_tools/CostEstimation.h"
-#include "folly/String.h"
 #include "folly/init/Init.h"
 #include "folly/logging/xlog.h"
 

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorAppTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorAppTest.cpp
@@ -24,8 +24,6 @@
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptor.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/UdpEncryptorApp.h"
 #include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessApp.h"
-#include "fbpcs/emp_games/data_processing/unified_data_process/UdpProcessGameFactory.h"
-#include "fbpcs/performance_tools/CostEstimation.h"
 #include "folly/Format.h"
 #include "folly/Random.h"
 

--- a/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
+++ b/fbpcs/emp_games/data_processing/unified_data_process/UdpEncryptor/test/UdpEncryptorTest.cpp
@@ -11,7 +11,6 @@
 #include <gtest/gtest.h>
 #include <functional>
 #include <memory>
-#include <optional>
 #include "folly/Random.h"
 
 using namespace ::testing;

--- a/fbpcs/emp_games/dotproduct/test/DotproductGameTest.cpp
+++ b/fbpcs/emp_games/dotproduct/test/DotproductGameTest.cpp
@@ -15,7 +15,6 @@
 #include "folly/logging/xlog.h"
 
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
-#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"

--- a/fbpcs/emp_games/he_aggregation/AggregationInputMetrics.cpp
+++ b/fbpcs/emp_games/he_aggregation/AggregationInputMetrics.cpp
@@ -14,7 +14,6 @@
 #include <string>
 
 #include <re2/re2.h>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/fbpcs/emp_games/he_aggregation/HEAggGame.cpp
+++ b/fbpcs/emp_games/he_aggregation/HEAggGame.cpp
@@ -11,8 +11,6 @@
 #include "fbpcf/mpc_std_lib/oram/DifferenceCalculatorFactory.h"
 #include "fbpcf/mpc_std_lib/oram/LinearOramFactory.h"
 #include "fbpcf/mpc_std_lib/oram/ObliviousDeltaCalculatorFactory.h"
-#include "fbpcf/mpc_std_lib/oram/SinglePointArrayGeneratorFactory.h"
-#include "fbpcf/mpc_std_lib/oram/WriteOnlyOramFactory.h"
 #include "fbpcs/emp_games/he_aggregation/AttributionAdditiveSSResult.h"
 #include "fbpcs/emp_games/he_aggregation/HEAggOptions.h"
 

--- a/fbpcs/emp_games/he_aggregation/test/HEAggGameTest.cpp
+++ b/fbpcs/emp_games/he_aggregation/test/HEAggGameTest.cpp
@@ -21,7 +21,6 @@
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
 #include "fbpcf/scheduler/PlaintextScheduler.h"
-#include "fbpcf/scheduler/SchedulerHelper.h"
 #include "fbpcf/test/TestHelper.h"
 #include "fbpcs/emp_games/common/TestUtil.h"
 #include "fbpcs/emp_games/he_aggregation/AggregationInputMetrics.h"

--- a/fbpcs/emp_games/lift/calculator/test/CalculatorGameTest.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/CalculatorGameTest.cpp
@@ -23,7 +23,6 @@
 #include "../CalculatorGame.h"
 #include "../CalculatorGameConfig.h"
 #include "../InputData.h"
-#include "../OutputMetrics.h"
 #include "common/GenFakeData.h"
 #include "common/LiftCalculator.h"
 

--- a/fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp
+++ b/fbpcs/emp_games/lift/calculator/test/common/LiftCalculator.cpp
@@ -6,10 +6,8 @@
  */
 
 #include "LiftCalculator.h"
-#include <gflags/gflags.h>
 #include <fstream>
 #include <iomanip>
-#include <map>
 #include <sstream>
 #include <unordered_map>
 #include <vector>

--- a/fbpcs/emp_games/lift/common/LiftMetrics.cpp
+++ b/fbpcs/emp_games/lift/common/LiftMetrics.cpp
@@ -14,7 +14,6 @@
 #include "folly/json.h"
 
 #include <fbpcf/common/FunctionalUtil.h>
-#include <fbpcf/common/VectorUtil.h>
 
 namespace private_lift {
 bool LiftMetrics::operator==(const LiftMetrics& other) const noexcept {

--- a/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/LiftMetaDataSerializerTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/LiftMetaDataSerializerTest.cpp
@@ -14,7 +14,6 @@
 
 #include "fbpcs/emp_games/common/Util.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/serialization/LiftMetaDataSerializer.h"
-#include "fbpcs/emp_games/lift/pcf2_calculator/input_processing/test/TestUtil.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/sample_input/SampleInput.h"
 
 using namespace ::testing;

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/CalculatorAppTest.cpp
@@ -18,7 +18,6 @@
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcs/emp_games/common/Csv.h"
 #include "fbpcs/emp_games/common/test/TestUtils.h"

--- a/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftCalculatorLocalTest.cpp
+++ b/fbpcs/emp_games/lift/pcf2_calculator/test/common/common_test/LiftCalculatorLocalTest.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <fbpcf/io/api/FileIOWrappers.h>
-#include <sys/types.h>
 #include "fbpcs/emp_games/common/TestUtil.h"
 #include "fbpcs/emp_games/lift/pcf2_calculator/test/common/LiftCalculator.h"
 

--- a/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.cpp
@@ -14,7 +14,6 @@
 #include <string>
 
 #include <re2/re2.h>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -26,9 +25,7 @@
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/Util.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AggregationMetrics.h"
-#include "fbpcs/emp_games/pcf2_aggregation/AggregationOptions.h"
 #include "fbpcs/emp_games/pcf2_aggregation/AttributionResult.h"
-#include "fbpcs/emp_games/pcf2_aggregation/Constants.h"
 #include "fbpcs/emp_games/pcf2_aggregation/ConversionMetadata.h"
 #include "fbpcs/emp_games/pcf2_aggregation/TouchpointMetadata.h"
 

--- a/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_aggregation/test/AggregationAppTest.cpp
@@ -18,7 +18,6 @@
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcf/util/MetricCollector.h"
 #include "fbpcs/emp_games/common/Constants.h"

--- a/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/AttributionMetrics.cpp
@@ -8,7 +8,6 @@
 #include <re2/re2.h>
 #include <filesystem>
 #include <fstream>
-#include <map>
 #include <unordered_set>
 
 #include "fbpcs/emp_games/common/Constants.h"

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionAppTest.cpp
@@ -17,7 +17,6 @@
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"
-#include "fbpcf/engine/communication/test/SocketInTestHelper.h"
 #include "fbpcf/engine/communication/test/TlsCommunicationUtils.h"
 #include "fbpcs/emp_games/common/Constants.h"
 #include "fbpcs/emp_games/common/TestUtil.h"

--- a/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
+++ b/fbpcs/emp_games/pcf2_attribution/test/AttributionGameTest.cpp
@@ -10,10 +10,8 @@
 #include <future>
 
 #include "folly/dynamic.h"
-#include "folly/json.h"
 #include "folly/logging/Init.h"
 #include "folly/logging/xlog.h"
-#include "folly/test/JsonTestUtil.h"
 
 #include "fbpcf/engine/communication/InMemoryPartyCommunicationAgentFactory.h"
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"

--- a/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/ShardCombinerAppTest.cpp
@@ -18,7 +18,6 @@
 #include <folly/json.h>
 
 #include <fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h>
-#include <fbpcf/engine/communication/test/SocketInTestHelper.h>
 #include <fbpcf/engine/communication/test/TlsCommunicationUtils.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include "fbpcf/engine/communication/test/AgentFactoryCreationHelper.h"

--- a/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
+++ b/fbpcs/emp_games/pcf2_shard_combiner/main.cpp
@@ -15,7 +15,6 @@
 #include <fbpcf/aws/AwsSdk.h>
 #include <fbpcf/exception/ExceptionBase.h>
 #include <fbpcf/exception/exceptions.h>
-#include <folly/Synchronized.h>
 #include <folly/init/Init.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>

--- a/fbpcs/emp_games/private_id_dfca_aggregator/main.cpp
+++ b/fbpcs/emp_games/private_id_dfca_aggregator/main.cpp
@@ -11,11 +11,8 @@
 #include <fbpcf/scheduler/LazySchedulerFactory.h>
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
-#include <glog/logging.h>
 #include <signal.h>
 #include <filesystem>
-#include <fstream>
-#include <sstream>
 #include <string>
 
 #include "fbpcs/emp_games/common/Constants.h"

--- a/fbpcs/emp_games/private_id_dfca_aggregator/test/PrivateIdDfcaAggregatorTest.cpp
+++ b/fbpcs/emp_games/private_id_dfca_aggregator/test/PrivateIdDfcaAggregatorTest.cpp
@@ -16,11 +16,9 @@
 
 #include <folly/Format.h>
 #include <folly/Random.h>
-#include <folly/json.h>
 
 #include <fbpcf/engine/communication/SocketPartyCommunicationAgentFactory.h>
 #include <fbpcf/engine/communication/test/AgentFactoryCreationHelper.h>
-#include <fbpcf/engine/communication/test/SocketInTestHelper.h>
 #include <fbpcf/engine/communication/test/TlsCommunicationUtils.h>
 #include <fbpcf/io/api/FileIOWrappers.h>
 #include <fbpcs/emp_games/common/TestUtil.h>


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.fbpcs.emp_games.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.fbpcs.emp_games
Autodiff bookmark: ad.uif.fbcode.fbpcs.emp_games

Reviewed By: mdas7

Differential Revision: D65957899
